### PR TITLE
Revert "Update to .NET 5 Preview 8 and update compiler toolset package"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ global.json
 .nuget
 .nupkg
 nuget/Microsoft.Windows.CsWinRT.Prerelease.targets
-*.binlog

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,11 @@
     <IntDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'obj'))</IntDir>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
     <LinkIncremental>true</LinkIncremental>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,16 +19,11 @@
       https://api.nuget.org/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 
  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-   <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0-3.20428.4" />
- </ItemGroup>
-
- <ItemGroup>
-   <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
+   <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.7.0" />
  </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ Component Authors need to build a C#/WinRT projection for .NET5+ targets.
 
 However, C#/WinRT is a general effort and is intended to support other scenarios and versions of the .NET runtime, compatible down to .NET Standard 2.0.
 
-## Installing and running C#/WinRT
+## Running C#/WinRT
 
 Download the C#/WinRT NuGet package here: <http://aka.ms/cswinrt/nuget>
 
+Please see [usage](USAGE.md) for details on running the C#/WinRT tool. For additional documentation visit <http://aka.ms/cswinrt>.
+
+## Building C#/WinRT
+
 C#/WinRT currently requires the following packages to build:
 
-- Visual Studio 16.8 Preview 2 or newer
-- Microsoft.Net.Compilers.Toolset >= 3.8.0-3.20428.4
-- .NET 5 SDK 5.0.100 Preview 8
+- Visual Studio 16.6 (more specifically, MSBuild 16.6.0 for "net5.0" TFM support)
+- Microsoft.Net.Compilers.Toolset >= 3.7.0 or Visual Studio 16.8 preview (for function pointer support)
+- .NET 5 SDK 5.0.100-preview.5.20279.10
 - WinUI 3 3.0.0-preview1.200515.3
 
 **Note:** As prereleases may make breaking changes before final release, any other combinations above may work but are not supported and will generate a build warning.
@@ -53,9 +57,7 @@ After a successful command-line build, the cswinrt.sln can be launched from the 
 
 **Note:** When building the first time, the build clones the testwinrt project. The build depends on this project, but msbuild doesn't consistently pick up the change when the repo is first cloned repo. You may need to build a second time if this is your first build to address the timing issue.
 
-## Developer Guidance
-
-Please read the [usage](USAGE.md) and [repository structure](STRUCTURE.md) docs for a detailed breakdown. For additional documentation visit <http://aka.ms/cswinrt>.
+Please see the [repository structure](STRUCTURE.md) for a detailed breakdown on the repo contents.
 
 ## Related Projects
 

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--Target .NET Core 2.0 to test .NET Standard 2.0 projection -->
+    <!--Target .NET Core 2.0 to ensure .NET Standard 2.0 compatibility-->
     <TargetFrameworks>netcoreapp2.0;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;x86</Platforms>
@@ -10,6 +10,8 @@
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1701;1702;0436;1658</NoWarn>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <AssetTargetFallback>netcoreapp5.0</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,17 +20,26 @@
     <ProjectReference Include="..\Projections\Test\Test.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
-   <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -113,9 +113,9 @@ namespace WinRT
             IUnknownVftblPtr = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IUnknownVftbl), sizeof(IUnknownVftbl));
             (*(IUnknownVftbl*)IUnknownVftblPtr) = new IUnknownVftbl
             {
-                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)qi,
-                AddRef = (delegate* unmanaged[Stdcall]<IntPtr, uint>)addRef,
-                Release = (delegate* unmanaged[Stdcall]<IntPtr, uint>)release,
+                QueryInterface = (delegate* stdcall<IntPtr, ref Guid, out IntPtr, int>)qi,
+                AddRef = (delegate* stdcall<IntPtr, uint>)addRef,
+                Release = (delegate* stdcall<IntPtr, uint>)release,
             };
         }
 

--- a/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -129,9 +129,9 @@ namespace WinRT
             IUnknownVftblPtr = Marshal.AllocHGlobal(sizeof(IUnknownVftbl));
             (*(IUnknownVftbl*)IUnknownVftblPtr) = new IUnknownVftbl
             {
-                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)Marshal.GetFunctionPointerForDelegate(Abi_QueryInterface),
-                AddRef = (delegate* unmanaged[Stdcall]<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_AddRef),
-                Release = (delegate* unmanaged[Stdcall]<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_Release),
+                QueryInterface = (delegate* stdcall<IntPtr, ref Guid, out IntPtr, int>)Marshal.GetFunctionPointerForDelegate(Abi_QueryInterface),
+                AddRef = (delegate* stdcall<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_AddRef),
+                Release = (delegate* stdcall<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_Release),
             };
         }
         

--- a/WinRT.Runtime/IInspectable.cs
+++ b/WinRT.Runtime/IInspectable.cs
@@ -23,13 +23,13 @@ namespace WinRT
         {
             public IUnknownVftbl IUnknownVftbl;
             private void* _GetIids;
-            public delegate* unmanaged[Stdcall]<IntPtr, int*, IntPtr*, int> GetIids { get => (delegate* unmanaged[Stdcall]<IntPtr, int*, IntPtr*, int>)_GetIids; set => _GetIids = (void*)value; }
+            public delegate* stdcall<IntPtr, int*, IntPtr*, int> GetIids { get => (delegate* stdcall<IntPtr, int*, IntPtr*, int>)_GetIids; set => _GetIids = (void*)value; }
             
             private void* _GetRuntimeClassName;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetRuntimeClassName { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetRuntimeClassName; set => _GetRuntimeClassName = (void*)value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetRuntimeClassName { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetRuntimeClassName; set => _GetRuntimeClassName = (void*)value; }
             
             private void* _GetTrustLevel;
-            public delegate* unmanaged[Stdcall]<IntPtr, TrustLevel*, int> GetTrustLevel { get => (delegate* unmanaged[Stdcall]<IntPtr, TrustLevel*, int>)_GetTrustLevel; set => _GetTrustLevel = (void*)value; }
+            public delegate* stdcall<IntPtr, TrustLevel*, int> GetTrustLevel { get => (delegate* stdcall<IntPtr, TrustLevel*, int>)_GetTrustLevel; set => _GetTrustLevel = (void*)value; }
 
             public static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Interop/ExceptionErrorInfo.cs
+++ b/WinRT.Runtime/Interop/ExceptionErrorInfo.cs
@@ -94,15 +94,15 @@ namespace ABI.WinRT.Interop
         {
             internal global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _GetGuid_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, Guid*, int> GetGuid_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, Guid*, int>)_GetGuid_0; set => _GetGuid_0 = value; }
+            public delegate* stdcall<IntPtr, Guid*, int> GetGuid_0 { get => (delegate* stdcall<IntPtr, Guid*, int>)_GetGuid_0; set => _GetGuid_0 = value; }
             private void* _GetSource_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetSource_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetSource_1; set => _GetSource_1 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetSource_1 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetSource_1; set => _GetSource_1 = value; }
             private void* _GetDescription_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetDescription_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetDescription_2; set => _GetDescription_2 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetDescription_2 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetDescription_2; set => _GetDescription_2 = value; }
             private void* _GetHelpFile_3;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetHelpFile_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetHelpFile_3; set => _GetHelpFile_3 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetHelpFile_3 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetHelpFile_3; set => _GetHelpFile_3 = value; }
             private void* _GetHelpFileContent_4;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetHelpFileContent_4 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetHelpFileContent_4; set => _GetHelpFileContent_4 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetHelpFileContent_4 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetHelpFileContent_4; set => _GetHelpFileContent_4 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -325,7 +325,7 @@ namespace ABI.WinRT.Interop
         {
             internal global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _GetLanguageException_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetLanguageException_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetLanguageException_0;
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetLanguageException_0 => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetLanguageException_0;
         }
 
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
@@ -369,7 +369,7 @@ namespace ABI.WinRT.Interop
         {
             internal global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _InterfaceSupportsErrorInfo_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, Guid*, int> InterfaceSupportsErrorInfo_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, Guid*, int>)_InterfaceSupportsErrorInfo_0; set => _InterfaceSupportsErrorInfo_0 = value; }
