### PR TITLE
Pin the GCHandle used in HStringReference for the string.

### DIFF
--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -387,9 +387,9 @@ namespace WinRT
         private HStringHeader _header;
         private GCHandle _gchandle;
 
-        public HStringReference(String value)
+        public HStringReference(string value)
         {
-            _gchandle = GCHandle.Alloc(value);
+            _gchandle = GCHandle.Alloc(value, GCHandleType.Pinned);
             unsafe
             {
                 fixed (void* chars = value, pHeader = &_header, pHandle = &Handle)


### PR DESCRIPTION
Fixes #6 