### PR TITLE
Authoring bug fixes

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -935,7 +935,7 @@ namespace Generator
         private void ProcessCustomMappedInterfaces(INamedTypeSymbol classSymbol)
         {
             Logger.Log("writing custom mapped interfaces for " + QualifiedName(classSymbol));
-            Dictionary<INamedTypeSymbol, bool> IsPublicImplementation = new Dictionary<INamedTypeSymbol, bool>();
+            Dictionary<INamedTypeSymbol, bool> isPublicImplementation = new Dictionary<INamedTypeSymbol, bool>();
 
             // Mark custom mapped interface members for removal later.
             // Note we want to also mark members from interfaces without mappings.
@@ -951,13 +951,13 @@ namespace Generator
                     currentTypeDeclaration.CustomMappedSymbols.Add(classMember);
                     isPubliclyImplemented |= (classMember.DeclaredAccessibility == Accessibility.Public);
                 }
-                IsPublicImplementation[implementedInterface] = isPubliclyImplemented;
+                isPublicImplementation[implementedInterface] = isPubliclyImplemented;
             }
 
             foreach (var implementedInterface in GetInterfaces(classSymbol)
                         .Where(symbol => MappedCSharpTypes.ContainsKey(QualifiedName(symbol))))
             {
-                WriteCustomMappedTypeMembers(implementedInterface, true, IsPublicImplementation[implementedInterface]);
+                WriteCustomMappedTypeMembers(implementedInterface, true, isPublicImplementation[implementedInterface]);
             }
         }
 

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -949,6 +949,12 @@ namespace Generator
                 {
                     var classMember = classSymbol.FindImplementationForInterfaceMember(interfaceMember);
                     currentTypeDeclaration.CustomMappedSymbols.Add(classMember);
+
+                    // For custom mapped interfaces, we don't have 1 to 1 mapping of members between the mapped from
+                    // and mapped to interface and due to that we need to decide if the mapped inteface as a whole
+                    // is public or not (explicitly implemented).  Due to that, as long as one member is not
+                    // explicitly implemented (i.e accessible via the class), we treat the entire mapped interface
+                    // also as accessible via the class.
                     isPubliclyImplemented |= (classMember.DeclaredAccessibility == Accessibility.Public);
                 }
                 isPublicImplementation[implementedInterface] = isPubliclyImplemented;

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -47,6 +47,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="AuthoringTest.InterfaceInheritance"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
         name="AuthoringTest.SingleInterfaceClass"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -15,6 +15,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="AuthoringTest.CustomDictionary2"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />    
+    <activatableClass
         name="AuthoringTest.CustomReadOnlyDictionary"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -51,6 +51,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="AuthoringTest.MultipleInterfaceMappingClass"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />    
+    <activatableClass
         name="AuthoringTest.SingleInterfaceClass"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -99,6 +99,8 @@ TEST(AuthoringTest, InterfaceInheritance)
     EXPECT_EQ(interfaceInheritance.GetNumStr(2.5), hstring(L"2.5"));
     interfaceInheritance.SetNumber(4);
     EXPECT_EQ(interfaceInheritance.Number(), 4);
+    EXPECT_EQ(interfaceInheritance.Name(), hstring(L"IInterfaceInheritance"));
+    EXPECT_EQ(interfaceInheritance.Value(), hstring(L"InterfaceInheritance"));
 
     IDouble doubleInterface = interfaceInheritance;
     EXPECT_EQ(doubleInterface.GetDouble(false), 2.5);
@@ -106,6 +108,10 @@ TEST(AuthoringTest, InterfaceInheritance)
     IInterfaceInheritance interfaceInheritanceInterface = interfaceInheritance;
     interfaceInheritanceInterface.SetNumber(2);
     EXPECT_EQ(interfaceInheritanceInterface.Number(), 2);
+
+    IWwwFormUrlDecoderEntry www = interfaceInheritance;
+    EXPECT_EQ(www.Name(), hstring(L"IInterfaceInheritance"));
+    EXPECT_EQ(www.Value(), hstring(L"InterfaceInheritance"));
 }
 
 TEST(AuthoringTest, ReturnTypes)

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -529,4 +529,45 @@ TEST(AuthoringTest, ExplicitInterfaces)
     EXPECT_TRUE(eventTriggered);
     EXPECT_TRUE(event2Triggered);
     token.revoke();