+            public delegate* stdcall<IntPtr, Guid*, int> InterfaceSupportsErrorInfo_0 { get => (delegate* stdcall<IntPtr, Guid*, int>)_InterfaceSupportsErrorInfo_0; set => _InterfaceSupportsErrorInfo_0 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -440,9 +440,9 @@ namespace ABI.WinRT.Interop
 
             internal global::WinRT.Interop.IUnknownVftbl unknownVftbl;
             private void* _GetErrorDetails_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int> GetErrorDetails_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int>)_GetErrorDetails_0;
+            public delegate* stdcall<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int> GetErrorDetails_0 => (delegate* stdcall<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int>)_GetErrorDetails_0;
             private void* _GetReference_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> GetReference_1 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_GetReference_1;
+            public delegate* stdcall<IntPtr, IntPtr*, int> GetReference_1 => (delegate* stdcall<IntPtr, IntPtr*, int>)_GetReference_1;
         }
 
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/WinRT.Runtime/Interop/IAgileReference.cs
+++ b/WinRT.Runtime/Interop/IAgileReference.cs
@@ -41,7 +41,7 @@ namespace ABI.WinRT.Interop
         {
             public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _Resolve;
-            public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
+            public delegate* stdcall<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* stdcall<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
 
             public static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -163,11 +163,11 @@ namespace ABI.WinRT.Interop
         {
             public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _RegisterInterfaceInGlobal;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ref Guid, out IntPtr, int> RegisterInterfaceInGlobal => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ref Guid, out IntPtr, int>)_RegisterInterfaceInGlobal;
+            public delegate* stdcall<IntPtr, IntPtr, ref Guid, out IntPtr, int> RegisterInterfaceInGlobal => (delegate* stdcall<IntPtr, IntPtr, ref Guid, out IntPtr, int>)_RegisterInterfaceInGlobal;
             private void* _RevokeInterfaceFromGlobal;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int> RevokeInterfaceFromGlobal => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)_RevokeInterfaceFromGlobal;
+            public delegate* stdcall<IntPtr, IntPtr, int> RevokeInterfaceFromGlobal => (delegate* stdcall<IntPtr, IntPtr, int>)_RevokeInterfaceFromGlobal;
             private void* _GetInterfaceFromGlobal;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ref Guid, out IntPtr, int> GetInterfaceFromGlobal => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ref Guid, out IntPtr, int>)_GetInterfaceFromGlobal;
+            public delegate* stdcall<IntPtr, IntPtr, ref Guid, out IntPtr, int> GetInterfaceFromGlobal => (delegate* stdcall<IntPtr, IntPtr, ref Guid, out IntPtr, int>)_GetInterfaceFromGlobal;
         }
 
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/WinRT.Runtime/Interop/IContextCallback.cs
@@ -43,9 +43,9 @@ namespace ABI.WinRT.Interop
         {
             global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _ContextCallback;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4
+            public delegate* stdcall<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4
             {
-                get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int>)_ContextCallback;
+                get => (delegate* stdcall<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int>)_ContextCallback;
                 set => _ContextCallback = (void*)value;
             }
         }

--- a/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -9,11 +9,11 @@ namespace WinRT.Interop
     public unsafe struct IUnknownVftbl
     {
         private void* _QueryInterface;
-        public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> QueryInterface { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_QueryInterface; set => _QueryInterface = (void*)value; }
+        public delegate* stdcall<IntPtr, ref Guid, out IntPtr, int> QueryInterface { get => (delegate* stdcall<IntPtr, ref Guid, out IntPtr, int>)_QueryInterface; set => _QueryInterface = (void*)value; }
         private void* _AddRef;
-        public delegate* unmanaged[Stdcall]<IntPtr, uint> AddRef { get => (delegate* unmanaged[Stdcall]<IntPtr, uint>)_AddRef; set => _AddRef = (void*)value; }
+        public delegate* stdcall<IntPtr, uint> AddRef { get => (delegate* stdcall<IntPtr, uint>)_AddRef; set => _AddRef = (void*)value; }
         private void* _Release;
-        public delegate* unmanaged[Stdcall]<IntPtr, uint> Release { get => (delegate* unmanaged[Stdcall]<IntPtr, uint>)_Release; set => _Release = (void*)value; }
+        public delegate* stdcall<IntPtr, uint> Release { get => (delegate* stdcall<IntPtr, uint>)_Release; set => _Release = (void*)value; }
 
         public static IUnknownVftbl AbiToProjectionVftbl => ComWrappersSupport.IUnknownVftbl;
         public static IntPtr AbiToProjectionVftblPtr => ComWrappersSupport.IUnknownVftblPtr;

--- a/WinRT.Runtime/Interop/IWeakReferenceSource.cs
+++ b/WinRT.Runtime/Interop/IWeakReferenceSource.cs
@@ -56,7 +56,7 @@ namespace ABI.WinRT.Interop
         {
             public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _GetWeakReference;
-            public delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int> GetWeakReference { get => (delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int>)_GetWeakReference; set => _GetWeakReference = value; }
+            public delegate* stdcall<IntPtr, out IntPtr, int> GetWeakReference { get => (delegate* stdcall<IntPtr, out IntPtr, int>)_GetWeakReference; set => _GetWeakReference = value; }
 
             public static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -136,7 +136,7 @@ namespace ABI.WinRT.Interop
         {
             public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
             private void* _Resolve;
-            public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
+            public delegate* stdcall<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* stdcall<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
 
             public static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Projections/Bindable.cs
+++ b/WinRT.Runtime/Projections/Bindable.cs
@@ -66,11 +66,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _get_Current_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_Current_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_Current_0; set => _get_Current_0 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> get_Current_0 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_get_Current_0; set => _get_Current_0 = value; }
             private void* _get_HasCurrent_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
+            public delegate* stdcall<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* stdcall<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
             private void* _MoveNext_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> MoveNext_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
+            public delegate* stdcall<IntPtr, byte*, int> MoveNext_2 { get => (delegate* stdcall<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -221,11 +221,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _GetAt_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr*, int> GetAt_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr*, int>)_GetAt_0; set => _GetAt_0 = value; }
+            public delegate* stdcall<IntPtr, uint, IntPtr*, int> GetAt_0 { get => (delegate* stdcall<IntPtr, uint, IntPtr*, int>)_GetAt_0; set => _GetAt_0 = value; }
             private void* _get_Size_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, uint*, int> get_Size_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>)_get_Size_1; set => _get_Size_1 = value; }
+            public delegate* stdcall<IntPtr, uint*, int> get_Size_1 { get => (delegate* stdcall<IntPtr, uint*, int>)_get_Size_1; set => _get_Size_1 = value; }
             private void* _IndexOf_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, uint*, byte*, int> IndexOf_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, uint*, byte*, int>)_IndexOf_2; set => _IndexOf_2 = value; }
