### PR TITLE
Build Break: Multi-targeting DispatchToInnerBuilds doesn't play nicely with ResolveAssemblyReferences

### DIFF
--- a/Projections/Test/Test.csproj
+++ b/Projections/Test/Test.csproj
@@ -29,7 +29,7 @@
     <InternalsVisibleTo Include="UnitTest" />
   </ItemGroup>
   
-  <Target Name="GenerateProjection" AfterTargets="ResolveAssemblyReferences" BeforeTargets="DispatchToInnerBuilds;Build" Condition="'$(GenerateTestProjection)' == 'true'">
+  <Target Name="GenerateProjection" Condition="'$(GenerateTestProjection)' == 'true'">
     <PropertyGroup>
       <!--PkgMicrosoft_WinUI is set in in obj\*.csproj.nuget.g.props with TargetFramework condition, doesn't support multi-targeting-->
       <PkgMicrosoft_WinUI Condition="'$(PkgMicrosoft_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.winui', '$(MicrosoftWinUIVersion)'))</PkgMicrosoft_WinUI>
@@ -52,26 +52,26 @@
 -verbose
 -in 10.0.18362.0
 -in @(ReferenceWinMDs->'"%(FullPath)"', ' ')
--out "$(ProjectDir)Generated Files"
+-out "$(IntermediateOutputPath)Generated Files"
 -exclude Windows
 -exclude Microsoft
 -include TestComponent
 -include TestComponentCSharp
       </CsWinRTParams>
     </PropertyGroup>
-    <MakeDir Directories="$(ProjectDir)Generated Files" />
+    <MakeDir Directories="$(IntermediateOutputPath)Generated Files" />
     <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
     <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTVerbosity)" />
     <Exec Command="$(CsWinRTCommand)" />
   </Target>
 
-  <Target Name="IncludeProjection" BeforeTargets="CoreCompile" AfterTargets="GenerateProjection">
+  <Target Name="IncludeProjection" DependsOnTargets="GenerateProjection" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <!--PkgMicrosoft_WinUI is set in in obj\*.csproj.nuget.g.props with TargetFramework condition, doesn't support multi-targeting-->
       <PkgMicrosoft_WinUI Condition="'$(PkgMicrosoft_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.winui', '$(MicrosoftWinUIVersion)'))</PkgMicrosoft_WinUI>
     </PropertyGroup>
     <ItemGroup>
-      <Compile Include="$(ProjectDir)Generated Files/*.cs" Exclude="@(Compile)" />
+      <Compile Include="$(IntermediateOutputPath)Generated Files/*.cs" Exclude="@(Compile)" />
       <!--Remove references to projection source winmds to prevent compile conflict warnings-->
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'TestComponent'" />
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'TestComponentCSharp'" />

--- a/Projections/WinUI/WinUI.csproj
+++ b/Projections/WinUI/WinUI.csproj
@@ -28,7 +28,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <Target Name="GenerateProjection" AfterTargets="ResolveAssemblyReferences" BeforeTargets="DispatchToInnerBuilds;Build" Condition="'$(GenerateTestProjection)' == 'true'">
+  <Target Name="GenerateProjection" Condition="'$(GenerateTestProjection)' == 'true'">
     <PropertyGroup>
       <!--PkgMicrosoft_WinUI is set in in obj\*.csproj.nuget.g.props with TargetFramework condition, doesn't support multi-targeting-->
       <PkgMicrosoft_WinUI Condition="'$(PkgMicrosoft_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.winui', '$(MicrosoftWinUIVersion)'))</PkgMicrosoft_WinUI>
@@ -48,7 +48,7 @@
 -verbose
 -in 10.0.18362.0
 -in @(ReferenceWinMDs->'"%(FullPath)"', ' ')
--out "$(ProjectDir)Generated Files"
+-out "$(IntermediateOutputPath)Generated Files"
 -exclude Windows
 -include Microsoft
 # The current WinUI nuget incorrectly references several Windows.* types that should be
@@ -68,15 +68,15 @@
 -include Windows.UI.Xaml.Media.Animation.ConditionallyIndependentlyAnimatableAttribute
       </CsWinRTParams>
     </PropertyGroup>
-    <MakeDir Directories="$(ProjectDir)Generated Files" />
+    <MakeDir Directories="$(IntermediateOutputPath)Generated Files" />
     <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
     <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTVerbosity)" />
     <Exec Command="$(CsWinRTCommand)" />
   </Target>
 
-  <Target Name="IncludeProjection" BeforeTargets="CoreCompile" AfterTargets="GenerateProjection">
+  <Target Name="IncludeProjection" DependsOnTargets="GenerateProjection" BeforeTargets="CoreCompile">
     <ItemGroup>
-      <Compile Include="$(ProjectDir)Generated Files/*.cs" Exclude="@(Compile)" />
+      <Compile Include="$(IntermediateOutputPath)Generated Files/*.cs" Exclude="@(Compile)" />
     </ItemGroup>
   </Target>
 

--- a/Projections/Windows/Windows.csproj
+++ b/Projections/Windows/Windows.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\..\cswinrt\cswinrt.vcxproj" />
   </ItemGroup>
 
-  <Target Name="GenerateProjection" AfterTargets="ResolveAssemblyReferences" BeforeTargets="DispatchToInnerBuilds;Build" Condition="'$(GenerateTestProjection)' == 'true'">
+  <Target Name="GenerateProjection" Condition="'$(GenerateTestProjection)' == 'true'">
     <PropertyGroup>
       <CsWinRTVerbosity>high</CsWinRTVerbosity>
       <CsWinRTResponseFile>$(IntermediateOutputPath)cswinrt_windows.rsp</CsWinRTResponseFile>
@@ -40,7 +40,7 @@
       <CsWinRTParams>
 -verbose
 -in 10.0.18362.0
--out "$(ProjectDir)Generated Files"
+-out "$(IntermediateOutputPath)Generated Files"
 -include Windows
 # Exclude causality types colliding with those in System.Private.CoreLib.dll
 -exclude Windows.Foundation.Diagnostics 
@@ -61,15 +61,15 @@
 -include Windows.UI.Xaml.Media.Animation.ConditionallyIndependentlyAnimatableAttribute
       </CsWinRTParams>
     </PropertyGroup>
-    <MakeDir Directories="$(ProjectDir)Generated Files" />
+    <MakeDir Directories="$(IntermediateOutputPath)Generated Files" />
     <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
     <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTVerbosity)" />
     <Exec Command="$(CsWinRTCommand)" />
   </Target>
 
-  <Target Name="IncludeProjection" BeforeTargets="CoreCompile" AfterTargets="GenerateProjection">
+  <Target Name="IncludeProjection" DependsOnTargets="GenerateProjection" BeforeTargets="CoreCompile">
     <ItemGroup>
-      <Compile Include="$(ProjectDir)Generated Files/*.cs" Exclude="@(Compile)" />
+      <Compile Include="$(IntermediateOutputPath)Generated Files/*.cs" Exclude="@(Compile)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Since cswinrt.exe is moving to forked code gen based on TFM, will just adopt that now, and resolve build breaks.

see also https://github.com/Microsoft/msbuild/issues/2781