### PR TITLE
Don't directly use the underlying ObjectReference as the marshaler when marshalling ABI interface types.

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -1176,4 +1176,17 @@ namespace winrt::TestComponentCSharp::implementation
         // Compile-only test for keyword escaping
         throw hresult_not_implemented();
     }
+
+    struct native_properties1 : winrt::implements<native_properties1, TestComponentCSharp::IProperties1>
+    {
+        int32_t ReadWriteProperty()
+        {
+            return 42;
+        }
+    };
+
+    TestComponentCSharp::IProperties1 Class::NativeProperties1()
+    {
+        return winrt::make<native_properties1>();
+    }
 }

--- a/TestComponentCSharp/Class.h
+++ b/TestComponentCSharp/Class.h
@@ -296,6 +296,8 @@ namespace winrt::TestComponentCSharp::implementation
 
         hstring Catch(hstring const& params, hstring& locks);
 
+        static IProperties1 NativeProperties1();
+
         // IStringable
         hstring ToString();
 

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -306,6 +306,9 @@ namespace TestComponentCSharp
 
         // Keyword escapes
         String Catch(String params, out String lock);
+
+        // Interface projections
+        static IProperties1 NativeProperties1 { get; };
     }
 
     [threading(sta), marshaling_behavior(standard)]

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1645,5 +1645,15 @@ namespace UnitTest
             GC.WaitForPendingFinalizers();
             Assert.Equal(0, ComImports.NumObjects);
         }
+
+        [Fact]
+        public void TestInterfaceObjectMarshalling()
+        {
+            var nativeProperties = Class.NativeProperties1;
+
+            TestObject.CopyProperties(nativeProperties);
+
+            Assert.Equal(TestObject.ReadWriteProperty, nativeProperties.ReadWriteProperty);
+        }
     }
 }

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -840,7 +840,11 @@ namespace WinRT
                 {
                     _ToAbi = BindToAbi();
                 }
-                return _ToAbi(value);
+                var ptr = _ToAbi(value).GetRef();
+                // We can use ObjectReference.Attach here since this API is
+                // only used during marshalling where we deterministically dispose
+                // on the same thread (and as a result don't need to capture context).
+                return ObjectReference<IUnknownVftbl>.Attach(ref ptr);
             }
 
             if (_As is null)


### PR DESCRIPTION
We need to create a new ObjectReference, otherwise we'll dispose the ObjectReference instance that the ABI interface object contains, making all future usages fail with an ObjectDisposedException.

I discovered this bug with @stevenbrix when working on our prototype XAML compiler that emits IL. I've validated that it fixes the issue.