+
+    DisposableClass disposed;
+    disposed.Close();
+    MultipleInterfaceMappingClass multipleInterfaces;
+    Microsoft::UI::Xaml::Interop::IBindableIterable bindable = multipleInterfaces;
+    Windows::Foundation::Collections::IVector<DisposableClass> vector = multipleInterfaces;
+    Microsoft::UI::Xaml::Interop::IBindableVector bindableVector = multipleInterfaces;
+    EXPECT_EQ(vector.Size(), 0);
+    EXPECT_EQ(bindableVector.Size(), 0);
+    vector.Append(DisposableClass());
+    vector.Append(DisposableClass());
+    vector.Append(disposed);
+    bindableVector.Append(DisposableClass());
+    EXPECT_EQ(vector.Size(), 4);
+    EXPECT_EQ(bindableVector.Size(), 4);
+
+    auto first = vector.First();
+    EXPECT_TRUE(first.HasCurrent());
+    EXPECT_FALSE(first.Current().IsDisposed());
+    auto bindableFirst = bindable.First();
+    EXPECT_TRUE(bindableFirst.HasCurrent());
+    EXPECT_FALSE(bindableFirst.Current().as<DisposableClass>().IsDisposed());
+    bindableFirst.Current().as<DisposableClass>().Close();
+    EXPECT_TRUE(first.Current().IsDisposed());
+    EXPECT_FALSE(vector.GetAt(1).IsDisposed());
+    EXPECT_TRUE(vector.GetAt(2).IsDisposed());
+    EXPECT_TRUE(bindableVector.First().Current().as<DisposableClass>().IsDisposed());
+    EXPECT_FALSE(bindableVector.GetAt(3).as<DisposableClass>().IsDisposed());
+    EXPECT_TRUE(bindableVector.GetAt(2).as<DisposableClass>().IsDisposed());
+    for (auto obj : vector.GetView())
+    {
+        obj.Close();
+    }
+
+    std::array<DisposableClass, 2> view{};
+    EXPECT_EQ(vector.GetMany(1, view), 2);
+    EXPECT_EQ(view.size(), 2);
+    for (auto& obj : view)
+    {
+        EXPECT_TRUE(obj.IsDisposed());
+    }
 }

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -92,6 +92,22 @@ TEST(AuthoringTest, ImplementExternalInterface)
     EXPECT_EQ(www.Value(), hstring(L"CsWinRT"));
 }
 
+TEST(AuthoringTest, InterfaceInheritance)
+{
+    InterfaceInheritance interfaceInheritance;
+    EXPECT_EQ(interfaceInheritance.GetDouble(), 2);
+    EXPECT_EQ(interfaceInheritance.GetNumStr(2.5), hstring(L"2.5"));
+    interfaceInheritance.SetNumber(4);
+    EXPECT_EQ(interfaceInheritance.Number(), 4);
+
+    IDouble doubleInterface = interfaceInheritance;
+    EXPECT_EQ(doubleInterface.GetDouble(false), 2.5);
+
+    IInterfaceInheritance interfaceInheritanceInterface = interfaceInheritance;
+    interfaceInheritanceInterface.SetNumber(2);
+    EXPECT_EQ(interfaceInheritanceInterface.Number(), 2);
+}
+
 TEST(AuthoringTest, ReturnTypes)
 {
     BasicClass basicClass;

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -10,6 +10,32 @@ TEST(AuthoringTest, Statics)
     EXPECT_EQ(TestClass::GetDefaultNumber(), 2);
     EXPECT_EQ(StaticClass::GetNumber(), 4);
     EXPECT_EQ(StaticClass::GetNumber(2), 2);
+    EXPECT_EQ(TestClass::DefaultNumber(), 0);
+    TestClass::DefaultNumber(4);
+    EXPECT_EQ(TestClass::DefaultNumber(), 4);
+
+    int result = 0;
+    auto token = TestClass::StaticDelegateEvent(auto_revoke, [&result](uint32_t value)
+    {
+        result = value;
+    });
+    TestClass::FireStaticDelegate(1);
+    EXPECT_EQ(result, 1);
+    token.revoke();
+    TestClass::FireStaticDelegate(2);
+    EXPECT_EQ(result, 1);
+
+    EXPECT_EQ(StaticClass::Number(), 0);
+    StaticClass::Number(2);
+    EXPECT_EQ(StaticClass::Number(), 2);
+
+    double result2 = 0;
+    auto token2 = StaticClass::DelegateEvent(auto_revoke, [&result2](double value)
+    {
+        result2 = value;
+    });
+    StaticClass::FireDelegate(4.5);
+    EXPECT_EQ(result2, 4.5);
 }
 
 TEST(AuthoringTest, FunctionCalls)

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -570,4 +570,21 @@ TEST(AuthoringTest, ExplicitInterfaces)
     {
         EXPECT_TRUE(obj.IsDisposed());
     }
