### PR TITLE
Fix test failures in CI.

### DIFF
--- a/WinRT.Runtime/Interop/IWeakReferenceSource.cs
+++ b/WinRT.Runtime/Interop/IWeakReferenceSource.cs
@@ -43,6 +43,7 @@ namespace WinRT.Interop
         }
     }
 
+    [WindowsRuntimeType]
     [Guid("00000037-0000-0000-C000-000000000046")]
     internal interface IWeakReference
     {

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -179,7 +179,12 @@ namespace WinRT
                 }
                 return false;
             }
-            return CustomTypeToAbiTypeNameMappings.ContainsKey(type) || type.GetCustomAttribute<WindowsRuntimeTypeAttribute>() is object;
+            return CustomTypeToAbiTypeNameMappings.ContainsKey(type)
+                || type.IsPrimitive
+                || type == typeof(string)
+                || type == typeof(Guid)
+                || type == typeof(object)
+                || type.GetCustomAttribute<WindowsRuntimeTypeAttribute>() is object;
         }
 
         public static bool TryGetCompatibleWindowsRuntimeTypeForVariantType(Type type, out Type compatibleType)


### PR DESCRIPTION
The new extended checks for "is this a WinRT type" didn't fully cover everything. This should fix that problem.