### PR TITLE
Fixing scenarios where default interface isn't passed for custom projections and perf improvements

### DIFF
--- a/Projections/Test/TestHost.ProbeByHost.cs
+++ b/Projections/Test/TestHost.ProbeByHost.cs
@@ -54,7 +54,7 @@ namespace ABI.Windows.Foundation
                 try
                 {
                     __instance = global::WinRT.ComWrappersSupport.FindObject<global::Windows.Foundation.IActivationFactory>(thisPtr).ActivateInstance();
-                    instance = MarshalInspectable.FromManaged(__instance);
+                    instance = MarshalInspectable<object>.FromManaged(__instance);
                 }
                 catch (Exception __exception__)
                 {
@@ -84,11 +84,11 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.ActivateInstance_0(ThisPtr, out __retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }
@@ -123,7 +123,7 @@ namespace WinRT
                     if (ctor != null)
                     {
                         var factory = new WinRT.Host.ActivationFactory(ctor);
-                        return MarshalInspectable.FromManaged(factory);
+                        return MarshalInspectable<WinRT.Host.ActivationFactory>.FromManaged(factory);
                     }
                 }
             }

--- a/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
+++ b/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
@@ -54,7 +54,7 @@ namespace ABI.Windows.Foundation
                 try
                 {
                     __instance = global::WinRT.ComWrappersSupport.FindObject<global::Windows.Foundation.IActivationFactory>(thisPtr).ActivateInstance();
-                    instance = MarshalInspectable.FromManaged(__instance);
+                    instance = MarshalInspectable<object>.FromManaged(__instance);
                 }
                 catch (Exception __exception__)
                 {
@@ -84,11 +84,11 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.ActivateInstance_0(ThisPtr, out __retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }
@@ -123,7 +123,7 @@ namespace WinRT
                     if (ctor != null)
                     {
                         var factory = new WinRT.Host.ActivationFactory(ctor);
-                        return MarshalInspectable.FromManaged(factory);
+                        return MarshalInspectable<WinRT.Host.ActivationFactory>.FromManaged(factory);
                     }
                 }
             }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -22,6 +22,8 @@ using System.Collections;
 using WinRT.Interop;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Security.Cryptography;
+using Windows.Security.Cryptography.Core;
 
 namespace UnitTest
 {
@@ -1780,6 +1782,16 @@ namespace UnitTest
             TestObject.CopyProperties(nativeProperties);
 
             Assert.Equal(TestObject.ReadWriteProperty, nativeProperties.ReadWriteProperty);
+        }
+
+        [Fact]
+        public void TestNonProjectedRuntimeClass()
+        {
+            string key = ".....";
+            IBuffer keyMaterial = CryptographicBuffer.ConvertStringToBinary(key, BinaryStringEncoding.Utf8);
+            MacAlgorithmProvider mac = MacAlgorithmProvider.OpenAlgorithm(MacAlgorithmNames.HmacSha1);
+            CryptographicKey cryptoKey = mac.CreateKey(keyMaterial);
+            Assert.NotNull(cryptoKey);
         }
     }
 }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -87,9 +87,13 @@ namespace UnitTest
                 (object sender, Uri value) => Assert.Equal(managedUri, value);
             TestObject.RaiseUriChanged();
 
-            var uri2 = MarshalInspectable.FromAbi(ABI.System.Uri.FromManaged(managedUri));
+            var uri2 = MarshalInspectable<System.Uri>.FromAbi(ABI.System.Uri.FromManaged(managedUri));
             var str2 = uri2.ToString();
             Assert.Equal(full_uri, str2);
+
+            var uri3 = MarshalInspectable<object>.FromAbi(ABI.System.Uri.FromManaged(managedUri));
+            var str3 = uri3.ToString();
+            Assert.Equal(full_uri, str3);
         }
 
         [Fact]
@@ -1615,9 +1619,13 @@ namespace UnitTest
         [Fact]
         public void TestUnwrapInspectable()
         {
-            using var objRef = MarshalInspectable.CreateMarshaler(TestObject);
+            using var objRef = MarshalInspectable<object>.CreateMarshaler(TestObject);
             var inspectable = IInspectable.FromAbi(objRef.ThisPtr);
             Assert.True(ComWrappersSupport.TryUnwrapObject(inspectable, out _));
+
+            using var objRef2 = MarshalInspectable<Class>.CreateMarshaler(TestObject);
+            var inspectable2 = IInspectable.FromAbi(objRef2.ThisPtr);
+            Assert.True(ComWrappersSupport.TryUnwrapObject(inspectable2, out _));
         }
 
         [Fact]

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -1784,6 +1784,7 @@ namespace UnitTest
             Assert.Equal(TestObject.ReadWriteProperty, nativeProperties.ReadWriteProperty);
         }
 
+        // Test scenario where type reported by runtimeclass name is not a valid type (i.e. internal type).
         [Fact]
         public void TestNonProjectedRuntimeClass()
         {

--- a/WinRT.Runtime/AgileReference.cs
+++ b/WinRT.Runtime/AgileReference.cs
@@ -103,7 +103,7 @@ namespace WinRT
         public new T Get() 
         {
             using var objRef = base.Get();
-            return (T) ComWrappersSupport.CreateRcwForComObject(objRef?.ThisPtr ?? IntPtr.Zero);
+            return ComWrappersSupport.CreateRcwForComObject<T>(objRef?.ThisPtr ?? IntPtr.Zero);
         }
     }
 }

--- a/WinRT.Runtime/CastExtensions.cs
+++ b/WinRT.Runtime/CastExtensions.cs
@@ -30,7 +30,7 @@ namespace WinRT
                 {
                     using (objRef)
                     {
-                        return (TInterface)ComWrappersSupport.CreateRcwForComObject(objRef.ThisPtr);
+                        return ComWrappersSupport.CreateRcwForComObject<TInterface>(objRef.ThisPtr);
                     }
                 }
             }

--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -347,7 +347,7 @@ namespace WinRT
             string runtimeClassName = inspectable.GetRuntimeClassName(noThrow: true);
             if (staticallyDeterminedType != null && staticallyDeterminedType != typeof(object))
             {
-                // We have a static type which we can use to construct the object.  But, we can't just it for all scenarios
+                // We have a static type which we can use to construct the object.  But, we can't just use it for all scenarios
                 // and primarily use it for tear off scenarios and for scenarios where runtimeclass isn't accurate.
                 // For instance if the static type is an interface, we return an IInspectable to represent the interface.
                 // But it isn't convertable back to the class via the as operator which would be possible if we use runtimeclass.

--- a/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -79,15 +79,6 @@ namespace WinRT
                 ABI.System.Nullable<Type> nt => (T)(object) nt.Value,
                 _ => (T) rcw
             };
