### PR TITLE
Allow using non WinRT attributes on authored types

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2637,7 +2637,7 @@ namespace Generator
                     AddMappedType(type);
                 }
             }
-            else if(treatAsProjectedType)
+            else if (treatAsProjectedType)
             {
                 // Prioritize any mapped types before treating an attribute as a projected type.
                 AddProjectedType(type);

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -991,6 +992,7 @@ namespace AuthoringTest
         private double _number;
         private DoubleDelegate _doubleDelegate;
 
+        [Required(ErrorMessage = "Number is required")]
         public double Number { get => _number; set => _number = value; }
 
         public event DoubleDelegate DoubleDelegateEvent


### PR DESCRIPTION
Previously it seems .NET supported using C# attributes which had no WinRT type mapping on an authored type.  Given there doesn't seem to be any disadvantage to doing that, adding support for that to allow those source to continue to work with C#/WinRT authoring.

Fixes #695 