+
+    CustomDictionary2 dictionary;
+
+    EXPECT_FALSE(dictionary.Insert(L"first", 1));
+    EXPECT_FALSE(dictionary.Insert(L"second", 2));
+    EXPECT_TRUE(dictionary.Insert(L"second", 4));
+    EXPECT_FALSE(dictionary.Insert(L"third", 4));
+    EXPECT_EQ(dictionary.Size(), 3);
+
+    EXPECT_TRUE(dictionary.HasKey(L"first"));
+    EXPECT_FALSE(dictionary.HasKey(L"fourth"));
+    EXPECT_TRUE(dictionary.HasKey(L"third"));
+
+    dictionary.Clear();
+    EXPECT_FALSE(dictionary.HasKey(L"first"));
+    EXPECT_FALSE(dictionary.HasKey(L"fourth"));
+    EXPECT_FALSE(dictionary.HasKey(L"third"));
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1233,128 +1233,115 @@ namespace AuthoringTest
         }
     }
 
-    // Windows.Foundation.Collections.IObservableVector<DisposableClass>
-    /*    public sealed class MultipleInterfaceMappingClass : IList<DisposableClass>, IList
+    public sealed class MultipleInterfaceMappingClass : IList<DisposableClass>, IList
+    {
+        private List<DisposableClass> _list = new List<DisposableClass>();
+
+        DisposableClass IList<DisposableClass>.this[int index] { get => _list[index]; set => _list[index] = value; }
+        object IList.this[int index] { get => _list[index]; set => ((IList)_list) [index] = value; }
+
+        int ICollection<DisposableClass>.Count => _list.Count;
+
+        int ICollection.Count => _list.Count;
+
+        bool ICollection<DisposableClass>.IsReadOnly => true;
+
+        bool IList.IsReadOnly => true;
+
+        bool IList.IsFixedSize => false;
+
+        bool ICollection.IsSynchronized => true;
+
+        object ICollection.SyncRoot => ((ICollection) _list).SyncRoot;
+
+        void ICollection<DisposableClass>.Add(DisposableClass item)
         {
-            DisposableClass IList<DisposableClass>.this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-            object IList.this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-            int ICollection<DisposableClass>.Count => throw new NotImplementedException();
-
-            int ICollection.Count => throw new NotImplementedException();
-
-            bool ICollection<DisposableClass>.IsReadOnly => throw new NotImplementedException();
-
-            bool IList.IsReadOnly => throw new NotImplementedException();
-
-            bool IList.IsFixedSize => throw new NotImplementedException();
-
-            bool ICollection.IsSynchronized => throw new NotImplementedException();
-
-            object ICollection.SyncRoot => throw new NotImplementedException();
-
-            void ICollection<DisposableClass>.Add(DisposableClass item)
-            {
-                throw new NotImplementedException();
-            }
-
-            int IList.Add(object value)
-            {
-                throw new NotImplementedException();
-            }
-
-            void ICollection<DisposableClass>.Clear()
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList.Clear()
-            {
-                throw new NotImplementedException();
-            }
-
-            bool ICollection<DisposableClass>.Contains(DisposableClass item)
-            {
-                throw new NotImplementedException();
-            }
-
-            bool IList.Contains(object value)
-            {
-                throw new NotImplementedException();
-            }
-
-            void ICollection<DisposableClass>.CopyTo(DisposableClass[] array, int arrayIndex)
-            {
-                throw new NotImplementedException();
-            }
-
-            void ICollection.CopyTo(Array array, int index)
-            {
-                throw new NotImplementedException();
-            }
-
-            IEnumerator<DisposableClass> IEnumerable<DisposableClass>.GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
-
-            int IList<DisposableClass>.IndexOf(DisposableClass item)
-            {
-                throw new NotImplementedException();
-            }
-
-            int IList.IndexOf(object value)
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList<DisposableClass>.Insert(int index, DisposableClass item)
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList.Insert(int index, object value)
-            {
-                throw new NotImplementedException();
-            }
-
-            bool ICollection<DisposableClass>.Remove(DisposableClass item)
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList.Remove(object value)
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList<DisposableClass>.RemoveAt(int index)
-            {
-                throw new NotImplementedException();
-            }
-
-            void IList.RemoveAt(int index)
-            {
-                throw new NotImplementedException();
-            }
-        }*/
-
-    /*    public sealed partial class PartialClass
-        {
-            public void function1()
-            {
-            }
+            _list.Add(item);
         }
 
-        public partial class PartialClass
+        int IList.Add(object value)
         {
-            public void function2()
-            {
-            }
-        }*/
+            return ((IList) _list).Add(value);
+        }
+
+        void ICollection<DisposableClass>.Clear()
+        {
+            _list.Clear();
+        }
+
+        void IList.Clear()
+        {
+            _list.Clear();
+        }
+
+        bool ICollection<DisposableClass>.Contains(DisposableClass item)
+        {
+            return _list.Contains(item);
+        }
+
+        bool IList.Contains(object value)
+        {
+            return ((IList) _list).Contains(value);
+        }
+
+        void ICollection<DisposableClass>.CopyTo(DisposableClass[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+             ((ICollection) _list).CopyTo(array, index);
+        }
+
+        IEnumerator<DisposableClass> IEnumerable<DisposableClass>.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        int IList<DisposableClass>.IndexOf(DisposableClass item)
+        {
+            return _list.IndexOf(item);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return ((IList) _list).IndexOf(value);
+        }
+
+        void IList<DisposableClass>.Insert(int index, DisposableClass item)
+        {
+            _list.Insert(index, item);
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            ((IList) _list).Insert(index, value);
+        }
+
+        bool ICollection<DisposableClass>.Remove(DisposableClass item)
+        {
+            return _list.Remove(item);
+        }
+
+        void IList.Remove(object value)
+        {
+            ((IList) _list).Remove(value);
+        }
+
+        void IList<DisposableClass>.RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+    }
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -270,6 +270,17 @@ namespace AuthoringTest
             return 2;
         }
 
