### PR TITLE
Make sure Marshaler<T> treats System.Type as a struct.

### DIFF
--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1436,6 +1436,12 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestGenericTypeMarshalling()
+        {
+            Assert.Equal(typeof(ABI.System.Type), Marshaler<Type>.AbiType);
+        }
+
+        [Fact]
         public void TestStringUnboxing()
         {
             var str1 = Class.EmptyString;

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -1023,7 +1023,7 @@ namespace WinRT
                 DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
                 DisposeAbi = (object box) => { };
             }
-            else if (type.IsValueType)
+            else if (type.IsValueType || type == typeof(Type))
             {
                 AbiType = type.FindHelperType();
                 if (AbiType != null)


### PR DESCRIPTION
Fixes marshaling of System.Type in generic contexts.

cc: @stevenbrix @azchohfi 