+            public delegate* stdcall<IntPtr, IntPtr, uint*, byte*, int> IndexOf_2 { get => (delegate* stdcall<IntPtr, IntPtr, uint*, byte*, int>)_IndexOf_2; set => _IndexOf_2 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -459,7 +459,7 @@ namespace ABI.System.Collections
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _First_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> First_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_First_0; set => _First_0 = value; }
+            public delegate* stdcall<IntPtr, IntPtr*, int> First_0 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_First_0; set => _First_0 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -996,16 +996,16 @@ namespace ABI.System.Collections
             private void* _RemoveAtEnd_8;
             private void* _Clear_9;
 
-            public delegate* unmanaged[Stdcall]<IntPtr , uint , IntPtr* , int> GetAt_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr * , int >)_GetAt_0; set => _GetAt_0 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , uint* , int> get_Size_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint * , int >)_get_Size_1; set => _get_Size_1 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , IntPtr* , int> GetView_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr * , int >)_GetView_2; set => _GetView_2 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , IntPtr , uint* , byte* , int> IndexOf_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, uint * , byte * , int >)_IndexOf_3; set => _IndexOf_3 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , uint , IntPtr , int> SetAt_4 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr, int >)_SetAt_4; set => _SetAt_4 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , uint , IntPtr , int> InsertAt_5 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr, int >)_InsertAt_5; set => _InsertAt_5 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , uint , int> RemoveAt_6 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint, int >)_RemoveAt_6; set => _RemoveAt_6 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , IntPtr , int> Append_7 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int >)_Append_7; set => _Append_7 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , int> RemoveAtEnd_8 { get => (delegate* unmanaged[Stdcall]<IntPtr, int >)_RemoveAtEnd_8; set => _RemoveAtEnd_8 = value; }
-            public delegate* unmanaged[Stdcall]<IntPtr , int> Clear_9 { get => (delegate* unmanaged[Stdcall]<IntPtr, int >)_Clear_9; set => _Clear_9 = value; }
+            public delegate* stdcall<IntPtr , uint , IntPtr* , int> GetAt_0 { get => (delegate* stdcall<IntPtr, uint, IntPtr * , int >)_GetAt_0; set => _GetAt_0 = value; }
+            public delegate* stdcall<IntPtr , uint* , int> get_Size_1 { get => (delegate* stdcall<IntPtr, uint * , int >)_get_Size_1; set => _get_Size_1 = value; }
+            public delegate* stdcall<IntPtr , IntPtr* , int> GetView_2 { get => (delegate* stdcall<IntPtr, IntPtr * , int >)_GetView_2; set => _GetView_2 = value; }
+            public delegate* stdcall<IntPtr , IntPtr , uint* , byte* , int> IndexOf_3 { get => (delegate* stdcall<IntPtr, IntPtr, uint * , byte * , int >)_IndexOf_3; set => _IndexOf_3 = value; }
+            public delegate* stdcall<IntPtr , uint , IntPtr , int> SetAt_4 { get => (delegate* stdcall<IntPtr, uint, IntPtr, int >)_SetAt_4; set => _SetAt_4 = value; }
+            public delegate* stdcall<IntPtr , uint , IntPtr , int> InsertAt_5 { get => (delegate* stdcall<IntPtr, uint, IntPtr, int >)_InsertAt_5; set => _InsertAt_5 = value; }
+            public delegate* stdcall<IntPtr , uint , int> RemoveAt_6 { get => (delegate* stdcall<IntPtr, uint, int >)_RemoveAt_6; set => _RemoveAt_6 = value; }
+            public delegate* stdcall<IntPtr , IntPtr , int> Append_7 { get => (delegate* stdcall<IntPtr, IntPtr, int >)_Append_7; set => _Append_7 = value; }
+            public delegate* stdcall<IntPtr , int> RemoveAtEnd_8 { get => (delegate* stdcall<IntPtr, int >)_RemoveAtEnd_8; set => _RemoveAtEnd_8 = value; }
+            public delegate* stdcall<IntPtr , int> Clear_9 { get => (delegate* stdcall<IntPtr, int >)_Clear_9; set => _Clear_9 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Projections/ICommand.cs
+++ b/WinRT.Runtime/Projections/ICommand.cs
@@ -121,8 +121,8 @@ namespace ABI.System.Windows.Input
     internal sealed unsafe class CanExecuteChangedEventSource : EventSource<global::System.EventHandler>
     {
         internal CanExecuteChangedEventSource(IObjectReference obj,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
+            delegate* stdcall<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
+            delegate* stdcall<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
             : base(obj, addHandler, removeHandler)
         {
         }
@@ -146,13 +146,13 @@ namespace ABI.System.Windows.Input
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _add_CanExecuteChanged_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CanExecuteChanged_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CanExecuteChanged_0; set => _add_CanExecuteChanged_0 = value; }
+            public delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CanExecuteChanged_0 { get => (delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CanExecuteChanged_0; set => _add_CanExecuteChanged_0 = value; }
             private void* _remove_CanExecuteChanged_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CanExecuteChanged_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CanExecuteChanged_1; set => _remove_CanExecuteChanged_1 = value; }
+            public delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CanExecuteChanged_1 { get => (delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CanExecuteChanged_1; set => _remove_CanExecuteChanged_1 = value; }
             private void* _CanExecute_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out byte, int> CanExecute_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out byte, int>)_CanExecute_2; set => _CanExecute_2 = value; }
+            public delegate* stdcall<IntPtr, IntPtr, out byte, int> CanExecute_2 { get => (delegate* stdcall<IntPtr, IntPtr, out byte, int>)_CanExecute_2; set => _CanExecute_2 = value; }
             private void* _Execute_3;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int> Execute_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)_Execute_3; set => _Execute_3 = value; }
+            public delegate* stdcall<IntPtr, IntPtr, int> Execute_3 { get => (delegate* stdcall<IntPtr, IntPtr, int>)_Execute_3; set => _Execute_3 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Projections/IDisposable.cs
+++ b/WinRT.Runtime/Projections/IDisposable.cs
@@ -16,7 +16,7 @@ namespace ABI.System
             private delegate int CloseDelegate(IntPtr thisPtr);
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _Close_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, int> Close_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, int>)_Close_0; set => _Close_0 = value; }
+            public delegate* stdcall<IntPtr, int> Close_0 { get => (delegate* stdcall<IntPtr, int>)_Close_0; set => _Close_0 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Projections/INotifyCollectionChanged.cs
+++ b/WinRT.Runtime/Projections/INotifyCollectionChanged.cs
@@ -18,14 +18,14 @@ namespace ABI.System.Collections.Specialized
             internal IInspectable.Vftbl IInspectableVftbl;
 #if NETSTANDARD2_0
             private void* _add_CollectionChanged_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CollectionChanged_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CollectionChanged_0; set => _add_CollectionChanged_0=(void*)value; }
+            public delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CollectionChanged_0 { get => (delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CollectionChanged_0; set => _add_CollectionChanged_0=(void*)value; }
             private void* _remove_CollectionChanged_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CollectionChanged_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CollectionChanged_1; set => _remove_CollectionChanged_1=(void*)value; }
+            public delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CollectionChanged_1 { get => (delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CollectionChanged_1; set => _remove_CollectionChanged_1=(void*)value; }
 #else
             private delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> _add_CollectionChanged_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CollectionChanged_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CollectionChanged_0; set => _add_CollectionChanged_0=(delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)value; }
