### PR TITLE
Don't look up obviously WinRT types in the .NET core runtime library

### DIFF
--- a/WinRT.Runtime/TypeNameSupport.cs
+++ b/WinRT.Runtime/TypeNameSupport.cs
@@ -62,6 +62,14 @@ namespace WinRT
 
                 foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
+                    if (runtimeClassName.StartsWith("Windows.") && assembly == typeof(object).Assembly)
+                    {
+                        // WORKAROUND:
+                        // Some WinRT types currently are also defined privately in .NET.
+                        // These types are meant to support the old projections system.
+                        // Ignore them here.
+                        continue;
+                    }
                     Type type = assembly.GetType(runtimeClassName);
                     if (type is object)
                     {


### PR DESCRIPTION
Don't look up obviously WinRT types in the .NET core library, anything we find there isn't what we're looking for.

cc: @llongley 
