### PR TITLE
Fix build breaks

### DIFF
--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -1251,7 +1251,7 @@ IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             element, target);
     }
 
-    void write_mapped_collection_members(writer& w, std::string_view target, mapped_type const& mapping)
+    void write_custom_mapped_type_members(writer& w, std::string_view target, mapped_type const& mapping)
     {
         if (mapping.abi_name == "IIterable`1") 
         {
@@ -1260,9 +1260,6 @@ IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         else if (mapping.abi_name == "IIterator`1") 
         {
             write_enumerator_members(w, target);
-        }
-        else if (mapping.abi_name == "IKeyValuePair`2")
-        {
         }
         else if (mapping.abi_name == "IMapView`2") 
         {
@@ -1306,9 +1303,9 @@ private % AsInternal(InterfaceTag<%> _) => new %(_default.ObjRef);
                         interface_abi_name);
                 }
 
-                if(auto mapping = get_mapped_type(interface_type.TypeNamespace(), interface_type.TypeName()))
+                if(auto mapping = get_mapped_type(interface_type.TypeNamespace(), interface_type.TypeName()); mapping && mapping->has_custom_members_output)
                 {
-                    write_mapped_collection_members(w, target, *mapping);
+                    write_custom_mapped_type_members(w, target, *mapping);
                     return;
                 }
 

--- a/cswinrt/helpers.h
+++ b/cswinrt/helpers.h
@@ -417,6 +417,7 @@ namespace cswinrt
         std::string_view mapped_namespace;
         std::string_view mapped_name;
         bool requires_marshaling;
+        bool has_custom_members_output;
     };
 
     inline const std::initializer_list<mapped_type> get_mapped_types_in_namespace(std::string_view typeNamespace)
@@ -451,13 +452,13 @@ namespace cswinrt
             },
             { "Windows.Foundation.Collections",
                 {
-                    { "IIterable`1", "System.Collections.Generic", "IEnumerable`1", true },
-                    { "IIterator`1", "System.Collections.Generic", "IEnumerator`1", true },
+                    { "IIterable`1", "System.Collections.Generic", "IEnumerable`1", true, true },
+                    { "IIterator`1", "System.Collections.Generic", "IEnumerator`1", true, true },
                     { "IKeyValuePair`2", "System.Collections.Generic", "KeyValuePair`2", true },
-                    { "IMapView`2", "System.Collections.Generic", "IReadOnlyDictionary`2", true },
-                    { "IMap`2", "System.Collections.Generic", "IDictionary`2", true },
-                    { "IVectorView`1", "System.Collections.Generic", "IReadOnlyList`1", true },
-                    { "IVector`1", "System.Collections.Generic", "IList`1", true },
+                    { "IMapView`2", "System.Collections.Generic", "IReadOnlyDictionary`2", true, true },
+                    { "IMap`2", "System.Collections.Generic", "IDictionary`2", true, true },
+                    { "IVectorView`1", "System.Collections.Generic", "IReadOnlyList`1", true, true },
+                    { "IVector`1", "System.Collections.Generic", "IList`1", true, true },
                 }
             },
             { "Windows.UI.Xaml",
@@ -470,6 +471,11 @@ namespace cswinrt
                     { "INotifyPropertyChanged", "System.ComponentModel", "INotifyPropertyChanged" },
                     { "PropertyChangedEventArgs", "System.ComponentModel", "PropertyChangedEventArgs" },
                     { "PropertyChangedEventHandler", "System.ComponentModel", "PropertyChangedEventHandler" },
+                }
+            },
+            { "Windows.UI.Xaml.Input",
+                {
+                    { "ICommand", "System.Windows.Input", "ICommand", true }
                 }
             },
             {


### PR DESCRIPTION
Only write out custom members instead of the actual type members for specific type mappings. Add back WUX ICommand -> .NET ICommand mapping (got lost in the collections work).