+        public static int DefaultNumber { get; set; }
+
+        internal static int DefaultNumber2 { get; set; }
+
+        public static event BasicDelegate StaticDelegateEvent;
+
+        public static void FireStaticDelegate(uint value)
+        {
+            StaticDelegateEvent?.Invoke(value);
+        }
+
         // Default interface
 
         public void FireBasicDelegate(uint value)
@@ -795,6 +806,17 @@ namespace AuthoringTest
         {
             return number;
         }
+
+        public static int Number { get; set; }
+
+        internal static int Number2 { get; set; }
+
+        public static event DoubleDelegate DelegateEvent;
+
+        public static void FireDelegate(double value)
+        {
+            DelegateEvent?.Invoke(value);
+        }
     }
 
     public static class ButtonUtils
@@ -1168,4 +1190,18 @@ namespace AuthoringTest
             throw new NotImplementedException();
         }
     }
+
+/*    public sealed partial class PartialClass
+    {
+        public void function1()
+        {
+        }
+    }
+
+    public partial class PartialClass
+    {
+        public void function2()
+        {
+        }
+    }*/
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1344,4 +1344,74 @@ namespace AuthoringTest
             _list.RemoveAt(index);
         }
     }
+
+    public sealed class CustomDictionary2 : IDictionary<string, int>
+    {
+        private readonly Dictionary<string, int> _dictionary = new Dictionary<string, int>();
+
+        int IDictionary<string, int>.this[string key] { get => _dictionary[key]; set => _dictionary[key] = value; }
+
+        ICollection<string> IDictionary<string, int>.Keys => _dictionary.Keys;
+
+        ICollection<int> IDictionary<string, int>.Values => _dictionary.Values;
+
+        int ICollection<KeyValuePair<string, int>>.Count => _dictionary.Count;
+
+        bool ICollection<KeyValuePair<string, int>>.IsReadOnly => false;
+
+        void IDictionary<string, int>.Add(string key, int value)
+        {
+            _dictionary.Add(key, value);
+        }
+
+        void ICollection<KeyValuePair<string, int>>.Add(KeyValuePair<string, int> item)
+        {
+            ((ICollection<KeyValuePair<string, int>>) _dictionary).Add(item);
+        }
+
+        void ICollection<KeyValuePair<string, int>>.Clear()
+        {
+            _dictionary.Clear();
+        }
+
+        bool ICollection<KeyValuePair<string, int>>.Contains(KeyValuePair<string, int> item)
+        {
+            return _dictionary.Contains(item);
+        }
+
+        bool IDictionary<string, int>.ContainsKey(string key)
+        {
+            return _dictionary.ContainsKey(key);
+        }
+
+        void ICollection<KeyValuePair<string, int>>.CopyTo(KeyValuePair<string, int>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<string, int>>) _dictionary).CopyTo(array, arrayIndex);
+        }
+
+        IEnumerator<KeyValuePair<string, int>> IEnumerable<KeyValuePair<string, int>>.GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
+        }
+
+        bool IDictionary<string, int>.Remove(string key)
+        {
+            return _dictionary.Remove(key);
+        }
+
+        bool ICollection<KeyValuePair<string, int>>.Remove(KeyValuePair<string, int> item)
+        {
+            return ((ICollection<KeyValuePair<string, int>>) _dictionary).Remove(item);
+        }
+
+        bool IDictionary<string, int>.TryGetValue(string key, out int value)
+        {
+            return _dictionary.TryGetValue(key, out value);
+        }
+    }
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1191,7 +1191,7 @@ namespace AuthoringTest
         }
     }
 
