### PR TITLE
Adding support for agile references

### DIFF
--- a/TestComponentCSharp/NonAgileClass.cpp
+++ b/TestComponentCSharp/NonAgileClass.cpp
@@ -1,0 +1,125 @@
+#include "pch.h"
+#include "NonAgileClass.h"
+#include "NonAgileClass.g.cpp"
+
+using namespace winrt;
+
+namespace
+{
+    struct __declspec(uuid("624cd4e1-d007-43b1-9c03-af4d3e6258c4")) __declspec(novtable)
+        INonAgileBindableVectorChangedEventHandler : ::IUnknown
+    {
+        virtual int32_t __stdcall Invoke(void*, void*) noexcept = 0;
+    };
+
+    struct NonAgileDelegate : implements<NonAgileDelegate, non_agile, INonAgileBindableVectorChangedEventHandler, IMarshal>
+    {
+        NonAgileDelegate()
+        {
+        }
+        
+        int32_t __stdcall Invoke(void* p1, void* p2) noexcept override
+        {
+            VectorChanged(*reinterpret_cast<Microsoft::UI::Xaml::Interop::IBindableObservableVector const*>(&p1),
+                          *reinterpret_cast<Windows::Foundation::IInspectable const*>(&p2));
+            return S_OK;
+        }
+
+        HRESULT __stdcall GetUnmarshalClass(REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags, CLSID* pCid) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->GetUnmarshalClass(riid, pv, dwDestContext, pvDestContext, mshlflags, pCid);
+            }
+
+            return E_OUTOFMEMORY;
+        }
+
+        HRESULT __stdcall GetMarshalSizeMax(REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags, DWORD* pSize) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->GetMarshalSizeMax(riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
+            }
+
+            return E_OUTOFMEMORY;
+        }
+
+        HRESULT __stdcall MarshalInterface(IStream* pStm, REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->MarshalInterface(pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
+            }
+
+            return E_OUTOFMEMORY;
+        }
+
+        HRESULT __stdcall UnmarshalInterface(IStream* pStm, REFIID riid, void** ppv) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->UnmarshalInterface(pStm, riid, ppv);
+            }
+
+            *ppv = nullptr;
+            return E_OUTOFMEMORY;
+        }
+
+        HRESULT __stdcall ReleaseMarshalData(IStream* pStm) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->ReleaseMarshalData(pStm);
+            }
+
+            return E_OUTOFMEMORY;
+        }
+
+        HRESULT __stdcall DisconnectObject(DWORD dwReserved) noexcept final
+        {
+            if (m_marshaler)
+            {
+                return m_marshaler->DisconnectObject(dwReserved);
+            }
+
+            return E_OUTOFMEMORY;
+        }
+
+        void VectorChanged(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector, Windows::Foundation::IInspectable e)
+        {
+            int32_t sum = 0;
+            auto view = vector.GetView();
+            for (uint32_t i = 0; i < view.Size(); i++)
+            {
+                sum += winrt::unbox_value<int32_t>(view.GetAt(i));
+            }
+            e.as<winrt::TestComponentCSharp::IProperties2>().ReadWriteProperty(sum);
+        }
+
+    private:
+
+        static com_ptr<::IMarshal> get_marshaler() noexcept
+        {
+            com_ptr<::IUnknown> unknown;
+            WINRT_VERIFY_(S_OK, CoCreateFreeThreadedMarshaler(nullptr, unknown.put()));
+            return unknown ? unknown.try_as<::IMarshal>() : nullptr;
+        }
+
+        com_ptr<::IMarshal> m_marshaler{ get_marshaler() };
+    };
+}
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    NonAgileClass::NonAgileClass()
+    {
+    }
+
+    void NonAgileClass::Observe(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector)
+    {
+        Microsoft::UI::Xaml::Interop::BindableVectorChangedEventHandler handler;
+        *put_abi(handler) = make<NonAgileDelegate>().detach();               
+        vector.VectorChanged(handler);
+    }
+}

--- a/TestComponentCSharp/NonAgileClass.cpp
+++ b/TestComponentCSharp/NonAgileClass.cpp
@@ -27,63 +27,32 @@ namespace
 
         HRESULT __stdcall GetUnmarshalClass(REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags, CLSID* pCid) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->GetUnmarshalClass(riid, pv, dwDestContext, pvDestContext, mshlflags, pCid);
