### PR TITLE
Perf improvements in CCW creation.

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -90,10 +90,10 @@ namespace WinRT
             return obj;
         }
 
-        internal static List<ComInterfaceEntry> GetInterfaceTableEntries(object obj)
+        internal static List<ComInterfaceEntry> GetInterfaceTableEntries(Type type)
         {
             var entries = new List<ComInterfaceEntry>();
-            var objType = obj.GetType().GetRuntimeClassCCWType() ?? obj.GetType();
+            var objType = type.GetRuntimeClassCCWType() ?? type;
             var interfaces = objType.GetInterfaces();
             foreach (var iface in interfaces)
             {
@@ -122,12 +122,12 @@ namespace WinRT
                 }
             }
 
-            if (obj is Delegate)
+            if (type.IsDelegate())
             {
                 entries.Add(new ComInterfaceEntry
                 {
-                    IID = GuidGenerator.GetIID(obj.GetType()),
-                    Vtable = (IntPtr)obj.GetType().GetHelperType().GetAbiToProjectionVftblPtr()
+                    IID = GuidGenerator.GetIID(type),
+                    Vtable = (IntPtr)type.GetHelperType().GetAbiToProjectionVftblPtr()
                 });
             }
 
@@ -140,15 +140,15 @@ namespace WinRT
                     Vtable = (IntPtr)ifaceAbiType.GetAbiToProjectionVftblPtr()
                 });
             }
-            else if (ShouldProvideIReference(obj))
+            else if (ShouldProvideIReference(type))
             {
                 entries.Add(IPropertyValueEntry);
-                entries.Add(ProvideIReference(obj));
+                entries.Add(ProvideIReference(type));
             }
-            else if (ShouldProvideIReferenceArray(obj))
+            else if (ShouldProvideIReferenceArray(type))
             {
                 entries.Add(IPropertyValueEntry);
-                entries.Add(ProvideIReferenceArray(obj));
+                entries.Add(ProvideIReferenceArray(type));
             }
 
             entries.Add(new ComInterfaceEntry
@@ -178,16 +178,14 @@ namespace WinRT
             return entries;
         }
 
-        internal static (InspectableInfo inspectableInfo, List<ComInterfaceEntry> interfaceTableEntries) PregenerateNativeTypeInformation(object obj)
+        internal static (InspectableInfo inspectableInfo, List<ComInterfaceEntry> interfaceTableEntries) PregenerateNativeTypeInformation(Type type)
         {
-            var interfaceTableEntries = GetInterfaceTableEntries(obj);
+            var interfaceTableEntries = GetInterfaceTableEntries(type);
             var iids = new Guid[interfaceTableEntries.Count];
             for (int i = 0; i < interfaceTableEntries.Count; i++)
             {
                 iids[i] = interfaceTableEntries[i].IID;
             }
-
-            Type type = obj.GetType();
 
             if (type.FullName.StartsWith("ABI."))
             {
@@ -337,11 +335,10 @@ namespace WinRT
             return runtimeClassName;
         }
 
-        private static bool ShouldProvideIReference(object obj)
+        private static bool ShouldProvideIReference(Type type)
         {
-            return obj.GetType().IsValueType || obj is string || obj is Type || obj is Delegate;
+            return type.IsValueType || type == typeof(string) || type == typeof(Type) || type.IsDelegate();
         }
-
 
         private static ComInterfaceEntry IPropertyValueEntry =>
             new ComInterfaceEntry
@@ -350,10 +347,8 @@ namespace WinRT
                 Vtable = ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
             };
 
-        private static ComInterfaceEntry ProvideIReference(object obj)
+        private static ComInterfaceEntry ProvideIReference(Type type)
         {
-            Type type = obj.GetType();
-
             if (type == typeof(int))
             {
                 return new ComInterfaceEntry
@@ -482,7 +477,7 @@ namespace WinRT
                     Vtable = BoxedValueIReferenceImpl<object>.AbiToProjectionVftablePtr
                 };
             }
-            if (obj is Type)
+            if (type == typeof(Type))
             {
                 return new ComInterfaceEntry
                 {
@@ -498,14 +493,15 @@ namespace WinRT
             };
         }
 
-        private static bool ShouldProvideIReferenceArray(object obj)
+        private static bool ShouldProvideIReferenceArray(Type type)
         {
-            return obj is Array arr && arr.Rank == 1 && arr.GetLowerBound(0) == 0 && !obj.GetType().GetElementType().IsArray;
+            // Check if one dimensional array with lower bound of 0
+            return type.IsArray && type == type.GetElementType().MakeArrayType() && !type.GetElementType().IsArray;
         }
 
