### PR TITLE
Fix issue where the same component can be loaded in multiple ALC and cause cast issues 

### DIFF
--- a/src/Authoring/WinRT.Host.Shim/Module.cs
+++ b/src/Authoring/WinRT.Host.Shim/Module.cs
@@ -2,14 +2,8 @@
 // to simplify deployment
 
 using System;
-using System.Collections.Generic;
-using System.IO;
+using System.Collections.Concurrent;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using Windows.Foundation;
-using WinRT;
 
 #if !NETSTANDARD2_0
 using System.Runtime.Loader;
@@ -70,12 +64,13 @@ namespace WinRT.Host
 #else
         private class ActivationLoader : AssemblyLoadContext
         {
+            private static readonly ConcurrentDictionary<string, ActivationLoader> ALCMapping = new ConcurrentDictionary<string, ActivationLoader>();
             private AssemblyDependencyResolver _resolver;
 
             public static Assembly LoadAssembly(string targetAssembly)
             {
-                var loader = new ActivationLoader(targetAssembly);
-                return loader.LoadFromAssemblyPath(targetAssembly);
+                return ALCMapping.GetOrAdd(targetAssembly, (_) => new ActivationLoader(targetAssembly))
+                    .LoadFromAssemblyPath(targetAssembly);
             }
 
             private ActivationLoader(string path)
@@ -95,7 +90,6 @@ namespace WinRT.Host
                     return null;
                 };
             }
-
 
             protected override Assembly Load(AssemblyName assemblyName)
             {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,7 +36,7 @@
     <CsWinRTPath Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([MSBuild]::NormalizeDirectory('$(SolutionDir)_build', 'x86', '$(Configuration)', 'cswinrt', 'bin'))</CsWinRTPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.wapproj'">
     <OutDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'bin'))</OutDir>
     <IntDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'obj'))</IntDir>
   </PropertyGroup>

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -308,9 +308,7 @@ TEST(AuthoringTest, CustomDictionaryImplementations)
 
     EXPECT_EQ(dictionary.GetView().TryLookup(L"second").value(), basicStruct2);
     EXPECT_FALSE(dictionary.GetView().TryLookup(L"fourth").has_value());
-
-    // TODO: Broken due to ALC type mismatch.
-/*  
+  
     TestClass testClass;
     EXPECT_EQ(testClass.GetSum(dictionary, L"second"), 4);
 
@@ -330,15 +328,13 @@ TEST(AuthoringTest, CustomDictionaryImplementations)
     EXPECT_TRUE(mapSplit1.HasKey(L"first"));
     EXPECT_FALSE(mapSplit1.HasKey(L"third"));
     EXPECT_TRUE(mapSplit2.HasKey(L"third"));
-    */
 
     Windows::Foundation::Collections::IMap<hstring, AuthoringTest::BasicStruct> map = dictionary;
     map.Clear();
     EXPECT_EQ(map.Size(), 0);
 }
 
-// TODO: Broken due to ALC type mismatch.
-TEST(AuthoringTest, DISABLED_CustomVectorImplementations)
+TEST(AuthoringTest, CustomVectorImplementations)
 {
     TestClass testClass;
     testClass.SetProjectedDisposableObject();


### PR DESCRIPTION
Previously if you activate multiple types from a component, you can run into cast issues when you pass things between them.  This was because each type activation from a component was going into its own ALC.  Now we have a singleton pattern where for a given component binary, it gets loaded in the same ALC preventing the cast issues.  There is still a possibility if multiple components are in use and they pass dependent authored types between each other, we can possibly still run into similar issues which I am not addressing as part of this PR.

Also changing bin directory of wapproj projects to _build folder.

Fixes #633 