### PR TITLE
Fix generating string RCWs for duplicate boxed WinRT strings

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -1139,4 +1139,8 @@ namespace winrt::TestComponentCSharp::implementation
         return type.Name;
     }
 
+    Windows::Foundation::IInspectable Class::EmptyString()
+    {
+        return winrt::box_value(hstring{});
+    }
 }

--- a/TestComponentCSharp/Class.h
+++ b/TestComponentCSharp/Class.h
@@ -284,6 +284,8 @@ namespace winrt::TestComponentCSharp::implementation
         static bool VerifyTypeIsThisClassType(Windows::UI::Xaml::Interop::TypeName const& type_name);
         static hstring GetTypeNameForType(Windows::UI::Xaml::Interop::TypeName const& type);
 
+        static Windows::Foundation::IInspectable EmptyString();
+
         // IStringable
         hstring ToString();
 

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -294,5 +294,7 @@ namespace TestComponentCSharp
         static Boolean VerifyTypeIsReferenceInt32Type(Windows.UI.Xaml.Interop.TypeName type);
 
         static String GetTypeNameForType(Windows.UI.Xaml.Interop.TypeName type);
+
+        static Object EmptyString { get; };
     }
 }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1399,5 +1399,16 @@ namespace UnitTest
 
             Assert.Equal("Windows.Foundation.Collections.IVector`1<Int32>", typeName);
         }
+
+        [Fact]
+        public void TestStringUnboxing()
+        {
+            var str1 = Class.EmptyString;
+            var str2 = Class.EmptyString;
+            Assert.IsType<string>(str1);
+            Assert.IsType<string>(str2);
+            Assert.Equal(string.Empty, (string)str1);
+            Assert.Equal(string.Empty, (string)str2);
+        }
     }
 }

--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -263,7 +263,7 @@ namespace WinRT
             // PropertySet and ValueSet can return IReference<String> but Nullable<String> is illegal
             if (runtimeClassName == "Windows.Foundation.IReference`1<String>")
             {
-                return (IInspectable obj) => new ABI.System.Nullable<String>(obj.ObjRef).Value;
+                return (IInspectable obj) => new ABI.System.Nullable<String>(obj.ObjRef);
             }
 
             var (implementationType, _) = TypeNameSupport.FindTypeByName(runtimeClassName.AsSpan());

--- a/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -51,7 +51,13 @@ namespace WinRT
                 }).TryGetTarget(out object rcw);
 
             GC.KeepAlive(keepAliveSentinel);
-            return rcw;
+
+            // Because .NET will de-duplicate strings and WinRT doesn't,
+            // our RCW factory returns a wrapper of our string instance.
+            // This ensures that our cache never sees the same managed object for two different
+            // native pointers. We unwrap here to ensure that the user-experience is expected
+            // and consumers get a string object for a Windows.Foundation.IReference<String>.
+            return rcw is ABI.System.Nullable<string> ns ? ns.Value : rcw;
         }
     
         public static void RegisterObjectForInterface(object obj, IntPtr thisPtr)


### PR DESCRIPTION
Ensure that we don't get in a state of "two native pointers for the same RCW". We could get in this case with strings. Now we wrap the strings through adding them to the cache and unwrap them when giving them to the user.

Fixes an issue reported in email with a NotSupportedException when creating an RCW.

cc: @stevenbrix