### PR TITLE
Fix linq casts

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -512,6 +512,11 @@ namespace winrt::TestComponentCSharp::implementation
         _uriChanged.remove(token);
     }
 
+    Windows::Foundation::Collections::IVector<Windows::Foundation::IInspectable> Class::GetUriVectorAsIInspectableVector()
+    {
+        return single_threaded_vector<Windows::Foundation::IInspectable>({ Uri(L"https://microsoft.com"), Uri(L"https://github.com") });
+    };
+
     IAsyncOperation<int32_t> Class::GetIntAsync()
     {
         co_return _int;

--- a/TestComponentCSharp/Class.h
+++ b/TestComponentCSharp/Class.h
@@ -24,6 +24,8 @@ namespace winrt::TestComponentCSharp::implementation
         winrt::event<Windows::Foundation::TypedEventHandler<TestComponentCSharp::Class, Windows::Foundation::Collections::IVector<hstring>>> _nestedTypedEvent;
         winrt::event<TestComponentCSharp::EventWithReturn> _returnEvent;
 
+        Windows::Foundation::Collections::IVector<Windows::Foundation::IInspectable> GetUriVectorAsIInspectableVector();
+
         int32_t _int = 0;
         winrt::event<Windows::Foundation::EventHandler<int32_t>> _intChanged;
         bool _bool = false;

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -187,6 +187,7 @@ namespace TestComponentCSharp
         void CallForStringPair(ProvideStringPair provideStringPair);
         event Windows.Foundation.EventHandler<Windows.Foundation.Collections.IKeyValuePair<String, String> > StringPairPropertyChanged;
 
+        Windows.Foundation.Collections.IVector<IInspectable> GetUriVectorAsIInspectableVector();
         ProvideUri GetUriDelegate();
         void AddUriHandler(IUriHandler uriHandler);
 

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -185,6 +185,15 @@ namespace UnitTest
             Assert.Equal("UnitTest.TestCSharp+CustomDictionary, UnitTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", name);
         }
 
+        [Fact]
+        public void TestVectorCastConversion()
+        {
+            var vector = TestObject.GetUriVectorAsIInspectableVector();
+            var uriVector = vector.Cast<Uri>();
+            var first = uriVector.First();
+            Assert.Equal(vector, uriVector);
+        }
+
 #if NET5_0
         [Fact]
         public void TestAsStream()

--- a/UnitTest/TestComponent_Tests.cs
+++ b/UnitTest/TestComponent_Tests.cs
@@ -599,6 +599,16 @@ namespace UnitTest
         }
 
         [Fact]
+        public void CastListToEnum_String()
+        {
+            string[] a = new string[] { "apples", "oranges", "pears" };
+            IList<string> b = null;
+            var c = Tests.Collection5(a, out b);
+            var j = (IEnumerable<string>)(object)b;
+            Assert.True(SequencesEqual(a, b, j));
+        }
+
+        [Fact]
         public void Collections_ReadOnly_List()
         {
             string[] a = new string[] { "apples", "oranges", "pears" };

--- a/WinRT.Runtime/IInspectable.net5.cs
+++ b/WinRT.Runtime/IInspectable.net5.cs
@@ -9,6 +9,7 @@ namespace WinRT
         bool IWinRTObject.HasUnwrappableNativeObject => true;
 
         ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
     }
 
 }