-
-/*            if ((typeof(T) == typeof(string) || typeof(T) == typeof(Type)) && rcw is ABI.System.Nullable<T> ns)
-            {
-                return ns.Value;
-            }
-            else
-            {
-                return (T)rcw;
-            }*/
         }
 
         public static void RegisterObjectForInterface(object obj, IntPtr thisPtr) => TryRegisterObjectForInterface(obj, thisPtr);
@@ -228,20 +219,12 @@ namespace WinRT
             {
                 IInspectable inspectable = new IInspectable(inspectableRef);
 
-                string runtimeClassName;
-                if(ComWrappersSupport.CreateRCWType.Value != null)
+                string runtimeClassName = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType.Value);
+                if (runtimeClassName == null)
                 {
-                    runtimeClassName = TypeNameSupport.GetNameForType(ComWrappersSupport.CreateRCWType.Value, TypeNameGenerationFlags.GenerateBoxedName);
-                }
-                else
-                {
-                    runtimeClassName = inspectable.GetRuntimeClassName(noThrow: true);
-                    if (runtimeClassName == null)
-                    {
-                        // If the external IInspectable has not implemented GetRuntimeClassName,
-                        // we use the Inspectable wrapper directly.
-                        return inspectable;
-                    }
+                    // If the external IInspectable has not implemented GetRuntimeClassName,
+                    // we use the Inspectable wrapper directly.
+                    return inspectable;
                 }
                 return ComWrappersSupport.GetTypedRcwFactory(runtimeClassName)(inspectable);
             }

--- a/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -59,10 +59,11 @@ namespace WinRT
                 return default;
             }
 
-            if (typeof(T) != typeof(object))
-            {
-                CreateRCWType.Value = typeof(T);
-            }
+            // CreateRCWType is a thread local which is set here to communicate the statically known type
+            // when we are called by the ComWrappers API to create the object.  We can't pass this through the
+            // ComWrappers API surface, so we are achieving it via a thread local.  We unset it after in case
+            // there is other calls to it via other means.
+            CreateRCWType.Value = typeof(T);
             var rcw = ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.TrackerObject);
             CreateRCWType.Value = null;
             // Because .NET will de-duplicate strings and WinRT doesn't,

--- a/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -18,11 +18,11 @@ namespace WinRT
 
         internal static InspectableInfo GetInspectableInfo(IntPtr pThis) => UnmanagedObject.FindObject<ComCallableWrapper>(pThis).InspectableInfo;
 
-        public static object CreateRcwForComObject(IntPtr ptr)
+        public static T CreateRcwForComObject<T>(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
             {
-                return null;
+                return default;
             }
 
             IObjectReference identity = GetObjectReferenceForInterface(ptr).As<IUnknownVftbl>();
@@ -35,7 +35,7 @@ namespace WinRT
                 if (identity.TryAs<IInspectable.Vftbl>(out var inspectableRef) == 0)
                 {
                     var inspectable = new IInspectable(identity);
-                    string runtimeClassName = inspectable.GetRuntimeClassName();
+                    string runtimeClassName = typeof(T) != typeof(object) ? typeof(T).FullName : inspectable.GetRuntimeClassName();
                     runtimeWrapper = TypedObjectFactoryCache.GetOrAdd(runtimeClassName, className => CreateTypedRcwFactory(className))(inspectable);
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)
@@ -69,12 +69,14 @@ namespace WinRT
             // and consumers get a string object for a Windows.Foundation.IReference<String>.
             // We need to do the same thing for System.Type because there can be multiple MUX.Interop.TypeName's
             // for a single System.Type.
-            return rcw switch
+            if ((typeof(T) == typeof(string) || typeof(T) == typeof(Type)) && rcw is ABI.System.Nullable<T> ns)
             {
-                ABI.System.Nullable<string> ns => ns.Value,
-                ABI.System.Nullable<Type> nt => nt.Value,
-                _ => rcw
-            };
+                return ns.Value;
+            }
+            else
+            {
+                return (T)rcw;
+            }
         }
     
         public static void RegisterObjectForInterface(object obj, IntPtr thisPtr)

--- a/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -103,7 +103,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(ptr);
+                MarshalInspectable<object>.DisposeAbi(ptr);
             }
         }
     }
@@ -187,7 +187,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(ptr);
+                MarshalInspectable<object>.DisposeAbi(ptr);
             }
         }
     }

--- a/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
+++ b/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
@@ -106,7 +106,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(ptr);
+                MarshalInspectable<object>.DisposeAbi(ptr);
             }
         }
     }
@@ -201,7 +201,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(ptr);
+                MarshalInspectable<object>.DisposeAbi(ptr);
             }
         }
     }

--- a/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -109,7 +109,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(objRef);
+                MarshalInspectable<object>.DisposeAbi(objRef);
             }
         }
     }

--- a/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
+++ b/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
@@ -123,7 +123,7 @@ namespace ABI.WinRT.Interop
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(objRef);
+                MarshalInspectable<object>.DisposeAbi(objRef);
             }
         }
     }

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -810,7 +810,7 @@ namespace WinRT
                 return (T)(object)null;
             }
 
-            object primaryManagedWrapper = MarshalInspectable.FromAbi(ptr);
+            object primaryManagedWrapper = MarshalInspectable<T>.FromAbi(ptr);
 
             if (primaryManagedWrapper is T obj)
             {
@@ -856,7 +856,7 @@ namespace WinRT
                 _As = BindAs();
             }
 
-            var inspectable = MarshalInspectable.CreateMarshaler(value, true);
+            var inspectable = MarshalInspectable<T>.CreateMarshaler(value, true);
 
             return _As(inspectable);
         }
@@ -930,9 +930,9 @@ namespace WinRT
         }
     }
 
