### PR TITLE
Remove another reference to Host.Shim dll

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -21,8 +21,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Remove WinRT.Host.Shim.dll references -->
   <Target Name="CsWinRTRemoveShimDllReferences" AfterTargets="ResolvePackageAssets" BeforeTargets="ResolveLockFileAnalyzers" Outputs="@(Reference)">
     <ItemGroup>
-     <Reference             Remove="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll"/>
-     <RuntimeCopyLocalItems Remove="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll"/>
+     <Reference                      Remove="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll"/>
+     <RuntimeCopyLocalItems          Remove="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll"/>
+     <ResolvedCompileFileDefinitions Remove="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Discovered this morning that I missed a spot to remove the references to Host.Shim 