### PR TITLE
Use custom marshalers when type is erased with MarshalInspectable<object>

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -442,6 +442,10 @@ namespace winrt::TestComponentCSharp::implementation
     }
     void Class::ObjectProperty(WF::IInspectable const& value)
     {
+        if (auto uri = value.try_as<Windows::Foundation::Uri>())
+        {
+            _uri = uri;
+        }
         _object = value;
     }
     void Class::RaiseObjectChanged()

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -624,6 +624,10 @@ namespace UnitTest
         [Fact]
         public void TestObjectCasting()
         {
+            object expected_uri = new Uri("http://aka.ms/cswinrt");
+            TestObject.ObjectProperty = expected_uri;
+            Assert.Equal(expected_uri, TestObject.UriProperty);
+
             var expected = new KeyValuePair<string, string>("key", "value");
             TestObject.ObjectProperty = expected;
             var out_pair = (KeyValuePair<string, string>)TestObject.ObjectProperty;

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -627,6 +627,7 @@ namespace UnitTest
             object expected_uri = new Uri("http://aka.ms/cswinrt");
             TestObject.ObjectProperty = expected_uri;
             Assert.Equal(expected_uri, TestObject.UriProperty);
+            Assert.Equal(expected_uri, TestObject.ObjectProperty);
 
             var expected = new KeyValuePair<string, string>("key", "value");
             TestObject.ObjectProperty = expected;

--- a/WinRT.Runtime/Marshalers.cs
+++ b/WinRT.Runtime/Marshalers.cs
@@ -932,6 +932,10 @@ namespace WinRT
                 return null;
             }
 
+            if (o is Uri uri)
+            {
+                return ABI.System.Uri.CreateMarshaler(uri);
+            }
             if (unwrapObject && ComWrappersSupport.TryUnwrapObject(o, out var objRef))
             {
                 return objRef.As<IInspectable.Vftbl>();


### PR DESCRIPTION
fixes #567 