### PR TITLE
Update nuget targets

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -43,27 +43,6 @@ To use the component in a C# app, the authored component just needs to be added 
 
 For native (C++) apps, there are DLLs needed to host your authored component. When you use the automatic nuget packaging on-build support (in Visual Studio) to make a nupkg for your runtime component, the DLLs/WinMD are automatically added to your nupkg, before the ```GenerateNuspec``` MSBuild step.
 
-You will need to create a targets file for your component, if you are not already, that imports a CsWinRT targets file. The imported targets file configures the native app to use the hosting dlls at runtime.
-This means for your component ```MyAuthoredComponent```, you will need a targets file that has an import statment for ```MyAuthoredComponent.CsWinRT.targets```. 
-The targets file you need **must** be named ```MyAuthoredComponent.targets```, otherwise NuGet will ignore it.
-
-For example, the simplest definition of ```MyAuthoredComponent.targets``` would be:
-``` targets
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildThisDirectory)MyAuthoredComponent.CsWinRT.targets"	/>
-</Project>
-```
-
-The ```MyAuthoredComponent.CsWinRT.targets``` is added to the package by CsWinRT, you'll just need to add your ```MyAuthoredComponent.targets``` file to the package as well.
-Do this by adding the following to ``MyAuthoredComponent.csproj```
-
-``` csproj
-<ItemGroup>
-  <_PackageFiles Include="MyAuthoredComponent.targets" PackagePath="build;buildTransitive"/>
-</ItemGroup>
-```
-
 **If you are going to write your own nuspec, i.e. not rely on automatic packaging** then the CsWinRT target that adds the hosting dlls to your package will not run, and you should make sure your nuspec contains the following ```file``` entries for ```MyAuthoredComponent``` (note: your TargetFramework may vary). If adding a file entry for ```Coords.targets``` does not work, then update the project file per the above example. 
 
 ``` nuspec

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -47,24 +47,24 @@ For native (C++) apps, there are DLLs needed to host your authored component. Wh
 
 ``` nuspec
 <files>
-  <file src="$(TargetDir)MyAuthoredComponent.dll"                    target="lib\native\MyAuthoredComponent.dll" />
-  <file src="$(TargetDir)MyAuthoredComponent.winmd"                  target="winmd\MyAuthoredComponent.winmd" />
+  <file src="$(TargetDir)MyAuthoredComponent.dll"        target="native\MyAuthoredComponent.dll" />
+  <file src="$(TargetDir)MyAuthoredComponent.winmd"      target="winmd\MyAuthoredComponent.winmd" />
   
-  <file src="$(TargetDir)Microsoft.Windows.SDK.NET.dll"              target="lib\native\Microsoft.Windows.SDK.NET.dll" />
+  <file src="$(TargetDir)Microsoft.Windows.SDK.NET.dll"  target="native\Microsoft.Windows.SDK.NET.dll" />
    
   <!-- Note: you must rename the CsWinRt.Authoring.Targets as follows -->
   <file src="C:\Path\To\CsWinRT\NugetDir\buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets"   
-        target="buildTransitive\MyAuthoredComponent.CsWinRT.targets" />
+        target="buildTransitive\MyAuthoredComponent.targets" />
    
   <file src="C:\Path\To\CsWinRT\NugetDir\build\Microsoft.Windows.CsWinRT.Authoring.targets"       
-        target="build\MyAuthoredComponent.CsWinRT.targets" />
+        target="build\MyAuthoredComponent.targets" />
    
   <!-- Include the managed DLLs -->
   <file src="C:\Path\To\CsWinRT\NugetDir\lib\net5.0\WinRT.Host.Shim.dll"                                  
-        target="lib\native\WinRT.Host.Shim.dll" />
+        target="native\WinRT.Host.Shim.dll" />
     
   <file src="C:\Path\To\CsWinRT\NugetDir\lib\net5.0\WinRT.Runtime.dll"                                  
-        target="lib\native\WinRT.Runtime.dll" />
+        target="native\WinRT.Runtime.dll" />
     
   <!-- Include the native DLLs -->
   <file src="C:\Path\To\CsWinRT\NugetDir\runtimes\win-x64\native\WinRT.Host.dll"                                  

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -19,6 +19,7 @@
   <Target Name="CsWinRTAddAuthoredWinMDReference" 
           Condition="'$(HostingSupport-IsNative)' == 'true'"
           Outputs="@(Reference)">
+    <!-- Add the WinMD file as a reference of the native app -->
     <ItemGroup> 
       <Reference Include="$(HostingSupport-MetadataDir)\*" />
     </ItemGroup>

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <HostingSupport-NativeDir>$(MSBuildThisFileDirectory)..\lib\native</HostingSupport-NativeDir>
+      <HostingSupport-NativeDir>$(MSBuildThisFileDirectory)..\native</HostingSupport-NativeDir>
       <HostingSupport-MetadataDir>$(MSBuildThisFileDirectory)..\winmd</HostingSupport-MetadataDir>
       <HostingSupport-RuntimesDir>$(MSBuildThisFileDirectory)..\runtimes</HostingSupport-RuntimesDir>
       <HostingSupport-IsNative  Condition="'$(TargetFramework)' == 'native' OR '$(TargetFramework)' == ''">true</HostingSupport-IsNative>
@@ -16,19 +16,16 @@
   </PropertyGroup> 
 
   <!-- Happens before building, so C++/WinRT can make the corresponding header files -->
-  <Target Name="CsWinRTAddAuthoredWinMDReference" 
-          Condition="'$(HostingSupport-IsNative)' == 'true'"
-          Outputs="@(Reference)">
-    <!-- Add the WinMD file as a reference of the native app -->
-    <ItemGroup> 
+  <Target Name="CsWinRTAddAuthoredWinMDReference" Condition="'$(HostingSupport-IsNative)' == 'true'" Outputs="@(Reference)">
+    
+    <ItemGroup Label="Add the WinMD file as a reference of the native app"> 
       <Reference Include="$(HostingSupport-MetadataDir)\*" />
     </ItemGroup>
+
   </Target>
 
   <!-- Happens when resolving references, so the app can be hosted -->
-  <Target Name="CsWinRTCopyAuthoringDlls" 
-          Condition="'$(HostingSupport-IsNative)' == 'true'"
-          Outputs="@(ReferenceCopyLocalPaths)">
+  <Target Name="CsWinRTCopyAuthoringDlls" Condition="'$(HostingSupport-IsNative)' == 'true'" Outputs="@(ReferenceCopyLocalPaths)">
     
     <ItemGroup Label="Copy Dlls needed for hosting/using authored components">
       <ReferenceCopyLocalPaths Include="$(HostingSupport-NativeDir)\*" />
@@ -41,6 +38,7 @@
       <ReferenceCopyLocalPaths Include="$(HostingSupport-RuntimesDir)\win-x86\native\WinRT.Host.dll" 
                                Condition="'$(Platform)' == 'Win32'"/> 
     </ItemGroup> 
+
   </Target>
 
 </Project>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -163,7 +163,7 @@ $(CsWinRTFilters)
       <!-- Custom targets that copy dlls for consumers of the authored component.
            `buildTransitive\` is for PackageReference, `build\` is for packages.config -->
       <_PackageFiles Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets"
-                     PackagePath="buildTransitive\$(AssemblyName).CsWinRT.targets;build\$(AssemblyName).CsWinRT.targets"/>
+                     PackagePath="buildTransitive\$(AssemblyName).targets;build\$(AssemblyName).targets"/>
 
       <!-- WinRT.Host.dll is architecture specific -->
       <!-- x64 --> 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -140,50 +140,58 @@ $(CsWinRTFilters)
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets')"/>
 
   <!-- Copy Authored winmd to output folder -->
-  <Target Name="CsWinRTPlaceWinMDInOutputFolder"
-          Condition="'$(CsWinRTComponent)' == 'true'" 
-          BeforeTargets="AfterBuild">
+  <Target Name="CsWinRTPlaceWinMDInOutputFolder" Condition="'$(CsWinRTComponent)' == 'true'" BeforeTargets="AfterBuild">
     <Copy SourceFiles="$(GeneratedFilesDir)\$(AssemblyName).winmd" DestinationFolder="$(TargetDir)" UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- When an authored component packs (nuget), add the necessary hosting assets to the package -->
-  <Target Name="CsWinRTIncludeHostDlls"  
-          Condition="'$(CsWinRTComponent)' == 'true'" 
-          BeforeTargets="GenerateNuspec" 
-          Outputs="@(_PackageFiles)">
+  <!-- When an authored component makes a nupkg, add the necessary hosting assets to the package -->
+  <Target Name="CsWinRTIncludeHostDlls"  Condition="'$(CsWinRTComponent)' == 'true'" BeforeTargets="AfterBuild" Outputs="@(Content)">
     <ItemGroup>
-      <_PackageFiles Include="$(TargetDir)$(AssemblyName).winmd"
-                     PackagePath="winmd\"/>
+      <Content Include="$(TargetDir)$(AssemblyName).winmd"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="winmd" />
       
       <!-- The authored component gets the WinRT.Runtime and NET.SDK dlls from ReferenceCopyLocalPaths 
-            (because CopyLocalLockFileAssemblies == true); $(TargetPath) has the assembly (e.g. PackageId.dll) -->
-      <_PackageFiles Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll;@(ReferenceCopyLocalPaths);$(TargetPath)"
-                     PackagePath="lib\native"/>
+            (because CopyLocalLockFileAssemblies == true) and $(TargetPath) has the assembly (e.g. PackageId.dll) -->
+      <Content Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll;@(ReferenceCopyLocalPaths);$(TargetPath)"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="native" />
 
       <!-- Custom targets that copy dlls for consumers of the authored component.
            `buildTransitive\` is for PackageReference, `build\` is for packages.config -->
-      <_PackageFiles Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets"
-                     PackagePath="buildTransitive\$(AssemblyName).targets;build\$(AssemblyName).targets"/>
+      <Content Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="buildTransitive\$(AssemblyName).targets;build\$(AssemblyName).targets"/>
 
       <!-- WinRT.Host.dll is architecture specific -->
       <!-- x64 --> 
-      <_PackageFiles Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll')" 
-                     Include="$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll"
-                     PackagePath="runtimes\win-x64\native"/>
+      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll')" 
+               Include="$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="runtimes\win-x64\native"/>
       <!-- x86 --> 
-      <_PackageFiles Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll')" 
-                     Include="$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll"
-                     PackagePath="runtimes\win-x86\native"/>
+      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll')" 
+               Include="$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="runtimes\win-x86\native"/>
       <!-- arm --> 
-      <_PackageFiles Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll')" 
-                     Include="$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll"
-                     PackagePath="runtimes\win-arm\native"/>
+      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll')" 
+               Include="$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="runtimes\win-arm\native"/>
       <!-- arm64 --> 
-      <_PackageFiles Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll')" 
-                     Include="$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll"
-                     PackagePath="runtimes\win-arm64\native"/>
+      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll')" 
+               Include="$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll"
+               Pack="true"
+               PackageCopyToOutput="true"
+               PackagePath="runtimes\win-arm64\native"/>
    </ItemGroup>
   </Target>
-
 
 </Project>


### PR DESCRIPTION
This PR makes two updates to our Authoring/Hosting support targets. 
1) We now automatically make the author's targets file -- if we get complaints about this in the future, then we can make a property that users can set to opt-out of this behavior. 

2) We do not use _PackageFiles anymore and authors do not have to create a targets file nor update their project file to include it. The latter part of this comes from (1), and the former from switching to "Content" type instead of "_PackageFiles". 

I tested this in my app, and it worked fine. 