### PR TITLE
track source metadata for authoring projections

### DIFF
--- a/Strings.props
+++ b/Strings.props
@@ -4,6 +4,9 @@
     <PrepareForBuildDependsOn>
       UpdateStringSources;UpdateStringsHeader;$(PrepareForBuildDependsOn)
     </PrepareForBuildDependsOn>
+    <ComputeCompileInputsTargets>
+      AddStringSources;$(ComputeCompileInputsTargets)
+    </ComputeCompileInputsTargets>
   </PropertyGroup>
 
   <UsingTask TaskName="WriteStringSources"
@@ -143,13 +146,6 @@
       <Source>$([System.String]::new('$(IntDir)strings\%(RecursiveDir)%(Filename).cpp'))</Source>
       <File>$([System.String]::new('%(Filename)'))</File>
     </StaticStrings>
-    <!--'Visible' metadata does not support vcxproj, so use a dummy DependentUpon to hide string sources-->
-    <ClCompile Include="@(StaticStrings->'%(Source)')" AutoGen="true" Visible="false">
-      <DependentUpon>Generated Files</DependentUpon>
-    </ClCompile>
-    <ClInclude Include="$(IntDir)strings.h" AutoGen="true" Visible="false">
-      <DependentUpon>Generated Files</DependentUpon>
-    </ClInclude>
   </ItemGroup>
 
   <Target Name="SetStaticStringIndex">
@@ -159,6 +155,12 @@
         <Index>$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($([System.String]::new('%(RecursiveDir)'))))))</Index>
         <Namespace>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.String]::new('%(RecursiveDir)'))))))</Namespace>
       </StaticStrings>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddStringSources">
+    <ItemGroup>
+      <ClCompile Include="@(StaticStrings->'%(Source)')" />
     </ItemGroup>
   </Target>
 

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />

--- a/WinRT.Runtime/Attributes.cs
+++ b/WinRT.Runtime/Attributes.cs
@@ -36,5 +36,11 @@ namespace WinRT
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Delegate | AttributeTargets.Struct | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
     public sealed class WindowsRuntimeTypeAttribute : Attribute
     {
+        public WindowsRuntimeTypeAttribute(string sourceMetadata = null)
+        {
+            SourceMetadata = sourceMetadata;
+        }
+
+        public string SourceMetadata { get; }
     }
 }

--- a/WinRT.Runtime/Projections/Type.cs
+++ b/WinRT.Runtime/Projections/Type.cs
@@ -5,7 +5,7 @@ using WinRT;
 
 namespace ABI.System
 {
-    [WindowsRuntimeType]
+    [WindowsRuntimeType("Windows.UI.Xaml")]
     internal enum TypeKind : int
     {
         Primitive,

--- a/WinRT.Runtime/Projections/Type.cs
+++ b/WinRT.Runtime/Projections/Type.cs
@@ -5,7 +5,7 @@ using WinRT;
 
 namespace ABI.System
 {
-    [WindowsRuntimeType("Windows.UI.Xaml")]
+    [WindowsRuntimeType("Windows.UI.Xaml.Interop")]
     internal enum TypeKind : int
     {
         Primitive,

--- a/WinRT.Runtime/Projections/Type.cs
+++ b/WinRT.Runtime/Projections/Type.cs
@@ -5,7 +5,7 @@ using WinRT;
 
 namespace ABI.System
 {
-    [WindowsRuntimeType("Windows.UI.Xaml.Interop")]
+    [WindowsRuntimeType("Windows.UI.Xaml")]
     internal enum TypeKind : int
     {
         Primitive,


### PR DESCRIPTION
fixes #371 

Jeremy - any concern with piggybacking the source metadata (sans path, extension) onto WindowsRuntimeType for authoring support?  trying to economize on attributes