+            public delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_CollectionChanged_0 { get => (delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_CollectionChanged_0; set => _add_CollectionChanged_0=(delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)value; }
             private delegate*<IntPtr, global::WinRT.EventRegistrationToken, int> _remove_CollectionChanged_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CollectionChanged_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CollectionChanged_1; set => _remove_CollectionChanged_1=(delegate*<IntPtr, global::WinRT.EventRegistrationToken, int>)value; }
+            public delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int> remove_CollectionChanged_1 { get => (delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_CollectionChanged_1; set => _remove_CollectionChanged_1=(delegate*<IntPtr, global::WinRT.EventRegistrationToken, int>)value; }
 #endif
 
             private static readonly Vftbl AbiToProjectionVftable;

--- a/WinRT.Runtime/Projections/INotifyPropertyChanged.cs
+++ b/WinRT.Runtime/Projections/INotifyPropertyChanged.cs
@@ -18,14 +18,14 @@ namespace ABI.System.ComponentModel
             internal IInspectable.Vftbl IInspectableVftbl;
 #if NETSTANDARD2_0
             private void* _add_PropertyChanged_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_PropertyChanged_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_PropertyChanged_0; set => _add_PropertyChanged_0=(void*)value; }
+            public delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_PropertyChanged_0 { get => (delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_PropertyChanged_0; set => _add_PropertyChanged_0=(void*)value; }
             private void* _remove_PropertyChanged_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int> remove_PropertyChanged_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_PropertyChanged_1; set => _remove_PropertyChanged_1=(void*)value; }
+            public delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int> remove_PropertyChanged_1 { get => (delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_PropertyChanged_1; set => _remove_PropertyChanged_1=(void*)value; }
 #else
             private delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> _add_PropertyChanged_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_PropertyChanged_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_PropertyChanged_0; set => _add_PropertyChanged_0=(delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)value; }
+            public delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int> add_PropertyChanged_0 { get => (delegate* stdcall<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)_add_PropertyChanged_0; set => _add_PropertyChanged_0=(delegate*<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)value; }
             private delegate*<IntPtr, global::WinRT.EventRegistrationToken, int> _remove_PropertyChanged_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int> remove_PropertyChanged_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_PropertyChanged_1; set => _remove_PropertyChanged_1=(delegate*<IntPtr, global::WinRT.EventRegistrationToken, int>)value; }
+            public delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int> remove_PropertyChanged_1 { get => (delegate* stdcall<IntPtr, global::WinRT.EventRegistrationToken, int>)_remove_PropertyChanged_1; set => _remove_PropertyChanged_1=(delegate*<IntPtr, global::WinRT.EventRegistrationToken, int>)value; }
 #endif
 
             private static readonly Vftbl AbiToProjectionVftable;

--- a/WinRT.Runtime/Projections/IPropertyValue.cs
+++ b/WinRT.Runtime/Projections/IPropertyValue.cs
@@ -1300,83 +1300,83 @@ namespace ABI.Windows.Foundation
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             internal void* _get_Type_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.PropertyType, int> get_Type_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.PropertyType, int>)_get_Type_0; set => _get_Type_0 = value; }
+            public delegate* stdcall<IntPtr, out global::Windows.Foundation.PropertyType, int> get_Type_0 { get => (delegate* stdcall<IntPtr, out global::Windows.Foundation.PropertyType, int>)_get_Type_0; set => _get_Type_0 = value; }
             public void* _get_IsNumericScalar_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, out byte, int> get_IsNumericScalar_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, out byte, int>)_get_IsNumericScalar_1; set => _get_IsNumericScalar_1 = value; }
+            public delegate* stdcall<IntPtr, out byte, int> get_IsNumericScalar_1 { get => (delegate* stdcall<IntPtr, out byte, int>)_get_IsNumericScalar_1; set => _get_IsNumericScalar_1 = value; }
             internal void* _GetUInt8_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, out byte, int> GetUInt8_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, out byte, int>)_GetUInt8_2; set => _GetUInt8_2 = value; }
+            public delegate* stdcall<IntPtr, out byte, int> GetUInt8_2 { get => (delegate* stdcall<IntPtr, out byte, int>)_GetUInt8_2; set => _GetUInt8_2 = value; }
             internal void* _GetInt16_3;
-            public delegate* unmanaged[Stdcall]<IntPtr, out short, int> GetInt16_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, out short, int>)_GetInt16_3; set => _GetInt16_3 = value; }
+            public delegate* stdcall<IntPtr, out short, int> GetInt16_3 { get => (delegate* stdcall<IntPtr, out short, int>)_GetInt16_3; set => _GetInt16_3 = value; }
             internal void* _GetUInt16_4;
-            public delegate* unmanaged[Stdcall]<IntPtr, out ushort, int> GetUInt16_4 { get => (delegate* unmanaged[Stdcall]<IntPtr, out ushort, int>)_GetUInt16_4; set => _GetUInt16_4 = value; }
+            public delegate* stdcall<IntPtr, out ushort, int> GetUInt16_4 { get => (delegate* stdcall<IntPtr, out ushort, int>)_GetUInt16_4; set => _GetUInt16_4 = value; }
             internal void* _GetInt32_5;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int, int> GetInt32_5 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int, int>)_GetInt32_5; set => _GetInt32_5 = value; }
+            public delegate* stdcall<IntPtr, out int, int> GetInt32_5 { get => (delegate* stdcall<IntPtr, out int, int>)_GetInt32_5; set => _GetInt32_5 = value; }
             internal void* _GetUInt32_6;
-            public delegate* unmanaged[Stdcall]<IntPtr, out uint, int> GetUInt32_6 { get => (delegate* unmanaged[Stdcall]<IntPtr, out uint, int>)_GetUInt32_6; set => _GetUInt32_6 = value; }
+            public delegate* stdcall<IntPtr, out uint, int> GetUInt32_6 { get => (delegate* stdcall<IntPtr, out uint, int>)_GetUInt32_6; set => _GetUInt32_6 = value; }
             internal void* _GetInt64_7;
-            public delegate* unmanaged[Stdcall]<IntPtr, out long, int> GetInt64_7 { get => (delegate* unmanaged[Stdcall]<IntPtr, out long, int>)_GetInt64_7; set => _GetInt64_7 = value; }
+            public delegate* stdcall<IntPtr, out long, int> GetInt64_7 { get => (delegate* stdcall<IntPtr, out long, int>)_GetInt64_7; set => _GetInt64_7 = value; }
             internal void* _GetUInt64_8;
-            public delegate* unmanaged[Stdcall]<IntPtr, out ulong, int> GetUInt64_8 { get => (delegate* unmanaged[Stdcall]<IntPtr, out ulong, int>)_GetUInt64_8; set => _GetUInt64_8 = value; }
+            public delegate* stdcall<IntPtr, out ulong, int> GetUInt64_8 { get => (delegate* stdcall<IntPtr, out ulong, int>)_GetUInt64_8; set => _GetUInt64_8 = value; }
             internal void* _GetSingle_9;
-            public delegate* unmanaged[Stdcall]<IntPtr, out float, int> GetSingle_9 { get => (delegate* unmanaged[Stdcall]<IntPtr, out float, int>)_GetSingle_9; set => _GetSingle_9 = value; }
+            public delegate* stdcall<IntPtr, out float, int> GetSingle_9 { get => (delegate* stdcall<IntPtr, out float, int>)_GetSingle_9; set => _GetSingle_9 = value; }
             internal void* _GetDouble_10;