-    static public class MarshalInspectable
+    static public class MarshalInspectable<T>
     {
-        public static IObjectReference CreateMarshaler(object o, bool unwrapObject = true)
+        public static IObjectReference CreateMarshaler(T o, bool unwrapObject = true)
         {
             if (o is null)
             {
@@ -944,69 +944,69 @@ namespace WinRT
                 return objRef.As<IInspectable.Vftbl>();
             }
             using (var ccw = ComWrappersSupport.CreateCCWForObject(ComWrappersSupport.GetRuntimeClassCCWTypeIfAny(o)))
-            { 
+            {
                 return ccw.As<IInspectable.Vftbl>();
             }
         }
 
-        public static IntPtr GetAbi(IObjectReference objRef) => 
-            objRef is null ? IntPtr.Zero : MarshalInterfaceHelper<object>.GetAbi(objRef);
+        public static IntPtr GetAbi(IObjectReference objRef) =>
+            objRef is null ? IntPtr.Zero : MarshalInterfaceHelper<T>.GetAbi(objRef);
 
-        public static object FromAbi(IntPtr ptr)
+        public static T FromAbi(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
             {
-                return (object)null;
+                return default;
             }
             using var objRef = ObjectReference<IUnknownVftbl>.FromAbi(ptr);
             using var unknownObjRef = objRef.As<IUnknownVftbl>();
             if (unknownObjRef.IsReferenceToManagedObject)
             {
-                return ComWrappersSupport.FindObject<object>(unknownObjRef.ThisPtr);
+                return (T) ComWrappersSupport.FindObject<object>(unknownObjRef.ThisPtr);
             }
-            else if (Projections.TryGetMarshalerTypeForProjectedRuntimeClass(objRef, out Type type))
+            else if (Projections.TryGetMarshalerTypeForProjectedRuntimeClass<T>(objRef, out Type type))
             {
                 var fromAbiMethod = type.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
                 if (fromAbiMethod is null)
                 {
                     throw new MissingMethodException();
                 }
-                return fromAbiMethod.Invoke(null, new object[] { ptr });
+                return (T) fromAbiMethod.Invoke(null, new object[] { ptr });
             }
             else
             {
-                return ComWrappersSupport.CreateRcwForComObject(ptr);
+                return ComWrappersSupport.CreateRcwForComObject<T>(ptr);
             }
         }
 
-        public static void DisposeMarshaler(IObjectReference objRef) => MarshalInterfaceHelper<object>.DisposeMarshaler(objRef);
+        public static void DisposeMarshaler(IObjectReference objRef) => MarshalInterfaceHelper<T>.DisposeMarshaler(objRef);
 
-        public static void DisposeAbi(IntPtr ptr) => MarshalInterfaceHelper<object>.DisposeAbi(ptr);
-        public static IntPtr FromManaged(object o, bool unwrapObject = true)
+        public static void DisposeAbi(IntPtr ptr) => MarshalInterfaceHelper<T>.DisposeAbi(ptr);
+        public static IntPtr FromManaged(T o, bool unwrapObject = true)
         {
             var objRef = CreateMarshaler(o, unwrapObject);
             return objRef?.GetRef() ?? IntPtr.Zero;
         }
 
-        public static unsafe void CopyManaged(object o, IntPtr dest, bool unwrapObject = true)
+        public static unsafe void CopyManaged(T o, IntPtr dest, bool unwrapObject = true)
         {
             var objRef = CreateMarshaler(o, unwrapObject);
             *(IntPtr*)dest.ToPointer() = objRef?.GetRef() ?? IntPtr.Zero;
         }
 
-        public static unsafe MarshalInterfaceHelper<object>.MarshalerArray CreateMarshalerArray(object[] array) => MarshalInterfaceHelper<object>.CreateMarshalerArray(array, (o) => CreateMarshaler(o));
+        public static unsafe MarshalInterfaceHelper<T>.MarshalerArray CreateMarshalerArray(T[] array) => MarshalInterfaceHelper<T>.CreateMarshalerArray(array, (o) => CreateMarshaler(o));
 
-        public static (int length, IntPtr data) GetAbiArray(object box) => MarshalInterfaceHelper<object>.GetAbiArray(box);
+        public static (int length, IntPtr data) GetAbiArray(T box) => MarshalInterfaceHelper<T>.GetAbiArray(box);
 
-        public static unsafe object[] FromAbiArray(object box) => MarshalInterfaceHelper<object>.FromAbiArray(box, FromAbi);
+        public static unsafe T[] FromAbiArray(T box) => MarshalInterfaceHelper<T>.FromAbiArray(box, FromAbi);
 
-        public static unsafe (int length, IntPtr data) FromManagedArray(object[] array) => MarshalInterfaceHelper<object>.FromManagedArray(array, (o) => FromManaged(o));
+        public static unsafe (int length, IntPtr data) FromManagedArray(T[] array) => MarshalInterfaceHelper<T>.FromManagedArray(array, (o) => FromManaged(o));
 
-        public static unsafe void CopyManagedArray(object[] array, IntPtr data) => MarshalInterfaceHelper<object>.CopyManagedArray(array, data, (o, dest) => CopyManaged(o, dest));
+        public static unsafe void CopyManagedArray(T[] array, IntPtr data) => MarshalInterfaceHelper<T>.CopyManagedArray(array, data, (o, dest) => CopyManaged(o, dest));
 
-        public static void DisposeMarshalerArray(object box) => MarshalInterfaceHelper<object>.DisposeMarshalerArray(box);
+        public static void DisposeMarshalerArray(T box) => MarshalInterfaceHelper<T>.DisposeMarshalerArray(box);
 
-        public static unsafe void DisposeAbiArray(object box) => MarshalInterfaceHelper<object>.DisposeAbiArray(box);
+        public static unsafe void DisposeAbiArray(T box) => MarshalInterfaceHelper<T>.DisposeAbiArray(box);
     }
 
     public class Marshaler<T>
@@ -1103,7 +1103,7 @@ namespace WinRT
                 AbiType = typeof(IntPtr);
                 CreateMarshaler = (T value) => MarshalInterface<T>.CreateMarshaler(value);
                 GetAbi = (object objRef) => MarshalInterface<T>.GetAbi((IObjectReference)objRef);
-                FromAbi = (object value) => (T)(object)MarshalInterface<T>.FromAbi((IntPtr)value);
+                FromAbi = (object value) => MarshalInterface<T>.FromAbi((IntPtr)value);
                 FromManaged = (T value) => ((IObjectReference)CreateMarshaler(value)).GetRef();
                 DisposeMarshaler = (object objRef) => MarshalInterface<T>.DisposeMarshaler((IObjectReference)objRef);
                 DisposeAbi = (object box) => MarshalInterface<T>.DisposeAbi((IntPtr)box);
@@ -1111,13 +1111,13 @@ namespace WinRT
             else if (typeof(T) == typeof(object))
             {
                 AbiType = typeof(IntPtr);
-                CreateMarshaler = (T value) => MarshalInspectable.CreateMarshaler(value);
-                GetAbi = (object objRef) => MarshalInspectable.GetAbi((IObjectReference)objRef);
-                FromAbi = (object box) => (T)MarshalInspectable.FromAbi((IntPtr)box);
-                FromManaged = (T value) => MarshalInspectable.FromManaged(value);
-                CopyManaged = (T value, IntPtr dest) => MarshalInspectable.CopyManaged(value, dest);
-                DisposeMarshaler = (object objRef) => MarshalInspectable.DisposeMarshaler((IObjectReference)objRef);
-                DisposeAbi = (object box) => MarshalInspectable.DisposeAbi((IntPtr)box);
+                CreateMarshaler = (T value) => MarshalInspectable<T>.CreateMarshaler(value);
+                GetAbi = (object objRef) => MarshalInspectable<T>.GetAbi((IObjectReference)objRef);
+                FromAbi = (object box) => MarshalInspectable<T>.FromAbi((IntPtr)box);
+                FromManaged = (T value) => MarshalInspectable<T>.FromManaged(value);
+                CopyManaged = (T value, IntPtr dest) => MarshalInspectable<T>.CopyManaged(value, dest);
+                DisposeMarshaler = (object objRef) => MarshalInspectable<T>.DisposeMarshaler((IObjectReference)objRef);
+                DisposeAbi = (object box) => MarshalInspectable<T>.DisposeAbi((IntPtr)box);
             }
             else // delegate, class 
             {

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -810,23 +810,7 @@ namespace WinRT
                 return (T)(object)null;
             }
 
-            object primaryManagedWrapper = MarshalInspectable<T>.FromAbi(ptr);
-
-            if (primaryManagedWrapper is T obj)
-            {
-                return obj;
-            }
-#if !NETSTANDARD2_0
-            return (T)(object)IInspectable.FromAbi(ptr);
-#else
-            // If the metadata type doesn't implement the interface, then create a tear-off RCW.
-            // TODO: Uniqueness of tear-offs?
-            if (_FromAbi == null)
-            {
-                _FromAbi = BindFromAbi();
-            }
-            return _FromAbi(ptr);
-#endif
+            return MarshalInspectable<T>.FromAbi(ptr);
         }
 
         public static IObjectReference CreateMarshaler(T value)

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -19,6 +19,7 @@ namespace WinRT
         private static readonly Dictionary<string, Type> CustomAbiTypeNameToTypeMappings = new Dictionary<string, Type>();
         private static readonly Dictionary<Type, string> CustomTypeToAbiTypeNameMappings = new Dictionary<Type, string>();
         private static readonly HashSet<string> ProjectedRuntimeClassNames = new HashSet<string>();
