### PR TITLE
Add vtable entry for covariant IEnumerable<object> for WinRT types too.

### DIFF
--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -481,6 +481,34 @@ namespace winrt::TestComponentCSharp::implementation
     {
         _objectIterableChanged.remove(token);
     }
+    IIterable<IIterable<WF::Point>> Class::IterableOfPointIterablesProperty()
+    {
+        return _pointIterableIterable;
+    }
+    void Class::IterableOfPointIterablesProperty(IIterable<IIterable<WF::Point>> const& value)
+    {
+        for (auto pointList : value)
+        {
+            for (auto point : pointList)
+            {
+            }
+        }
+        _pointIterableIterable = value;
+    }
+    IIterable<IIterable<WF::IInspectable>> Class::IterableOfObjectIterablesProperty()
+    {
+        return _objectIterableIterable;
+    }
+    void Class::IterableOfObjectIterablesProperty(IIterable<IIterable<WF::IInspectable>> const& value)
+    {
+        for (auto objectList : value)
+        {
+            for (auto object : objectList)
+            {
+            }
+        }
+        _objectIterableIterable = value;
+    }
     Uri Class::UriProperty()
     {
         return _uri;

--- a/TestComponentCSharp/Class.cpp
+++ b/TestComponentCSharp/Class.cpp
@@ -487,9 +487,9 @@ namespace winrt::TestComponentCSharp::implementation
     }
     void Class::IterableOfPointIterablesProperty(IIterable<IIterable<WF::Point>> const& value)
     {
-        for (auto pointList : value)
+        for (auto points : value)
         {
-            for (auto point : pointList)
+            for (auto point : points)
             {
             }
         }
@@ -501,9 +501,9 @@ namespace winrt::TestComponentCSharp::implementation
     }
     void Class::IterableOfObjectIterablesProperty(IIterable<IIterable<WF::IInspectable>> const& value)
     {
-        for (auto objectList : value)
+        for (auto objects : value)
         {
-            for (auto object : objectList)
+            for (auto object : objects)
             {
             }
         }

--- a/TestComponentCSharp/Class.h
+++ b/TestComponentCSharp/Class.h
@@ -37,6 +37,8 @@ namespace winrt::TestComponentCSharp::implementation
         Windows::Foundation::IInspectable _object;
         winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::IInspectable>> _objectChanged;
         Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable> _objectIterable;
+        Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::Point>> _pointIterableIterable;
+        Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable>> _objectIterableIterable;
         winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable>>> _objectIterableChanged;
         Windows::Foundation::Uri _uri;
         winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::Uri>> _uriChanged;
@@ -153,6 +155,10 @@ namespace winrt::TestComponentCSharp::implementation
         void CallForObjectIterable(TestComponentCSharp::ProvideObjectIterable const& provideObjectIterable);
         winrt::event_token ObjectIterablePropertyChanged(Windows::Foundation::EventHandler<Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable>> const& handler);
         void ObjectIterablePropertyChanged(winrt::event_token const& token) noexcept;
+        Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::Point>> IterableOfPointIterablesProperty();
+        void IterableOfPointIterablesProperty(Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::Point>> const& value);
+        Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable>> IterableOfObjectIterablesProperty();
+        void IterableOfObjectIterablesProperty(Windows::Foundation::Collections::IIterable<Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable>> const& value);
         Windows::Foundation::Uri UriProperty();
         void UriProperty(Windows::Foundation::Uri const& value);
         void RaiseUriChanged();

--- a/TestComponentCSharp/TestComponentCSharp.idl
+++ b/TestComponentCSharp/TestComponentCSharp.idl
@@ -176,6 +176,8 @@ namespace TestComponentCSharp
         void RaiseObjectIterableChanged();
         void CallForObjectIterable(ProvideObjectIterable provideObjectIterable);
         event Windows.Foundation.EventHandler<Windows.Foundation.Collections.IIterable<Object> > ObjectIterablePropertyChanged;
+        Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IIterable<Windows.Foundation.Point> > IterableOfPointIterablesProperty;
+        Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IIterable<Object> > IterableOfObjectIterablesProperty;
 
         Windows.Foundation.Uri UriProperty;
         void RaiseUriChanged();

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -707,14 +707,6 @@ namespace UnitTest
             var objectUriArray = new object[] { new Uri("http://github.com") };
             TestObject.ObjectIterableProperty = objectUriArray;
             Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(objectUriArray));
-
-            var listOfListOfUris = new List<List<Uri>>() {
-                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://github.com") },
-                new List<Uri>{ new Uri("http://aka.ms/cswinrt") },
-                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://microsoft.com") }
-            };
-            TestObject.IterableOfObjectIterablesProperty = listOfListOfUris;
-            Assert.True(TestObject.IterableOfObjectIterablesProperty.SequenceEqual(listOfListOfUris));
         }
 
         [Fact]
@@ -2289,6 +2281,14 @@ namespace UnitTest
             };
             TestObject.IterableOfPointIterablesProperty = listOfListOfPoints;
             Assert.True(TestObject.IterableOfPointIterablesProperty.SequenceEqual(listOfListOfPoints));
+
+            var listOfListOfUris = new List<List<Uri>>() {
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://github.com") },
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt") },
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://microsoft.com") }
+            };
+            TestObject.IterableOfObjectIterablesProperty = listOfListOfUris;
+            Assert.True(TestObject.IterableOfObjectIterablesProperty.SequenceEqual(listOfListOfUris));
         }
     }
 }

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -688,6 +688,21 @@ namespace UnitTest
             var objects = new List<ManagedType>() { new ManagedType(), new ManagedType() };
             var query = from item in objects select item;
             TestObject.ObjectIterableProperty = query;