-            public delegate* unmanaged[Stdcall]<IntPtr, out double, int> GetDouble_10 { get => (delegate* unmanaged[Stdcall]<IntPtr, out double, int>)_GetDouble_10; set => _GetDouble_10 = value; }
+            public delegate* stdcall<IntPtr, out double, int> GetDouble_10 { get => (delegate* stdcall<IntPtr, out double, int>)_GetDouble_10; set => _GetDouble_10 = value; }
             internal void* _GetChar16_11;
-            public delegate* unmanaged[Stdcall]<IntPtr, out ushort, int> GetChar16_11 { get => (delegate* unmanaged[Stdcall]<IntPtr, out ushort, int>)_GetChar16_11; set => _GetChar16_11 = value; }
+            public delegate* stdcall<IntPtr, out ushort, int> GetChar16_11 { get => (delegate* stdcall<IntPtr, out ushort, int>)_GetChar16_11; set => _GetChar16_11 = value; }
             internal void* _GetBoolean_12;
-            public delegate* unmanaged[Stdcall]<IntPtr, out byte, int> GetBoolean_12 { get => (delegate* unmanaged[Stdcall]<IntPtr, out byte, int>)_GetBoolean_12; set => _GetBoolean_12 = value; }
+            public delegate* stdcall<IntPtr, out byte, int> GetBoolean_12 { get => (delegate* stdcall<IntPtr, out byte, int>)_GetBoolean_12; set => _GetBoolean_12 = value; }
             internal void* _GetString_13;
-            public delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int> GetString_13 { get => (delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int>)_GetString_13; set => _GetString_13 = value; }
+            public delegate* stdcall<IntPtr, out IntPtr, int> GetString_13 { get => (delegate* stdcall<IntPtr, out IntPtr, int>)_GetString_13; set => _GetString_13 = value; }
             internal void* _GetGuid_14;
-            public delegate* unmanaged[Stdcall]<IntPtr, out Guid, int> GetGuid_14 { get => (delegate* unmanaged[Stdcall]<IntPtr, out Guid, int>)_GetGuid_14; set => _GetGuid_14 = value; }
+            public delegate* stdcall<IntPtr, out Guid, int> GetGuid_14 { get => (delegate* stdcall<IntPtr, out Guid, int>)_GetGuid_14; set => _GetGuid_14 = value; }
             internal void* _GetDateTime_15;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::ABI.System.DateTimeOffset, int> GetDateTime_15 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::ABI.System.DateTimeOffset, int>)_GetDateTime_15; set => _GetDateTime_15 = value; }
+            public delegate* stdcall<IntPtr, out global::ABI.System.DateTimeOffset, int> GetDateTime_15 { get => (delegate* stdcall<IntPtr, out global::ABI.System.DateTimeOffset, int>)_GetDateTime_15; set => _GetDateTime_15 = value; }
             internal void* _GetTimeSpan_16;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::ABI.System.TimeSpan, int> GetTimeSpan_16 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::ABI.System.TimeSpan, int>)_GetTimeSpan_16; set => _GetTimeSpan_16 = value; }
+            public delegate* stdcall<IntPtr, out global::ABI.System.TimeSpan, int> GetTimeSpan_16 { get => (delegate* stdcall<IntPtr, out global::ABI.System.TimeSpan, int>)_GetTimeSpan_16; set => _GetTimeSpan_16 = value; }
             internal void* _GetPoint_17;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Point, int> GetPoint_17 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Point, int>)_GetPoint_17; set => _GetPoint_17 = value; }
+            public delegate* stdcall<IntPtr, out global::Windows.Foundation.Point, int> GetPoint_17 { get => (delegate* stdcall<IntPtr, out global::Windows.Foundation.Point, int>)_GetPoint_17; set => _GetPoint_17 = value; }
             internal void* _GetSize_18;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Size, int> GetSize_18 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Size, int>)_GetSize_18; set => _GetSize_18 = value; }
+            public delegate* stdcall<IntPtr, out global::Windows.Foundation.Size, int> GetSize_18 { get => (delegate* stdcall<IntPtr, out global::Windows.Foundation.Size, int>)_GetSize_18; set => _GetSize_18 = value; }
             internal void* _GetRect_19;
-            public delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Rect, int> GetRect_19 { get => (delegate* unmanaged[Stdcall]<IntPtr, out global::Windows.Foundation.Rect, int>)_GetRect_19; set => _GetRect_19 = value; }
+            public delegate* stdcall<IntPtr, out global::Windows.Foundation.Rect, int> GetRect_19 { get => (delegate* stdcall<IntPtr, out global::Windows.Foundation.Rect, int>)_GetRect_19; set => _GetRect_19 = value; }
             internal void* _GetUInt8Array_20;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetUInt8Array_20 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetUInt8Array_20; set => _GetUInt8Array_20 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetUInt8Array_20 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetUInt8Array_20; set => _GetUInt8Array_20 = value; }
             internal void* _GetInt16Array_21;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetInt16Array_21 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetInt16Array_21; set => _GetInt16Array_21 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetInt16Array_21 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetInt16Array_21; set => _GetInt16Array_21 = value; }
             internal void* _GetUInt16Array_22;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetUInt16Array_22 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetUInt16Array_22; set => _GetUInt16Array_22 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetUInt16Array_22 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetUInt16Array_22; set => _GetUInt16Array_22 = value; }
             internal void* _GetInt32Array_23;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetInt32Array_23 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetInt32Array_23; set => _GetInt32Array_23 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetInt32Array_23 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetInt32Array_23; set => _GetInt32Array_23 = value; }
             internal void* _GetUInt32Array_24;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetUInt32Array_24 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetUInt32Array_24; set => _GetUInt32Array_24 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetUInt32Array_24 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetUInt32Array_24; set => _GetUInt32Array_24 = value; }
             internal void* _GetInt64Array_25;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetInt64Array_25 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetInt64Array_25; set => _GetInt64Array_25 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetInt64Array_25 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetInt64Array_25; set => _GetInt64Array_25 = value; }
             internal void* _GetUInt64Array_26;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetUInt64Array_26 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetUInt64Array_26; set => _GetUInt64Array_26 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetUInt64Array_26 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetUInt64Array_26; set => _GetUInt64Array_26 = value; }
             internal void* _GetSingleArray_27;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetSingleArray_27 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetSingleArray_27; set => _GetSingleArray_27 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetSingleArray_27 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetSingleArray_27; set => _GetSingleArray_27 = value; }
             internal void* _GetDoubleArray_28;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetDoubleArray_28 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetDoubleArray_28; set => _GetDoubleArray_28 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetDoubleArray_28 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetDoubleArray_28; set => _GetDoubleArray_28 = value; }
             internal void* _GetChar16Array_29;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetChar16Array_29 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetChar16Array_29; set => _GetChar16Array_29 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetChar16Array_29 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetChar16Array_29; set => _GetChar16Array_29 = value; }
             internal void* _GetBooleanArray_30;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetBooleanArray_30 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetBooleanArray_30; set => _GetBooleanArray_30 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetBooleanArray_30 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetBooleanArray_30; set => _GetBooleanArray_30 = value; }
             internal void* _GetStringArray_31;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetStringArray_31 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetStringArray_31; set => _GetStringArray_31 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetStringArray_31 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetStringArray_31; set => _GetStringArray_31 = value; }
             internal void* _GetInspectableArray_32;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetInspectableArray_32 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetInspectableArray_32; set => _GetInspectableArray_32 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetInspectableArray_32 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetInspectableArray_32; set => _GetInspectableArray_32 = value; }
             internal void* _GetGuidArray_33;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetGuidArray_33 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetGuidArray_33; set => _GetGuidArray_33 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetGuidArray_33 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetGuidArray_33; set => _GetGuidArray_33 = value; }
             internal void* _GetDateTimeArray_34;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetDateTimeArray_34 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetDateTimeArray_34; set => _GetDateTimeArray_34 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetDateTimeArray_34 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetDateTimeArray_34; set => _GetDateTimeArray_34 = value; }
             internal void* _GetTimeSpanArray_35;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetTimeSpanArray_35 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetTimeSpanArray_35; set => _GetTimeSpanArray_35 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetTimeSpanArray_35 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetTimeSpanArray_35; set => _GetTimeSpanArray_35 = value; }
             internal void* _GetPointArray_36;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetPointArray_36 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetPointArray_36; set => _GetPointArray_36 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetPointArray_36 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetPointArray_36; set => _GetPointArray_36 = value; }
             internal void* _GetSizeArray_37;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetSizeArray_37 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetSizeArray_37; set => _GetSizeArray_37 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetSizeArray_37 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetSizeArray_37; set => _GetSizeArray_37 = value; }
             internal void* _GetRectArray_38;