+        private static readonly HashSet<Type> ProjectedCustomTypeRuntimeClasses = new HashSet<Type>();
 
         static Projections()
         {
@@ -94,14 +95,20 @@ namespace WinRT
             if (isRuntimeClass)
             {
                 ProjectedRuntimeClassNames.Add(winrtTypeName);
+                ProjectedCustomTypeRuntimeClasses.Add(publicType);
             }
         }
 
-        public static Type FindCustomHelperTypeMapping(Type publicType)
+        public static Type FindCustomHelperTypeMapping(Type publicType, bool filterToRuntimeClass = false)
         {
             rwlock.EnterReadLock();
             try
             {
+                if(filterToRuntimeClass && !ProjectedCustomTypeRuntimeClasses.Contains(publicType))
+                {
+                    return null;
+                }
+
                 if (publicType.IsGenericType)
                 {
                     return CustomTypeToHelperTypeMappings.TryGetValue(publicType.GetGenericTypeDefinition(), out Type abiTypeDefinition)
@@ -268,29 +275,38 @@ namespace WinRT
             return defaultInterface;
         }
 
-        internal static bool TryGetMarshalerTypeForProjectedRuntimeClass(IObjectReference objectReference, out Type type)
+        internal static bool TryGetMarshalerTypeForProjectedRuntimeClass<T>(IObjectReference objectReference, out Type type)
         {
-            if(objectReference.TryAs<IInspectable.Vftbl>(out var inspectablePtr) == 0)
+            Type projectedType = typeof(T);
+            if (projectedType == typeof(object))
             {
-                rwlock.EnterReadLock();
-                try
+                if (objectReference.TryAs<IInspectable.Vftbl>(out var inspectablePtr) == 0)
                 {
-                    IInspectable inspectable = inspectablePtr;
-                    string runtimeClassName = inspectable.GetRuntimeClassName(true);
-                    if (runtimeClassName is object)
+                    rwlock.EnterReadLock();
+                    try
                     {
-                        if (ProjectedRuntimeClassNames.Contains(runtimeClassName))
+                        IInspectable inspectable = inspectablePtr;
+                        string runtimeClassName = inspectable.GetRuntimeClassName(true);
+                        if (runtimeClassName is object)
                         {
-                            type = CustomTypeToHelperTypeMappings[CustomAbiTypeNameToTypeMappings[runtimeClassName]];
-                            return true;
+                            if (ProjectedRuntimeClassNames.Contains(runtimeClassName))
+                            {
+                                type = CustomTypeToHelperTypeMappings[CustomAbiTypeNameToTypeMappings[runtimeClassName]];
+                                return true;
+                            }
                         }
                     }
+                    finally
+                    {
+                        inspectablePtr.Dispose();
+                        rwlock.ExitReadLock();
+                    }
                 }
-                finally
-                {
-                    inspectablePtr.Dispose();
-                    rwlock.ExitReadLock();
-                }
+            }
+            else
+            {
+                type = FindCustomHelperTypeMapping(projectedType, true);
+                return type != null;
             }
             type = null;
             return false;

--- a/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -127,7 +127,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     __value = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableIterator>(thisPtr).Current;
-                    *value = MarshalInspectable.FromManaged(__value);
+                    *value = MarshalInspectable<object>.FromManaged(__value);
                 }
                 catch (Exception __exception__)
                 {
@@ -177,11 +177,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Current_0(ThisPtr, &__retval));
-                    return MarshalInspectable.FromAbi(__retval);
+                    return MarshalInspectable<object>.FromAbi(__retval);
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeAbi(__retval);
+                    MarshalInspectable<object>.DisposeAbi(__retval);
                 }
             }
         }