--- a/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+using WinRT;
+
+#pragma warning disable 0169 // warning CS0169: The field '...' is never used
+#pragma warning disable 0649 // warning CS0169: Field '...' is never assigned to
+
+namespace ABI.System.Collections.Generic
+{
+    [DynamicInterfaceCastableImplementation]
+    interface IReadOnlyCollection<T> : global::System.Collections.Generic.IReadOnlyCollection<T>
+    {
+        private static global::System.Collections.Generic.IReadOnlyCollection<T> CreateHelper(IWinRTObject _this)
+        {
+            var genericType = typeof(T);
+            if (genericType.IsGenericType && genericType.GetGenericTypeDefinition() == typeof(global::System.Collections.Generic.KeyValuePair<,>))
+            {
+                var iReadOnlyDictionary = typeof(global::System.Collections.Generic.IReadOnlyDictionary<,>).MakeGenericType(genericType.GetGenericArguments());
+                if (_this.IsInterfaceImplemented(iReadOnlyDictionary.TypeHandle, false))
+                {
+                    return (global::System.Collections.Generic.IReadOnlyCollection<T>) 
+                        iReadOnlyDictionary.FindHelperType().GetMethod(
+                            "_FromMapView",
+                            global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static
+                        ).Invoke(null, global::System.Reflection.BindingFlags.Default, null, new object[] { _this }, null);
+                }
+            }
+
+            var iReadOnlyList = typeof(global::System.Collections.Generic.IReadOnlyList<T>);
+            if (_this.IsInterfaceImplemented(iReadOnlyList.TypeHandle, false))
+            {
+                return IReadOnlyList<T>._FromVectorView(_this);
+            }
+
+            throw new InvalidOperationException("IReadOnlyCollection helper can not determine derived type.");
+        }
+
+        private static global::System.Collections.Generic.IReadOnlyCollection<T> GetHelper(IWinRTObject _this)
+        {
+            return (global::System.Collections.Generic.IReadOnlyCollection<T>) _this.GetOrCreateTypeHelperData(
+                typeof(global::System.Collections.Generic.IReadOnlyCollection<T>).TypeHandle,
+                () => CreateHelper(_this));
+        }
+
+        int global::System.Collections.Generic.IReadOnlyCollection<T>.Count
+            => GetHelper((IWinRTObject)this).Count;
+
+        IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
+            => GetHelper((IWinRTObject)this).GetEnumerator();
+
+        global::System.Collections.Generic.IEnumerator<T> global::System.Collections.Generic.IEnumerable<T>.GetEnumerator()
+            => GetHelper((IWinRTObject)this).GetEnumerator();
+    }
+
+    [DynamicInterfaceCastableImplementation]
+    interface ICollection<T> : global::System.Collections.Generic.ICollection<T>
+    {
+        private static global::System.Collections.Generic.ICollection<T> CreateHelper(IWinRTObject _this)
+        {
+            var genericType = typeof(T);
+            if (genericType.IsGenericType && genericType.GetGenericTypeDefinition() == typeof(global::System.Collections.Generic.KeyValuePair<,>))
+            {
+                var iDictionary = typeof(global::System.Collections.Generic.IDictionary<,>).MakeGenericType(genericType.GetGenericArguments());
+                if (_this.IsInterfaceImplemented(iDictionary.TypeHandle, false))
+                {
+                    return (global::System.Collections.Generic.ICollection<T>)
+                        iDictionary.FindHelperType().GetMethod(
+                            "_FromMap",
+                            global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static
+                        ).Invoke(null, global::System.Reflection.BindingFlags.Default, null, new object[] { _this }, null);
+                }
+            }
+
+            var iList = typeof(global::System.Collections.Generic.IList<T>);
+            if (_this.IsInterfaceImplemented(iList.TypeHandle, false))
+            {
+                return IList<T>._FromVector(_this);
+            }
+
+            throw new InvalidOperationException("ICollection helper can not determine derived type.");
+        }
+
+        private static global::System.Collections.Generic.ICollection<T> GetHelper(IWinRTObject _this)
+        {
+            return (global::System.Collections.Generic.ICollection<T>)_this.GetOrCreateTypeHelperData(
+                typeof(global::System.Collections.Generic.ICollection<T>).TypeHandle,
+                () => CreateHelper(_this));
+        }
+
+        int global::System.Collections.Generic.ICollection<T>.Count
+            => GetHelper((IWinRTObject)this).Count;
+
+        bool global::System.Collections.Generic.ICollection<T>.IsReadOnly
+            => GetHelper((IWinRTObject)this).IsReadOnly;
+
+        void global::System.Collections.Generic.ICollection<T>.Add(T item)
+            => GetHelper((IWinRTObject)this).Add(item);
+
+        void global::System.Collections.Generic.ICollection<T>.Clear()
+            => GetHelper((IWinRTObject)this).Clear();
+
+        bool global::System.Collections.Generic.ICollection<T>.Contains(T item)
+            => GetHelper((IWinRTObject)this).Contains(item);
+
+        void global::System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex)
+            => GetHelper((IWinRTObject)this).CopyTo(array, arrayIndex);
+
+        bool global::System.Collections.Generic.ICollection<T>.Remove(T item)
+            => GetHelper((IWinRTObject)this).Remove(item);
+
+        IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
+            => GetHelper((IWinRTObject)this).GetEnumerator();
+
+        global::System.Collections.Generic.IEnumerator<T> global::System.Collections.Generic.IEnumerable<T>.GetEnumerator()
+            => GetHelper((IWinRTObject)this).GetEnumerator();
+    }
+}

