### PR TITLE
Fix runtime class signature generation.

### DIFF
--- a/WinRT.Runtime/GuidGenerator.cs
+++ b/WinRT.Runtime/GuidGenerator.cs
@@ -100,10 +100,9 @@ namespace WinRT
                 return "string";
             }
 
-            var _default = type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault((FieldInfo fi) => fi.Name == "_default");
-            if (_default != null)
+            if (Projections.TryGetDefaultInterfaceTypeForRuntimeClassType(type, out Type iface))
             {
-                return "rc(" + type.FullName + ";" + GetSignature(_default.FieldType) + ")";
+                return "rc(" + type.FullName + ";" + GetSignature(iface) + ")";
             }
 
             if (type.IsDelegate())

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -142,15 +142,26 @@ namespace WinRT
             return CustomTypeToAbiTypeNameMappings.ContainsKey(typeToTest) || typeToTest.GetCustomAttribute<WindowsRuntimeTypeAttribute>() is object;
         }
 
-        internal static Type GetDefaultInterfaceTypeForRuntimeClassType(Type runtimeClass)
+        internal static bool TryGetDefaultInterfaceTypeForRuntimeClassType(Type runtimeClass, out Type defaultInterface)
         {
+            defaultInterface = null;
             ProjectedRuntimeClassAttribute attr = runtimeClass.GetCustomAttribute<ProjectedRuntimeClassAttribute>();
             if (attr is null)
             {
-                throw new ArgumentException($"The provided type '{runtimeClass.FullName}' is not a WinRT projected runtime class.", nameof(runtimeClass));
+                return false;
             }
 
-            return runtimeClass.GetProperty(attr.DefaultInterfaceProperty, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly).PropertyType;
+            defaultInterface = runtimeClass.GetProperty(attr.DefaultInterfaceProperty, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly).PropertyType;
+            return true;
+        }
+
+        internal static Type GetDefaultInterfaceTypeForRuntimeClassType(Type runtimeClass)
+        {
+            if (!TryGetDefaultInterfaceTypeForRuntimeClassType(runtimeClass, out Type defaultInterface))
+            {
+                throw new ArgumentException($"The provided type '{runtimeClass.FullName}' is not a WinRT projected runtime class.", nameof(runtimeClass));
+            }
+            return defaultInterface;
         }
     }
 }


### PR DESCRIPTION
When we changed `_default` to be a property in #115, we didn't update the signature generation code.

This PR updates the signature generation code to use the same infrastructure around the `ProjectedRuntimeClassAttribute` to discover the default interface type.