@@ -251,7 +251,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).GetAt(index);
-                    *result = MarshalInspectable.FromManaged(__result);
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -274,7 +274,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
                 try
                 {
-                    __returnValue = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).IndexOf(MarshalInspectable.FromAbi(value), out __index);
+                    __returnValue = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).IndexOf(MarshalInspectable<object>.FromAbi(value), out __index);
                     *index = __index;
                     *returnValue = (byte)(__returnValue ? 1 : 0);
 
@@ -322,11 +322,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
 
@@ -339,14 +339,14 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             byte __retval = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_2(ThisPtr, MarshalInspectable.GetAbi(__value), &__index, &__retval));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_2(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
                 index = __index;
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1026,7 +1026,7 @@ namespace ABI.System.Collections
                 try
                 {
                     __result = FindAdapter(thisPtr).GetAt(index);
-                    *result = MarshalInspectable.FromManaged(__result);
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -1066,7 +1066,7 @@ namespace ABI.System.Collections
                 uint __index = default;
                 try
                 {
-                    __returnValue = FindAdapter(thisPtr).IndexOf(MarshalInspectable.FromAbi(value), out __index);
+                    __returnValue = FindAdapter(thisPtr).IndexOf(MarshalInspectable<object>.FromAbi(value), out __index);
                     *index = __index;
                     *returnValue = (byte)(__returnValue ? 1 : 0);
                 }
@@ -1084,7 +1084,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).SetAt(index, MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).SetAt(index, MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1100,7 +1100,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).InsertAt(index, MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).InsertAt(index, MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1132,7 +1132,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).Append(MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).Append(MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1218,11 +1218,11 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
 
@@ -1251,14 +1251,14 @@ namespace ABI.System.Collections
             byte __retval = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_3(ThisPtr, MarshalInspectable.GetAbi(__value), &__index, &__retval));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_3(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
                 index = __index;
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1269,12 +1269,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.SetAt_4(ThisPtr, index, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.SetAt_4(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1285,12 +1285,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.InsertAt_5(ThisPtr, index, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.InsertAt_5(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1308,12 +1308,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Append_7(ThisPtr, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Append_7(ThisPtr, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 

--- a/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
@@ -118,7 +118,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     __value = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableIterator>(thisPtr).Current;
-                    *value = MarshalInspectable.FromManaged(__value);
+                    *value = MarshalInspectable<object>.FromManaged(__value);
                 }
                 catch (Exception __exception__)
                 {
@@ -174,11 +174,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Current_0(ThisPtr, &__retval));
-                    return MarshalInspectable.FromAbi(__retval);
+                    return MarshalInspectable<object>.FromAbi(__retval);
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeAbi(__retval);
+                    MarshalInspectable<object>.DisposeAbi(__retval);
                 }
             }
         }
@@ -246,7 +246,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).GetAt(index);
-                    *result = MarshalInspectable.FromManaged(__result);
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -267,7 +267,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
                 try
                 {
-                    __returnValue = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).IndexOf(MarshalInspectable.FromAbi(value), out __index);
+                    __returnValue = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>(thisPtr).IndexOf(MarshalInspectable<object>.FromAbi(value), out __index);
                     *index = __index;
                     *returnValue = (byte)(__returnValue ? 1 : 0);
 
@@ -322,11 +322,11 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
 
@@ -337,14 +337,14 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             byte __retval = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_2(ThisPtr, MarshalInspectable.GetAbi(__value), &__index, &__retval));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_2(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
                 index = __index;
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1028,7 +1028,7 @@ namespace ABI.System.Collections
                 try
                 {
                     __result = FindAdapter(thisPtr).GetAt(index);
-                    *result = MarshalInspectable.FromManaged(__result);
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -1064,7 +1064,7 @@ namespace ABI.System.Collections
                 uint __index = default;
                 try
                 {
-                    __returnValue = FindAdapter(thisPtr).IndexOf(MarshalInspectable.FromAbi(value), out __index);
+                    __returnValue = FindAdapter(thisPtr).IndexOf(MarshalInspectable<object>.FromAbi(value), out __index);
                     *index = __index;
                     *returnValue = (byte)(__returnValue ? 1 : 0);
                 }
@@ -1080,7 +1080,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).SetAt(index, MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).SetAt(index, MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1094,7 +1094,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).InsertAt(index, MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).InsertAt(index, MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1122,7 +1122,7 @@ namespace ABI.System.Collections
             {
                 try
                 {
-                    FindAdapter(thisPtr).Append(MarshalInspectable.FromAbi(value));
+                    FindAdapter(thisPtr).Append(MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -1208,11 +1208,11 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
 
@@ -1237,14 +1237,14 @@ namespace ABI.System.Collections
             byte __retval = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_3(ThisPtr, MarshalInspectable.GetAbi(__value), &__index, &__retval));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_3(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
                 index = __index;
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1253,12 +1253,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.SetAt_4(ThisPtr, index, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.SetAt_4(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1267,12 +1267,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.InsertAt_5(ThisPtr, index, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.InsertAt_5(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 
@@ -1286,12 +1286,12 @@ namespace ABI.System.Collections
             IObjectReference __value = default;
             try
             {
-                __value = MarshalInspectable.CreateMarshaler(value);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Append_7(ThisPtr, MarshalInspectable.GetAbi(__value)));
+                __value = MarshalInspectable<object>.CreateMarshaler(value);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Append_7(ThisPtr, MarshalInspectable<object>.GetAbi(__value)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__value);
+                MarshalInspectable<object>.DisposeMarshaler(__value);
             }
         }
 

--- a/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -62,7 +62,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             finally
             {
                 MarshalString.DisposeMarshaler(__name);
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }

--- a/WinRT.Runtime/Projections/EventHandler.cs
+++ b/WinRT.Runtime/Projections/EventHandler.cs
@@ -77,15 +77,15 @@ namespace ABI.System
                 var __params = new object[] { ThisPtr, null, null };
                 try
                 {
-                    __sender = MarshalInspectable.CreateMarshaler(sender);
-                    __params[1] = MarshalInspectable.GetAbi(__sender);
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
+                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
                     __args = Marshaler<T>.CreateMarshaler(args);
                     __params[2] = Marshaler<T>.GetAbi(__args);
                     abiInvoke.DynamicInvokeAbi(__params);
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeMarshaler(__sender);
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
                     Marshaler<T>.DisposeMarshaler(__args);
                 }
 
@@ -105,7 +105,7 @@ namespace ABI.System
             {
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(new IntPtr(thisPtr), (global::System.Delegate invoke) =>
                 {
-                    invoke.DynamicInvoke(MarshalInspectable.FromAbi(sender), Marshaler<T>.FromAbi(args));
+                    invoke.DynamicInvoke(MarshalInspectable<object>.FromAbi(sender), Marshaler<T>.FromAbi(args));
                 });
             }
             catch (global::System.Exception __exception__)

--- a/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -76,16 +76,16 @@ namespace ABI.System.Windows.Input
                 var __params = new object[] { ThisPtr, null, null };
                 try
                 {
-                    __sender = MarshalInspectable.CreateMarshaler(sender);
-                    __params[1] = MarshalInspectable.GetAbi(__sender);
-                    __args = MarshalInspectable.CreateMarshaler(args);
-                    __params[2] = MarshalInspectable.GetAbi(__args);
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
+                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
+                    __args = MarshalInspectable<EventArgs>.CreateMarshaler(args);
+                    __params[2] = MarshalInspectable<EventArgs>.GetAbi(__args);
                     abiInvoke.DynamicInvokeAbi(__params);
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeMarshaler(__sender);
-                    MarshalInspectable.DisposeMarshaler(__args);
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
+                    MarshalInspectable<EventArgs>.DisposeMarshaler(__args);
                 }
 
             }
@@ -105,8 +105,8 @@ namespace ABI.System.Windows.Input
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
                 {
                     invoke.DynamicInvoke(
-                        MarshalInspectable.FromAbi(sender),
-                        MarshalInspectable.FromAbi(args) as EventArgs ?? EventArgs.Empty);
+                        MarshalInspectable<object>.FromAbi(sender),
+                        MarshalInspectable<EventArgs>.FromAbi(args) ?? EventArgs.Empty);
                 });
             }
             catch (global::System.Exception __exception__)
@@ -187,7 +187,7 @@ namespace ABI.System.Windows.Input
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).CanExecute(MarshalInspectable.FromAbi(parameter)); *result = (byte)(__result ? 1 : 0);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).CanExecute(MarshalInspectable<object>.FromAbi(parameter)); *result = (byte)(__result ? 1 : 0);
 
                 }
                 catch (global::System.Exception __exception__)
@@ -205,7 +205,7 @@ namespace ABI.System.Windows.Input
             {
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).Execute(MarshalInspectable.FromAbi(parameter));
+                    global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).Execute(MarshalInspectable<object>.FromAbi(parameter));
                 }
                 catch (global::System.Exception __exception__)
                 {
@@ -275,13 +275,13 @@ namespace ABI.System.Windows.Input
             {
                 var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle));
                 var ThisPtr = _obj.ThisPtr;
