### PR TITLE
Fix references to GuidGenerator in ABI.Windows.UI.Xaml.

### DIFF
--- a/cswinrt/strings/additions/Windows.UI.Xaml.cs
+++ b/cswinrt/strings/additions/Windows.UI.Xaml.cs
@@ -294,7 +294,9 @@ namespace ABI.Windows.UI.Xaml
     {
         public static string GetGuidSignature()
         {
-            return $"struct(Windows.UI.Xaml.Duration;{global::WinRT.GuidGenerator.GetSignature(typeof(global::System.TimeSpan))};{global::WinRT.GuidGenerator.GetSignature(typeof(global::Windows.UI.Xaml.DurationType))})";
+            string timeSpanSignature = global::WinRT.GuidGenerator.GetSignature(typeof(global::System.TimeSpan));
+            string durationTypeSignature = global::WinRT.GuidGenerator.GetSignature(typeof(global::Windows.UI.Xaml.DurationType));
+            return $"struct(Windows.UI.Xaml.Duration;{timeSpanSignature};{durationTypeSignature})";
         }
     }
 }


### PR DESCRIPTION
The additions for Windows.UI.Xaml also had an aliasing issue with namespaces similar to #84.