### PR TITLE
Fixed #553 and further issues in native to managed calls

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -12,16 +12,6 @@ using namespace Microsoft::UI::Xaml::Data;
 using namespace Microsoft::UI::Xaml::Interop;
 using Windows::UI::Xaml::Interop::TypeName;
 
-// Until C++/WinRT provides, to ensure that GetRuntimeClasName reports IVectorView rather than IVector
-namespace winrt
-{
-    template <typename T, typename Allocator = std::allocator<T>>
-    Windows::Foundation::Collections::IVectorView<T> single_threaded_vector_view(std::vector<T, Allocator>&& values = {})
-    {
-        return make<impl::input_vector_view<T, std::vector<T, Allocator>>>(std::move(values));
-    }
-}
-
 namespace winrt::TestComponentCSharp::implementation
 {
     namespace statics

--- a/TestComponentCSharp/ManualProjectionTestClasses.cpp
+++ b/TestComponentCSharp/ManualProjectionTestClasses.cpp
@@ -1,8 +1,7 @@
 #include "pch.h"
 #include "ManualProjectionTestClasses.h"
-#include "IBindableIteratorTest.g.cpp"
-#include "IDictionaryTest.g.cpp"
-#include "IDisposableTest.g.cpp"
+#include "CustomBindableIteratorTest.g.cpp"
+#include "CustomDisposableTest.g.cpp"
 
 namespace winrt
 {
@@ -21,84 +20,31 @@ namespace winrt
 
 namespace winrt::TestComponentCSharp::implementation
 {
-	IBindableIteratorTest::IBindableIteratorTest()
+	CustomBindableIteratorTest::CustomBindableIteratorTest()
 	{
 		
 	}
 
-	bool IBindableIteratorTest::MoveNext()
+	bool CustomBindableIteratorTest::MoveNext()
 	{
 		return true;
 	}
 
-	Windows::Foundation::IInspectable IBindableIteratorTest::Current()
+	Windows::Foundation::IInspectable CustomBindableIteratorTest::Current()
 	{
 		return Windows::Foundation::PropertyValue::CreateInt32(27861);
 	}
 
-	bool IBindableIteratorTest::HasCurrent()
+	bool CustomBindableIteratorTest::HasCurrent()
 	{
 		return true;
 	}
-	IDictionaryTest::IDictionaryTest()
+
+	CustomDisposableTest::CustomDisposableTest()
 	{
-	}
-	hstring IDictionaryTest::Lookup(hstring key)
-	{
-		return _map.Lookup(key);
-	}
-	bool IDictionaryTest::HasKey(hstring key)
-	{
-		return _map.HasKey(key);
-	}
-	Windows::Foundation::Collections::IMapView<hstring, hstring> IDictionaryTest::GetView()
-	{
-		return _map.GetView();
-	}
-	bool IDictionaryTest::Insert(hstring key, hstring value)
-	{
-		return _map.Insert(key, value);
-	}
-	void IDictionaryTest::Remove(hstring key)
-	{
-		_map.Remove(key);
-	}
-	void IDictionaryTest::Clear()
-	{
-		_map.Clear();
-	}
-	int IDictionaryTest::Size()
-	{
-		return _map.Size();
 	}
 
-	Windows::Foundation::Collections::IIterator<Windows::Foundation::Collections::IKeyValuePair<hstring, hstring>> IDictionaryTest::First()
-	{
-		return _map.First();
-	}
-
-	bool IDictionaryTest::Consume(Windows::Foundation::Collections::IMap<hstring, hstring> map)
-	{
-		map.Clear();
-
-		map.Insert(L"key.cpp", L"value.cpp");
-		if (map.Size() != 1)
-		{
-			return false;
-		}
-		if (!map.HasKey(L"key.cpp"))
-		{
-			return false;
-		}
-		
-		return true;
-		
-	}
-	
-	IDisposableTest::IDisposableTest()
-	{
-	}
-	void IDisposableTest::Close()
+	void CustomDisposableTest::Close()
 	{
 	}
 }

--- a/TestComponentCSharp/ManualProjectionTestClasses.cpp
+++ b/TestComponentCSharp/ManualProjectionTestClasses.cpp
@@ -3,21 +3,6 @@
 #include "CustomBindableIteratorTest.g.cpp"
 #include "CustomDisposableTest.g.cpp"
 
-namespace winrt
-{
-	template <typename T, typename Allocator = std::allocator<T>>
-	Windows::Foundation::Collections::IVectorView<T> single_threaded_vector_view(std::vector<T, Allocator>&& values = {})
-	{
-		return make<impl::input_vector_view<T, std::vector<T, Allocator>>>(std::move(values));
-	}
-
-	template <typename K, typename V, typename Allocator = std::allocator<K>>
-	Windows::Foundation::Collections::IMapView<K, V> single_threaded_map_view(std::map<K, V, Allocator>&& values = {})
-	{
-		return make<impl::input_map_view<K, V, std::map<K, V, Allocator>>>(std::move(values));
-	}
-}
-
 namespace winrt::TestComponentCSharp::implementation
 {
 	CustomBindableIteratorTest::CustomBindableIteratorTest()

--- a/TestComponentCSharp/ManualProjectionTestClasses.h
+++ b/TestComponentCSharp/ManualProjectionTestClasses.h
@@ -1,68 +1,33 @@
 #pragma once
-#include "IBindableIteratorTest.g.h"
-#include "IDictionaryTest.g.h"
-#include "IDisposableTest.g.h"
+#include "CustomBindableIteratorTest.g.h"
+#include "CustomDisposableTest.g.h"
 
 namespace winrt::TestComponentCSharp::implementation
 {
-	struct IBindableIteratorTest : IBindableIteratorTestT<IBindableIteratorTest>
+	struct CustomBindableIteratorTest : CustomBindableIteratorTestT<CustomBindableIteratorTest>
 	{
-		IBindableIteratorTest();
+		CustomBindableIteratorTest();
 		bool MoveNext();
 		Windows::Foundation::IInspectable Current();
 		bool HasCurrent();
 	};
 
-	struct IDictionaryTest : IDictionaryTestT<IDictionaryTest>
+	struct CustomDisposableTest : CustomDisposableTestT<CustomDisposableTest>
 	{
-	private:
-		Windows::Foundation::Collections::IMap<hstring, hstring> _map{
-			winrt::single_threaded_map<hstring, hstring>()
-		};
-	public:
-		IDictionaryTest();
-		hstring Lookup(hstring key);
-		bool HasKey(hstring key);
-		Windows::Foundation::Collections::IMapView<hstring, hstring> GetView();
-		bool Insert(hstring key, hstring value);
-		void Remove(hstring key);
-		void Clear();
-		int Size();
-		Windows::Foundation::Collections::IIterator<Windows::Foundation::Collections::IKeyValuePair<hstring, hstring>> First();
-
-		static bool Consume(Windows::Foundation::Collections::IMap<hstring, hstring> map);
-	};
-
-	struct IDisposableTest : IDisposableTestT<IDisposableTest>
-	{
-		IDisposableTest();
+		CustomDisposableTest();
 		void Close();
 	};
 }
 
 namespace winrt::TestComponentCSharp::factory_implementation
 {
-	struct IBindableIteratorTest : IBindableIteratorTestT<IBindableIteratorTest, implementation::IBindableIteratorTest, Windows::Foundation::IStringable>
+	struct CustomBindableIteratorTest : CustomBindableIteratorTestT<CustomBindableIteratorTest, implementation::CustomBindableIteratorTest>
 	{
-		hstring ToString()
-		{
-			return L"IBindableIteratorTest";
-		}
+
 	};
 
-	struct IDictionaryTest : IDictionaryTestT<IDictionaryTest, implementation::IDictionaryTest, Windows::Foundation::IStringable>
+	struct CustomDisposableTest : CustomDisposableTestT<CustomDisposableTest, implementation::CustomDisposableTest>
 	{
-		hstring ToString()
-		{
-			return L"IDictionaryTest";
-		}
-	};
 
-	struct IDisposableTest : IDisposableTestT<IDisposableTest, implementation::IDisposableTest, Windows::Foundation::IStringable>
-	{
-		hstring ToString()
-		{
-			return L"IDisposableTest";
-		}
 	};
 }

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -341,29 +341,16 @@ namespace TestComponentCSharp
         void Observe(Microsoft.UI.Xaml.Interop.IBindableObservableVector vector);
     }
 
-    //[default_interface]
-    //runtimeclass IBindableVectorTest : Microsoft.UI.Xaml.Interop.IBindableVector
-    //{
-    //    //IBindableVectorTest();
-    //}
-
     [default_interface]
-    runtimeclass IBindableIteratorTest : Microsoft.UI.Xaml.Interop.IBindableIterator
+    runtimeclass CustomBindableIteratorTest : Microsoft.UI.Xaml.Interop.IBindableIterator
     {
-        IBindableIteratorTest();
+        CustomBindableIteratorTest();
     }
 
     [default_interface]
-    runtimeclass IDictionaryTest : Windows.Foundation.Collections.IMap<String, String>
+    runtimeclass CustomDisposableTest : Windows.Foundation.IClosable
     {
-        IDictionaryTest();
-        static Boolean Consume(Windows.Foundation.Collections.IMap<String, String> map);
-    }
-
-    [default_interface]
-    runtimeclass IDisposableTest : Windows.Foundation.IClosable
-    {
-        IDisposableTest();
+        CustomDisposableTest();
     }
     
     // IInspectable-based interop interface

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -366,12 +366,6 @@ namespace TestComponentCSharp
         IDisposableTest();
     }
     
-    [default_interface]
-    runtimeclass IEnumerableTest //: Windows.Foundation.Collections.IIterable
-    {
-        //IEnumerableTest();
-    }
-
     // IInspectable-based interop interface
     [uuid(39E050C3-4E74-441A-8DC0-B81104DF949C)]
     interface IUserConsentVerifierInterop

--- a/TestComponentCSharp/pch.h
+++ b/TestComponentCSharp/pch.h
@@ -10,3 +10,19 @@
 #include <winrt/Microsoft.UI.Xaml.Interop.h>
 #include <winrt/Microsoft.UI.Xaml.Markup.h>
 #include <winrt/Microsoft.UI.Xaml.Navigation.h>
+
+// TODO: Replace with latest Cpp/WinRT
+namespace winrt
+{
+	template <typename T, typename Allocator = std::allocator<T>>
+	Windows::Foundation::Collections::IVectorView<T> single_threaded_vector_view(std::vector<T, Allocator>&& values = {})
+	{
+		return make<impl::input_vector_view<T, std::vector<T, Allocator>>>(std::move(values));
+	}
+
+	template <typename K, typename V, typename Allocator = std::allocator<K>>
+	Windows::Foundation::Collections::IMapView<K, V> single_threaded_map_view(std::map<K, V, Allocator>&& values = {})
+	{
+		return make<impl::input_map_view<K, V, std::map<K, V, Allocator>>>(std::move(values));
+	}
+}

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -2177,48 +2177,16 @@ namespace UnitTest
         [Fact(Skip="Operation not supported")]
         public void TestIBindableIterator()
         {
-            IBindableIteratorTest bindableIterator = new IBindableIteratorTest();
+            CustomBindableIteratorTest bindableIterator = new CustomBindableIteratorTest();
             Assert.True(bindableIterator.MoveNext());
             Assert.True(bindableIterator.HasCurrent);
             Assert.Equal(27861, bindableIterator.Current);
         }
 
         [Fact]
-        public void TestIDictionary()
-        {
-            IDictionaryTest dictionary = new IDictionaryTest();
-            
-            dictionary["key"] = "value";
-            Assert.Equal("value", dictionary["key"]);
-            
-            dictionary.Add("key2", "value2");
-            Assert.Equal(2, dictionary.Count);
-            
-            Assert.True(dictionary.ContainsKey("key2"));
-            
-            KeyValuePair<string, string> k = new KeyValuePair<string, string>("key2", "value2");
-            Assert.True(dictionary.Contains(k));
-            
-            KeyValuePair<string, string>[] pairs = new KeyValuePair<string, string>[2];
-            dictionary.CopyTo(pairs, 0);
-            Assert.Equal(2, pairs.Length);
-
-            dictionary.Remove("key2");
-            Assert.ThrowsAny<Exception>(() => dictionary["key2"]);
-            Assert.False(dictionary.TryGetValue("key2", out var key2Val));
-
-            Assert.True(dictionary.TryGetValue("key", out var keyVal));
-            Assert.Equal("value", keyVal);
-
-            dictionary.Clear();
-            Assert.Empty(dictionary);
-
-        }
-
-        [Fact]
         public void TestIDisposable()
         {
-            IDisposableTest disposable = new IDisposableTest();
+            CustomDisposableTest disposable = new CustomDisposableTest();
             disposable.Dispose();
         }
     }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -2174,7 +2174,7 @@ namespace UnitTest
             Assert.NotNull(cryptoKey);
         }
 