-                __parameter = MarshalInspectable.CreateMarshaler(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable.GetAbi(__parameter), out __retval));
+                __parameter = MarshalInspectable<object>.CreateMarshaler(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), out __retval));
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__parameter);
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
             }
         }
 
@@ -292,12 +292,12 @@ namespace ABI.System.Windows.Input
             IObjectReference __parameter = default;
             try
             {
-                __parameter = MarshalInspectable.CreateMarshaler(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable.GetAbi(__parameter)));
+                __parameter = MarshalInspectable<object>.CreateMarshaler(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__parameter);
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
             }
         }
 

--- a/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
@@ -76,16 +76,16 @@ namespace ABI.System.Windows.Input
                 var __params = new object[] { ThisPtr, null, null };
                 try
                 {
-                    __sender = MarshalInspectable.CreateMarshaler(sender);
-                    __params[1] = MarshalInspectable.GetAbi(__sender);
-                    __args = MarshalInspectable.CreateMarshaler(args);
-                    __params[2] = MarshalInspectable.GetAbi(__args);
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
+                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
+                    __args = MarshalInspectable<EventArgs>.CreateMarshaler(args);
+                    __params[2] = MarshalInspectable<EventArgs>.GetAbi(__args);
                     abiInvoke.DynamicInvokeAbi(__params);
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeMarshaler(__sender);
-                    MarshalInspectable.DisposeMarshaler(__args);
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
+                    MarshalInspectable<EventArgs>.DisposeMarshaler(__args);
                 }
 
             }
@@ -105,8 +105,8 @@ namespace ABI.System.Windows.Input
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
                 {
                     invoke.DynamicInvoke(
-                        MarshalInspectable.FromAbi(sender),
-                        MarshalInspectable.FromAbi(args) as EventArgs ?? EventArgs.Empty);
+                        MarshalInspectable<object>.FromAbi(sender),
+                        MarshalInspectable<EventArgs>.FromAbi(args) ?? EventArgs.Empty);
                 });
             }
             catch (global::System.Exception __exception__)
@@ -185,7 +185,7 @@ namespace ABI.System.Windows.Input
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).CanExecute(MarshalInspectable.FromAbi(parameter)); *result = (byte)(__result ? 1 : 0);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).CanExecute(MarshalInspectable<object>.FromAbi(parameter)); *result = (byte)(__result ? 1 : 0);
 
                 }
                 catch (global::System.Exception __exception__)
@@ -201,7 +201,7 @@ namespace ABI.System.Windows.Input
             {
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).Execute(MarshalInspectable.FromAbi(parameter));
+                    global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr).Execute(MarshalInspectable<object>.FromAbi(parameter));
                 }
                 catch (global::System.Exception __exception__)
                 {
@@ -275,13 +275,13 @@ namespace ABI.System.Windows.Input
             byte __retval = default;
             try
             {
-                __parameter = MarshalInspectable.CreateMarshaler(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable.GetAbi(__parameter), out __retval));
+                __parameter = MarshalInspectable<object>.CreateMarshaler(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), out __retval));
                 return __retval != 0;
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__parameter);
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
             }
         }
 