-    public interface IInterfaceInheritance : IDouble
+    public interface IInterfaceInheritance : IDouble, IWwwFormUrlDecoderEntry
     {
         void SetNumber(double number);
     }
@@ -1200,6 +1200,10 @@ namespace AuthoringTest
     {
         private double _number;
         public double Number { get => _number; set => _number = value; }
+
+        public string Name => "IInterfaceInheritance";
+
+        public string Value => "InterfaceInheritance";
 
         public event DoubleDelegate DoubleDelegateEvent;
 

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1018,17 +1018,17 @@ namespace AuthoringTest
         // Tests DefaultOverload attribute specified in projected interface.
         public IXamlType GetXamlType(Type type)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
         public IXamlType GetXamlType(string fullName)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
         public XmlnsDefinition[] GetXmlnsDefinitions()
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1191,17 +1191,166 @@ namespace AuthoringTest
         }
     }
 
-/*    public sealed partial class PartialClass
+    public interface IInterfaceInheritance : IDouble
     {
-        public void function1()
+        void SetNumber(double number);
+    }
+
+    public sealed class InterfaceInheritance : IInterfaceInheritance
+    {
+        private double _number;
+        public double Number { get => _number; set => _number = value; }
+
+        public event DoubleDelegate DoubleDelegateEvent;
+
+        public double GetDouble()
         {
+            return 2;
+        }
+
+        public double GetDouble(bool ignoreFactor)
+        {
+            return 2.5;
+        }
+
+        public string GetNumStr(int num)
+        {
+            return num.ToString();
+        }
+
+        public string GetNumStr(double num)
+        {
+            return num.ToString();
+        }
+
+        public void SetNumber(double number)
+        {
+            Number = number;
         }
     }
 
-    public partial class PartialClass
-    {
-        public void function2()
+    // Windows.Foundation.Collections.IObservableVector<DisposableClass>
+    /*    public sealed class MultipleInterfaceMappingClass : IList<DisposableClass>, IList
         {
+            DisposableClass IList<DisposableClass>.this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            object IList.this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            int ICollection<DisposableClass>.Count => throw new NotImplementedException();
+
+            int ICollection.Count => throw new NotImplementedException();
+
+            bool ICollection<DisposableClass>.IsReadOnly => throw new NotImplementedException();
+
+            bool IList.IsReadOnly => throw new NotImplementedException();
+
+            bool IList.IsFixedSize => throw new NotImplementedException();
+
+            bool ICollection.IsSynchronized => throw new NotImplementedException();
+
+            object ICollection.SyncRoot => throw new NotImplementedException();
+
+            void ICollection<DisposableClass>.Add(DisposableClass item)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IList.Add(object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection<DisposableClass>.Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList.Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ICollection<DisposableClass>.Contains(DisposableClass item)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool IList.Contains(object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection<DisposableClass>.CopyTo(DisposableClass[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<DisposableClass> IEnumerable<DisposableClass>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            int IList<DisposableClass>.IndexOf(DisposableClass item)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IList.IndexOf(object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList<DisposableClass>.Insert(int index, DisposableClass item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList.Insert(int index, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ICollection<DisposableClass>.Remove(DisposableClass item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList.Remove(object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList<DisposableClass>.RemoveAt(int index)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList.RemoveAt(int index)
+            {
+                throw new NotImplementedException();
+            }
+        }*/
+
+    /*    public sealed partial class PartialClass
+        {
+            public void function1()
+            {
+            }
         }
-    }*/
+
+        public partial class PartialClass
+        {
+            public void function2()
+            {
+            }
+        }*/
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -975,6 +975,29 @@ namespace AuthoringTest
         }
     }
 
