### PR TITLE
removing unsupported AnyCPU option for unittest project

### DIFF
--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!--Target .NET Core 2.0 to test .NET Standard 2.0 projection -->
     <TargetFrameworks>netcoreapp2.0;net5.0</TargetFrameworks>
-    <Platforms>AnyCPU;x64;x86</Platforms>
+    <Platforms>x64;x86</Platforms>
     <ProjectName>UnitTest</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Attempting to build and run in this configuration will lead to errors / failures that are difficult to debug. Removing the option to avoid confusion.