@@ -290,12 +290,12 @@ namespace ABI.System.Windows.Input
             IObjectReference __parameter = default;
             try
             {
-                __parameter = MarshalInspectable.CreateMarshaler(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable.GetAbi(__parameter)));
+                __parameter = MarshalInspectable<object>.CreateMarshaler(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
             }
             finally
             {
-                MarshalInspectable.DisposeMarshaler(__parameter);
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
             }
         }
 

--- a/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
+++ b/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
@@ -76,8 +76,8 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetValue(MarshalInspectable.FromAbi(target)); 
-                    *result = MarshalInspectable.FromManaged(__result);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetValue(MarshalInspectable<object>.FromAbi(target)); 
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -96,7 +96,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(value));
+                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -114,8 +114,8 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetIndexedValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(index)); 
-                    *result = MarshalInspectable.FromManaged(__result);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetIndexedValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(index)); 
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -134,7 +134,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetIndexedValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(value), MarshalInspectable.FromAbi(index));
+                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetIndexedValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(value), MarshalInspectable<object>.FromAbi(index));
                 }
                 catch (Exception __exception__)
                 {

--- a/WinRT.Runtime/Projections/ICustomPropertyProvider.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/ICustomPropertyProvider.netstandard2.0.cs
@@ -76,8 +76,8 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetValue(MarshalInspectable.FromAbi(target)); 
-                    *result = MarshalInspectable.FromManaged(__result);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetValue(MarshalInspectable<object>.FromAbi(target)); 
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -94,7 +94,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(value));
+                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(value));
                 }
                 catch (Exception __exception__)
                 {
@@ -110,8 +110,8 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetIndexedValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(index)); 
-                    *result = MarshalInspectable.FromManaged(__result);
+                    __result = global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).GetIndexedValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(index)); 
+                    *result = MarshalInspectable<object>.FromManaged(__result);
 
                 }
                 catch (Exception __exception__)
@@ -128,7 +128,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
 
                 try
                 {
-                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetIndexedValue(MarshalInspectable.FromAbi(target), MarshalInspectable.FromAbi(value), MarshalInspectable.FromAbi(index));
+                    global::WinRT.ComWrappersSupport.FindObject<global::Microsoft.UI.Xaml.Data.ICustomProperty>(thisPtr).SetIndexedValue(MarshalInspectable<object>.FromAbi(target), MarshalInspectable<object>.FromAbi(value), MarshalInspectable<object>.FromAbi(index));
                 }
                 catch (Exception __exception__)
                 {

--- a/WinRT.Runtime/Projections/IPropertyValue.net5.cs
+++ b/WinRT.Runtime/Projections/IPropertyValue.net5.cs
@@ -982,7 +982,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 __value = CoerceArray<object>(global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr));
-                (*__valueSize, *value) = MarshalInspectable.FromManagedArray(__value);
+                (*__valueSize, *value) = MarshalInspectable<object>.FromManagedArray(__value);
             }
             catch (global::System.Exception __exception__)
             {
@@ -1733,11 +1733,11 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInspectableArray_32(ThisPtr, out __value_length, out __value_data));
-                value = MarshalInspectable.FromAbiArray((__value_length, __value_data));
+                value = MarshalInspectable<object>.FromAbiArray((__value_length, __value_data));
             }
             finally
             {
-                MarshalInspectable.DisposeAbiArray((__value_length, __value_data));
+                MarshalInspectable<object>.DisposeAbiArray((__value_length, __value_data));
             }
         }
 

--- a/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
@@ -922,7 +922,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 __value = CoerceArray<object>(global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr));
-                (*__valueSize, *value) = MarshalInspectable.FromManagedArray(__value);
+                (*__valueSize, *value) = MarshalInspectable<object>.FromManagedArray(__value);
             }
             catch (global::System.Exception __exception__)
             {
@@ -1610,11 +1610,11 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInspectableArray_32(ThisPtr, out __value_length, out __value_data));
-                value = MarshalInspectable.FromAbiArray((__value_length, __value_data));
+                value = MarshalInspectable<object>.FromAbiArray((__value_length, __value_data));
             }
             finally
             {
-                MarshalInspectable.DisposeAbiArray((__value_length, __value_data));
+                MarshalInspectable<object>.DisposeAbiArray((__value_length, __value_data));
             }
         }
 

--- a/WinRT.Runtime/Projections/IServiceProvider.cs
+++ b/WinRT.Runtime/Projections/IServiceProvider.cs
@@ -57,7 +57,7 @@ namespace ABI.System
                 try
                 {
                     __result = global::WinRT.ComWrappersSupport.FindObject<global::System.IServiceProvider>(thisPtr).GetService(global::ABI.System.Type.FromAbi(type));
-                    *result = MarshalInspectable.FromManaged(__result);
+                    *result = MarshalInspectable<object>.FromManaged(__result);
                 }
                 catch (global::System.Exception __exception__)
                 {
@@ -89,12 +89,12 @@ namespace ABI.System
             {
                 __type = global::ABI.System.Type.CreateMarshaler(type);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetService_0(ThisPtr, global::ABI.System.Type.GetAbi(__type), &__retval));
-                return MarshalInspectable.FromAbi(__retval);
+                return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
             {
                 global::ABI.System.Type.DisposeMarshaler(__type);
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }

--- a/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -144,8 +144,8 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             {
                 __newItems = MarshalInterface<global::System.Collections.IList>.CreateMarshaler(newItems);
                 __oldItems = MarshalInterface<global::System.Collections.IList>.CreateMarshaler(oldItems);
-                __baseInterface = MarshalInspectable.CreateMarshaler(baseInterface);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstanceWithAllParameters_0(ThisPtr, action, MarshalInterface<global::System.Collections.IList>.GetAbi(__newItems), MarshalInterface<global::System.Collections.IList>.GetAbi(__oldItems), newIndex, oldIndex, MarshalInspectable.GetAbi(__baseInterface), out __innerInterface, out __retval));
+                __baseInterface = MarshalInspectable<object>.CreateMarshaler(baseInterface);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstanceWithAllParameters_0(ThisPtr, action, MarshalInterface<global::System.Collections.IList>.GetAbi(__newItems), MarshalInterface<global::System.Collections.IList>.GetAbi(__oldItems), newIndex, oldIndex, MarshalInspectable<object>.GetAbi(__baseInterface), out __innerInterface, out __retval));
                 innerInterface = ObjectReference<IUnknownVftbl>.FromAbi(__innerInterface);
                 return ObjectReference<IUnknownVftbl>.FromAbi(__retval);
             }