-            public delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int> GetRectArray_38 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int , out IntPtr, int>)_GetRectArray_38; set => _GetRectArray_38 = value; }
+            public delegate* stdcall<IntPtr, out int , out IntPtr, int> GetRectArray_38 { get => (delegate* stdcall<IntPtr, out int , out IntPtr, int>)_GetRectArray_38; set => _GetRectArray_38 = value; }
         }
 
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/WinRT.Runtime/Projections/IStringable.cs
+++ b/WinRT.Runtime/Projections/IStringable.cs
@@ -13,7 +13,7 @@ namespace ABI.Windows.Foundation
 
         internal IInspectable.Vftbl IInspectableVftbl;
         private void* _ToString_0;
-        private delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> ToString_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_ToString_0; set => _ToString_0 = value; }
+        private delegate* stdcall<IntPtr, IntPtr*, int> ToString_0 { get => (delegate* stdcall<IntPtr, IntPtr*, int>)_ToString_0; set => _ToString_0 = value; }
 
         private static readonly ManagedIStringableVftbl AbiToProjectionVftable;
         public static readonly IntPtr AbiToProjectionVftablePtr;

--- a/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -19,15 +19,15 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _get_Action_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction*, int> get_Action_0 => (delegate* unmanaged[Stdcall]<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction*, int>)_get_Action_0;
+            public delegate* stdcall<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction*, int> get_Action_0 => (delegate* stdcall<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction*, int>)_get_Action_0;
             private void* _get_NewItems_1;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_NewItems_1 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_NewItems_1;
+            public delegate* stdcall<IntPtr, IntPtr*, int> get_NewItems_1 => (delegate* stdcall<IntPtr, IntPtr*, int>)_get_NewItems_1;
             private void* _get_OldItems_2;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_OldItems_2 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_OldItems_2;
+            public delegate* stdcall<IntPtr, IntPtr*, int> get_OldItems_2 => (delegate* stdcall<IntPtr, IntPtr*, int>)_get_OldItems_2;
             private void* _get_NewStartingIndex_3;
-            public delegate* unmanaged[Stdcall]<IntPtr, int*, int> get_NewStartingIndex_3 => (delegate* unmanaged[Stdcall]<IntPtr, int*, int>)_get_NewStartingIndex_3;
+            public delegate* stdcall<IntPtr, int*, int> get_NewStartingIndex_3 => (delegate* stdcall<IntPtr, int*, int>)_get_NewStartingIndex_3;
             private void* _get_OldStartingIndex_4;
-            public delegate* unmanaged[Stdcall]<IntPtr, int*, int> get_OldStartingIndex_4 => (delegate* unmanaged[Stdcall]<IntPtr, int*, int>)_get_OldStartingIndex_4;
+            public delegate* stdcall<IntPtr, int*, int> get_OldStartingIndex_4 => (delegate* stdcall<IntPtr, int*, int>)_get_OldStartingIndex_4;
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
@@ -118,7 +118,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _CreateInstanceWithAllParameters_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction, IntPtr, IntPtr, int, int, IntPtr, out IntPtr, out IntPtr, int> CreateInstanceWithAllParameters_0 => (delegate* unmanaged[Stdcall]<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction, IntPtr, IntPtr, int, int, IntPtr, out IntPtr, out IntPtr, int>)_CreateInstanceWithAllParameters_0;
+            public delegate* stdcall<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction, IntPtr, IntPtr, int, int, IntPtr, out IntPtr, out IntPtr, int> CreateInstanceWithAllParameters_0 => (delegate* stdcall<IntPtr, global::System.Collections.Specialized.NotifyCollectionChangedAction, IntPtr, IntPtr, int, int, IntPtr, out IntPtr, out IntPtr, int>)_CreateInstanceWithAllParameters_0;
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 

--- a/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -14,7 +14,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
     {
         internal IInspectable.Vftbl IInspectableVftbl;
         private void* _get_PropertyName_0;
-        public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_PropertyName_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_PropertyName_0;
+        public delegate* stdcall<IntPtr, IntPtr*, int> get_PropertyName_0 => (delegate* stdcall<IntPtr, IntPtr*, int>)_get_PropertyName_0;
     }
 
 
@@ -28,7 +28,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _CreateInstance_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int> CreateInstance_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int>)_CreateInstance_0;
+            public delegate* stdcall<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int> CreateInstance_0 => (delegate* stdcall<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int>)_CreateInstance_0;
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 

--- a/WinRT.Runtime/Projections/Uri.cs
+++ b/WinRT.Runtime/Projections/Uri.cs
@@ -22,7 +22,7 @@ namespace ABI.Windows.Foundation
         public IntPtr get_Query_8;
         public IntPtr get_QueryParsed_9;
         public void* _get_RawUri_10;
-        public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_RawUri_10 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_RawUri_10;
+        public delegate* stdcall<IntPtr, IntPtr*, int> get_RawUri_10 => (delegate* stdcall<IntPtr, IntPtr*, int>)_get_RawUri_10;
         public IntPtr get_SchemeName_11;
         public IntPtr get_UserName_12;
         public IntPtr get_Port_13;
@@ -45,7 +45,7 @@ namespace ABI.System
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _CreateUri_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out IntPtr, int> CreateUri_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out IntPtr, int>)_CreateUri_0;
+            public delegate* stdcall<IntPtr, IntPtr, out IntPtr, int> CreateUri_0 => (delegate* stdcall<IntPtr, IntPtr, out IntPtr, int>)_CreateUri_0;
             public IntPtr _CreateWithRelativeUri;
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/WinUIDesktopSample/MainPage.xaml.cs
+++ b/WinUIDesktopSample/MainPage.xaml.cs
@@ -20,8 +20,6 @@ namespace WinUIDesktopSample
             this.AddHandler(UIElement.TappedEvent, new TappedEventHandler(Foo_PointerTapped), true /*handledEventsToo*/);
         }
 
-        partial void InitializeComponent();
-
         private void Foo_PointerTapped(object sender, TappedRoutedEventArgs e)
         {
         }

