### PR TITLE
Update StreamOperationsImplementation

### DIFF
--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -318,6 +318,22 @@ namespace UnitTest
         }
 
 #if NET5_0
+        async Task InvokeStreamWriteZeroBytes()
+        {
+            var random = new Random(42);
+            byte[] data = new byte[256];
+            random.NextBytes(data);
+
+            using var stream = new InMemoryRandomAccessStream().AsStream();
+            await stream.WriteAsync(data, 0, 0);
+            await stream.WriteAsync(data, data.Length, 0);
+        }
+
+        [Fact]
+        public void TestStreamWriteZeroByte()
+        {
+            Assert.True(InvokeStreamWriteZeroBytes().Wait(1000));
+        }
 
         async Task InvokeStreamWriteAsync()
         {

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -318,6 +318,24 @@ namespace UnitTest
         }
 
 #if NET5_0
+
+        async Task InvokeStreamWriteAsync()
+        {
+            using var fileStream = File.OpenWrite("TestFile.txt");
+            using var winRTStream = fileStream.AsOutputStream();
+
+            var winRTBuffer = new Windows.Storage.Streams.Buffer(capacity: 0);
+
+            await winRTStream.WriteAsync(winRTBuffer);
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void TestStreamWriteAsync()
+        {
+            Assert.True(InvokeStreamWriteAsync().Wait(1000));
+        }
+
         [Fact]
         public void TestAsStream()
         {

--- a/cswinrt/strings/additions/Windows.Storage.Streams/StreamOperationsImplementation.cs
+++ b/cswinrt/strings/additions/Windows.Storage.Streams/StreamOperationsImplementation.cs
@@ -201,8 +201,9 @@ namespace Windows.Storage.Streams
                     int buffSize = 0x4000;
                     if (bytesToWrite < buffSize)
                         buffSize = (int)bytesToWrite;
-
-                    await dataStream.CopyToAsync(stream, buffSize, cancelToken).ConfigureAwait(continueOnCapturedContext: false);
+                    
+                    if (buffSize > 0)
+                        await dataStream.CopyToAsync(stream, buffSize, cancelToken).ConfigureAwait(continueOnCapturedContext: false);
 
                     if (progressListener != null)
                         progressListener.Report((uint)bytesToWrite);


### PR DESCRIPTION
Adds a condition when writing to a WinRT buffer to skip copying when 0 bytes to copy. 
Also adds a unit test for this case that was failing previously. 

Fixes #580 

