### PR TITLE
Move delegates to share the same CCW infrastructure as objects.

### DIFF
--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -182,9 +182,7 @@ namespace WinRT
         // IDelegate
         public struct IDelegateVftbl
         {
-            public IntPtr QueryInterface;
-            public IntPtr AddRef;
-            public IntPtr Release;
+            public IUnknownVftbl IUnknownVftbl;
             public IntPtr Invoke;
         }
 


### PR DESCRIPTION
This reduces the amount of code we need to mantain as well as centralizes the CCW interface creation, making adding default WinRT interface implementations easier.

Fixes #46

Update delegate RCW design to have a well-defined target type to enable easily adding forced-release semantics in the runtime-supported CCW design.