### PR TITLE
Emit public interface name instead of ABI name in ABI implementations of required interfaces

### DIFF
--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -1565,7 +1565,7 @@ remove => _%.Event -= value;
                 return;
             }
 
-            auto requiredInterfaceName = w.write_temp("%", bind<write_type_name>(required_interface, true, false));
+            auto requiredInterfaceName = write_type_name_temp(w, required_interface);
             method_signature signature{ method };
         w.write(R"(
 % %.%(%) => As<%>().%(%);


### PR DESCRIPTION
Output the public interface name instead of the ABI name when emitting explicit implementations of required interfaces since only the public interface name is an interface.