+
+            TestObject.ObjectProperty = "test";
+            Assert.Equal("test", TestObject.ObjectProperty);
+
+            var objectArray = new ManagedType[] { new ManagedType(), new ManagedType() };
+            TestObject.ObjectIterableProperty = objectArray;
+            Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(objectArray));
+
+            var strArray = new string[] { "str1", "str2", "str3" };
+            TestObject.ObjectIterableProperty = strArray;
+            Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(strArray));
+
+            var uriArray = new Uri[] { new Uri("http://aka.ms/cswinrt"), new Uri("http://github.com") };
+            TestObject.ObjectIterableProperty = uriArray;
+            Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(uriArray));
         }
 
         [Fact]

--- a/UnitTest/TestComponentCSharp_Tests.cs
+++ b/UnitTest/TestComponentCSharp_Tests.cs
@@ -703,6 +703,18 @@ namespace UnitTest
             var uriArray = new Uri[] { new Uri("http://aka.ms/cswinrt"), new Uri("http://github.com") };
             TestObject.ObjectIterableProperty = uriArray;
             Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(uriArray));
+
+            var objectUriArray = new object[] { new Uri("http://github.com") };
+            TestObject.ObjectIterableProperty = objectUriArray;
+            Assert.True(TestObject.ObjectIterableProperty.SequenceEqual(objectUriArray));
+
+            var listOfListOfUris = new List<List<Uri>>() {
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://github.com") },
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt") },
+                new List<Uri>{ new Uri("http://aka.ms/cswinrt"), new Uri("http://microsoft.com") }
+            };
+            TestObject.IterableOfObjectIterablesProperty = listOfListOfUris;
+            Assert.True(TestObject.IterableOfObjectIterablesProperty.SequenceEqual(listOfListOfUris));
         }
 
         [Fact]
@@ -2265,6 +2277,18 @@ namespace UnitTest
         {
             CustomBindableVectorTest vector = new CustomBindableVectorTest();
             Assert.NotNull(vector);
+        }
+
+        [Fact]
+        public void TestCovariance()
+        {
+            var listOfListOfPoints = new List<List<Point>>() {
+                new List<Point>{ new Point(1, 1), new Point(1, 2), new Point(1, 3) },
+                new List<Point>{ new Point(2, 1), new Point(2, 2), new Point(2, 3) },
+                new List<Point>{ new Point(3, 1), new Point(3, 2), new Point(3, 3) }
+            };
+            TestObject.IterableOfPointIterablesProperty = listOfListOfPoints;
+            Assert.True(TestObject.IterableOfPointIterablesProperty.SequenceEqual(listOfListOfPoints));
         }
     }
 }

--- a/WinRT.Runtime/ComWrappersSupport.cs
+++ b/WinRT.Runtime/ComWrappersSupport.cs
@@ -107,14 +107,17 @@ namespace WinRT
                 }
 
                 if (iface.IsConstructedGenericType
-                    && Projections.TryGetCompatibleWindowsRuntimeTypeForVariantType(iface, out var compatibleIface))
+                    && Projections.TryGetCompatibleWindowsRuntimeTypesForVariantType(iface, out var compatibleIfaces))
                 {
-                    var compatibleIfaceAbiType = compatibleIface.FindHelperType();
-                    entries.Add(new ComInterfaceEntry
+                    foreach (var compatibleIface in compatibleIfaces)
                     {
-                        IID = GuidGenerator.GetIID(compatibleIfaceAbiType),
-                        Vtable = (IntPtr)compatibleIfaceAbiType.GetAbiToProjectionVftblPtr()
-                    });
+                        var compatibleIfaceAbiType = compatibleIface.FindHelperType();
+                        entries.Add(new ComInterfaceEntry
+                        {
+                            IID = GuidGenerator.GetIID(compatibleIfaceAbiType),
+                            Vtable = (IntPtr)compatibleIfaceAbiType.GetAbiToProjectionVftblPtr()
+                        });
+                    }
                 }
             }
 

--- a/WinRT.Runtime/Projections.cs
+++ b/WinRT.Runtime/Projections.cs
@@ -226,21 +226,14 @@ namespace WinRT
             var newArguments = new Type[genericArguments.Length];
             for (int i = 0; i < genericArguments.Length; i++)
             {
-                if (!IsTypeWindowsRuntimeTypeNoArray(genericArguments[i]))
+                bool argumentCovariant = (genericConstraints[i].GenericParameterAttributes & GenericParameterAttributes.VarianceMask) == GenericParameterAttributes.Covariant;
+                if (argumentCovariant && !genericArguments[i].IsValueType)
                 {
-                    bool argumentCovariant = (genericConstraints[i].GenericParameterAttributes & GenericParameterAttributes.VarianceMask) == GenericParameterAttributes.Covariant;
-                    if (argumentCovariant && !genericArguments[i].IsValueType)
-                    {
-                        newArguments[i] = typeof(object);
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    newArguments[i] = typeof(object);
                 }
                 else
                 {
-                    newArguments[i] = genericArguments[i];
+                    return false;
                 }
             }
             compatibleType = definition.MakeGenericType(newArguments);


### PR DESCRIPTION
Adding a more complete covariant support.  For covariant interfaces, we get all the possible types that can be passed for the generic and create a vtable entry for them.  Along with that, if the generic is itself a covariant interface, we do the same for it.

For now, I haven't removed the previous version of this function as it was a public function.

Fixes #592 
Fixes #598  