### PR TITLE
Fix our auto generation target to not cause race with sourcelink and add sourcelink for winrt.runtime

### DIFF
--- a/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/WinRT.Runtime/WinRT.Runtime.csproj
@@ -40,5 +40,6 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -8,7 +8,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <CsWinRTMessageImportance Condition="'$(CsWinRTMessageImportance)' == ''">normal</CsWinRTMessageImportance>
     <CsWinRTCommandVerbosity Condition="'$(CsWinRTMessageImportance)' == 'high'">-verbose</CsWinRTCommandVerbosity>
-    <ResolveAssemblyReferencesDependsOn Condition="'$(CsWinRTRemoveWindowsReference)'!='false'">$(CsWinRTRemoveWindowsReference);CsWinRTRemoveWindowsReference</ResolveAssemblyReferencesDependsOn>
+    <ResolveAssemblyReferencesDependsOn Condition="'$(CsWinRTRemoveWindowsReference)'!='false'">$(ResolveAssemblyReferencesDependsOn);CsWinRTRemoveWindowsReference</ResolveAssemblyReferencesDependsOn>
     <CsWinRTEnabled Condition="'$(CsWinRTEnabled)' == ''">true</CsWinRTEnabled>
     <CsWinRTEnabled Condition="'$(CsWinRTEnabled)' != 'true'">false</CsWinRTEnabled>
     <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
@@ -25,7 +25,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="CsWinRTRemoveWinMDReferences" BeforeTargets="ResolveReferences;CoreCompile" AfterTargets="AfterResolveReferences">
+  <Target Name="CsWinRTRemoveWinMDReferences" BeforeTargets="ResolveReferences;BeforeCompile" AfterTargets="AfterResolveReferences">
     <ItemGroup>
       <!--Move winmd references into private item group to prevent subsequent winmd reference errors-->
       <CsWinRTRemovedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true'" />
@@ -49,7 +49,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <Target Name="CsWinRTGenerateProjection" DependsOnTargets="CsWinRTPrepareProjection" Condition="'$(CsWinRTGenerateProjection)' == 'true'">
+  <Target Name="CsWinRTGenerateProjection" DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences" Condition="'$(CsWinRTGenerateProjection)' == 'true'">
     <PropertyGroup>
       <CsWinRTResponseFile>$(CsWinRTGeneratedFilesDir)cswinrt.rsp</CsWinRTResponseFile>
       <CsWinRTCommand>$(CsWinRTExe) %40"$(CsWinRTResponseFile)"</CsWinRTCommand>
@@ -81,7 +81,7 @@ $(CsWinRTFilters)
     <Exec Command="$(CsWinRTCommand)" />
   </Target>
   
-  <Target Name="CsWinRTIncludeProjection" BeforeTargets="CoreCompile" DependsOnTargets="CsWinRTGenerateProjection" Condition="$(CsWinRTEnabled)">
+  <Target Name="CsWinRTIncludeProjection" BeforeTargets="BeforeCompile" DependsOnTargets="CsWinRTGenerateProjection" Condition="$(CsWinRTEnabled)">
     <ItemGroup>
       <Compile Include="$(CsWinRTGeneratedFilesDir)*.cs" Exclude="@(Compile)" />
     </ItemGroup>


### PR DESCRIPTION
- Added sourcelink for winrt.runtime
- In our auto generation of the projection, we were adding the sources before CoreCompile.  But sourcelink indicates any sources it includes should come before BeforeCompile as they also have a BeforeTargets of CoreCompile.  In my sample runs even though both of us are before CoreCompile, our targets still ran before sourcelink and was fine.  But I feel like this order is not defined and can be not deterministic, so this changes moves our source generation to be before BeforeCompile.  This change helps projection generators who may use sourcelink.
- Also making our source generation be dependent on CsWinRTRemoveWinMDReferences as it consumes the winmds it gathers
- ResolveAssemblyReferencesDependsOn seems like had a typo which probably dropped all the other depends, so fixing that.