### PR TITLE
Fixed ObjectDisposedException on delegates

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -117,7 +117,7 @@ namespace WinRT
             var rcw = ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
 
             // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
-            var target = rcw is System.Delegate del ? del.Target : rcw;
+            var target = rcw is Delegate del ? del.Target : rcw;
             if (target is IWinRTObject winrtObj)
             {
                 winrtObj.Resurrect();

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -112,7 +112,18 @@ namespace WinRT
 
         public static void RegisterObjectForInterface(object obj, IntPtr thisPtr) => TryRegisterObjectForInterface(obj, thisPtr);
 
-        public static object TryRegisterObjectForInterface(object obj, IntPtr thisPtr) => ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
+        public static object TryRegisterObjectForInterface(object obj, IntPtr thisPtr)
+        {
+            var rcw = ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
+
+            // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
+            var target = rcw is System.Delegate del ? del.Target : rcw;
+            if (target is IWinRTObject winrtObj)
+            {
+                winrtObj.Resurrect();
+            }
+            return rcw;
+        }
 
         public static IObjectReference CreateCCWForObject(object obj)
         {


### PR DESCRIPTION
A delegate previously associated with a this ptr may be reused by the ComWrappers API even though its native object has already been disposed.  In this case, resurrect them similar to how we did with the non delegate scenario.

Fixes #640 