### PR TITLE
Add fallback loop for projected app types

### DIFF
--- a/WinRT.Runtime/TypeNameSupport.cs
+++ b/WinRT.Runtime/TypeNameSupport.cs
@@ -84,6 +84,19 @@ namespace WinRT
                 }
             }
 
+            if (resolvedType is null)
+            { 
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    Type type = assembly.GetType(runtimeClassName);
+                    if (type is object)
+                    {
+                        resolvedType = type;
+                        break;
+                    }
+                }
+            }
+
             if (resolvedType is object)
             {
                 if (genericTypes != null)


### PR DESCRIPTION
This PR adds back a loop to resolve projected XAML types. The loop only goes if we failed to resolve a type for the given runtime class name via `projectionAssemblies`. This failure to resolve a type has been causing problems with XAML apps, and this should prevent them from needing to explicitly register projection assemblies. 

The related issue: https://github.com/microsoft/CsWinRT/issues/465