### PR TITLE
Fixing handling of lists of C#-only types 

### DIFF
--- a/WinUI/WinUIDesktopSample.Package/WinUIDesktopSample.Package.wapproj
+++ b/WinUI/WinUIDesktopSample.Package/WinUIDesktopSample.Package.wapproj
@@ -86,4 +86,9 @@
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" Condition="'$(BuildingInsideVisualStudio)'=='true'" />
   <Import Project="$(MSBuildThisFileDirectory)NoBuild.targets" Condition="'$(BuildingInsideVisualStudio)'!='true'" />
+  <PropertyGroup>
+    <_AddWinUIAssembliesToReferenceCopyLocalPaths>true</_AddWinUIAssembliesToReferenceCopyLocalPaths>
+  </PropertyGroup>
+  <Import Project="..\..\packages\Microsoft.WinUI.$(MicrosoftWinUIVersion)\build\Microsoft.WinUI.AppX.targets"  Condition="'$(BuildingInsideVisualStudio)'=='true'" />
+  <Import Project="..\..\packages\Microsoft.WinUI.$(MicrosoftWinUIVersion)\build\Microsoft.WinUI.References.targets"  Condition="'$(BuildingInsideVisualStudio)'=='true'" />
 </Project>


### PR DESCRIPTION
Rather than just checking whether a type itself is a WinRT type, we should also check to see whether its generic type arguments (if they exist) are WinRT types - not doing this extra step can lead to us attempting and failing to retrieve the ABI counterpart to, for example, IList<Foo>, where Foo is a C# type declared in a desktop app, rather than a WinRT type.

While I was at it, I also added a couple imports to the WAP project that are needed to be able to F5 to test it out.  Without those imports, we aren't properly compiling all of the WinUI binaries into the AppX, and aren't adding type activation information to the AppX manifest.

Fixes #172