### PR TITLE
Fix diagnostic bug for structs

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -23,7 +23,6 @@ CsWinRT1015 | Usage | Error | Do not use `DefaultOverloadAttribute` more than on
 CsWinRT1016 | Usage | Error | Exactly one overload should be marked as DefaultOverload
 CsWinRT1017 | Usage | Error | Array types should be one dimensional, not jagged
 CsWinRT1018 | Usage | Error | Array types should be one dimensional
-CsWinRT1019 | Usage | Error | Do not use the `System.Array` type for array parameters or array return values 
 CsWinRT1020 | Usage | Error | Do not pass parameters by `ref`
 CsWinRT1021 | Usage | Error | Array parameters should not be marked `InAttribute` or `OutAttribute` 
 CsWinRT1022 | Usage | Error | Parameters should not be marked `InAttribute` or `OutAttribute`

--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -93,7 +93,7 @@ namespace Generator
                     CheckMethods(methods, @interface.Identifier);
                 }
 
-                var structs = nodes.OfType<StructDeclarationSyntax>();
+                var structs = nodes.OfType<StructDeclarationSyntax>().Where(IsPublic);
                 foreach (StructDeclarationSyntax @struct in structs)
                 {
                     CheckStructFields(@struct); 

--- a/src/Tests/DiagnosticTests/PositiveData.cs
+++ b/src/Tests/DiagnosticTests/PositiveData.cs
@@ -4,6 +4,19 @@ namespace DiagnosticTests
 {
     public sealed partial class UnitTesting
     {
+        private const string Valid_PrivateStruct = @"
+namespace DiagnosticTests
+{
+    public sealed class PrivateSetter
+    {
+        struct ExampleStruct
+        {
+            int i;
+            public void SetValue(int value) { i = value; }
+        }
+    }
+}";
+
         private const string Valid_PrivateSetter = @"
 namespace DiagnosticTests
 {

--- a/src/Tests/DiagnosticTests/UnitTesting.cs
+++ b/src/Tests/DiagnosticTests/UnitTesting.cs
@@ -396,6 +396,7 @@ namespace DiagnosticTests
         {
             get
             {
+                yield return new TestCaseData(Valid_PrivateStruct).SetName("Valid. Struct. Private struct");
                 yield return new TestCaseData(Valid_PrivateSetter).SetName("Valid. Property. Private Setter");
                 yield return new TestCaseData(Valid_RollYourOwnAsyncAction).SetName("Valid. AsyncInterfaces. Implementing your own IAsyncAction");
                 yield return new TestCaseData(Valid_CustomDictionary).SetName("Valid. CustomProjection. IDictionary<string,BasicStruct>");


### PR DESCRIPTION
Before we were checking all structs, but we should only check the public ones. 

A bug came in for the following scenario

```
namespace DiagnosticTests
{
    public sealed class PrivateSetter
    {
        struct ExampleStruct
        {
            int i;
            public void SetValue(int value) { i = value; }
        }
    }
}
```

I tested this scenario in WinMDExp and it is valid. So I added a valid case, and changed the implementation to only raise diagnostics for public structs. 