### PR TITLE
Provide IStringable in all CCWs.

### DIFF
--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -167,6 +167,12 @@ namespace WinRT
 
             entries.Add(new ComInterfaceEntry
             {
+                IID = typeof(ManagedIStringableVftbl).GUID,
+                Vtable = ManagedIStringableVftbl.AbiToProjectionVftablePtr
+            });
+
+            entries.Add(new ComInterfaceEntry
+            {
                 IID = typeof(IWeakReferenceSourceVftbl).GUID,
                 Vtable = IWeakReferenceSourceVftbl.AbiToProjectionVftablePtr
             });

--- a/WinRT.Runtime/Projections/IStringable.cs
+++ b/WinRT.Runtime/Projections/IStringable.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.InteropServices;
+using WinRT;
+
+namespace ABI.Windows.Foundation
+{
+    [Guid("96369F54-8EB6-48F0-ABCE-C1B211E627C3")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ManagedIStringableVftbl
+    {
+        private unsafe delegate int _ToString_0(IntPtr thisPtr, out IntPtr value);
+
+        internal IInspectable.Vftbl IInspectableVftbl;
+        private _ToString_0 ToString_0;
+
+        private static readonly ManagedIStringableVftbl AbiToProjectionVftable;
+        public static readonly IntPtr AbiToProjectionVftablePtr;
+        static unsafe ManagedIStringableVftbl()
+        {
+            AbiToProjectionVftable = new ManagedIStringableVftbl
+            {
+                IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+                ToString_0 = Do_Abi_ToString_0
+            };
+            var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(ManagedIStringableVftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+            Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+            AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+        }
+
+        private static unsafe int Do_Abi_ToString_0(IntPtr thisPtr, out IntPtr value)
+        {
+            value = default;
+            try
+            {
+                string __value = global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr).ToString();
+                value = MarshalString.FromManaged(__value);
+            }
+            catch (Exception __exception__)
+            {
+                global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+            }
+            return 0;
+        }
+    }
+}

--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -697,7 +697,6 @@ namespace cswinrt
                         {
                             method_spec = "override ";
                             return_type = "string";
-                            write_explicit_implementation = true;
                         }
                     }
                 }
@@ -1946,7 +1945,7 @@ internal static _% Instance => _instance.Value;
 public unsafe %% %(%)
 {%}
 )",
-                (method.Name() == "ToString"sv) ? "new " : "",
+                (method.Name() == "ToString"sv) ? "override " : "",
                 bind<write_projection_return_type>(signature),
                 method.Name(),
                 bind_list<write_projection_parameter>(", ", signature.params()),


### PR DESCRIPTION
The .NET runtime's projection provides IStringable on all CCWs, so we should as well.