### PR TITLE
Change build output layout to support having multi-targetting binaries.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,12 +22,15 @@
     <BuildVersion Condition="'$(BuildVersion)'==''">1.0.0.0</BuildVersion>
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
-    <BuildOutDir Condition="'$(BuildOutDir)'==''">$([System.IO.Path]::GetFullPath('$(SolutionDir)_build\$(BuildPlatform)\$(Configuration)\'))</BuildOutDir>
-    <CsWinRTDir>$(BuildOutDir)</CsWinRTDir>
-    <CsWinRTDir Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([System.IO.Path]::GetFullPath('$(SolutionDir)_build\x86\$(Configuration)\'))</CsWinRTDir>
+    <BuildOutDir Condition="'$(BuildOutDir)'==''">$([MSBuild]::NormalizeDirectory('$(SolutionDir)_build', '$(BuildPlatform)', '$(Configuration)'))</BuildOutDir>
+    <CsWinRTDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', 'cswinrt', 'bin'))</CsWinRTDir>
+    <CsWinRTDir Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([MSBuild]::NormalizeDirectory('$(SolutionDir)_build', 'x86', '$(Configuration)', 'cswinrt', 'bin'))</CsWinRTDir>
     <CsWinRTExe>$(CsWinRTDir)cswinrt.exe</CsWinRTExe>
-    <OutDir>$(BuildOutDir)</OutDir>
-    <IntDir>$(OutDir)$(ProjectName)\</IntDir>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
+    <OutDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'bin'))</OutDir>
+    <IntDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'obj'))</IntDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,5 @@
 <!--NOTE: Directory.Build.* files are temporary until C#/WinRT nuget contains msbuild support-->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
     <ResolveAssemblyReferencesDependsOn Condition="'$(RemoveWindowsReference)'=='true'">$(ResolveAssemblyReferencesDependsOn);RemoveWindowsReference</ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>

--- a/UnitTest/Directory.Build.targets
+++ b/UnitTest/Directory.Build.targets
@@ -9,13 +9,19 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   
-  <Target Name="CopyBinaries" BeforeTargets="PreBuildEvent">
-    <Exec Command="xcopy /D /Y &quot;$(OutDir)TestComponentCSharp\TestComponentCSharp.dll&quot; &quot;$(TargetDir)&quot;" />
-    <Exec Command="xcopy /D /Y &quot;$(OutDir)TestComponentCSharp\TestComponentCSharp.pdb&quot; &quot;$(TargetDir)&quot;" />
+  <Target Name="CopyTestComponent" BeforeTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <Content Include="
+                $(BuildOutDir)TestComponent\bin\TestComponent.dll;
+                $(BuildOutDir)TestComponent\bin\TestComponent.pdb;
+                $(BuildOutDir)TestComponentCSharp\bin\TestComponentCSharp\TestComponentCSharp.dll;
+                $(BuildOutDir)TestComponentCSharp\bin\TestComponentCSharp\TestComponentCSharp.pdb"
+               CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
   </Target>
 
   <Target Name="GenerateProjection" BeforeTargets="CoreCompile" Condition="'$(GenerateTestProjection)' == 'true'">
-    <Exec Command="$(CsWinrtExe) -verbose -in 10.0.18362.0 $(OutDir)TestComponentCSharp\TestComponentCSharp.winmd $(OutDir)TestComponent.winmd -out &quot;$(ProjectDir)Generated Files&quot; -include TestComponentCSharp TestComponent Windows.Foundation -exclude Windows.Foundation.Diagnostics -exclude Windows.Foundation.Metadata" />
+    <Exec Command="$(CsWinrtExe) -verbose -in 10.0.18362.0 $(BuildOutDir)TestComponentCSharp\bin\TestComponentCSharp\TestComponentCSharp.winmd $(BuildOutDir)TestComponent\bin\TestComponent.winmd -out &quot;$(ProjectDir)Generated Files&quot; -include TestComponentCSharp TestComponent Windows.Foundation -exclude Windows.Foundation.Diagnostics -exclude Windows.Foundation.Metadata" />
   </Target>
 
   <Target Name="IncludeProjection" BeforeTargets="CoreCompile" AfterTargets="GenerateProjection">

--- a/WinUITest/Directory.Build.targets
+++ b/WinUITest/Directory.Build.targets
@@ -9,9 +9,13 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <Target Name="CopyTestComponent" BeforeTargets="PreBuildEvent">
-    <Exec Condition="'$(Platform)'=='x64'" Command="xcopy /D /Y &quot;$(PkgMicrosoft_UI_Xaml)\runtimes\win10-x64\native\*.dll&quot; &quot;$(TargetDir)&quot;" />
-    <Exec Condition="'$(Platform)'=='win32'" Command="xcopy /D /Y &quot;$(PkgMicrosoft_UI_Xaml)\runtimes\win10-x86\native\*.dll&quot; &quot;$(TargetDir)&quot;" />
+  <Target Name="CopyTestComponent" BeforeTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <Content Include="
+                $(PkgMicrosoft_UI_Xaml)\runtimes\win10-x64\native\*.dll;
+                $(PkgMicrosoft_UI_Xaml)\runtimes\win10-x86\native\*.dll"
+               CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
   </Target>
 
   <Target Name="GenerateWinUIProjection" BeforeTargets="CoreCompile" Condition="'$(GenerateTestProjection)' == 'true'">
@@ -21,7 +25,7 @@
     </ItemGroup>
     <PropertyGroup>
       <CsWinRTVerbosity>high</CsWinRTVerbosity>
-      <CsWinRTResponseFile>$(IntDir)cswinrt_platform.rsp</CsWinRTResponseFile>
+      <CsWinRTResponseFile>$(IntermediateOutputPath)/cswinrt_platform.rsp</CsWinRTResponseFile>
       <CsWinRTCommand>$(CsWinrtExe) %40"$(CsWinRTResponseFile)"</CsWinRTCommand>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Move the outputs of each package to their own folder in the bin directory.

Let the managed test projects output to their own folder in the bin directory.

Use more standard MSBuild in our scripts to limit the amount of work we have to do ourselves.

This is prep work for creating a "WinRT.Runtime" library for a subset of the generated code that has to have one definition in the program.