@@ -153,9 +153,9 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             {
                 MarshalInterface<global::System.Collections.IList>.DisposeMarshaler(__newItems);
                 MarshalInterface<global::System.Collections.IList>.DisposeMarshaler(__oldItems);
-                MarshalInspectable.DisposeMarshaler(__baseInterface);
-                MarshalInspectable.DisposeAbi(__innerInterface);
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeMarshaler(__baseInterface);
+                MarshalInspectable<object>.DisposeAbi(__innerInterface);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }

--- a/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -72,13 +72,13 @@ namespace ABI.System.Collections.Specialized
                 IObjectReference __e = default;
                 try
                 {
-                    __sender = MarshalInspectable.CreateMarshaler(sender);
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
                     __e = global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.CreateMarshaler(e);
-                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable.GetAbi(__sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.GetAbi(__e)));
+                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable<object>.GetAbi(__sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.GetAbi(__e)));
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeMarshaler(__sender);
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
                     global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.DisposeMarshaler(__e);
                 }
 
@@ -98,7 +98,7 @@ namespace ABI.System.Collections.Specialized
             {
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler invoke) =>
                 {
-                    invoke(MarshalInspectable.FromAbi(sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.FromAbi(e));
+                    invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.FromAbi(e));
                 });
             }
             catch (global::System.Exception __exception__)

--- a/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -53,17 +53,17 @@ namespace ABI.Microsoft.UI.Xaml.Data
             try
             {
                 __name = MarshalString.CreateMarshaler(name);
-                __baseInterface = MarshalInspectable.CreateMarshaler(baseInterface);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(__name), MarshalInspectable.GetAbi(__baseInterface), &__innerInterface, &__retval));
+                __baseInterface = MarshalInspectable<object>.CreateMarshaler(baseInterface);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(__name), MarshalInspectable<object>.GetAbi(__baseInterface), &__innerInterface, &__retval));
                 innerInterface = ObjectReference<IUnknownVftbl>.FromAbi(__innerInterface);
                 return ObjectReference<IUnknownVftbl>.Attach(ref __retval);
             }
             finally
             {
                 MarshalString.DisposeMarshaler(__name);
-                MarshalInspectable.DisposeMarshaler(__baseInterface);
-                MarshalInspectable.DisposeAbi(__innerInterface);
-                MarshalInspectable.DisposeAbi(__retval);
+                MarshalInspectable<object>.DisposeMarshaler(__baseInterface);
+                MarshalInspectable<object>.DisposeAbi(__innerInterface);
+                MarshalInspectable<object>.DisposeAbi(__retval);
             }
         }
     }

--- a/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -71,13 +71,13 @@ namespace ABI.System.ComponentModel
                 IObjectReference __e = default;
                 try
                 {
-                    __sender = MarshalInspectable.CreateMarshaler(sender);
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
                     __e = global::ABI.System.ComponentModel.PropertyChangedEventArgs.CreateMarshaler(e);
-                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable.GetAbi(__sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.GetAbi(__e)));
+                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable<object>.GetAbi(__sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.GetAbi(__e)));
                 }
                 finally
                 {
-                    MarshalInspectable.DisposeMarshaler(__sender);
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
                     global::ABI.System.ComponentModel.PropertyChangedEventArgs.DisposeMarshaler(__e);
                 }
 
@@ -99,7 +99,7 @@ namespace ABI.System.ComponentModel
             {
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.ComponentModel.PropertyChangedEventHandler invoke) =>
                 {
-                    invoke(MarshalInspectable.FromAbi(sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.FromAbi(e));
+                    invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.FromAbi(e));
                 });
             }
             catch (global::System.Exception __exception__)

--- a/WinRT.Runtime/Projections/Uri.cs
+++ b/WinRT.Runtime/Projections/Uri.cs
@@ -112,7 +112,7 @@ namespace ABI.System
                 return null;
             }
 
-            using var uri = ObjectReference<IUnknownVftbl>.FromAbi(ptr).As<ABI.Windows.Foundation.IUriRuntimeClassVftbl>();
+            using var uri = ObjectReference<ABI.Windows.Foundation.IUriRuntimeClassVftbl>.FromAbi(ptr);
             IntPtr rawUri = IntPtr.Zero;
             try
             {

--- a/WinRT.Runtime/WeakReference.cs
+++ b/WinRT.Runtime/WeakReference.cs
@@ -60,7 +60,7 @@ namespace WinRT
                 return null;
             }
             using var resolved = reference.Resolve(typeof(IUnknownVftbl).GUID);
-            return ComWrappersSupport.CreateRcwForComObject(resolved.ThisPtr);
+            return ComWrappersSupport.CreateRcwForComObject<object>(resolved.ThisPtr);
         }
     }
 }

--- a/cswinrt/strings/WinRT.cs
+++ b/cswinrt/strings/WinRT.cs
@@ -298,7 +298,7 @@ namespace WinRT
             }
             finally
             {
-                MarshalInspectable.DisposeAbi(instancePtr);
+                MarshalInspectable<object>.DisposeAbi(instancePtr);
             }
         }
 
@@ -320,8 +320,7 @@ namespace WinRT
         public IntPtr ActivateInstance()
         {
             T comp = new T();
-            using var marshaler = MarshalInspectable.CreateMarshaler(comp);
-            return marshaler.GetRef();
+            return MarshalInspectable<T>.FromManaged(comp);
         }
     }
 


### PR DESCRIPTION
- If the default interface wasn't passed for custom projections, like IStringable for URI, you can end up in crashes or unexpected results.  This PR addresses it by making MarshalInspectable generic and consulting the type information statically known from the caller to make a decision on whether to use the runtimeclass name reported by the object or the statically known type.
- If the statically known type is implemented by the runtimeclass, the runtimeclass is still used to allow conversion to class types which would otherwise be not possible.  But if it isn't or the runtimeclass name is not a valid type, the static type is used instead.
- As part of making MarshalInspectable generic and passing the type information to CreateObject, we are also able to reduce QIs for scenarios where the runtimeclass name is misreported like DataPackage / DataPackageView.
- Added a cache for the custom attributes retrieved when unwrapping objects as getting the custom attribute was found to be expensive and the result was going to be the same each for time for a specific type.  This can probably be further improved for .NET 5 as mentioned in the issue, but it got tricky with composable types, so putting this fix out for now.

Resolves #360 
Contributes to #437 