### PR TITLE
Fix comparison to IntPtr.Zero. 

### DIFF
--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -124,7 +124,7 @@ namespace WinRT
                         marshaler?.Dispose();
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }
@@ -442,7 +442,7 @@ namespace WinRT
                         Marshaler<T>.DisposeMarshaler(marshaler);
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }
@@ -624,7 +624,7 @@ namespace WinRT
                         DisposeMarshaler(marshaler);
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }


### PR DESCRIPTION
The current implementation is allowed by a Roslyn bug that's preserved for backcompat, but it doesn't work.

Discovered by WPF while they were taking in a new .NET SDK version.