-            }
-
-            return E_OUTOFMEMORY;
+            return m_marshaler->GetUnmarshalClass(riid, pv, dwDestContext, pvDestContext, mshlflags, pCid);
         }
 
         HRESULT __stdcall GetMarshalSizeMax(REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags, DWORD* pSize) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->GetMarshalSizeMax(riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
-            }
-
-            return E_OUTOFMEMORY;
+            return m_marshaler->GetMarshalSizeMax(riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
         }
 
         HRESULT __stdcall MarshalInterface(IStream* pStm, REFIID riid, void* pv, DWORD dwDestContext, void* pvDestContext, DWORD mshlflags) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->MarshalInterface(pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
-            }
-
-            return E_OUTOFMEMORY;
+            return m_marshaler->MarshalInterface(pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
         }
 
         HRESULT __stdcall UnmarshalInterface(IStream* pStm, REFIID riid, void** ppv) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->UnmarshalInterface(pStm, riid, ppv);
-            }
-
-            *ppv = nullptr;
-            return E_OUTOFMEMORY;
+            return m_marshaler->UnmarshalInterface(pStm, riid, ppv);
         }
 
         HRESULT __stdcall ReleaseMarshalData(IStream* pStm) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->ReleaseMarshalData(pStm);
-            }
-
-            return E_OUTOFMEMORY;
+            return m_marshaler->ReleaseMarshalData(pStm);
         }
 
         HRESULT __stdcall DisconnectObject(DWORD dwReserved) noexcept final
         {
-            if (m_marshaler)
-            {
-                return m_marshaler->DisconnectObject(dwReserved);
-            }
-
-            return E_OUTOFMEMORY;
+            return m_marshaler->DisconnectObject(dwReserved);
         }
 
         void VectorChanged(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector, Windows::Foundation::IInspectable e)

--- a/TestComponentCSharp/NonAgileClass.h
+++ b/TestComponentCSharp/NonAgileClass.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "NonAgileClass.g.h"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    struct NonAgileClass : NonAgileClassT<NonAgileClass, winrt::non_agile>
+    {
+    public:
+        NonAgileClass();
+        void Observe(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector);
+        void VectorChanged(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector, Windows::Foundation::IInspectable e);
+    };
+}
+namespace winrt::TestComponentCSharp::factory_implementation
+{
+    struct NonAgileClass : NonAgileClassT<NonAgileClass, implementation::NonAgileClass>
+    {
+    };
+}

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -307,4 +307,11 @@ namespace TestComponentCSharp
         // Keyword escapes
         String Catch(String params, out String lock);
     }
+
+    [threading(sta), marshaling_behavior(standard)]
+    runtimeclass NonAgileClass
+    {
+        NonAgileClass();
+        void Observe(Microsoft.UI.Xaml.Interop.IBindableObservableVector vector);
+    }
 }

--- a/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="Class.h">
       <DependentUpon>TestComponentCSharp.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="NonAgileClass.h" />
     <ClInclude Include="StaticClass.h" />
   </ItemGroup>
   <ItemGroup>
@@ -79,6 +80,7 @@
     <ClCompile Include="Class.cpp">
       <DependentUpon>TestComponentCSharp.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="NonAgileClass.cpp" />
     <ClCompile Include="StaticClass.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -11,11 +11,13 @@
     <ClCompile Include="Class.cpp" />
     <ClCompile Include="StaticClass.cpp" />
     <ClCompile Include="Generated Files\module.g.cpp" />
+    <ClCompile Include="NonAgileClass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
     <ClInclude Include="StaticClass.h" />
     <ClInclude Include="$(IntDir)strings.h" />
+    <ClInclude Include="NonAgileClass.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/UnitTest/Directory.Build.targets
+++ b/UnitTest/Directory.Build.targets
@@ -48,6 +48,7 @@
 -include TestComponentCSharp 
 -include TestComponent
 -include Windows.Foundation 
+-include Windows.UI.Popups
 -include Windows.UI.Color
 -include Microsoft.UI.Xaml.CornerRadius
 -include Microsoft.UI.Xaml.Duration

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -19,6 +19,8 @@ using Microsoft.UI.Xaml.Media.Media3D;
 using TestComponentCSharp;
 using System.Collections.Generic;
 using System.Collections;
+using TestComponent;
+using WinRT.Interop;
 
 namespace UnitTest
 {
@@ -651,14 +653,14 @@ namespace UnitTest
             private void OnChanged()
             {
                 VectorChanged.Invoke(this, _observation = new TObservation());
-            } 
+            }
 
             public event BindableVectorChangedEventHandler VectorChanged;
 