-        [Fact]
+        [Fact(Skip="Operation not supported")]
         public void TestIBindableIterator()
         {
             IBindableIteratorTest bindableIterator = new IBindableIteratorTest();

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -65,13 +65,12 @@ namespace WinRT
             RegisterCustomAbiTypeMappingNoLock(typeof(Vector3), typeof(ABI.System.Numerics.Vector3), "Windows.Foundation.Numerics.Vector3");
             RegisterCustomAbiTypeMappingNoLock(typeof(Vector4), typeof(ABI.System.Numerics.Vector4), "Windows.Foundation.Numerics.Vector4");
 
+            // TODO: Ideally we should not need these
             CustomTypeToHelperTypeMappings.Add(typeof(IMap<,>), typeof(ABI.System.Collections.Generic.IDictionary<,>));
             CustomTypeToHelperTypeMappings.Add(typeof(IVector<>), typeof(ABI.System.Collections.Generic.IList<>));
             CustomTypeToHelperTypeMappings.Add(typeof(IMapView<,>), typeof(ABI.System.Collections.Generic.IReadOnlyDictionary<,>));
             CustomTypeToHelperTypeMappings.Add(typeof(IVectorView<>), typeof(ABI.System.Collections.Generic.IReadOnlyList<>));
             CustomTypeToHelperTypeMappings.Add(typeof(global::Microsoft.UI.Xaml.Interop.IBindableVector), typeof(ABI.System.Collections.IList));
-            CustomTypeToHelperTypeMappings.Add(typeof(IIterable<>), typeof(global::ABI.System.Collections.Generic.IEnumerable<>));
-            CustomTypeToHelperTypeMappings.Add(typeof(IIterator<>), typeof(global::ABI.System.Collections.Generic.IEnumerator<>));
 
             CustomTypeToAbiTypeNameMappings.Add(typeof(System.Type), "Windows.UI.Xaml.Interop.TypeName");
         }

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -70,6 +70,8 @@ namespace WinRT
             CustomTypeToHelperTypeMappings.Add(typeof(IMapView<,>), typeof(ABI.System.Collections.Generic.IReadOnlyDictionary<,>));
             CustomTypeToHelperTypeMappings.Add(typeof(IVectorView<>), typeof(ABI.System.Collections.Generic.IReadOnlyList<>));
             CustomTypeToHelperTypeMappings.Add(typeof(global::Microsoft.UI.Xaml.Interop.IBindableVector), typeof(ABI.System.Collections.IList));
