### PR TITLE
Update sample for net5 GA

### DIFF
--- a/Samples/Net5ProjectionSample/Directory.Build.props
+++ b/Samples/Net5ProjectionSample/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <BuildOutDir>$([MSBuild]::NormalizeDirectory('$(SolutionDir.Replace("$(SolutionFileName)\", ""))', '_build', '$(Platform)', '$(Configuration)'))</BuildOutDir>
+    <BuildOutDir>$([MSBuild]::NormalizeDirectory('$(SolutionDir)', '_build', '$(Platform)', '$(Configuration)'))</BuildOutDir>
     <OutDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'bin'))</OutDir>
     <IntDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'obj'))</IntDir>
   </PropertyGroup>

--- a/Samples/Net5ProjectionSample/README.md
+++ b/Samples/Net5ProjectionSample/README.md
@@ -2,12 +2,10 @@
 
 This sample demonstrates how to invoke C#/WinRT to build a .NET5 projection for a C++/WinRT Runtime Component, create a NuGet package for the component, and reference the NuGet package from a .NET5 console app.
 
-**Note**: This sample is accurate as of RC2, and there are expected tooling improvements to be made for the developer experience in our future GA release.
-
 ## Requirements
 
-- Visual Studio 16.8 Preview 3
-- .NET 5 SDK RC2
+- Visual Studio 16.8
+- .NET 5.0 SDK
 - Nuget.exe 5.8.0-preview.2 (for command line MSBuild)
 
 ## Build and run the sample
@@ -16,7 +14,7 @@ Using Visual Studio:
 
 1. Build the *CppWinRTComponentProjectionSample* solution first. This generates the projection and interop assembly using cswinrt, and creates *SimpleMathComponent.nupkg* which can be referenced in consuming apps. If you run into errors restoring NuGet packages, look at the docs on [NuGet restore options](https://docs.microsoft.com/nuget/consume-packages/package-restore). You may need to configure your NuGet package manager settings to allow for package restores on build.
 
-2. Build the *ConsoleAppSample* solution which references and restores  *SimpleMathComponent.nupkg* to consume the projection.
+2. Build the *ConsoleAppSample* solution which references and restores  the SimpleMathComponent *.nupkg* to consume the projection.
 
 For building with the command line, execute the following:
 

--- a/Samples/Net5ProjectionSample/README.md
+++ b/Samples/Net5ProjectionSample/README.md
@@ -12,9 +12,9 @@ This sample demonstrates how to invoke C#/WinRT to build a .NET5 projection for 
 
 Using Visual Studio:
 
-1. Build the *CppWinRTComponentProjectionSample* solution first. This generates the projection and interop assembly using cswinrt, and creates *SimpleMathComponent.nupkg* which can be referenced in consuming apps. If you run into errors restoring NuGet packages, look at the docs on [NuGet restore options](https://docs.microsoft.com/nuget/consume-packages/package-restore). You may need to configure your NuGet package manager settings to allow for package restores on build.
+1. Build the *CppWinRTComponentProjectionSample* solution first. This generates the projection and interop assembly using cswinrt, and creates the SimpleMathComponent NuGet package which can be referenced in consuming apps. If you run into errors restoring NuGet packages, look at the docs on [NuGet restore options](https://docs.microsoft.com/nuget/consume-packages/package-restore). You may need to configure your NuGet package manager settings to allow for package restores on build.
 
-2. Build the *ConsoleAppSample* solution which references and restores  the SimpleMathComponent *.nupkg* to consume the projection.
+2. Build the *ConsoleAppSample* solution which references and restores the SimpleMathComponent NuGet package to consume the projection.
 
 For building with the command line, execute the following:
 

--- a/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
+++ b/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
@@ -14,7 +14,6 @@
   <PropertyGroup>
     <CsWinRTIncludes>SimpleMathComponent</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!--Properties for generating the NuGet package-->

--- a/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
+++ b/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <CsWinRTIncludes>SimpleMathComponent</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
+	<CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!--Properties for generating the NuGet package-->
@@ -22,19 +23,6 @@
     <NuspecFile>$(GeneratedNugetDir)SimpleMathProjection.nuspec</NuspecFile>
     <OutputPath>$(GeneratedNugetDir)</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
-
-  <!--The C# compiler package below is not needed with Visual Studio 16.8 Preview 4-->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <RestoreSources>
-	https://api.nuget.org/v3/index.json;
-	https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
-    </RestoreSources>
   </PropertyGroup>
 
 </Project>

--- a/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
+++ b/Samples/Net5ProjectionSample/SimpleMathProjection/SimpleMathProjection.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <CsWinRTIncludes>SimpleMathComponent</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-	<CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <!--Properties for generating the NuGet package-->
@@ -24,5 +24,10 @@
     <OutputPath>$(GeneratedNugetDir)</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <!--Specify Windows SDK Metadata-->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- remove compilers.toolset package
- update readme requirements
- add windowsmetadata property
- remove ".sln" workaround (bug fixed in VS 16.8)