--- a/WinUIDesktopSample/WinUIDesktopSample.csproj
+++ b/WinUIDesktopSample/WinUIDesktopSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
     <ApplicationManifest>WinUIDesktopSample.exe.manifest</ApplicationManifest>
     <!--
@@ -28,7 +29,7 @@
       since we are building our own in the WinUIProjection project
     -->
     <PackageReference Include="Microsoft.WinUI" Version="$(MicrosoftWinUIVersion)" GeneratePathProperty="true">
-      <ExcludeAssets>compile; runtime; build</ExcludeAssets>
+      <ExcludeAssets>compile; runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set CsWinRTNet5SdkVersion=5.0.100-preview.8.20417.9
+set CsWinRTNet5SdkVersion=5.0.100-preview.7.20366.6
 
 :dotnet
 rem Install required .NET 5 SDK version and add to environment
@@ -84,11 +84,12 @@ if not "%cswinrt_label%"=="" goto %cswinrt_label%
 if not exist .nuget md .nuget
 if not exist .nuget\nuget.exe powershell -Command "Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe -OutFile .nuget\nuget.exe"
 .nuget\nuget update -self
+.nuget\nuget.exe restore
 
 :build
 call get_testwinrt.cmd
 echo Building cswinrt for %cswinrt_platform% %cswinrt_configuration%
-msbuild /restore cswinrt.sln %cswinrt_build_params% /p:platform=%cswinrt_platform%;configuration=%cswinrt_configuration%;VersionNumber=%cswinrt_version_number%;VersionString=%cswinrt_version_string%;GenerateTestProjection=true /bl
+msbuild cswinrt.sln %cswinrt_build_params% /p:platform=%cswinrt_platform%;configuration=%cswinrt_configuration%;VersionNumber=%cswinrt_version_number%;VersionString=%cswinrt_version_string%;GenerateTestProjection=true
 
 :test
 rem Build/Run xUnit tests, generating xml output report for Azure Devops reporting, via XunitXml.TestLogger NuGet

--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -3386,7 +3386,6 @@ return 0;)",
     {
         if (method.SpecialName()) return;
 
-        auto generic_type = distance(method.Parent().GenericParam()) > 0;
         method_signature signature{ method };
         auto return_sig = signature.return_signature();
         auto type_name = write_type_name_temp(w, method.Parent());
@@ -3403,7 +3402,7 @@ private static unsafe int Do_Abi_%%
 {
 %
 })",
-            !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+            !settings.netstandard_compat && !have_generic_params ? "[UnmanagedCallersOnly]" : "",
             vmethod_name,
             bind<write_abi_signature>(method),
             bind<write_managed_method_call>(
@@ -3419,7 +3418,6 @@ private static unsafe int Do_Abi_%%
     {
         auto [getter, setter] = get_property_methods(prop);
         auto type_name = write_type_name_temp(w, prop.Parent());
-        auto generic_type = distance(prop.Parent().GenericParam()) > 0;
         if (setter)
         {
             method_signature setter_sig{ setter };
@@ -3439,7 +3437,7 @@ private static unsafe int Do_Abi_%%
 {
 %
 })",
-            !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+            !settings.netstandard_compat ? "[UnmanagedCallersOnly]" : "",
             vmethod_name,
             bind<write_abi_signature>(setter),
             bind<write_managed_method_call>(
@@ -3469,7 +3467,7 @@ private static unsafe int Do_Abi_%%
 {
 %
 })",
-                !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+                !settings.netstandard_compat ? "[UnmanagedCallersOnly]" : "",
                 vmethod_name,
                 bind<write_abi_signature>(getter),
                 bind<write_managed_method_call>(
@@ -3486,7 +3484,6 @@ private static unsafe int Do_Abi_%%
     void write_event_abi_invoke(writer& w, Event const& evt)
     {
         auto type_name = write_type_name_temp(w, evt.Parent());
-        auto generic_type = distance(evt.Parent().GenericParam()) > 0;
         auto semantics = get_type_semantics(evt.EventType());
         auto [add_method, remove_method] = get_event_methods(evt);
         auto add_signature = method_signature{ add_method };
@@ -3521,7 +3518,7 @@ catch (Exception __ex)
 return __ex.HResult;
 }
 })",
-            !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+            !settings.netstandard_compat ? "[UnmanagedCallersOnly]" : "",
             get_vmethod_name(w, add_method.Parent(), add_method),
             bind<write_abi_signature>(add_method),
             settings.netstandard_compat ? "" : "*",
@@ -3552,7 +3549,7 @@ catch (Exception __ex)
 return __ex.HResult;
 }
 })",
-            !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+            !settings.netstandard_compat ? "[UnmanagedCallersOnly]" : "",
             get_vmethod_name(w, remove_method.Parent(), remove_method),
             bind<write_abi_signature>(remove_method),
             type_name,
@@ -3606,26 +3603,36 @@ internal IInspectable.Vftbl IInspectableVftbl;
                     }
                     else
                     {
-                        if (settings.netstandard_compat || is_generic)
+                        if (settings.netstandard_compat)
                         {
                             nongeneric_delegates.push_back(delegate_definition);
+                            vtable_field_type = w.write_temp("delegate* stdcall<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
                         }
-
-                        vtable_field_type = w.write_temp("delegate* unmanaged[Stdcall]<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
+                        else
+                        {
+                            vtable_field_type = w.write_temp("delegate* stdcall<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
+                        }
                         function_pointer = true;
                     }
                 }
                 else
                 {
                     // We're a well-known delegate type, but we still need to get the function pointer type.
-                    vtable_field_type = w.write_temp("delegate* unmanaged[Stdcall]<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
+                    if (settings.netstandard_compat)
+                    {
+                        vtable_field_type = w.write_temp("delegate* stdcall<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
+                    }
+                    else
+                    {
+                        vtable_field_type = w.write_temp("delegate* stdcall<%, int>", bind<write_abi_parameter_types>(method_signature{ method }));
+                    }
                     function_pointer = true;
                 }
                 if (!function_pointer)
                 {
                     w.write("public % %;", vtable_field_type, vmethod_name);
                 }
-                else if (settings.netstandard_compat || is_generic)
+                else if (settings.netstandard_compat)
                 {
                     // Work around https://github.com/dotnet/runtime/issues/37295
                     w.write("private void* _%;\n", vmethod_name);
@@ -3687,7 +3694,7 @@ internal IInspectable.Vftbl IInspectableVftbl;
                                         }
                                     }, method_signature{ method })));
                     }
-                    else
+                    else if (settings.netstandard_compat)
                     {
                         method_create_delegates_to_projection.emplace_back(
                             w.write_temp("_% = (void*)Marshal.GetFunctionPointerForDelegate(DelegateCache[%] = new %(Do_Abi_%))",
@@ -3695,6 +3702,14 @@ internal IInspectable.Vftbl IInspectableVftbl;
                                 delegate_cache_index,
                                 delegate_type,
                                 vmethod_name));
+                    }
+                    else
+                    {
+                        // Work around C# compiler's lack of support for UnmanagedCallersOnly
+                        method_create_delegates_to_projection.emplace_back(
+                            w.write_temp("_% = &Do_Abi_%",
+                                vmethod_name, vmethod_name)
+                        );
                     }
                 }
                 else if (settings.netstandard_compat)