--- a/WinRT.Runtime/Projections/EventHandler.cs
+++ b/WinRT.Runtime/Projections/EventHandler.cs
@@ -75,6 +75,7 @@ namespace ABI.System
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
             ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 #endif
 
             public void Invoke(object sender, T args)

--- a/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -69,6 +69,7 @@ namespace ABI.System.Windows.Input
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
             ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 
             public void Invoke(object sender, EventArgs args)
             {

--- a/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -142,9 +142,9 @@ namespace ABI.System.Collections.Generic
                 Insert(_map, key, value);
             }
 
-            public ICollection<K> Keys { get => new DictionaryKeyCollection(this); }
+            public global::System.Collections.Generic.ICollection<K> Keys { get => new DictionaryKeyCollection(this); }
 
-            public ICollection<V> Values { get => new DictionaryValueCollection(this); }
+            public global::System.Collections.Generic.ICollection<V> Values { get => new DictionaryValueCollection(this); }
 
             public bool ContainsKey(K key)
             {
@@ -271,12 +271,12 @@ namespace ABI.System.Collections.Generic
 
                 public bool IsReadOnly => true;
 
-                void ICollection<K>.Add(K item)
+                void global::System.Collections.Generic.ICollection<K>.Add(K item)
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_KeyCollectionSet);
                 }
 
-                void ICollection<K>.Clear()
+                void global::System.Collections.Generic.ICollection<K>.Clear()
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_KeyCollectionSet);
                 }
@@ -286,7 +286,7 @@ namespace ABI.System.Collections.Generic
                     return dictionary.ContainsKey(item);
                 }
 
-                bool ICollection<K>.Remove(K item)
+                bool global::System.Collections.Generic.ICollection<K>.Remove(K item)
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_KeyCollectionSet);
                 }
@@ -365,12 +365,12 @@ namespace ABI.System.Collections.Generic
 
                 public bool IsReadOnly => true;
 
-                void ICollection<V>.Add(V item)
+                void global::System.Collections.Generic.ICollection<V>.Add(V item)
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_ValueCollectionSet);
                 }
 
-                void ICollection<V>.Clear()
+                void global::System.Collections.Generic.ICollection<V>.Clear()
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_ValueCollectionSet);
                 }
@@ -384,7 +384,7 @@ namespace ABI.System.Collections.Generic
                     return false;
                 }
 
-                bool ICollection<V>.Remove(V item)
+                bool global::System.Collections.Generic.ICollection<V>.Remove(V item)
                 {
                     throw new NotSupportedException(ErrorStrings.NotSupported_ValueCollectionSet);
                 }
@@ -815,8 +815,8 @@ namespace ABI.System.Collections.Generic
                 () => new FromAbiHelper((global::Windows.Foundation.Collections.IMap<K, V>)(IWinRTObject)obj));
         }
 
-        ICollection<K> global::System.Collections.Generic.IDictionary<K, V>.Keys => _FromMap((IWinRTObject)this).Keys;
-        ICollection<V> global::System.Collections.Generic.IDictionary<K, V>.Values => _FromMap((IWinRTObject)this).Values;
+        global::System.Collections.Generic.ICollection<K> global::System.Collections.Generic.IDictionary<K, V>.Keys => _FromMap((IWinRTObject)this).Keys;
+        global::System.Collections.Generic.ICollection<V> global::System.Collections.Generic.IDictionary<K, V>.Values => _FromMap((IWinRTObject)this).Values;
         int global::System.Collections.Generic.ICollection<global::System.Collections.Generic.KeyValuePair<K, V>>.Count => _FromMap((IWinRTObject)this).Count;
         bool global::System.Collections.Generic.ICollection<global::System.Collections.Generic.KeyValuePair<K, V>>.IsReadOnly => _FromMap((IWinRTObject)this).IsReadOnly;
         V global::System.Collections.Generic.IDictionary<K, V>.this[K key] { get => _FromMap((IWinRTObject)this)[key]; set => _FromMap((IWinRTObject)this)[key] = value; }