-            public object this[int index] 
-            { 
-                get => _list[index]; 
-                set{ _list[index] = value; OnChanged(); } 
+            public object this[int index]
+            {
+                get => _list[index];
+                set { _list[index] = value; OnChanged(); }
             }
 
             public bool IsFixedSize => false;
@@ -1116,7 +1118,7 @@ namespace UnitTest
         [Fact]
         public void TestGridLengthTypeMapping()
         {
-            var gridLength = new GridLength( 42, GridUnitType.Pixel );
+            var gridLength = new GridLength(42, GridUnitType.Pixel);
             TestObject.GridLengthProperty = gridLength;
             Assert.Equal(gridLength.GridUnitType, TestObject.GridLengthProperty.GridUnitType);
             Assert.Equal(gridLength.Value, TestObject.GridLengthProperty.Value);
@@ -1171,8 +1173,12 @@ namespace UnitTest
         [Fact]
         public void TestRepeatBehaviorTypeMapping()
         {
-            var repeatBehavior = new RepeatBehavior { 
-                Count = 1, Duration = TimeSpan.FromTicks(42), Type = RepeatBehaviorType.Forever };
+            var repeatBehavior = new RepeatBehavior
+            {
+                Count = 1,
+                Duration = TimeSpan.FromTicks(42),
+                Type = RepeatBehaviorType.Forever
+            };
             TestObject.RepeatBehaviorProperty = repeatBehavior;
             Assert.Equal(repeatBehavior.Count, TestObject.RepeatBehaviorProperty.Count);
             Assert.Equal(repeatBehavior.Duration, TestObject.RepeatBehaviorProperty.Duration);
@@ -1183,11 +1189,12 @@ namespace UnitTest
         [Fact]
         public void TestMatrix3DTypeMapping()
         {
-            var matrix3D = new Matrix3D { 
+            var matrix3D = new Matrix3D {
                 M11 = 11, M12 = 12, M13 = 13, M14 = 14,
                 M21 = 21, M22 = 22, M23 = 23, M24 = 24,
                 M31 = 31, M32 = 32, M33 = 33, M34 = 34,
                 OffsetX = 41, OffsetY = 42, OffsetZ = 43,M44 = 44 };
+
             TestObject.Matrix3DProperty = matrix3D;
             Assert.Equal(matrix3D.M11, TestObject.Matrix3DProperty.M11);
             Assert.Equal(matrix3D.M12, TestObject.Matrix3DProperty.M12);
@@ -1502,6 +1509,82 @@ namespace UnitTest
         {
             var inspectable = IInspectable.FromAbi(TestObject.ThisPtr);
             Assert.True(ComWrappersSupport.TryUnwrapObject(inspectable, out _));
+        }
+
+        [Fact]
+        public void TestManagedAgileObject()
+        {
+            var testObjectAgileRef = TestObject.AsAgile();
+            var agileTestObject = testObjectAgileRef.Get();
+            Assert.Equal(TestObject, agileTestObject);
+
+            IProperties1 properties = new ManagedProperties(42);
+            var propertiesAgileRef = properties.AsAgile();
+            var agileProperties = propertiesAgileRef.Get();
+            Assert.Equal(properties.ReadWriteProperty, agileProperties.ReadWriteProperty);
+
+            var agileObject = TestObject.As<IAgileObject>();
+            Assert.NotNull(agileObject);
+        }
+
+        class NonAgileClassCaller
+        {
+            public void AcquireObject()
+            {
+                Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+                nonAgileObject = new Windows.UI.Popups.PopupMenu();
+                nonAgileObject.Commands.Add(new Windows.UI.Popups.UICommand("test"));
+                nonAgileObject.Commands.Add(new Windows.UI.Popups.UICommand("test2"));
+                Assert.ThrowsAny<System.Exception>(() => nonAgileObject.As<IAgileObject>());
+
+                agileReference = nonAgileObject.AsAgile();
+                objectAcquired.Set();
+                valueAcquired.WaitOne();
+                Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands.Count);
+            }
+
+            public void CheckValue()
+            {
+                objectAcquired.WaitOne();
+
+                Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
+                proxyObject = agileReference.Get();
+                Assert.Equal(2, proxyObject.Commands.Count);
+                valueAcquired.Set();
+            }
+
+            private Windows.UI.Popups.PopupMenu nonAgileObject;
+            private Windows.UI.Popups.PopupMenu proxyObject;
+            private AgileReference<Windows.UI.Popups.PopupMenu> agileReference;
+            private readonly AutoResetEvent objectAcquired = new AutoResetEvent(false);
+            private readonly AutoResetEvent valueAcquired = new AutoResetEvent(false);
+        }
+
+
+        [Fact]
+        public void TestNonAgileObjectCall()
+        {
+            NonAgileClassCaller caller = new NonAgileClassCaller();
+            Thread staThread = new Thread(new ThreadStart(caller.AcquireObject));
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+
+            Thread mtaThread = new Thread(new ThreadStart(caller.CheckValue));
+            mtaThread.SetApartmentState(ApartmentState.MTA);
+            mtaThread.Start();
+            mtaThread.Join();
+            staThread.Join();
+        }
+
+        [Fact]
+        public void TestNonAgileDelegateCall()
+        {
+            var expected = new int[] { 0, 1, 2 };
+            var observable = new ManagedBindableObservable(expected);
+            var nonAgileClass = new NonAgileClass();
+            nonAgileClass.Observe(observable);
+            observable.Add(3);
+            Assert.Equal(6, observable.Observation);
         }
     }
 }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1540,6 +1540,8 @@ namespace UnitTest
                 agileReference = nonAgileObject.AsAgile();
                 objectAcquired.Set();
                 valueAcquired.WaitOne();
+
+                // Call to proxy object acquired from MTA which should throw
                 Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands.Count);
             }
 

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1514,12 +1514,12 @@ namespace UnitTest
         [Fact]
         public void TestManagedAgileObject()
         {
-            var testObjectAgileRef = TestObject.AsAgile();
+            using var testObjectAgileRef = TestObject.AsAgile();
             var agileTestObject = testObjectAgileRef.Get();
             Assert.Equal(TestObject, agileTestObject);
 
             IProperties1 properties = new ManagedProperties(42);
-            var propertiesAgileRef = properties.AsAgile();
+            using var propertiesAgileRef = properties.AsAgile();
             var agileProperties = propertiesAgileRef.Get();
             Assert.Equal(properties.ReadWriteProperty, agileProperties.ReadWriteProperty);
 
@@ -1543,6 +1543,7 @@ namespace UnitTest
 
                 // Call to proxy object acquired from MTA which should throw
                 Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands.Count);
