### PR TITLE
Authoring: Diagnostic for private getter

### DIFF
--- a/src/Authoring/DiagnosticTests/NegativeData.cs
+++ b/src/Authoring/DiagnosticTests/NegativeData.cs
@@ -2,6 +2,15 @@ namespace DiagnosticTests
 {
     public sealed partial class UnitTesting
     {
+        private const string PropertyNoGetter = @"
+namespace DiagnosticTests
+{
+    public sealed class PrivateSetter
+    {
+        public int MyInt { set { } }
+    }
+}";
+
         private const string PrivateGetter = @"
 namespace DiagnosticTests
 {

--- a/src/Authoring/DiagnosticTests/NegativeData.cs
+++ b/src/Authoring/DiagnosticTests/NegativeData.cs
@@ -2,6 +2,16 @@ namespace DiagnosticTests
 {
     public sealed partial class UnitTesting
     {
+        private const string PrivateGetter = @"
+namespace DiagnosticTests
+{
+    public sealed class PrivateGetter
+    {
+        public int MyInt { private get; set; }
+    }
+}";
+
+
         private const string SameNameNamespacesDisjoint = @"
 namespace DiagnosticTests
 {

--- a/src/Authoring/DiagnosticTests/PositiveData.cs
+++ b/src/Authoring/DiagnosticTests/PositiveData.cs
@@ -2,6 +2,16 @@ namespace DiagnosticTests
 {
     public sealed partial class UnitTesting
     {
+
+        private const string Valid_PrivateSetter = @"
+namespace DiagnosticTests
+{
+    public sealed class PrivateSetter
+    {
+        public int MyInt { get; private set; }
+    }
+}";
+
         private const string Valid_RollYourOwnAsyncAction = @"
 using System;
 using Windows.Foundation;

--- a/src/Authoring/DiagnosticTests/PositiveData.cs
+++ b/src/Authoring/DiagnosticTests/PositiveData.cs
@@ -1,8 +1,9 @@
+using NUnit.Framework;
+
 namespace DiagnosticTests
 {
     public sealed partial class UnitTesting
     {
-
         private const string Valid_PrivateSetter = @"
 namespace DiagnosticTests
 {

--- a/src/Authoring/DiagnosticTests/UnitTesting.cs
+++ b/src/Authoring/DiagnosticTests/UnitTesting.cs
@@ -98,6 +98,7 @@ namespace DiagnosticTests
             {
                 // private getter
                 yield return new TestCaseData(PrivateGetter, WinRTRules.PrivateGetterRule).SetName("Property. PrivateGetter");
+                yield return new TestCaseData(PropertyNoGetter).SetName("Property. No Get, public Setter");
                 // namespace tests
                 yield return new TestCaseData(SameNameNamespacesDisjoint, WinRTRules.DisjointNamespaceRule).SetName("Namespace. isn't accessible without Test prefix, doesn't use type");
                 yield return new TestCaseData(NamespacesDifferByCase, WinRTRules.NamespacesDifferByCase).SetName("Namespace. names only differ by case");

--- a/src/Authoring/DiagnosticTests/UnitTesting.cs
+++ b/src/Authoring/DiagnosticTests/UnitTesting.cs
@@ -96,6 +96,8 @@ namespace DiagnosticTests
         {
             get 
             {
+                // private getter
+                yield return new TestCaseData(PrivateGetter, WinRTRules.PrivateGetterRule).SetName("Property. PrivateGetter");
                 // namespace tests
                 yield return new TestCaseData(SameNameNamespacesDisjoint, WinRTRules.DisjointNamespaceRule).SetName("Namespace. isn't accessible without Test prefix, doesn't use type");
                 yield return new TestCaseData(NamespacesDifferByCase, WinRTRules.NamespacesDifferByCase).SetName("Namespace. names only differ by case");
@@ -392,6 +394,7 @@ namespace DiagnosticTests
         {
             get
             {
+                yield return new TestCaseData(Valid_PrivateSetter).SetName("Valid. Property. Private Setter");
                 yield return new TestCaseData(Valid_RollYourOwnAsyncAction).SetName("Valid. AsyncInterfaces. Implementing your own IAsyncAction");
                 yield return new TestCaseData(Valid_CustomDictionary).SetName("Valid. CustomProjection. IDictionary<string,BasicStruct>");
                 yield return new TestCaseData(Valid_CustomList).SetName("Valid. CustomProjection. IList<DisposableClass>");

--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -230,7 +230,7 @@ namespace Generator
                 var propSym = GetModel(prop.SyntaxTree).GetDeclaredSymbol(prop);
                 var loc = prop.GetLocation();
 
-                if (!propSym.GetMethod.DeclaredAccessibility.Equals(Accessibility.Public))
+                if (propSym.GetMethod == null || !propSym.GetMethod.DeclaredAccessibility.Equals(Accessibility.Public))
                 {
                     Report(WinRTRules.PrivateGetterRule, loc, prop.Identifier);
                 }

--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -230,7 +230,7 @@ namespace Generator
                 var propSym = GetModel(prop.SyntaxTree).GetDeclaredSymbol(prop);
                 var loc = prop.GetLocation();
 
-                if (propSym.GetMethod.DeclaredAccessibility.Equals(Accessibility.Private))
+                if (!propSym.GetMethod.DeclaredAccessibility.Equals(Accessibility.Public))
                 {
                     Report(WinRTRules.PrivateGetterRule, loc, prop.Identifier);
                 }

--- a/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
@@ -21,6 +21,11 @@ namespace WinRT.SourceGenerator
                 helpLinkUri: "https://docs.microsoft.com/en-us/previous-versions/hh977010(v=vs.110)");
         }
 
+        public static DiagnosticDescriptor PrivateGetterRule = MakeRule(
+            "WME", 
+            "Property must have public getter",
+            "Property '{0}' does not have a public getter method. Windows Metadata does not support setter-only properties.");
+        
         public static DiagnosticDescriptor DisjointNamespaceRule = MakeRule(
             "WME1044",
             "Namespace is disjoint from main (winmd) namespace",


### PR DESCRIPTION
There was a diagnostic missed for private getters, I am adding a positive and negative test case for private setter and private getter on properties (respectively). My change is to look at the method accessibility on all property symbols, via the `CheckProperties` function -- which is the new name of `CheckPropertySignature`. 

The function `CheckPropertySignature` used in checking classe **and** interfaces, and this check really only needs to happen for classes. Originally, I thought to take the loop out of the helper function and leave it in the class loop of `FindDiagnostics`. But felt like looping over properties twice wasn't essential. Open to feedback on whether to do this check for interfaces or not. 