### PR TITLE
Fix passing IStringable array by ref scenarios

### DIFF
--- a/UnitTest/TestComponent_Tests.cs
+++ b/UnitTest/TestComponent_Tests.cs
@@ -421,6 +421,20 @@ namespace UnitTest
             Assert.True(AllEqual(a, b, c, d));
         }
 
+        [Fact]
+        public void Array_Stringable()
+        {
+            IStringable[] a = new IStringable[] {
+                Windows.Data.Json.JsonValue.CreateNumberValue(3),
+                Windows.Data.Json.JsonValue.CreateNumberValue(4),
+                Windows.Data.Json.JsonValue.CreateNumberValue(5.0)
+            };
+            IStringable[] b = new IStringable[a.Length];
+            IStringable[] c;
+            IStringable[] d = Tests.Array16(a, b, out c);
+            Assert.True(AllEqual(a, b, c, d));
+        }
+
         private T[] Array_Call<T>(T[] a, T[] b, out T[] c)
         {
             Assert.True(a.Length == b.Length);
@@ -517,6 +531,12 @@ namespace UnitTest
         public void Array_Nested_Call()
         {
             Tests.Array15Call(Array_Call);
+        }
+
+        [Fact]
+        public void Array_Stringable_Call()
+        {
+            Tests.Array16Call(Array_Call);
         }
 
         [Fact]

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -685,6 +685,20 @@ namespace WinRT
             return array;
         }
 
+        public static unsafe void CopyAbiArray(T[] array, object box, Func<IntPtr, T> fromAbi)
+        {
+            if (box is null)
+            {
+                return;
+            }
+            var abi = ((int length, IntPtr data))box;
+            var data = (IntPtr*)abi.data.ToPointer();
+            for (int i = 0; i < abi.length; i++)
+            {
+                array[i] = fromAbi(data[i]);
+            }
+        }
+
         public static unsafe (int length, IntPtr data) FromManagedArray(T[] array, Func<T, IntPtr> fromManaged)
         {
             if (array is null)
@@ -866,6 +880,8 @@ namespace WinRT
         public static (int length, IntPtr data) GetAbiArray(object box) => MarshalInterfaceHelper<T>.GetAbiArray(box);
 
         public static unsafe T[] FromAbiArray(object box) => MarshalInterfaceHelper<T>.FromAbiArray(box, FromAbi);
+
+        public static unsafe void CopyAbiArray(T[] array, object box) => MarshalInterfaceHelper<T>.CopyAbiArray(array, box, FromAbi);
 
         public static unsafe (int length, IntPtr data) FromManagedArray(T[] array) => MarshalInterfaceHelper<T>.FromManagedArray(array, (o) => FromManaged(o));
 

--- a/WinRT.Runtime/Projections/Uri.cs
+++ b/WinRT.Runtime/Projections/Uri.cs
@@ -131,7 +131,7 @@ namespace ABI.System
                 return null;
             }
 
-            using var uri = ObjectReference<ABI.Windows.Foundation.IUriRuntimeClassVftbl>.FromAbi(ptr);
+            using var uri = ObjectReference<IUnknownVftbl>.FromAbi(ptr).As<ABI.Windows.Foundation.IUriRuntimeClassVftbl>();
             IntPtr rawUri = IntPtr.Zero;
             try
             {

--- a/get_testwinrt.cmd
+++ b/get_testwinrt.cmd
@@ -12,7 +12,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard 6d72afbcb51ab3981c6cd620d24954020f4d2bbc
+git reset -q --hard e058f2fc16e4812a16b5453da7ef4d65b3cf0bfe
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 ..\.nuget\nuget.exe restore


### PR DESCRIPTION
- MarshalInterface was missing CopyAbiArray causing for scenarios where an array of interfaces such as IStringable is passed by ref to not compile.  This PR adds that function.
- Added the test cases from the testwinrt repo that validates these scenarios
- One of the test cases ended up discovering another issue where the FromAbi API can be called with a ThisPtr which isn't for the default interface and end up calling the wrong API.  Handled this by doing a QueryInterface via As to make the test pass, but I believe this is a generic problem that can affect any class and needs a generic fix.

Fixes #352 