+            CustomTypeToHelperTypeMappings.Add(typeof(IIterable<>), typeof(global::ABI.System.Collections.Generic.IEnumerable<>));
+            CustomTypeToHelperTypeMappings.Add(typeof(IIterator<>), typeof(global::ABI.System.Collections.Generic.IEnumerator<>));
 
             CustomTypeToAbiTypeNameMappings.Add(typeof(System.Type), "Windows.UI.Xaml.Interop.TypeName");
         }

--- a/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -14,13 +14,13 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+    //Need to rethink how to name/define this interface
     [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
     interface IMap<K, V> : IIterable<IKeyValuePair<K, V>>
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IReadOnlyDictionary<K, V> GetView();
+        IReadOnlyDictionary<K, V> GetView(); 
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();
@@ -33,6 +33,7 @@ namespace ABI.System.Collections.Generic
     using global::System;
     using global::System.Runtime.CompilerServices;
 
+    //This interface does not need to implement IMapView. Needs to be refactored
     [DynamicInterfaceCastableImplementation]
     [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
     interface IDictionary<K, V> : global::System.Collections.Generic.IDictionary<K, V>, global::Windows.Foundation.Collections.IMap<K, V>

--- a/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -20,7 +20,7 @@ namespace Windows.Foundation.Collections
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IReadOnlyDictionary<K, V> GetView(); 
+        IReadOnlyDictionary<K, V> GetView(); // Combining IMap & IReadOnlyDictionary needs redesign
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();

--- a/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -14,12 +14,13 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
     interface IMap<K, V> : IIterable<IKeyValuePair<K, V>>
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IMapView<K, V> GetView();
+        IReadOnlyDictionary<K, V> GetView();
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();
@@ -438,9 +439,8 @@ namespace ABI.System.Collections.Generic
 
             public ToAbiHelper(global::System.Collections.Generic.IDictionary<K, V> dictionary) => _dictionary = dictionary;
 
-            global::Windows.Foundation.Collections.IIterator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
-                new IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.ToAbiHelper(
-                    new KeyValuePair<K, V>.Enumerator(_dictionary.GetEnumerator()));
+            global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
+                new KeyValuePair<K, V>.Enumerator(_dictionary.GetEnumerator());
 
             public V Lookup(K key)
             {
@@ -462,13 +462,13 @@ namespace ABI.System.Collections.Generic
 
             public bool HasKey(K key) => _dictionary.ContainsKey(key);
 
-            global::Windows.Foundation.Collections.IMapView<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
+            global::System.Collections.Generic.IReadOnlyDictionary<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
             {
                 if (!(_dictionary is global::System.Collections.Generic.IReadOnlyDictionary<K, V> roDictionary))
                 {
                     roDictionary = new ReadOnlyDictionary<K, V>(_dictionary);
                 }
-                return new IReadOnlyDictionary<K, V>.ToAbiHelper(roDictionary);
+                return roDictionary;
             }
 
             public bool Insert(K key, V value)
@@ -600,14 +600,14 @@ namespace ABI.System.Collections.Generic
             }
             private static unsafe int Do_Abi_GetView_3(IntPtr thisPtr, out IntPtr __return_value__)
             {
-                global::Windows.Foundation.Collections.IMapView<K, V> ____return_value__ = default;
+                global::System.Collections.Generic.IReadOnlyDictionary<K, V> ____return_value__ = default;
 
                 __return_value__ = default;
 
                 try
                 {
                     ____return_value__ = FindAdapter(thisPtr).GetView();
-                    __return_value__ = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromManaged(____return_value__);
+                    __return_value__ = MarshalInterface<global::System.Collections.Generic.IReadOnlyDictionary<K, V>>.FromManaged(____return_value__);
 
                 }
                 catch (Exception __exception__)
@@ -734,7 +734,7 @@ namespace ABI.System.Collections.Generic
             }
         }
 
-        unsafe global::Windows.Foundation.Collections.IMapView<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
+        unsafe global::System.Collections.Generic.IReadOnlyDictionary<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
         {
             var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.Generic.IDictionary<K, V>).TypeHandle));
             var ThisPtr = _obj.ThisPtr;