+                agileReference.Dispose();
             }
 
             public void CheckValue()

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1525,6 +1525,11 @@ namespace UnitTest
 
             var agileObject = TestObject.As<IAgileObject>();
             Assert.NotNull(agileObject);
+
+            IProperties1 properties2 = null;
+            using var properties2AgileRef = properties2.AsAgile();
+            var agileProperties2 = properties2AgileRef.Get();
+            Assert.Null(agileProperties2);
         }
 
         class NonAgileClassCaller

--- a/WinRT.Runtime/AgileReference.cs
+++ b/WinRT.Runtime/AgileReference.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using WinRT.Interop;
+
+namespace WinRT
+{
+    public class AgileReference
+    {
+        private readonly IAgileReference _agileReference;
+
+        public unsafe AgileReference(IObjectReference instance)
+        {
+            Guid iid = typeof(IUnknownVftbl).GUID;
+            IntPtr agileReference = IntPtr.Zero;
+            try
+            {
+                Marshal.ThrowExceptionForHR(Platform.RoGetAgileReference(
+                    Platform.AgileReferenceOptions.AGILEREFERENCE_DEFAULT,
+                    ref iid,
+                    instance.ThisPtr,
+                    &agileReference));
+                _agileReference = ABI.WinRT.Interop.IAgileReference.FromAbi(agileReference).AsType<ABI.WinRT.Interop.IAgileReference>();
+            }
+            finally
+            {
+                MarshalInterface<IAgileReference>.DisposeAbi(agileReference);
+            }
+        }
+
+        public IObjectReference Get() => _agileReference?.Resolve(typeof(IUnknownVftbl).GUID);
+    }
+
+    public sealed class AgileReference<T> : AgileReference
+        where T : class
+    {
+        public unsafe AgileReference(IObjectReference instance)
+            : base(instance)
+        {
+        }
+
+        public new T Get() 
+        {
+            using var objRef = base.Get();
+            return (T) ComWrappersSupport.CreateRcwForComObject(objRef?.ThisPtr ?? IntPtr.Zero);
+        }
+    }
+}