+    public sealed class CustomNotifyDataErrorInfo2 : INotifyDataErrorInfo
+    {
+        bool INotifyDataErrorInfo.HasErrors => throw new NotImplementedException();
+
+        event EventHandler<DataErrorsChangedEventArgs> INotifyDataErrorInfo.ErrorsChanged
+        {
+            add
+            {
+                throw new NotImplementedException();
+            }
+
+            remove
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        IEnumerable INotifyDataErrorInfo.GetErrors(string propertyName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public sealed class CustomEnumerable : IEnumerable
     {
         private IEnumerable _enumerable;

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -159,6 +159,11 @@ namespace cswinrt
         w.write(to_csharp_type(type));
     }
 
+    void write_fundamental_non_projected_type(writer& w, fundamental_type type)
+    {
+        w.write(to_dotnet_type(type));
+    }
+
     void write_projection_type(writer& w, type_semantics const& semantics);
     void write_projection_type_for_name_type(writer& w, type_semantics const& semantics, typedef_name_type const& nameType);
 
@@ -320,7 +325,17 @@ namespace cswinrt
                     bind_list<write_projection_type_for_name_type>(", ", type.generic_args, nameType));
             },
             [&](generic_type_param const& param) { w.write(param.Name()); },
-            [&](fundamental_type const& type) { write_fundamental_type(w, type); });
+            [&](fundamental_type const& type)
+            { 
+                if (nameType == typedef_name_type::NonProjected)
+                {
+                    write_fundamental_non_projected_type(w, type);
+                }
+                else
+                {
+                    write_fundamental_type(w, type);
+                }
+            });
     }
 
     void write_projection_type(writer& w, type_semantics const& semantics)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1727,18 +1727,18 @@ MarshalInspectable<object>.DisposeAbi(ptr);
         write_method(w, signature, method.Name(), return_type, method_target, "public "sv, factory_class ? ""sv : "static "sv, platform_attribute);
     }
 
-    void write_static_property(writer& w, Property const& prop, std::string_view prop_target, std::string_view platform_attribute = ""sv)
+    void write_static_property(writer& w, Property const& prop, std::string_view prop_target, bool factory_class = false, std::string_view platform_attribute = ""sv)
     {
         auto [getter, setter] = get_property_methods(prop);
         auto getter_target = getter ? prop_target : "";
         auto setter_target = setter ? prop_target : "";
         write_property(w, prop.Name(), prop.Name(), write_prop_type(w, prop),
-            getter_target, setter_target, "public "sv, "static "sv, platform_attribute, platform_attribute);
+            getter_target, setter_target, "public "sv, factory_class ? ""sv : "static "sv, platform_attribute, platform_attribute);
     }
 
-    void write_static_event(writer& w, Event const& event, std::string_view event_target, std::string_view platform_attribute = ""sv)
+    void write_static_event(writer& w, Event const& event, std::string_view event_target, bool factory_class = false, std::string_view platform_attribute = ""sv)
     {
-        write_event(w, event.Name(), event, event_target, "public "sv, "static "sv, platform_attribute);
+        write_event(w, event.Name(), event, event_target, "public "sv, factory_class ? ""sv : "static "sv, platform_attribute);
     }
 
     void write_static_members(writer& w, TypeDef const& static_type, TypeDef const& class_type)
@@ -1746,8 +1746,8 @@ MarshalInspectable<object>.DisposeAbi(ptr);
         auto cache_object = write_static_cache_object(w, static_type.TypeName(), class_type);
         auto platform_attribute = write_platform_attribute_temp(w, static_type);
         w.write_each<write_static_method>(static_type.MethodList(), cache_object, false, platform_attribute);
