### PR TITLE
Fix ICustomQueryInterface.GetInterface implementation to never delegate a QI for IInspectable to the inner.

### DIFF
--- a/WinUI/WinUIDesktopSample/MainPage.xaml
+++ b/WinUI/WinUIDesktopSample/MainPage.xaml
@@ -6,12 +6,7 @@
         xmlns:local="NetCoreDesktopSample"
         mc:Ignorable="d"
         Height="450" Width="800">
-    <Page.Content>
-        <Grid>
-            <Grid.Children>
-                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="Hello from WinUI Desktop!" />
-            </Grid.Children>
-        </Grid>
-    </Page.Content>
-    
+    <Grid>
+        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="Hello from WinUI Desktop!" x:Name="text"/>
+    </Grid>
 </Page>

--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -3974,7 +3974,7 @@ default_interface_abi_name);
 global::System.Runtime.InteropServices.CustomQueryInterfaceResult global::System.Runtime.InteropServices.ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
 {
 ppv = IntPtr.Zero;
-if (IsOverridableInterface(iid))
+if (IsOverridableInterface(iid) || typeof(global::WinRT.IInspectable).GUID == iid)
 {
 return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHandled;
 }


### PR DESCRIPTION
Fixes #154 