--- a/WinRT.Runtime/AgileReference.cs
+++ b/WinRT.Runtime/AgileReference.cs
@@ -4,14 +4,19 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    public class AgileReference
+    public class AgileReference : IDisposable
     {
+        private readonly static Guid CLSID_StdGlobalInterfaceTable = Guid.Parse("00000323-0000-0000-c000-000000000046");
         private readonly IAgileReference _agileReference;
+        private readonly IGlobalInterfaceTable _git;
+        private readonly IntPtr _cookie;
+        private bool disposed;
 
         public unsafe AgileReference(IObjectReference instance)
         {
+            IntPtr agileReference = default;
+            IntPtr gitPtr = default;
             Guid iid = typeof(IUnknownVftbl).GUID;
-            IntPtr agileReference = IntPtr.Zero;
             try
             {
                 Marshal.ThrowExceptionForHR(Platform.RoGetAgileReference(
@@ -21,13 +26,58 @@ namespace WinRT
                     &agileReference));
                 _agileReference = ABI.WinRT.Interop.IAgileReference.FromAbi(agileReference).AsType<ABI.WinRT.Interop.IAgileReference>();
             }
+            catch(TypeLoadException)
+            {
+                Guid gitClsid = CLSID_StdGlobalInterfaceTable;
+                Guid gitIid = typeof(IGlobalInterfaceTable).GUID;
+                Marshal.ThrowExceptionForHR(Platform.CoCreateInstance(
+                    ref gitClsid,
+                    IntPtr.Zero,
+                    1 /*CLSCTX_INPROC_SERVER*/,
+                    ref gitIid,
+                    &gitPtr));
+                _git = ABI.WinRT.Interop.IGlobalInterfaceTable.FromAbi(gitPtr).AsType<ABI.WinRT.Interop.IGlobalInterfaceTable>();
+                _cookie = _git.RegisterInterfaceInGlobal(instance, iid);
+
+            }
             finally
             {
                 MarshalInterface<IAgileReference>.DisposeAbi(agileReference);
+                MarshalInterface<IGlobalInterfaceTable>.DisposeAbi(gitPtr);
             }
         }
 
-        public IObjectReference Get() => _agileReference?.Resolve(typeof(IUnknownVftbl).GUID);
+        public IObjectReference Get() => _agileReference?.Resolve(typeof(IUnknownVftbl).GUID) ?? _git?.GetInterfaceFromGlobal(_cookie, typeof(IUnknownVftbl).GUID);
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                try
+                {
+                    if (_git != null && _cookie != IntPtr.Zero)
+                    {
+                        _git.RevokeInterfaceFromGlobal(_cookie);
+                    }
+                }
+                catch(ObjectDisposedException)
+                {
+                    // TODO: How to handle removing from git when it has already been disposed.
+                }
+                disposed = true;
+            }
+        }
+
+        ~AgileReference()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 
     public sealed class AgileReference<T> : AgileReference

--- a/WinRT.Runtime/CastExtensions.cs
+++ b/WinRT.Runtime/CastExtensions.cs
@@ -44,6 +44,17 @@ namespace WinRT
             }
         }
 
+        /// <summary>
+        /// Create an agile reference for a given WinRT object.  The agile reference can be passed to another apartment
+        /// within the process from which the original object can be retrieved even if it wasn't agile.
+        /// </summary>
+        /// <typeparam name="T">Type of WinRT object.</typeparam>
+        /// <param name="value">The object.</param>
+        /// <returns>
+        /// If <paramref name="value"/> is a WinRT object, returns a AgileReference for it.
+        /// Otherwise, returns null.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the runtime type of <paramref name="value"/> is not a projected type.</exception>
         public static AgileReference<T> AsAgile<T>(this T value) where T : class
         {
             var marshal = Marshaler<T>.CreateMarshaler(value);
@@ -58,7 +69,7 @@ namespace WinRT
             {
                 Marshaler<T>.DisposeMarshaler(marshal);
             }
-            return null;
+            throw new InvalidOperationException($"Object type is not a projected type: {nameof(value)}.");
         }
 
         private static bool TryGetRefForObject(object value, bool allowComposed, out IObjectReference reference)

--- a/WinRT.Runtime/CastExtensions.cs
+++ b/WinRT.Runtime/CastExtensions.cs
@@ -44,6 +44,23 @@ namespace WinRT
             }
         }
 
