### PR TITLE
std::filesystem::canonical fails when running on a RAM drive

### DIFF
--- a/cswinrt/cmd_reader.h
+++ b/cswinrt/cmd_reader.h
@@ -416,7 +416,7 @@ namespace cswinrt
                     catch (std::filesystem::filesystem_error const&)
                     {
                         // If canonical fails try using the provided path directly
-                        files.insert(path);
+                        add_directory(path);
                     }
                     continue;
                 }

--- a/cswinrt/cmd_reader.h
+++ b/cswinrt/cmd_reader.h
@@ -409,13 +409,29 @@ namespace cswinrt
             {
                 if (std::filesystem::is_directory(path))
                 {
-                    add_directory(std::filesystem::canonical(path));
+                    try
+                    {
+                        add_directory(std::filesystem::canonical(path));
+                    }
+                    catch (std::filesystem::filesystem_error const&)
+                    {
+                        // If canonical fails try using the provided path directly
+                        files.insert(path);
+                    }
                     continue;
                 }
 
                 if (std::filesystem::is_regular_file(path))
                 {
-                    files.insert(std::filesystem::canonical(path).string());
+                    try
+                    {
+                        files.insert(std::filesystem::canonical(path).string());
+                    }
+                    catch (std::filesystem::filesystem_error const&)
+                    {
+                        // If canonical fails try using the provided path directly
+                        files.insert(path);
+                    }
                     continue;
                 }
                 if (path == "local")


### PR DESCRIPTION
std::filesystem::canonical can fail on some drivers not properly implementing support for __std_fs_get_final_path_name_by_handle. 
If that were to happen, rather then bailing out, retry using the provided path directly.