### PR TITLE
Fixing build issues due to adding WinUI projection

### DIFF
--- a/WinUI/WinUIProjection/Directory.Build.targets
+++ b/WinUI/WinUIProjection/Directory.Build.targets
@@ -1,9 +1,0 @@
-<!--NOTE: Directory.Build.* files are temporary until C#/WinRT nuget contains msbuild support-->  
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <GenerateTestProjection Condition="'$(GenerateTestProjection)$(Configuration)' == 'Release'">$(IsCrossTargetingBuild)</GenerateTestProjection>
-  </PropertyGroup>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
-</Project>

--- a/WinUI/WinUIProjection/WinUIProjection.csproj
+++ b/WinUI/WinUIProjection/WinUIProjection.csproj
@@ -23,7 +23,7 @@
     <InternalsVisibleTo Include="WinUITest"/>
   </ItemGroup>
 
-  <Target Name="GenerateWinUIProjection" BeforeTargets="DispatchToInnerBuilds;Build">
+  <Target Name="GenerateWinUIProjection" BeforeTargets="CoreCompile">
     <ItemGroup>
       <!--PkgMicrosoft_UI_Xaml is defined by Nuget reference-->
       <WinUIWinMDs Include="$(PkgMicrosoft_WinUI)/**/*.winmd" />


### PR DESCRIPTION
There were a few issues with the build that somehow didn't get caught while working on this:

1. Even though I set ExcludeAssets=Build, Nuget was still importing the WinUI targets, which depend on TargetPlatformVersion to be specified
2. After setting TargetPlatformVersionin the Projection project, there was a timing issue preventing the generated files from being compiled. This is why a subsequent build worked - because the files were already in the Generated Files directory