+        public static AgileReference<T> AsAgile<T>(this T value) where T : class
+        {
+            var marshal = Marshaler<T>.CreateMarshaler(value);
+            try
+            {
+                if (marshal is IObjectReference objref)
+                {
+                    return new AgileReference<T>(objref);
+                }
+            }
+            finally
+            {
+                Marshaler<T>.DisposeMarshaler(marshal);
+            }
+            return null;
+        }
+
         private static bool TryGetRefForObject(object value, bool allowComposed, out IObjectReference reference)
         {
             if (ComWrappersSupport.TryUnwrapObject(value, out var objRef))

--- a/WinRT.Runtime/CastExtensions.cs
+++ b/WinRT.Runtime/CastExtensions.cs
@@ -57,6 +57,11 @@ namespace WinRT
         /// <exception cref="InvalidOperationException">Thrown if the runtime type of <paramref name="value"/> is not a projected type.</exception>
         public static AgileReference<T> AsAgile<T>(this T value) where T : class
         {
+            if(value == null)
+            {
+                return new AgileReference<T>(null);
+            }
+
             var marshal = Marshaler<T>.CreateMarshaler(value);
             try
             {

--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -28,8 +28,6 @@ namespace WinRT
     {
         private readonly static ConcurrentDictionary<string, Func<IInspectable, object>> TypedObjectFactoryCache = new ConcurrentDictionary<string, Func<IInspectable, object>>();
 
-        private readonly static Guid IID_IAgileObject = Guid.Parse("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90");
-
         static ComWrappersSupport()
         {
             PlatformSpecificInitialize();
@@ -100,7 +98,7 @@ namespace WinRT
         {
             using var unknownRef = ObjectReference<IUnknownVftbl>.FromAbi(externalComObject);
 
-            if (unknownRef.TryAs<IUnknownVftbl>(IID_IAgileObject, out var agileRef) >= 0)
+            if (unknownRef.TryAs<IUnknownVftbl>(typeof(ABI.WinRT.Interop.IAgileObject.Vftbl).GUID, out var agileRef) >= 0)
             {
                 agileRef.Dispose();
                 return unknownRef.As<IUnknownVftbl>();
@@ -192,7 +190,7 @@ namespace WinRT
             // Add IAgileObject to all CCWs
             entries.Add(new ComInterfaceEntry
             {
-                IID = IID_IAgileObject,
+                IID = typeof(ABI.WinRT.Interop.IAgileObject.Vftbl).GUID,
                 Vtable = IUnknownVftbl.AbiToProjectionVftblPtr
             });
             return entries;

--- a/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -41,6 +41,11 @@ namespace WinRT
 
         public static object CreateRcwForComObject(IntPtr ptr)
         {
+            if (ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+
             var rcw = ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.TrackerObject);
             // Because .NET will de-duplicate strings and WinRT doesn't,
             // our RCW factory returns a wrapper of our string instance.

--- a/WinRT.Runtime/Interop/IAgileReference.cs
+++ b/WinRT.Runtime/Interop/IAgileReference.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace WinRT.Interop
+{
+    [WindowsRuntimeType]
+    [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
+    internal interface IAgileReference
+    {
+        IObjectReference Resolve(Guid riid);
+    }
+
+    [WindowsRuntimeType]
+    [Guid("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")]
+    public interface IAgileObject
+    {
+    }
+}
+
+namespace ABI.WinRT.Interop
+{
+    using global::WinRT;
+    using WinRT.Interop;
+
+    [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
+    internal class IAgileReference : global::WinRT.Interop.IAgileReference
+    {
+        [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
+        public struct Vftbl
+        {
+            public delegate int _Resolve(IntPtr thisPtr, ref Guid riid, out IntPtr objectReference);
+
+            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+            public _Resolve Resolve;
+
+            public static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
+                    Resolve = Do_Abi_Resolve
+                };
+                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
+                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
+            }
+
+            private static int Do_Abi_Resolve(IntPtr thisPtr, ref Guid riid, out IntPtr objectReference)
+            {
+                IObjectReference _objectReference = default;
+
+                objectReference = default;
+
+                try
+                {
+                    _objectReference = global::WinRT.ComWrappersSupport.FindObject<global::WinRT.Interop.IAgileReference>(thisPtr).Resolve(riid);
+                    objectReference = _objectReference?.GetRef() ?? IntPtr.Zero;
+                }
+                catch (Exception __exception__)
+                {
+                    return __exception__.HResult;
+                }
+                return 0;
+            }
+        }
+
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+
+        public static implicit operator IAgileReference(IObjectReference obj) => (obj != null) ? new IAgileReference(obj) : null;
+        public static implicit operator IAgileReference(ObjectReference<Vftbl> obj) => (obj != null) ? new IAgileReference(obj) : null;
+        protected readonly ObjectReference<Vftbl> _obj;
+        public IntPtr ThisPtr => _obj.ThisPtr;
+        public ObjectReference<I> AsInterface<I>() => _obj.As<I>();
+        public A As<A>() => _obj.AsType<A>();
+
+        public IAgileReference(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IAgileReference(ObjectReference<Vftbl> obj)
+        {
+            _obj = obj;
+        }
+
+        public IObjectReference Resolve(Guid riid)
+        {
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Resolve(ThisPtr, ref riid, out IntPtr ptr));
+            try
+            {
+                return ComWrappersSupport.GetObjectReferenceForInterface(ptr);
+            }
+            finally
+            {
+                MarshalInspectable.DisposeAbi(ptr);
+            }
+        }
+    }
+
+    [Guid("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")]
+    public class IAgileObject : global::WinRT.Interop.IAgileObject
+    {
+        [Guid("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")]
+        public struct Vftbl
+        {
+            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+
+            public static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
+                };
+                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
+                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
+            }
+        }
+
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+
+        public static implicit operator IAgileObject(IObjectReference obj) => (obj != null) ? new IAgileObject(obj) : null;
+        public static implicit operator IAgileObject(ObjectReference<Vftbl> obj) => (obj != null) ? new IAgileObject(obj) : null;
+        protected readonly ObjectReference<Vftbl> _obj;
+        public IntPtr ThisPtr => _obj.ThisPtr;
+        public ObjectReference<I> AsInterface<I>() => _obj.As<I>();
+        public A As<A>() => _obj.AsType<A>();
+
+        public IAgileObject(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IAgileObject(ObjectReference<Vftbl> obj)
+        {
+            _obj = obj;
+        }
+    }
+}

--- a/WinRT.Runtime/Interop/IAgileReference.cs
+++ b/WinRT.Runtime/Interop/IAgileReference.cs
@@ -17,6 +17,15 @@ namespace WinRT.Interop
     public interface IAgileObject
     {
     }
+
+    [WindowsRuntimeType]
+    [Guid("00000146-0000-0000-C000-000000000046")]
+    internal interface IGlobalInterfaceTable
+    {
+        IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid);
+        void RevokeInterfaceFromGlobal(IntPtr cookie);
+        IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid);
+    }
 }
 
 namespace ABI.WinRT.Interop
@@ -132,6 +141,63 @@ namespace ABI.WinRT.Interop
         public IAgileObject(ObjectReference<Vftbl> obj)
         {
             _obj = obj;
+        }
+    }
+
+    [Guid("00000146-0000-0000-C000-000000000046")]
+    internal class IGlobalInterfaceTable : global::WinRT.Interop.IGlobalInterfaceTable
+    {
+        [Guid("00000146-0000-0000-C000-000000000046")]
+        public struct Vftbl
+        {
+            public delegate int _RegisterInterfaceInGlobal(IntPtr thisPtr, IntPtr objRef, ref Guid riid, out IntPtr cookie);
+            public delegate int _RevokeInterfaceFromGlobal(IntPtr thisPtr, IntPtr cookie);
+            public delegate int _GetInterfaceFromGlobal(IntPtr thisPtr, IntPtr cookie, ref Guid riid, out IntPtr objectReference);
+
+            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+            public _RegisterInterfaceInGlobal RegisterInterfaceInGlobal;
+            public _RevokeInterfaceFromGlobal RevokeInterfaceFromGlobal;
+            public _GetInterfaceFromGlobal GetInterfaceFromGlobal;
+        }
+
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+
+        public static implicit operator IGlobalInterfaceTable(IObjectReference obj) => (obj != null) ? new IGlobalInterfaceTable(obj) : null;
+        public static implicit operator IGlobalInterfaceTable(ObjectReference<Vftbl> obj) => (obj != null) ? new IGlobalInterfaceTable(obj) : null;
+        protected readonly ObjectReference<Vftbl> _obj;
+        public IntPtr ThisPtr => _obj.ThisPtr;
+        public ObjectReference<I> AsInterface<I>() => _obj.As<I>();
+        public A As<A>() => _obj.AsType<A>();
+
+        public IGlobalInterfaceTable(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IGlobalInterfaceTable(ObjectReference<Vftbl> obj)
+        {
+            _obj = obj;
+        }
+
+        public IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid)
+        {
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, objRef.ThisPtr, ref riid, out IntPtr cookie));
+            return cookie;
+
+        }
+
+        public void RevokeInterfaceFromGlobal(IntPtr cookie)
+        {
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RevokeInterfaceFromGlobal(ThisPtr, cookie));
+        }
+
+        public IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid)
+        {
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInterfaceFromGlobal(ThisPtr, cookie, ref riid, out IntPtr ptr));
+            try
+            {
+                return ComWrappersSupport.GetObjectReferenceForInterface(ptr);
+            }
+            finally
+            {
+                MarshalInspectable.DisposeAbi(ptr);
+            }
         }
     }
 }

