### PR TITLE
Change checks of GetRuntimeClassName to EmptyOrNull

### DIFF
--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -311,7 +311,7 @@ namespace WinRT
                 // If it isn't, we use the statically determined type as it is a tear off.
 
                 Type implementationType = null;
-                if (runtimeClassName != null)
+                if (!string.IsNullOrEmpty(runtimeClassName))
                 {
                     try
                     {

--- a/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -242,7 +242,7 @@ namespace WinRT
                 IInspectable inspectable = new IInspectable(inspectableRef);
 
                 string runtimeClassName = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType.Value);
-                if (runtimeClassName == null)
+                if (string.IsNullOrEmpty(runtimeClassName))
                 {
                     // If the external IInspectable has not implemented GetRuntimeClassName,
                     // we use the Inspectable wrapper directly.

--- a/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -37,7 +37,7 @@ namespace WinRT
                 {
                     var inspectable = new IInspectable(identity);
                     string runtimeClassName = GetRuntimeClassForTypeCreation(inspectable, typeof(T));
-                    runtimeWrapper = TypedObjectFactoryCache.GetOrAdd(runtimeClassName, className => CreateTypedRcwFactory(className))(inspectable);
+                    runtimeWrapper = string.IsNullOrEmpty(runtimeClassName) ? inspectable : TypedObjectFactoryCache.GetOrAdd(runtimeClassName, className => CreateTypedRcwFactory(className))(inspectable);
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)
                 {


### PR DESCRIPTION
Changed the places that GetRuntimeClassName and GetRuntimeClassForTypeCreation  are used to handle return types properly 

Closes #510 