### PR TITLE
Fix authoring bugs

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <HostingSupport-NativeDir>$(MSBuildThisFileDirectory)..\lib\native</HostingSupport-NativeDir>
-      <HostingSupport-MetadataDir>$(MSBuildThisFileDirectory)..\winmd</HostingSupport-MetadataDir>
+      <HostingSupport-NativeDir>$(MSBuildThisFileDirectory)..\lib\net5.0*</HostingSupport-NativeDir>
+      <HostingSupport-MetadataDir>$(HostingSupport-NativeDir)\winmd</HostingSupport-MetadataDir>
       <HostingSupport-RuntimesDir>$(MSBuildThisFileDirectory)..\runtimes</HostingSupport-RuntimesDir>
       <HostingSupport-IsNative  Condition="'$(TargetFramework)' == 'native' OR '$(TargetFramework)' == ''">true</HostingSupport-IsNative>
       <HostingSupport-IsArmArch Condition="'$(Platform)' == 'arm' OR '$(Platform)' == 'arm64'">true</HostingSupport-IsArmArch>
@@ -19,7 +19,10 @@
   <Target Name="CsWinRTAddAuthoredWinMDReference" Condition="'$(HostingSupport-IsNative)' == 'true'" Outputs="@(Reference)">
     
     <ItemGroup Label="Add the WinMD file as a reference of the native app"> 
-      <Reference Include="$(HostingSupport-MetadataDir)\*" />
+      <Reference Include="$(HostingSupport-MetadataDir)\*.winmd">
+        <IsWinMDFile>true</IsWinMDFile>
+        <Implementation>WinRT.Host.dll</Implementation>
+      </Reference>
     </ItemGroup>
 
   </Target>
@@ -28,7 +31,7 @@
   <Target Name="CsWinRTCopyAuthoringDlls" Condition="'$(HostingSupport-IsNative)' == 'true'" Outputs="@(ReferenceCopyLocalPaths)">
     
     <ItemGroup Label="Copy Dlls needed for hosting/using authored components">
-      <ReferenceCopyLocalPaths Include="$(HostingSupport-NativeDir)\*" />
+      <ReferenceCopyLocalPaths Include="$(HostingSupport-NativeDir)\*.dll" />
     </ItemGroup>
 
     <ItemGroup Label="Copy the WinRT.Host dll, based on architecture">

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -147,20 +147,19 @@ $(CsWinRTFilters)
   <!-- When an authored component makes a nupkg, add the necessary hosting assets to the package -->
   <Target Name="CsWinRTIncludeHostDlls"  Condition="'$(CsWinRTComponent)' == 'true'" BeforeTargets="AfterBuild" Outputs="@(Content)">
     <ItemGroup>
