### PR TITLE
Don't create vtable entries for WinRT generic interfaces constructed over non-projected .NET types.

### DIFF
--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1417,6 +1417,7 @@ namespace UnitTest
         public void CCWOfListOfManagedType()
         {
             using var ccw = ComWrappersSupport.CreateCCWForObject(new List<ManagedType>());
+            using var qiResult = ccw.As(GuidGenerator.GetIID(typeof(ABI.System.Collections.Generic.IEnumerable<object>)));
         }
     }
 }

--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -119,19 +119,26 @@ namespace WinRT
             var interfaces = obj.GetType().GetInterfaces();
             foreach (var iface in interfaces)
             {
-                if (!Projections.IsTypeWindowsRuntimeType(iface))
+                if (Projections.IsTypeWindowsRuntimeType(iface))
                 {
-                    // This interface isn't a WinRT interface.
-                    continue;
+                    var ifaceAbiType = iface.FindHelperType();
+                    entries.Add(new ComInterfaceEntry
+                    {
+                        IID = GuidGenerator.GetIID(ifaceAbiType),
+                        Vtable = (IntPtr)ifaceAbiType.FindVftblType().GetField("AbiToProjectionVftablePtr", BindingFlags.Public | BindingFlags.Static).GetValue(null)
+                    });
                 }
 
-                var ifaceAbiType = iface.FindHelperType();
-
-                entries.Add(new ComInterfaceEntry
+                if (iface.IsConstructedGenericType
+                    && Projections.TryGetCompatibleWindowsRuntimeTypeForVariantType(iface, out var compatibleIface))
                 {
-                    IID = GuidGenerator.GetIID(ifaceAbiType),
-                    Vtable = (IntPtr)ifaceAbiType.FindVftblType().GetField("AbiToProjectionVftablePtr", BindingFlags.Public | BindingFlags.Static).GetValue(null)
-                });
+                    var compatibleIfaceAbiType = compatibleIface.FindHelperType();
+                    entries.Add(new ComInterfaceEntry
+                    {
+                        IID = GuidGenerator.GetIID(compatibleIfaceAbiType),
+                        Vtable = (IntPtr)compatibleIfaceAbiType.FindVftblType().GetField("AbiToProjectionVftablePtr", BindingFlags.Public | BindingFlags.Static).GetValue(null)
+                    });
+                }
             }
 
             if (obj is Delegate)


### PR DESCRIPTION
We can't create vtables for these types.

Fixes #192 
Fixes #172 
Superscedes #173 

cc: @stevenbrix