### PR TITLE
Upgrade to released version of dotnet preview 7

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -47,8 +47,12 @@
     <ItemGroup>
       <!--Remove references to projection source winmds to prevent compile conflict warnings-->
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'BenchmarkComponent'" />
-      <!--Also remove ReferencePath winmds to prevent error NETSDK1130 false positive-->
-      <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'BenchmarkComponent'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveWinMDReferences" BeforeTargets="ResolveReferences" AfterTargets="AfterResolveReferences" Condition="$(UseWinmd) == false">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/Projections/Benchmark/Benchmark.csproj
+++ b/Projections/Benchmark/Benchmark.csproj
@@ -27,7 +27,6 @@
 
   <Target Name="GenerateProjection" Condition="'$(GenerateTestProjection)' == 'true'">
     <ItemGroup>
-      <ReferenceWinMDs Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
       <!--Do not publish projection source winmds -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="%(ReferenceCopyLocalPaths.Filename) == 'BenchmarkComponent'" />
     </ItemGroup>
@@ -59,6 +58,13 @@
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'BenchmarkComponent'" />
       <!--Also remove ReferencePath winmds to prevent error NETSDK1130 false positive-->
       <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'BenchmarkComponent'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveWinMDReferences" BeforeTargets="ResolveReferences" AfterTargets="AfterResolveReferences">
+    <ItemGroup>
+      <ReferenceWinMDs Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/Projections/Test/Test.csproj
+++ b/Projections/Test/Test.csproj
@@ -36,7 +36,6 @@
     <ItemGroup>
       <!--Explicitly reference WinUI winmds from TFM uap10.0-->
       <ReferenceWinMDs Include="$(PkgMicrosoft_WinUI)/**/*.winmd" />
-      <ReferenceWinMDs Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
       <!--Do not publish projection source winmds -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="%(ReferenceCopyLocalPaths.Filename) == 'TestComponent'" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="%(ReferenceCopyLocalPaths.Filename) == 'TestComponentCSharp'" />
@@ -77,6 +76,13 @@
       <!--Also remove ReferencePath winmds to prevent error NETSDK1130 false positive-->
       <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'TestComponent'" />
       <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'TestComponentCSharp'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveWinMDReferences" BeforeTargets="ResolveReferences" AfterTargets="AfterResolveReferences">
+    <ItemGroup>
+      <ReferenceWinMDs Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -58,11 +58,14 @@
       <!--Remove references to projection source winmds to prevent compile conflict warnings-->
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'TestComponent'" />
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)" Condition="%(ReferencePathWithRefAssemblies.Filename) == 'TestComponentCSharp'" />
-      <!--Also remove ReferencePath winmds to prevent error NETSDK1130 false positive-->
-      <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'TestComponent'" />
-      <ReferencePath Remove="@(ReferencePath)" Condition="%(ReferencePath.Filename) == 'TestComponentCSharp'" />
       <!--Remove any ReferenceDependencyPaths winmds to prevent deps.json from failing unit test-->
       <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveWinMDReferences" BeforeTargets="ResolveReferences" AfterTargets="AfterResolveReferences">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set CsWinRTNet5SdkVersion=5.0.100-preview.7.20329.1
+set CsWinRTNet5SdkVersion=5.0.100-preview.7.20366.6
 
 :dotnet
 rem Install required .NET 5 SDK version and add to environment


### PR DESCRIPTION
Updating to dotnet 5.0.100-preview.7.20366.6.  After updating, the winmd reference removal logic broke again.  Attempting new fix which seems to be working.