### PR TITLE
Add DefaultOverload attribute to projected interface methods

### DIFF
--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -956,6 +957,25 @@ namespace AuthoringTest
         public IEnumerator GetEnumerator()
         {
             return _enumerable.GetEnumerator();
+        }
+    }
+
+    public sealed class CustomXamlMetadataProvider : IXamlMetadataProvider
+    {
+        // Tests DefaultOverload attribute specified in projected interface.
+        public IXamlType GetXamlType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IXamlType GetXamlType(string fullName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public XmlnsDefinition[] GetXmlnsDefinitions()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1303,7 +1303,7 @@ remove => %.% -= value;
                 }
             }
             // Skip metadata attributes
-            if (attribute_namespace == "Windows.Foundation.Metadata" && attribute_name != "DefaultOverload") continue;
+            if (attribute_namespace == "Windows.Foundation.Metadata" && attribute_name != "DefaultOverload" && attribute_name != "Overload") continue;
             attributes[attribute_full] = std::move(params);
         }
         if (auto&& usage = attributes.find("AttributeUsage"); usage != attributes.end())

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1303,7 +1303,7 @@ remove => %.% -= value;
                 }
             }
             // Skip metadata attributes
-            if (attribute_namespace == "Windows.Foundation.Metadata") continue;
+            if (attribute_namespace == "Windows.Foundation.Metadata" && attribute_name != "DefaultOverload") continue;
             attributes[attribute_full] = std::move(params);
         }
         if (auto&& usage = attributes.find("AttributeUsage"); usage != attributes.end())
@@ -2330,7 +2330,8 @@ private static global::System.Runtime.CompilerServices.ConditionalWeakTable<IWin
 
             method_signature signature{ method };
             w.write(R"(
-% %(%);)",
+%% %(%);)",
+                bind<write_custom_attributes>(method.CustomAttribute(), false),
                 bind<write_projection_return_type>(signature),
                 method.Name(),
                 bind_list<write_projection_parameter>(", ", signature.params())


### PR DESCRIPTION
Previous fix for DefaultOverload attribute was not enough because our projected interface methods in consumption scenarios do not project that attribute.  Given we need to be aware in authoring scenarios whether an method being implemented is the one with default overload specified, updating for that attribute to be projected.

Fixes #662 