### PR TITLE
Fix path to generated winmd

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -143,14 +143,14 @@ $(CsWinRTFilters)
   <Target Name="CsWinRTPlaceWinMDInOutputFolder"
           Condition="'$(CsWinRTComponent)' == 'true'" 
           BeforeTargets="AfterBuild">
-      <ItemGroup>
-        <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd"
-                               Condition="Exists('$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd')" />
+    <ItemGroup>
+      <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd"
+                             Condition="Exists('$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd')" />
 
-        <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\$(AssemblyName).winmd"
-                               Condition="Exists('$(GeneratedFilesDir)\$(AssemblyName).winmd')" />
-      </ItemGroup>
-      <Copy SourceFiles="@(CsWinRTGeneratedWinMD)" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+      <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\$(AssemblyName).winmd"
+                             Condition="Exists('$(GeneratedFilesDir)\$(AssemblyName).winmd')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CsWinRTGeneratedWinMD)" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>
 
   <!-- When an authored component packs (nuget), add the necessary hosting assets to the package -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -143,14 +143,7 @@ $(CsWinRTFilters)
   <Target Name="CsWinRTPlaceWinMDInOutputFolder"
           Condition="'$(CsWinRTComponent)' == 'true'" 
           BeforeTargets="AfterBuild">
-    <ItemGroup>
-      <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd"
-                             Condition="Exists('$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd')" />
-
-      <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\$(AssemblyName).winmd"
-                             Condition="Exists('$(GeneratedFilesDir)\$(AssemblyName).winmd')" />
-    </ItemGroup>
-    <Copy SourceFiles="@(CsWinRTGeneratedWinMD)" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(GeneratedFilesDir)\$(AssemblyName).winmd" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>
 
   <!-- When an authored component packs (nuget), add the necessary hosting assets to the package -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -143,10 +143,14 @@ $(CsWinRTFilters)
   <Target Name="CsWinRTPlaceWinMDInOutputFolder"
           Condition="'$(CsWinRTComponent)' == 'true'" 
           BeforeTargets="AfterBuild">
-    <Copy SourceFiles="Generated Files\$(AssemblyName).winmd"
-          DestinationFolder="$(TargetDir)"
-          UseHardlinksIfPossible="false"
-          SkipUnchangedFiles="true" />
+      <ItemGroup>
+        <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd"
+                               Condition="Exists('$(GeneratedFilesDir)\net5**\$(AssemblyName).winmd')" />
+
+        <CsWinRTGeneratedWinMD Include="$(GeneratedFilesDir)\$(AssemblyName).winmd"
+                               Condition="Exists('$(GeneratedFilesDir)\$(AssemblyName).winmd')" />
+      </ItemGroup>
+      <Copy SourceFiles="@(CsWinRTGeneratedWinMD)" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>
 
   <!-- When an authored component packs (nuget), add the necessary hosting assets to the package -->


### PR DESCRIPTION
My PR to update nuget targets had a bug when trying to copy the generated winmd to the output (bin) directory. This should fix it (tested locally)