-      <Content Include="$(TargetDir)$(AssemblyName).winmd"
-               Pack="true"
-               PackagePath="winmd" />
-      
-      <!-- The authored component gets the WinRT.Runtime and NET.SDK dlls from ReferenceCopyLocalPaths 
-            (because CopyLocalLockFileAssemblies == true) and $(TargetPath) has the assembly (e.g. PackageId.dll) -->
-      <Content Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll;@(ReferenceCopyLocalPaths);$(TargetPath)"
-               Pack="true"
-               PackagePath="lib\native" />
+      <CsWinRTAuthoringDependencyDlls Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll" />
+      <CsWinRTAuthoringDependencyDlls Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.FileName)%(Extension)' == 'WinRT.Runtime.dll'" />
+      <CsWinRTAuthoringDependencyDlls Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.FileName)%(Extension)' == 'Microsoft.Windows.SDK.NET.dll'" />
+    </ItemGroup> 
+
+    <ItemGroup>
+      <Content Include="@(CsWinRTAuthoringDependencyDlls)" Pack="true" PackagePath="lib\$(TargetFramework)" />
+      <Content Include="$(TargetDir)$(AssemblyName).winmd" Pack="true" PackagePath="lib\$(TargetFramework)\winmd" />
 
       <!-- Custom targets that copy dlls for consumers of the authored component.
            `buildTransitive\` is for PackageReference, `build\` is for packages.config -->
-      <Content Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets"
-               Pack="true"
+      <Content Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.targets" 
+               Pack="true" 
                PackagePath="buildTransitive\$(AssemblyName).targets;build\$(AssemblyName).targets"/>
 
       <!-- WinRT.Host.dll is architecture specific -->

--- a/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
@@ -36,7 +36,7 @@ namespace WinRT.SourceGenerator
         public static DiagnosticDescriptor NamespacesDifferByCase = MakeRule(
             "CsWinRT1002",
             "Namespace names cannot differ only by case",
-            "Multiple namespaces found with the name '{0}'; namespace names cannot differ only by case in the Windows Runtime.");
+            "Multiple namespaces found with the name '{0}'; namespace names cannot differ only by case in the Windows Runtime");
 
         public static DiagnosticDescriptor NoPublicTypesRule = MakeRule(
             "CsWinRT1003",
@@ -68,7 +68,7 @@ namespace WinRT.SourceGenerator
         public static DiagnosticDescriptor NonWinRTInterface = MakeRule(
             "CsWinRT1008",
             "Invalid Interface Inherited",
-            "Windows Runtime component class {0} cannot implement interface {1}, as the interface is not a valid Windows Runtime interface");
+            "Windows Runtime component type {0} cannot implement interface {1}, as the interface is not a valid Windows Runtime interface");
 
         public static DiagnosticDescriptor ClassConstructorRule = MakeRule(
             "CsWinRT1009",
@@ -79,7 +79,7 @@ namespace WinRT.SourceGenerator
             "CsWinRT1010",
             "Parameter Named Value Rule",
             "The parameter name {1} in method {0} is the same as the return value parameter name "
-            + "used in the generated C#/WinRT interop; use a different parameter name.");
+            + "used in the generated C#/WinRT interop; use a different parameter name");
 
         public static DiagnosticDescriptor StructHasPrivateFieldRule = MakeRule(
             "CsWinRT1011",
@@ -100,7 +100,7 @@ namespace WinRT.SourceGenerator
         public static DiagnosticDescriptor OperatorOverloadedRule = MakeRule(
             "CsWinRT1014",
             "Operator overload exposed",
-            "{0} is an operator overload. Managed types cannot expose operator overloads in the Windows Runtime");
+            "{0} is an operator overload. Managed types cannot expose operator overloads in the Windows Runtime.");
 
         public static DiagnosticDescriptor MultipleDefaultOverloadAttribute = MakeRule(
             "CsWinRT1015",
@@ -112,7 +112,7 @@ namespace WinRT.SourceGenerator
             "CsWinRT1016",
             "Multiple overloads seen, one needs a default", // todo better msg
             "In class {2}: The {0}-parameter overloads of {1} must have exactly one method specified as the default " 
-            + "overload by decorating it with Windows.Foundation.Metadata.DefaultOverloadAttribute.");
+            + "overload by decorating it with Windows.Foundation.Metadata.DefaultOverloadAttribute");
 
         public static DiagnosticDescriptor JaggedArrayRule = MakeRule(
             "CsWinRT1017",
@@ -123,12 +123,6 @@ namespace WinRT.SourceGenerator
             "CsWinRT1018",
             "Array signature found with multi-dimensional array, which is not a valid Windows Runtime type",
             "Method '{0}' has a multi-dimensional array of type '{1}' in its signature. Arrays in Windows Runtime method signatures must be one dimensional.");
-
-        public static DiagnosticDescriptor ArraySignature_SystemArrayRule = MakeRule(
-            "CsWinRT1019",
-            "Array signature found with System.Array instance, which is not a valid WinRT type",
-            "In type {0}: the method {1} has signature that contains a System.Array instance; SystemArray is not "
-            + "a valid Windows Runtime type. Try using a different type like IList");
 
         public static DiagnosticDescriptor RefParameterFound = MakeRule(
            "CsWinRT1020",
@@ -159,19 +153,19 @@ namespace WinRT.SourceGenerator
             "Array paramter marked both ReadOnlyArray and WriteOnlyArray",
             "Method '{0}' has parameter '{1}' which is an array, and which has both ReadOnlyArray and WriteOnlyArray. "
             + "In the Windows Runtime, the contents array parameters must be either readable "
-            + "or writable.Please remove one of the attributes from '{1}'.");
+            + "or writable. Please remove one of the attributes from '{1}'.");
 
         public static DiagnosticDescriptor ArrayOutputParamMarkedRead = MakeRule(
             "CsWinRT1024",
             "Array parameter marked `out` and ReadOnlyArray",
             "Method '{0}' has an output parameter '{1}' which is an array, but which has ReadOnlyArray attribute. In the Windows Runtime, "
-            + "the contents of output arrays are writable.Please remove the attribute from '{1}'.");
+            + "the contents of output arrays are writable. Please remove the attribute from '{1}'.");
 
         public static DiagnosticDescriptor ArrayParamNotMarked = MakeRule(
             "CsWinRT1025",
             "Array parameter not marked ReadOnlyArray or WriteOnlyArray way",
             "Method '{0}' has parameter '{1}' which is an array. In the Windows Runtime, the "
-            + "contents of array parameters must be either readable or writable.Please apply either ReadOnlyArray or WriteOnlyArray to '{1}'.");
+            + "contents of array parameters must be either readable or writable. Please apply either ReadOnlyArray or WriteOnlyArray to '{1}'.");
 
         public static DiagnosticDescriptor NonArrayMarked = MakeRule(
             "CsWinRT1026",


### PR DESCRIPTION
Previously, our targets that automate dll reference updating were too assumptive in what files would be in the authored nupkg. This PR introduces a filter on the dlls we package with an authored winmd/dll, as well as make some structural changes to remove warnings about the nupkg. Some bugs arose because of the assumption that only CsWinRT related dlls would be on our 
reference path when building, when in fact WinUI dlls/assets were being added just by nature of a package reference. 

I also found some things to cleanup in WinRTRules

Closes #693 #696 #697 