### PR TITLE
ensure that value/delegate types are projected before implementing IPropertyValue

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -327,6 +327,22 @@ TEST(AuthoringTest, CustomTypes)
     auto type = testClass.Type();
     EXPECT_EQ(type.Kind, Windows::UI::Xaml::Interop::TypeKind::Metadata);
     EXPECT_EQ(type.Name, L"AuthoringTest.TestClass");
+
+    auto erasedProjecteds = testClass.GetTypeErasedProjectedObjects();
+    EXPECT_EQ(erasedProjecteds.Size(), 4);
+    for (auto obj : erasedProjecteds)
+    {
+        auto pv = obj.try_as<IPropertyValue>();
+        EXPECT_NE(pv, nullptr);
+    }
+
+    auto erasedNonProjecteds = testClass.GetTypeErasedNonProjectedObjects();
+    EXPECT_EQ(erasedNonProjecteds.Size(), 3);
+    for (auto obj : erasedNonProjecteds)
+    {
+        auto pv = obj.try_as<IPropertyValue>();
+        EXPECT_EQ(pv, nullptr);
+    }
 }
 
 TEST(AuthoringTest, CustomDictionaryImplementations)

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -46,6 +46,7 @@ namespace AuthoringTest
     public delegate void BasicDelegate(uint value);
     public delegate bool ComplexDelegate(double value, int value2);
     public delegate void DoubleDelegate(double value);
+    internal delegate void PrivateDelegate(uint value);
 
     public sealed class BasicClass
     {
@@ -87,28 +88,16 @@ namespace AuthoringTest
             return new CustomWWW();
         }
 
-        public BasicStruct GetBasicStruct()
-        {
-            BasicStruct basicStruct;
-            basicStruct.X = 4;
-            basicStruct.Y = 8;
-            basicStruct.Value = "CsWinRT";
-            return basicStruct;
-        }
+        public BasicStruct GetBasicStruct() => 
+            new BasicStruct() { X = 4, Y = 8, Value = "CsWinRT" };
 
         public int GetSumOfInts(BasicStruct basicStruct)
         {
             return basicStruct.X + basicStruct.Y;
         }
 
-        public ComplexStruct GetComplexStruct()
-        {
-            ComplexStruct complexStruct;
-            complexStruct.X = 12;
-            complexStruct.Val = true;
-            complexStruct.BasicStruct = GetBasicStruct();
-            return complexStruct;
-        }
+        public ComplexStruct GetComplexStruct() =>
+            new ComplexStruct() { X = 12, Val = true, BasicStruct = GetBasicStruct() };
 
         public int? GetX(ComplexStruct basicStruct)
         {
@@ -189,6 +178,12 @@ namespace AuthoringTest
         public bool? Val;
         public BasicStruct BasicStruct;
     }
+    
+    internal struct PrivateStruct
+    {
+        public int X, Y;
+        public string Value;
+    }
 
     public sealed class CustomWWW : IWwwFormUrlDecoderEntry
     {
@@ -239,6 +234,7 @@ namespace AuthoringTest
         [Windows.Foundation.Metadata.Deprecated("test", DeprecationType.Deprecate, 3)]
         public int Deprecated { get; }
         public double Number { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
 
         public TestClass()
         {
@@ -430,6 +426,25 @@ namespace AuthoringTest
             return 3;
         }
 
+        // Type-erased objects
+        public IList<object> GetTypeErasedProjectedObjects()
+        {
+            return new List<object>() {
+                42,
+                BasicEnum.First,
+                new BasicStruct() { X = 1, Y = 2, Value = "Basic" },
+                new BasicDelegate((uint value) => {}),
+            };
+        }
+
+        public IList<object> GetTypeErasedNonProjectedObjects()
+        {
+            return new List<object>() {
+                PrivateEnum.PrivateFirst,
+                new PrivateStruct() { X = 1, Y = 2, Value = "Private" },
+                new PrivateDelegate((uint value) => { })
+            };
+        }
     }
 
     public sealed class DisposableClass : IDisposable

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -343,7 +343,6 @@ namespace WinRT
         {
             static bool IsWindowsRuntimeType(Type type)
             {
-                // TODO: attribute checks are expensive - cache per-vtable
                 if (type.GetCustomAttribute<WindowsRuntimeTypeAttribute>() is object)
                     return true;
                 type = type.GetAuthoringMetadataType();

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -352,9 +352,8 @@ namespace WinRT
                 return false;
             }
 
-            if (obj is string || obj is Type)
+            if (type == typeof(string) || type == typeof(Type))
                 return true;
-            var type = obj.GetType();
             if (type.IsDelegate())
                 return IsWindowsRuntimeType(type);
             if (!type.IsValueType)


### PR DESCRIPTION
fixes #605 