-        private static ComInterfaceEntry ProvideIReferenceArray(object obj)
+        private static ComInterfaceEntry ProvideIReferenceArray(Type arrayType)
         {
-            Type type = obj.GetType().GetElementType();
+            Type type = arrayType.GetElementType();
             if (type == typeof(int))
             {
                 return new ComInterfaceEntry
@@ -634,7 +630,7 @@ namespace WinRT
                     Vtable = BoxedArrayIReferenceArrayImpl<object>.AbiToProjectionVftablePtr
                 };
             }
-            if (obj is Type)
+            if (type == typeof(Type))
             {
                 return new ComInterfaceEntry
                 {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -26,7 +26,7 @@ namespace WinRT
             }
         }
 
-        internal static readonly ConditionalWeakTable<object, InspectableInfo> InspectableInfoTable = new ConditionalWeakTable<object, InspectableInfo>();
+        internal static readonly ConditionalWeakTable<Type, InspectableInfo> InspectableInfoTable = new ConditionalWeakTable<Type, InspectableInfo>();
         internal static readonly ThreadLocal<Type> CreateRCWType = new ThreadLocal<Type>();
 
         private static ComWrappers _comWrappers;
@@ -67,7 +67,7 @@ namespace WinRT
         internal static unsafe InspectableInfo GetInspectableInfo(IntPtr pThis)
         {
             var _this = FindObject<object>(pThis);
-            return InspectableInfoTable.GetValue(_this, o => PregenerateNativeTypeInformation(o).inspectableInfo);
+            return InspectableInfoTable.GetValue(_this.GetType(), o => PregenerateNativeTypeInformation(o).inspectableInfo);
         }
 
         public static T CreateRcwForComObject<T>(IntPtr ptr)
@@ -193,7 +193,7 @@ namespace WinRT
 
     public class DefaultComWrappers : ComWrappers
     {
-        private static ConditionalWeakTable<object, VtableEntriesCleanupScout> ComInterfaceEntryCleanupTable = new ConditionalWeakTable<object, VtableEntriesCleanupScout>();
+        private static readonly ConditionalWeakTable<Type, VtableEntries> TypeVtableEntryTable = new ConditionalWeakTable<Type, VtableEntries>();
         public static unsafe IUnknownVftbl IUnknownVftbl => Unsafe.AsRef<IUnknownVftbl>(IUnknownVftblPtr.ToPointer());
 
         internal static IntPtr IUnknownVftblPtr { get; }
@@ -213,50 +213,56 @@ namespace WinRT
 
         protected override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
         {
-            if (IsRuntimeImplementedRCW(obj))
+            var vtableEntries = TypeVtableEntryTable.GetValue(obj.GetType(), (type) => 
             {
-                // If the object is a runtime-implemented RCW, let the runtime create a CCW.
-                count = 0;
-                return null;
-            }
+                if (IsRuntimeImplementedRCW(type))
+                {
+                    // If the object is a runtime-implemented RCW, let the runtime create a CCW.
+                    return new VtableEntries();
+                }
 
-            var entries = ComWrappersSupport.GetInterfaceTableEntries(obj);
+                var entries = ComWrappersSupport.GetInterfaceTableEntries(type);
 
-            if (flags.HasFlag(CreateComInterfaceFlags.CallerDefinedIUnknown))
-            {
+                entries.Add(new ComInterfaceEntry
+                {
+                    IID = typeof(IInspectable).GUID,
+                    Vtable = IInspectable.Vftbl.AbiToProjectionVftablePtr
+                });
+
+                // This should be the last entry as it is included / excluded based on the flags.
                 entries.Add(new ComInterfaceEntry
                 {
                     IID = typeof(IUnknownVftbl).GUID,
                     Vtable = IUnknownVftbl.AbiToProjectionVftblPtr
                 });
-            }
 
-            entries.Add(new ComInterfaceEntry
-            {
-                IID = typeof(IInspectable).GUID,
-                Vtable = IInspectable.Vftbl.AbiToProjectionVftablePtr
+                ComInterfaceEntry* nativeEntries = (ComInterfaceEntry*)Marshal.AllocCoTaskMem(sizeof(ComInterfaceEntry) * entries.Count);
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    nativeEntries[i] = entries[i];
+                }
+
+                return new VtableEntries(nativeEntries, entries.Count);
             });
 
-            count = entries.Count;
-            ComInterfaceEntry* nativeEntries = (ComInterfaceEntry*)Marshal.AllocCoTaskMem(sizeof(ComInterfaceEntry) * count);
-
-            for (int i = 0; i < count; i++)
+            count = vtableEntries.Count;
+            if (count != 0 && !flags.HasFlag(CreateComInterfaceFlags.CallerDefinedIUnknown))
             {
-                nativeEntries[i] = entries[i];
+                // The vtable list unconditionally has the last entry as IUnknown, but it should
+                // only be included if the flag is set.  We achieve that by excluding the last entry
+                // from the count if the flag isn't set.
+                count -= 1;
             }
 
-            ComInterfaceEntryCleanupTable.Add(obj, new VtableEntriesCleanupScout(nativeEntries));
-
-            return nativeEntries;
+            return vtableEntries.Data;
         }
 
-        private static unsafe bool IsRuntimeImplementedRCW(object obj)
+        private static unsafe bool IsRuntimeImplementedRCW(Type objType)
         {
-            Type t = obj.GetType();
-            bool isRcw = t.IsCOMObject;
-            if (t.IsGenericType)
+            bool isRcw = objType.IsCOMObject;
+            if (objType.IsGenericType)
             {
-                foreach (var arg in t.GetGenericArguments())
+                foreach (var arg in objType.GetGenericArguments())
                 {
                     if (arg.IsCOMObject)
                     {
@@ -313,18 +319,29 @@ namespace WinRT
             }
         }
 
-        unsafe class VtableEntriesCleanupScout
+        unsafe class VtableEntries
         {
-            private readonly ComInterfaceEntry* _data;
+            public ComInterfaceEntry* Data { get; }
+            public int Count { get; }
 
-            public VtableEntriesCleanupScout(ComInterfaceEntry* data)
+            public VtableEntries()
             {
-                _data = data;
+                Data = null;
+                Count = 0;
             }
 
-            ~VtableEntriesCleanupScout()
+            public VtableEntries(ComInterfaceEntry* data, int count)
             {
-                Marshal.FreeCoTaskMem((IntPtr)_data);
+                Data = data;
+                Count = count;
+            }
+
+            ~VtableEntries()
+            {
+                if (Data != null)
+                {
+                    Marshal.FreeCoTaskMem((IntPtr)Data);
+                }
             }
         }
     }

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -236,13 +237,7 @@ namespace WinRT
                     Vtable = IUnknownVftbl.AbiToProjectionVftblPtr
                 });
 