@@ -742,7 +742,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetView_3(ThisPtr, out __retval));
-                return MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__retval);
+                return MarshalInterface<global::System.Collections.Generic.IReadOnlyDictionary<K, V>>.FromAbi(__retval);
             }
             finally
             {

--- a/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -14,12 +14,13 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
     interface IMap<K, V> : IIterable<IKeyValuePair<K, V>>
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IMapView<K, V> GetView();
+        IReadOnlyDictionary<K, V> GetView();
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();
@@ -444,9 +445,8 @@ namespace ABI.System.Collections.Generic
 
             public ToAbiHelper(global::System.Collections.Generic.IDictionary<K, V> dictionary) => _dictionary = dictionary;
 
-            global::Windows.Foundation.Collections.IIterator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
-                new IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.ToAbiHelper(
-                    new KeyValuePair<K,V>.Enumerator(_dictionary.GetEnumerator()));
+            global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
+                 new KeyValuePair<K,V>.Enumerator(_dictionary.GetEnumerator());
 
             public V Lookup(K key)
             {
@@ -468,13 +468,13 @@ namespace ABI.System.Collections.Generic
 
             public bool HasKey(K key) => _dictionary.ContainsKey(key);
 
-            global::Windows.Foundation.Collections.IMapView<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
+            global::System.Collections.Generic.IReadOnlyDictionary<K, V> global::Windows.Foundation.Collections.IMap<K, V>.GetView()
             {
                 if (!(_dictionary is global::System.Collections.Generic.IReadOnlyDictionary<K, V> roDictionary))
                 {
                     roDictionary = new ReadOnlyDictionary<K, V>(_dictionary);
                 }
-                return new IReadOnlyDictionary<K, V>.ToAbiHelper(roDictionary);
+                return roDictionary;
             }
 
             public bool Insert(K key, V value)
@@ -606,14 +606,14 @@ namespace ABI.System.Collections.Generic
             }
             private static unsafe int Do_Abi_GetView_3(IntPtr thisPtr, out IntPtr __return_value__)
             {
-                global::Windows.Foundation.Collections.IMapView<K, V> ____return_value__ = default;
+                global::System.Collections.Generic.IReadOnlyDictionary<K, V> ____return_value__ = default;
 
                 __return_value__ = default;
 
                 try
                 {
                     ____return_value__ = FindAdapter(thisPtr).GetView();
-                    __return_value__ = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromManaged(____return_value__);
+                    __return_value__ = MarshalInterface<global::System.Collections.Generic.IReadOnlyDictionary<K, V>>.FromManaged(____return_value__);
 
                 }
                 catch (Exception __exception__)

--- a/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -19,7 +19,7 @@ namespace Windows.Foundation.Collections
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IReadOnlyDictionary<K, V> GetView(); //TODO: Needs to be updated
+        IReadOnlyDictionary<K, V> GetView(); // Combining IMap & IReadOnlyDictionary needs redesign
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();

--- a/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -14,13 +14,12 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
     [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
     interface IMap<K, V> : IIterable<IKeyValuePair<K, V>>
     {
         V Lookup(K key);
         bool HasKey(K key);
-        IReadOnlyDictionary<K, V> GetView();
+        IReadOnlyDictionary<K, V> GetView(); //TODO: Needs to be updated
         bool Insert(K key, V value);
         void _Remove(K key);
         void Clear();

--- a/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -19,7 +19,7 @@ namespace Windows.Foundation.Collections
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
-        IEnumerator<T> First();
+        IEnumerator<T> First(); // Combining IIterable & IEnumerator needs redesign
     }
 
 

--- a/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -15,14 +15,14 @@ using Microsoft.UI.Xaml.Interop;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
         IEnumerator<T> First();
     }
 
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
     internal interface IIterator<T>
     {

--- a/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -15,11 +15,14 @@ using Microsoft.UI.Xaml.Interop;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
-        IIterator<T> First();
+        IEnumerator<T> First();
     }
+
+    [global::WinRT.WindowsRuntimeType]
     [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
     internal interface IIterator<T>
     {
@@ -93,8 +96,7 @@ namespace ABI.System.Collections.Generic
 
             internal ToAbiHelper(IEnumerable<T> enumerable) => m_enumerable = enumerable;
 
-            public global::Windows.Foundation.Collections.IIterator<T> First() =>
-                new IEnumerator<T>.ToAbiHelper(m_enumerable.GetEnumerator());
+            public global::System.Collections.Generic.IEnumerator<T> First() => m_enumerable.GetEnumerator();
         }
 
         [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
@@ -162,7 +164,7 @@ namespace ABI.System.Collections.Generic
                 () => new FromAbiHelper((global::System.Collections.Generic.IEnumerable<T>)_this));
         }
 
-        unsafe global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First()
+        unsafe global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First()
         {
             IntPtr __retval = default;
             try
@@ -170,14 +172,14 @@ namespace ABI.System.Collections.Generic
                 var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.Generic.IEnumerable<T>).TypeHandle));
                 var ThisPtr = _obj.ThisPtr;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.First_0(ThisPtr, out __retval));