@@ -3754,7 +3769,7 @@ IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
                     w.write(R"(
 private static readonly Vftbl AbiToProjectionVftable;
 public static readonly IntPtr AbiToProjectionVftablePtr;
-private static Delegate[] DelegateCache = new Delegate[%];
+%
 static unsafe Vftbl()
 {
 AbiToProjectionVftable = new Vftbl
@@ -3767,7 +3782,13 @@ var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl)
 AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
 }
 )",
-                        std::to_string(distance(methods)),
+                        bind([&](writer& w)
+                            {   
+                                if (settings.netstandard_compat)
+                                {
+                                    w.write("private static Delegate[] DelegateCache = new Delegate[%];", std::to_string(distance(methods)));
+                                }
+                            }),
                         bind_list(",\n", method_create_delegates_to_projection),
                         std::to_string(distance(methods)),
                         bind([&](writer& w)
@@ -3782,9 +3803,9 @@ AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
                                     w.write("%", bind_each(method_marshals_to_projection));
                                 }
                             }));
-                }
-                else
-                {
+                    }
+                    else
+                    {
                         w.write(R"(
 public static readonly IntPtr AbiToProjectionVftablePtr;
 %
@@ -4609,7 +4630,7 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
                 }
                 else
                 {
-                    w.write("var abiInvoke = (delegate* unmanaged[Stdcall]<%, int>)(delegateToInvoke.Vftbl.Invoke);",
+                    w.write("var abiInvoke = (delegate* stdcall<%, int>)(delegateToInvoke.Vftbl.Invoke);",
                         bind<write_abi_parameter_types>(signature));
                 }
             }),
@@ -4621,7 +4642,7 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             // DisposeAbi
             type_name,
             // Do_Abi_Invoke
-            !is_generic && !settings.netstandard_compat ? "\n[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
+            !is_generic && !settings.netstandard_compat ? "\n[UnmanagedCallersOnly]" : "",
             [&](writer& w) {
                 if (!is_generic)
                 {

--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -14,7 +14,6 @@ using System.Linq.Expressions;
 
 #pragma warning disable 0169 // The field 'xxx' is never used
 #pragma warning disable 0649 // Field 'xxx' is never assigned to, and will always have its default value
-#pragma warning disable CA1060
 
 namespace WinRT
 {
@@ -50,7 +49,7 @@ namespace WinRT
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool FreeLibrary(IntPtr moduleHandle);
 
-        [DllImport("kernel32.dll", SetLastError = true, BestFitMapping = false)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern IntPtr GetProcAddress(IntPtr moduleHandle, [MarshalAs(UnmanagedType.LPStr)] string functionName);
 
         internal static T GetProcAddress<T>(IntPtr moduleHandle)
@@ -317,13 +316,12 @@ namespace WinRT
         public static ObjectReference<I> ActivateInstance<I>() => _factory.Value._ActivateInstance<I>();
     }
 
-#pragma warning disable CA2002
     internal unsafe class EventSource<TDelegate>
         where TDelegate : class, MulticastDelegate
     {
         readonly IObjectReference _obj;
-        readonly delegate* unmanaged[Stdcall]<System.IntPtr, System.IntPtr, out WinRT.EventRegistrationToken, int> _addHandler;
-        readonly delegate* unmanaged[Stdcall]<System.IntPtr, WinRT.EventRegistrationToken, int> _removeHandler;
+        readonly delegate* stdcall<System.IntPtr, System.IntPtr, out WinRT.EventRegistrationToken, int> _addHandler;
+        readonly delegate* stdcall<System.IntPtr, WinRT.EventRegistrationToken, int> _removeHandler;
 
         private EventRegistrationToken _token;
         private TDelegate _event;
@@ -412,8 +410,8 @@ namespace WinRT
         }
 
         internal EventSource(IObjectReference obj,
-            delegate* unmanaged[Stdcall]<System.IntPtr, System.IntPtr, out WinRT.EventRegistrationToken, int> addHandler,
-            delegate* unmanaged[Stdcall]<System.IntPtr, WinRT.EventRegistrationToken, int> removeHandler)
+            delegate* stdcall<System.IntPtr, System.IntPtr, out WinRT.EventRegistrationToken, int> addHandler,
+            delegate* stdcall<System.IntPtr, WinRT.EventRegistrationToken, int> removeHandler)
         {
             _obj = obj;
             _addHandler = addHandler;
@@ -426,7 +424,6 @@ namespace WinRT
             _token.Value = 0;
         }
     }
-#pragma warning restore CA2002
 
     // An event registration token table stores mappings from delegates to event tokens, in order to support
     // sourcing WinRT style events from managed code.

--- a/cswinrt/strings/WinRT_Interop.cs
+++ b/cswinrt/strings/WinRT_Interop.cs
@@ -21,7 +21,7 @@ namespace WinRT.Interop
     {
         public IInspectable.Vftbl IInspectableVftbl;
         private void* _ActivateInstance;
-        public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> ActivateInstance => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_ActivateInstance;
+        public delegate* stdcall<IntPtr, IntPtr*, int> ActivateInstance => (delegate* stdcall<IntPtr, IntPtr*, int>)_ActivateInstance;
     }
 
     // IDelegate

--- a/cswinrt/strings/additions/Windows.Storage/IStorageFolderHandleAccess.cs
+++ b/cswinrt/strings/additions/Windows.Storage/IStorageFolderHandleAccess.cs
@@ -32,7 +32,7 @@ namespace ABI.Windows.Storage
         {
             public IUnknownVftbl IUnknownVftbl;
             private void* _Create_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::Windows.Storage.HANDLE_CREATION_OPTIONS, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int> Create_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::Windows.Storage.HANDLE_CREATION_OPTIONS, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int>)_Create_0;
+            public delegate* stdcall<IntPtr, IntPtr, global::Windows.Storage.HANDLE_CREATION_OPTIONS, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int> Create_0 => (delegate* stdcall<IntPtr, IntPtr, global::Windows.Storage.HANDLE_CREATION_OPTIONS, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int>)_Create_0;
         }
 
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/cswinrt/strings/additions/Windows.Storage/IStorageItemHandleAccess.cs
+++ b/cswinrt/strings/additions/Windows.Storage/IStorageItemHandleAccess.cs
@@ -28,7 +28,7 @@ namespace ABI.Windows.Storage
         {
             public IUnknownVftbl IUnknownVftbl;
             private void* _Create_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int> Create_0 => (delegate* unmanaged[Stdcall]<IntPtr, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int>)_Create_0;
+            public delegate* stdcall<IntPtr, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int> Create_0 => (delegate* stdcall<IntPtr, global::Windows.Storage.HANDLE_ACCESS_OPTIONS, global::Windows.Storage.HANDLE_SHARING_OPTIONS, global::Windows.Storage.HANDLE_OPTIONS, IntPtr, out IntPtr, int>)_Create_0;
         }
 
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);

--- a/cswinrt/type_writers.h
+++ b/cswinrt/type_writers.h
@@ -36,7 +36,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
 using WinRT.Interop;
@@ -44,7 +43,6 @@ using WinRT.Interop;
 
 #pragma warning disable 0169 // warning CS0169: The field '...' is never used
 #pragma warning disable 0649 // warning CS0169: Field '...' is never assigned to
-#pragma warning disable CA2207, CA1063, CA1033, CA1001, CA2213
 
 namespace %
 {


### PR DESCRIPTION
Need to put this on the backburner until VS 16.8 is deployed to Azure Devops agents (December, 2020)