-        w.write_each<write_static_property>(static_type.PropertyList(), cache_object, platform_attribute);
-        w.write_each<write_static_event>(static_type.EventList(), cache_object, platform_attribute);
+        w.write_each<write_static_property>(static_type.PropertyList(), cache_object, false, platform_attribute);
+        w.write_each<write_static_event>(static_type.EventList(), cache_object, false, platform_attribute);
     }
 
     void write_attributed_types(writer& w, TypeDef const& type)
@@ -6158,6 +6158,8 @@ bind_list<write_parameter_name_with_modifier>(", ", signature.params())
                 else if (factory.statics)
                 {
                     w.write_each<write_static_method>(factory.type.MethodList(), projected_type_name, true, ""sv);
+                    w.write_each<write_static_property>(factory.type.PropertyList(), projected_type_name, true, ""sv);
+                    w.write_each<write_static_event>(factory.type.EventList(), projected_type_name, true, ""sv);
                 }
             }
         }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -816,7 +816,7 @@ namespace cswinrt
 % %.%(%) => %.%(%);
 )",
             return_type,
-            bind<write_type_name>(method_interface, typedef_name_type::Projected, false),
+            bind<write_type_name>(method_interface, typedef_name_type::CCW, false),
             method.Name(),
             bind_list<write_projection_parameter>(", ", signature.params()),
             method_target,
@@ -1046,7 +1046,7 @@ namespace cswinrt
 
     std::string write_explicit_name(writer& w, TypeDef const& iface, std::string_view name)
     {
-        return w.write_temp("%.%", write_type_name_temp(w, iface), name);
+        return w.write_temp("%.%", write_type_name_temp(w, iface, "%", typedef_name_type::CCW), name);
     }
 
     std::string write_prop_type(writer& w, Property const& prop)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2125,26 +2125,24 @@ IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             visibility, self, target);
     }
 
-    void write_notify_data_error_info_members(writer& w, std::string_view target)
+    void write_notify_data_error_info_members(writer& w, std::string_view target, bool emit_explicit)
     {
-        w.write(R"(
-public global::System.Collections.IEnumerable GetErrors(string propertyName) => %.GetErrors(propertyName);
+        auto self = emit_explicit ? "global::System.ComponentModel.INotifyDataErrorInfo." : "";
+        auto visibility = emit_explicit ? "" : "public ";
 
-global::System.Collections.IEnumerable global::System.ComponentModel.INotifyDataErrorInfo.GetErrors(string propertyName) => GetErrors(propertyName);
-public event global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> ErrorsChanged
+        w.write(R"(
+%global::System.Collections.IEnumerable %GetErrors(string propertyName) => %.GetErrors(propertyName);
+
+%event global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> %ErrorsChanged
 {
 add => %.ErrorsChanged += value;
 remove => %.ErrorsChanged -= value;
 }
-
-event global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> global::System.ComponentModel.INotifyDataErrorInfo.ErrorsChanged
-{
-add => this.ErrorsChanged += value;
-remove => this.ErrorsChanged -= value;
-}
-public bool HasErrors => %.HasErrors;
-bool global::System.ComponentModel.INotifyDataErrorInfo.HasErrors {get => HasErrors; }
-)", target, target, target, target);
+%bool %HasErrors {get => %.HasErrors; }
+)", 
+    visibility, self, target,
+    visibility, self, target, target,
+    visibility, self, target);
     }
 
     void write_custom_mapped_type_members(writer& w, std::string_view target, mapped_type const& mapping, bool is_private)
@@ -2187,7 +2185,7 @@ bool global::System.ComponentModel.INotifyDataErrorInfo.HasErrors {get => HasErr
         }
         else if (mapping.mapped_namespace == "System.ComponentModel" && mapping.mapped_name == "INotifyDataErrorInfo")
         {
-            write_notify_data_error_info_members(w, target);
+            write_notify_data_error_info_members(w, target, is_private);
         }
     }
 

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -891,7 +891,8 @@ namespace cswinrt
     {
         Projected,
         CCW,
-        ABI
+        ABI,
+        NonProjected
     };
 
     std::string get_mapped_element_type(ElementType elementType)


### PR DESCRIPTION
- Fixing issue where properties and events weren't emitted for static classes
- Adding support for explicitly implemented interfaces which are represented as private functions on the class, but accessible through the interface
- Fixing issue with method impls for generic interface members where they could refer to the wrong override if there is multiple classes implementing the interface with different generics due to not keeping track of the generics.
- Fixing issues with interface inheritance

Fixes #714 