-                ComInterfaceEntry* nativeEntries = (ComInterfaceEntry*)Marshal.AllocCoTaskMem(sizeof(ComInterfaceEntry) * entries.Count);
-                for (int i = 0; i < entries.Count; i++)
-                {
-                    nativeEntries[i] = entries[i];
-                }
-
-                return new VtableEntries(nativeEntries, entries.Count);
+                return new VtableEntries(entries, type);
             });
 
             count = vtableEntries.Count;
@@ -330,18 +325,14 @@ namespace WinRT
                 Count = 0;
             }
 
-            public VtableEntries(ComInterfaceEntry* data, int count)
+            public VtableEntries(List<ComInterfaceEntry> entries, Type type)
             {
-                Data = data;
-                Count = count;
-            }
-
-            ~VtableEntries()
-            {
-                if (Data != null)
+                Data = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(type, sizeof(ComInterfaceEntry) * entries.Count);
+                for (int i = 0; i < entries.Count; i++)
                 {
-                    Marshal.FreeCoTaskMem((IntPtr)Data);
+                    Data[i] = entries[i];
                 }
+                Count = entries.Count;
             }
         }
     }

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -304,7 +304,7 @@ namespace WinRT
             _strongHandle = IntPtr.Zero;
             WeakHandle = GCHandle.Alloc(this, GCHandleType.WeakTrackResurrection);
             ManagedObject = obj;
-            var (inspectableInfo, interfaceTableEntries) = ComWrappersSupport.PregenerateNativeTypeInformation(ManagedObject);
+            var (inspectableInfo, interfaceTableEntries) = ComWrappersSupport.PregenerateNativeTypeInformation(ManagedObject.GetType());
 
             InspectableInfo = inspectableInfo;
 


### PR DESCRIPTION
- Caching the vtable entries per type and as part of that also moving vtable cleanup to per type rather than per object.
- Also moving to store IInspectableInfo per type rather than per object.

Based on a perf and memory analysis, it can be seen the memory consumption for storing the vtable entries is down as expected and in the repro scenario where CCW creation was found to be expensive, it is no longer near the top of the CPU usage and the execution time of the repro seems to have went down by half.

Fixes #438 
Fixes #554 