--- a/WinRT.Runtime/Projections/IList.net5.cs
+++ b/WinRT.Runtime/Projections/IList.net5.cs
@@ -726,7 +726,7 @@ namespace ABI.System.Collections.Generic
         }
         public static Guid PIID = Vftbl.PIID;
         
-        private static FromAbiHelper _FromVector(IWinRTObject _this)
+        internal static FromAbiHelper _FromVector(IWinRTObject _this)
         {
             return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Generic.IList<T>).TypeHandle,
                 () => new FromAbiHelper((global::Windows.Foundation.Collections.IVector<T>)_this));

--- a/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -343,7 +343,7 @@ namespace ABI.System.Collections.Generic
         }
         public static Guid PIID = Vftbl.PIID;
 
-        private static FromAbiHelper _FromVectorView(IWinRTObject _this)
+        internal static FromAbiHelper _FromVectorView(IWinRTObject _this)
         {
             var _obj = ((ObjectReference<Vftbl>)_this.GetObjectReferenceForType(typeof(global::System.Collections.Generic.IReadOnlyList<T>).TypeHandle));
             var ThisPtr = _obj.ThisPtr;

--- a/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -71,6 +71,7 @@ namespace ABI.System.Collections.Specialized
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
             ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 #endif
 
             public void Invoke(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -70,6 +70,7 @@ namespace ABI.System.ComponentModel
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
             ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 #endif
 
             public void Invoke(object sender, global::System.ComponentModel.PropertyChangedEventArgs e)

--- a/WinRT.Runtime/SingleInterfaceOptimizedObject.net5.cs
+++ b/WinRT.Runtime/SingleInterfaceOptimizedObject.net5.cs
@@ -31,6 +31,7 @@ namespace WinRT
         bool IWinRTObject.HasUnwrappableNativeObject => false;
 
         ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 
         bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
         {

--- a/cswinrt/code_writers.h
+++ b/cswinrt/code_writers.h
@@ -1136,6 +1136,7 @@ internal static % Instance => (%)_instance.Value;
 IObjectReference IWinRTObject.NativeObject => _obj;
 bool IWinRTObject.HasUnwrappableNativeObject => false;
 global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 }
 )",
                 cache_type_name,
@@ -2733,6 +2734,7 @@ internal static _% Instance => _instance.Value;
 IObjectReference IWinRTObject.NativeObject => _obj;
 bool IWinRTObject.HasUnwrappableNativeObject => false;
 global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 
 %
 }
@@ -5018,7 +5020,8 @@ IObjectReference IWinRTObject.NativeObject => _inner;)");
                 if (!has_base_type)
                 { 
                 w.write(R"(
-global::System.Collections.Concurrent.ConcurrentDictionary<global::System.RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();)");
+global::System.Collections.Concurrent.ConcurrentDictionary<global::System.RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();)");
                 }
             }),
             default_interface_name,
@@ -5194,6 +5197,7 @@ objRef.Dispose();
 IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
 bool IWinRTObject.HasUnwrappableNativeObject => true;
 global::System.Collections.Concurrent.ConcurrentDictionary<global::System.RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
 #endif
 
 public unsafe % Invoke(%)


### PR DESCRIPTION
- Fixing scenario where IEnumerable is not supported by native object but generic IEnumerable is
- Making use of a helper type which knows the appropriate GetEnumerator to redirect to based on which child type implements IEnumerable
- Fixing issue where AdditionalData dictionary was initialized each time with a new one
- The results of GetInterfaceImplementation is cached and used for other objects.  So instead of handling the logic to choose the right implementation there, implemented 2 helper types for the ones handled there and moved the logic to detect which type it is in the helper class itself which then redirects to the other types FromABIHelper.

Fixes #482 