-                return ABI.System.Collections.Generic.IEnumerator<T>.FromAbiInternal(__retval);
+                return ABI.System.Collections.Generic.IEnumerator<T>.FromAbi(__retval);
             }
             finally
             {
                 ABI.System.Collections.Generic.IEnumerator<T>.DisposeAbi(__retval);
             }
         }
-
+        //System.Collections.Generic.IEnumerable`1.GetEnumerator()
         global::System.Collections.Generic.IEnumerator<T> global::System.Collections.Generic.IEnumerable<T>.GetEnumerator() => _FromIterable((IWinRTObject)this).GetEnumerator();
         IEnumerator global::System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -19,7 +19,7 @@ namespace Windows.Foundation.Collections
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
-        IEnumerator<T> First();
+        IEnumerator<T> First(); // Combining IIterable & IEnumerator needs redesign
     }
 
 

--- a/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -15,14 +15,14 @@ using Microsoft.UI.Xaml.Interop;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
         IEnumerator<T> First();
     }
 
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
     internal interface IIterator<T>
     {

--- a/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -15,11 +15,14 @@ using Microsoft.UI.Xaml.Interop;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
     internal interface IIterable<T>
     {
-        IIterator<T> First();
+        IEnumerator<T> First();
     }
+
+    [global::WinRT.WindowsRuntimeType]
     [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
     internal interface IIterator<T>
     {
@@ -90,8 +93,7 @@ namespace ABI.System.Collections.Generic
 
             internal ToAbiHelper(IEnumerable<T> enumerable) => m_enumerable = enumerable;
 
-            public global::Windows.Foundation.Collections.IIterator<T> First() =>
-                new IEnumerator<T>.ToAbiHelper(m_enumerable.GetEnumerator());
+            public global::System.Collections.Generic.IEnumerator<T> First() => m_enumerable.GetEnumerator();
         }
 
         [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
@@ -169,13 +171,13 @@ namespace ABI.System.Collections.Generic
         }
         FromAbiHelper _FromIterable;
 
-        unsafe global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First()
+        unsafe global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First()
         {
             IntPtr __retval = default;
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.First_0(ThisPtr, out __retval));
-                return ABI.System.Collections.Generic.IEnumerator<T>.FromAbiInternal(__retval);
+                return ABI.System.Collections.Generic.IEnumerator<T>.FromAbi(__retval);
             }
             finally
             {

--- a/WinRT.Runtime/Projections/IList.net5.cs
+++ b/WinRT.Runtime/Projections/IList.net5.cs
@@ -19,7 +19,7 @@ namespace Windows.Foundation.Collections
     interface IVector<T> : IIterable<T>
     {
         T GetAt(uint index);
-        IReadOnlyList<T> GetView();
+        IReadOnlyList<T> GetView(); // Combining IVector & IReadOnlyList needs redesign
         bool IndexOf(T value, out uint index);
         void SetAt(uint index, T value);
         void InsertAt(uint index, T value);

--- a/WinRT.Runtime/Projections/IList.net5.cs
+++ b/WinRT.Runtime/Projections/IList.net5.cs
@@ -14,11 +14,12 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
     interface IVector<T> : IIterable<T>
     {
         T GetAt(uint index);
-        IVectorView<T> GetView();
+        IReadOnlyList<T> GetView();
         bool IndexOf(T value, out uint index);
         void SetAt(uint index, T value);
         void InsertAt(uint index, T value);
@@ -256,8 +257,7 @@ namespace ABI.System.Collections.Generic
 
             public ToAbiHelper(global::System.Collections.Generic.IList<T> list) => _list = list;
 
-            global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First() =>
-                new IEnumerator<T>.ToAbiHelper(_list.GetEnumerator());
+            global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First() => _list.GetEnumerator();
 
             private static void EnsureIndexInt32(uint index, int limit = int.MaxValue)
             {
@@ -287,7 +287,7 @@ namespace ABI.System.Collections.Generic
 
             public uint Size => (uint)_list.Count;
 
-            global::Windows.Foundation.Collections.IVectorView<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
+            global::System.Collections.Generic.IReadOnlyList<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
             {
                 // Note: This list is not really read-only - you could QI for a modifiable
                 // list.  We gain some perf by doing this.  We believe this is acceptable.
@@ -295,7 +295,7 @@ namespace ABI.System.Collections.Generic
                 {
                     roList = new ReadOnlyCollection<T>(_list);
                 }
-                return new IReadOnlyList<T>.ToAbiHelper(roList);
+                return roList;
             }
 
             public bool IndexOf(T value, out uint index)
@@ -544,14 +544,13 @@ namespace ABI.System.Collections.Generic
             }
             private static unsafe int Do_Abi_GetView_2(IntPtr thisPtr, out IntPtr __return_value__)
             {
-                global::Windows.Foundation.Collections.IVectorView<T> ____return_value__ = default;
-
+                global::System.Collections.Generic.IReadOnlyList<T> ____return_value__ = default;
                 __return_value__ = default;
 
                 try
                 {
                     ____return_value__ = FindAdapter(thisPtr).GetView();
-                    __return_value__ = MarshalInterface<global::Windows.Foundation.Collections.IVectorView<T>>.FromManaged(____return_value__);
+                    __return_value__ = MarshalInterface<global::System.Collections.Generic.IReadOnlyList<T>>.FromManaged(____return_value__);
 
                 }
                 catch (Exception __exception__)
@@ -749,7 +748,7 @@ namespace ABI.System.Collections.Generic
             }
         }
 
-        unsafe global::Windows.Foundation.Collections.IVectorView<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
+        unsafe global::System.Collections.Generic.IReadOnlyList<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
         {
             var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.Generic.IList<T>).TypeHandle));
             var ThisPtr = _obj.ThisPtr;
@@ -757,7 +756,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetView_2(ThisPtr, out __retval));
-                return MarshalInterface<global::Windows.Foundation.Collections.IVectorView<T>>.FromAbi(__retval);
+                return MarshalInterface<global::System.Collections.Generic.IReadOnlyList<T>>.FromAbi(__retval);
             }
             finally
             {

--- a/WinRT.Runtime/Projections/IList.net5.cs
+++ b/WinRT.Runtime/Projections/IList.net5.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
     interface IVector<T> : IIterable<T>
     {

--- a/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -14,11 +14,12 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
     interface IVector<T> : IIterable<T>
     {
         T GetAt(uint index);
-        IVectorView<T> GetView();
+        IReadOnlyList<T> GetView();
         bool IndexOf(T value, out uint index);
         void SetAt(uint index, T value);
         void InsertAt(uint index, T value);
@@ -265,8 +266,8 @@ namespace ABI.System.Collections.Generic
 
             public ToAbiHelper(global::System.Collections.Generic.IList<T> list) => _list = list;
 
-            global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First() =>
-                new IEnumerator<T>.ToAbiHelper(_list.GetEnumerator());
+            global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First() =>
+                _list.GetEnumerator();
 
             private static void EnsureIndexInt32(uint index, int limit = int.MaxValue)
             {
@@ -296,7 +297,7 @@ namespace ABI.System.Collections.Generic
 
             public uint Size => (uint)_list.Count;
 
-            global::Windows.Foundation.Collections.IVectorView<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
+            global::System.Collections.Generic.IReadOnlyList<T> global::Windows.Foundation.Collections.IVector<T>.GetView()
             {
                 // Note: This list is not really read-only - you could QI for a modifiable
                 // list.  We gain some perf by doing this.  We believe this is acceptable.
@@ -304,7 +305,7 @@ namespace ABI.System.Collections.Generic
                 {
                     roList = new ReadOnlyCollection<T>(_list);
                 }
-                return new IReadOnlyList<T>.ToAbiHelper(roList);
+                return roList;
             }
 
             public bool IndexOf(T value, out uint index)
@@ -553,15 +554,13 @@ namespace ABI.System.Collections.Generic
             }
             private static unsafe int Do_Abi_GetView_2(IntPtr thisPtr, out IntPtr __return_value__)
             {
-                global::Windows.Foundation.Collections.IVectorView<T> ____return_value__ = default;
-
+                global::System.Collections.Generic.IReadOnlyList<T> ____return_value__ = default;
                 __return_value__ = default;
 
                 try
                 {
                     ____return_value__ = FindAdapter(thisPtr).GetView();
-                    __return_value__ = MarshalInterface<global::Windows.Foundation.Collections.IVectorView<T>>.FromManaged(____return_value__);
-
+                    __return_value__ = MarshalInterface<global::System.Collections.Generic.IReadOnlyList<T>>.FromManaged(____return_value__);
                 }
                 catch (Exception __exception__)
                 {

--- a/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -19,7 +19,7 @@ namespace Windows.Foundation.Collections
     interface IVector<T> : IIterable<T>
     {
         T GetAt(uint index);
-        IReadOnlyList<T> GetView();
+        IReadOnlyList<T> GetView(); // Combining IVector & IReadOnlyList needs redesign
         bool IndexOf(T value, out uint index);
         void SetAt(uint index, T value);
         void InsertAt(uint index, T value);

--- a/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
     interface IVector<T> : IIterable<T>
     {

--- a/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("E480CE40-A338-4ADA-ADCF-272272E48CB9")]
     interface IMapView<K, V> : IIterable<IKeyValuePair<K, V>>
     {
@@ -263,9 +264,8 @@ namespace ABI.System.Collections.Generic
 
             uint global::Windows.Foundation.Collections.IMapView<K, V>.Size { get => (uint)_dictionary.Count; }
 
-            global::Windows.Foundation.Collections.IIterator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
-                new IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.ToAbiHelper(
-                    new KeyValuePair<K, V>.Enumerator(_dictionary.GetEnumerator()));
+            global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First() =>
+                new KeyValuePair<K, V>.Enumerator(_dictionary.GetEnumerator());
 
             public V Lookup(K key)
             {
@@ -301,7 +301,7 @@ namespace ABI.System.Collections.Generic
                 splittableMap.Split(out first, out second);
             }
 
-            private sealed class ConstantSplittableMap : global::Windows.Foundation.Collections.IMapView<K, V>
+            private sealed class ConstantSplittableMap : global::Windows.Foundation.Collections.IMapView<K, V>, global::System.Collections.Generic.IReadOnlyDictionary<K, V>
             {
                 private class KeyValuePairComparator : IComparer<global::System.Collections.Generic.KeyValuePair<K, V>>
                 {
@@ -349,9 +349,15 @@ namespace ABI.System.Collections.Generic
                     return kvArray;
                 }
 
+                public uint Size => (uint)(lastItemIndex - firstItemIndex + 1);
+
+                public global::System.Collections.Generic.IEnumerable<K> Keys => throw new NotImplementedException();
+
+                public global::System.Collections.Generic.IEnumerable<V> Values => throw new NotImplementedException();
+
                 public int Count => lastItemIndex - firstItemIndex + 1;
 
-                public uint Size => (uint)(lastItemIndex - firstItemIndex + 1);
+                public V this[K key] => Lookup(key);
 
                 public V Lookup(K key)
                 {
@@ -371,11 +377,7 @@ namespace ABI.System.Collections.Generic
                 public bool HasKey(K key) =>
                     TryGetValue(key, out _);
 
-                public global::Windows.Foundation.Collections.IIterator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> First() =>
-                    new IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.ToAbiHelper(GetEnumerator());
-
-                private global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> GetEnumerator() =>
-                    new Enumerator(items, firstItemIndex, lastItemIndex);
+                public global::System.Collections.Generic.IEnumerator<global::System.Collections.Generic.KeyValuePair<K, V>> First() => GetEnumerator();
 
                 public void Split(out global::Windows.Foundation.Collections.IMapView<K, V> firstPartition, out global::Windows.Foundation.Collections.IMapView<K, V> secondPartition)
                 {
@@ -406,16 +408,41 @@ namespace ABI.System.Collections.Generic
                     value = items[index].Value;
                     return true;
                 }
+
+                public bool ContainsKey(K key)
+                {
+                    return HasKey(key);
+                }
+
+                global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>> global::Windows.Foundation.Collections.IIterable<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>.First()
+                {
+                    var itemsAsIKeyValuePairs = new global::Windows.Foundation.Collections.IKeyValuePair<K, V>[items.Length];
+                    for (var i = 0; i < items.Length; i++)
+                    {
+                        itemsAsIKeyValuePairs[i] = new KeyValuePair<K, V>.ToIKeyValuePair(ref items[i]);
+                    }
+                    return new Enumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>(itemsAsIKeyValuePairs, firstItemIndex, lastItemIndex);
+                }
+
+                public global::System.Collections.Generic.IEnumerator<global::System.Collections.Generic.KeyValuePair<K, V>> GetEnumerator()
+                {
+                    return new Enumerator<global::System.Collections.Generic.KeyValuePair<K, V>>(items, firstItemIndex, lastItemIndex);
+                }
+
+                IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
+                {
+                    return new Enumerator<global::System.Collections.Generic.KeyValuePair<K, V>>(items, firstItemIndex, lastItemIndex);
+                }
             }
 
-            internal struct Enumerator : global::System.Collections.Generic.IEnumerator<global::Windows.Foundation.Collections.IKeyValuePair<K, V>>
+            internal struct Enumerator<T> : global::System.Collections.Generic.IEnumerator<T>
             {
-                private readonly global::System.Collections.Generic.KeyValuePair<K, V>[] _array;
+                private readonly T[] _array;
                 private readonly int _start;
                 private readonly int _end;
                 private int _current;
 
-                internal Enumerator(global::System.Collections.Generic.KeyValuePair<K, V>[] items, int first, int end)
+                internal Enumerator(T[] items, int first, int end)
                 {
                     _array = items;
                     _start = first;
@@ -433,13 +460,13 @@ namespace ABI.System.Collections.Generic
                     return false;
                 }
 
-                public global::Windows.Foundation.Collections.IKeyValuePair<K, V> Current
+                public T Current
                 {
                     get
                     {
                         if (_current < _start) throw new InvalidOperationException(ErrorStrings.InvalidOperation_EnumNotStarted);
                         if (_current > _end) throw new InvalidOperationException(ErrorStrings.InvalidOperation_EnumEnded);
-                        return new KeyValuePair<K, V>.ToIKeyValuePair(ref _array[_current]);
+                        return _array[_current];
                     }
                 }
 

--- a/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -351,9 +351,31 @@ namespace ABI.System.Collections.Generic
 
                 public uint Size => (uint)(lastItemIndex - firstItemIndex + 1);
 
-                public global::System.Collections.Generic.IEnumerable<K> Keys => throw new NotImplementedException();
+                public global::System.Collections.Generic.IEnumerable<K> Keys  
+                {
+                    get
+                    {
+                        K[] keys = new K[items.Length];
+                        for (var i = 0; i < items.Length; i++)
+                        {
+                            keys[i] = items[i].Key;
+                        }
+                        return keys;
+                    }
+                }
 
-                public global::System.Collections.Generic.IEnumerable<V> Values => throw new NotImplementedException();
+                public global::System.Collections.Generic.IEnumerable<V> Values
+                {
+                    get
+                    {
+                        V[] values = new V[items.Length];
+                        for (var i = 0; i < items.Length; i++)
+                        {
+                            values[i] = items[i].Value;
+                        }
+                        return values;
+                    }
+                }
 
                 public int Count => lastItemIndex - firstItemIndex + 1;
 

--- a/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
+
     [Guid("E480CE40-A338-4ADA-ADCF-272272E48CB9")]
     interface IMapView<K, V> : IIterable<IKeyValuePair<K, V>>
     {

--- a/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -357,9 +357,31 @@ namespace ABI.System.Collections.Generic
 
                 public uint Size => (uint)(lastItemIndex - firstItemIndex + 1);
 
-                public global::System.Collections.Generic.IEnumerable<K> Keys => throw new NotImplementedException();
+                public global::System.Collections.Generic.IEnumerable<K> Keys
+                {
+                    get
+                    {
+                        K[] keys = new K[items.Length];
+                        for (var i = 0; i < items.Length; i++)
+                        {
+                            keys[i] = items[i].Key;
+                        }
+                        return keys;
+                    }
+                }
 
-                public global::System.Collections.Generic.IEnumerable<V> Values => throw new NotImplementedException();
+                public global::System.Collections.Generic.IEnumerable<V> Values
+                {
+                    get
+                    {
+                        V[] values = new V[items.Length];
+                        for (var i = 0; i < items.Length; i++)
+                        {
+                            values[i] = items[i].Value;
+                        }
+                        return values;
+                    }
+                }
 
                 public int Count => lastItemIndex - firstItemIndex + 1;
 

--- a/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -14,7 +14,6 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
     [Guid("E480CE40-A338-4ADA-ADCF-272272E48CB9")]
     interface IMapView<K, V> : IIterable<IKeyValuePair<K, V>>
     {

--- a/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -14,7 +14,6 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
     [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
     interface IVectorView<T> : IIterable<T>
     {

--- a/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
     interface IVectorView<T> : IIterable<T>
     {
@@ -108,8 +109,7 @@ namespace ABI.System.Collections.Generic
 
             internal ToAbiHelper(global::System.Collections.Generic.IReadOnlyList<T> list) => _list = list;
 
-            global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First() =>
-                new IEnumerator<T>.ToAbiHelper(_list.GetEnumerator());
+            global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First() => _list.GetEnumerator();
 
             private static void EnsureIndexInt32(uint index, int limit = int.MaxValue)
             {

--- a/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -14,7 +14,6 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
-    [global::WinRT.WindowsRuntimeType]
     [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
     interface IVectorView<T> : IIterable<T>
     {

--- a/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 
 namespace Windows.Foundation.Collections
 {
+    [global::WinRT.WindowsRuntimeType]
     [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
     interface IVectorView<T> : IIterable<T>
     {
@@ -115,8 +116,7 @@ namespace ABI.System.Collections.Generic
 
             internal ToAbiHelper(global::System.Collections.Generic.IReadOnlyList<T> list) => _list = list;
 
-            global::Windows.Foundation.Collections.IIterator<T> global::Windows.Foundation.Collections.IIterable<T>.First() =>
-                new IEnumerator<T>.ToAbiHelper(_list.GetEnumerator());
+            global::System.Collections.Generic.IEnumerator<T> global::Windows.Foundation.Collections.IIterable<T>.First() => _list.GetEnumerator();
 
             private static void EnsureIndexInt32(uint index, int limit = int.MaxValue)
             {

--- a/get_testwinrt.cmd
+++ b/get_testwinrt.cmd
@@ -12,7 +12,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard 5cc3911373ac6ceac3aec2d5983fec0155d5e4e3
+git reset -q --hard 5df065fd3bccf314079e39e1bf2644fd239615c1
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 ..\.nuget\nuget.exe restore


### PR DESCRIPTION
Fixes #553 
The fix for that is simply adding `[global::WinRT.WindowsRuntimeType]` attribute to the interfaces

But there's another issue that comes up once `GetView()` is able to return the underlying `ToAbiHelper` object: When the native side tries to call methods on the underlying object (which is `ToAbiHelper` instance and not the actual instance of the object on C# side), the Do_Abi calls assume the underlying object also implements the C# equivalent of the interface and calls those methods (In this case the Do_Abi method would assume ToAbiHelper also implements IReadOnlyDictionary and thus would call the IReadOnlyDictionary methods instead of IMapView methods. But since ToAbiHelper does not implement IReadOnlyDictionary, the call fails).

To fix it, we need to either return the underlying object to the native side or make `ToAbiHelper` implement both `IReadOnlyDictionary` and `IMapView` (i.e. both managed and native side equivalent of the interface). I chose the first approach as it seemed a more logical thing to do: the native side should have reference to the managed side object and not some helper object. Also, there's no good motivation to add duplicate logic in ToAbiHelper. But to make this fix, I had to change the interface definitions for the projected types so as to have a proper return type which the managed code can create (because the managed side object to be returned would implement the managed side interface- IReadOnlyDictionary, not IMapView)