--- a/WinRT.Runtime/Projections/ICommand.cs
+++ b/WinRT.Runtime/Projections/ICommand.cs
@@ -50,16 +50,27 @@ namespace ABI.System.Windows.Input
         private class NativeDelegateWrapper
         {
             private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+            private readonly AgileReference _agileReference = default;
 
             public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
             {
                 _nativeDelegate = nativeDelegate;
+                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
+                {
+                    _agileReference = new AgileReference(_nativeDelegate);
+                }
+                else
+                {
+                    objRef.Dispose();
+                }
             }
 
             public void Invoke(object sender, EventArgs args)
             {
-                IntPtr ThisPtr = _nativeDelegate.ThisPtr;
-                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(_nativeDelegate.Vftbl.Invoke);
+                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(CanExecuteChangedEventHandler)));
+                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
+                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
+                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
                 IObjectReference __sender = default;
                 IObjectReference __args = default;
                 var __params = new object[] { ThisPtr, null, null };

--- a/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -47,16 +47,27 @@ namespace ABI.System.Collections.Specialized
         private class NativeDelegateWrapper
         {
             private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+            private readonly AgileReference _agileReference = default;
 
             public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
             {
                 _nativeDelegate = nativeDelegate;
+                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
+                {
+                    _agileReference = new AgileReference(_nativeDelegate);
+                }
+                else
+                {
+                    objRef.Dispose();
+                }
             }
 
             public void Invoke(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
             {
-                IntPtr ThisPtr = _nativeDelegate.ThisPtr;
-                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(_nativeDelegate.Vftbl.Invoke);
+                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(NotifyCollectionChangedEventHandler)));
+                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
+                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
+                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
                 IObjectReference __sender = default;
                 IObjectReference __e = default;
                 try

--- a/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -46,16 +46,27 @@ namespace ABI.System.ComponentModel
         private class NativeDelegateWrapper
         {
             private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+            private readonly AgileReference _agileReference = default;
 
             public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
             {
                 _nativeDelegate = nativeDelegate;
+                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
+                {
+                    _agileReference = new AgileReference(_nativeDelegate);
+                }
+                else
+                {
+                    objRef.Dispose();
+                }
             }
 
             public void Invoke(object sender, global::System.ComponentModel.PropertyChangedEventArgs e)
             {
-                IntPtr ThisPtr = _nativeDelegate.ThisPtr;
-                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(_nativeDelegate.Vftbl.Invoke);
+                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(PropertyChangedEventHandler)));
+                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
+                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
+                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
                 IObjectReference __sender = default;
                 IObjectReference __e = default;
                 try

--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -85,6 +85,15 @@ namespace WinRT
 
         [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", CallingConvention = CallingConvention.StdCall)]
         internal static extern unsafe char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
+
+        internal enum AgileReferenceOptions : uint
+        {
+            AGILEREFERENCE_DEFAULT = 0x0,
+            AGILEREFERENCE_DELAYEDMARSHAL = 0x1
+        }
+
+        [DllImport("api-ms-win-core-com-l1-1-1.dll", CallingConvention = CallingConvention.StdCall)]
+        internal static extern unsafe int RoGetAgileReference(AgileReferenceOptions options, ref Guid iid, IntPtr unknown, IntPtr* agileReference);
     }
 
     internal struct VftblPtr

--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -89,14 +89,8 @@ namespace WinRT
         [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", CallingConvention = CallingConvention.StdCall)]
         internal static extern unsafe char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
 
-        internal enum AgileReferenceOptions : uint
-        {
-            AGILEREFERENCE_DEFAULT = 0x0,
-            AGILEREFERENCE_DELAYEDMARSHAL = 0x1
-        }
-
         [DllImport("api-ms-win-core-com-l1-1-1.dll", CallingConvention = CallingConvention.StdCall)]
-        internal static extern unsafe int RoGetAgileReference(AgileReferenceOptions options, ref Guid iid, IntPtr unknown, IntPtr* agileReference);
+        internal static extern unsafe int RoGetAgileReference(uint options, ref Guid iid, IntPtr unknown, IntPtr* agileReference);
     }
 
     internal struct VftblPtr

--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -37,6 +37,9 @@ namespace WinRT
     internal class Platform
     {
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+        internal static extern unsafe int CoCreateInstance(ref Guid clsid, IntPtr outer, uint clsContext, ref Guid iid, IntPtr* instance);
+
+        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         internal static extern int CoDecrementMTAUsage(IntPtr cookie);
 
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]


### PR DESCRIPTION
- Added an AsAgile extension method which can be used on WinRT types to get an agile reference which can then be used to marshal an object across apartments in an agile way even if the original object wasn't agile.  Note an extension method was chosen to avoid filling up all the projected interfaces and classes with an AsAgile function.
- Making using of RoGetAgileReference when available (Win 8.1+) to accomplish this, otherwise falling back to using an git table
- Making delegates registered via the native ABI agile when they are aren't.
- Added tests to exercise these scenarios.