### PR TITLE
Revert "Add missing AsAsyncAction and AsAsyncOperation methods."

### DIFF
--- a/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -970,21 +970,5 @@ namespace System
                 }
             }
         }
-
-        public static IAsyncAction AsAsyncAction(this Task source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            return new TaskToAsyncActionAdapter(source, underlyingCancelTokenSource: null);
-        }
-
-        public static IAsyncOperation<TResult> AsAsyncOperation<TResult>(this Task<TResult> source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            return new TaskToAsyncOperationAdapter<TResult>(source, underlyingCancelTokenSource: null);
-        }
     }
 }


### PR DESCRIPTION
Build break:
error CS1106: Extension method must be defined in a non-generic static class 