### PR TITLE
Add version attribute for all types.

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1861,6 +1861,8 @@ namespace Generator
                 symbol.Name,
                 GetTypeReference("System", "MulticastDelegate", "mscorlib"));
             currentTypeDeclaration.Handle = typeDefinitionHandle;
+            typeDefinitionMapping[QualifiedName(symbol, true)] = currentTypeDeclaration;
+
             AddGuidAttribute(typeDefinitionHandle, symbol.ToString());
         }
 
@@ -2683,14 +2685,14 @@ namespace Generator
             }
 
             Logger.Log("adding default version attributes");
-            var interfaceDeclarations = typeDefinitionMapping.Values
-                .Where(declaration => declaration.Node is INamedTypeSymbol symbol && symbol.TypeKind == TypeKind.Interface)
+            var declarations = typeDefinitionMapping.Values
+                .Where(declaration => declaration.Node != null)
                 .ToList();
-            foreach (var interfaceDeclaration in interfaceDeclarations)
+            foreach (var declaration in declarations)
             {
-                INamedTypeSymbol interfaceSymbol = interfaceDeclaration.Node as INamedTypeSymbol;
-                string qualifiedNameWithGenerics = QualifiedName(interfaceSymbol, true);
-                if (typeDefinitionMapping[qualifiedNameWithGenerics].Handle != default && GetVersion(interfaceSymbol) == -1)
+                INamedTypeSymbol namedType = declaration.Node as INamedTypeSymbol;
+                string qualifiedNameWithGenerics = QualifiedName(namedType, true);
+                if (typeDefinitionMapping[qualifiedNameWithGenerics].Handle != default && GetVersion(namedType) == -1)
                 {
                     AddDefaultVersionAttribute(typeDefinitionMapping[qualifiedNameWithGenerics].Handle);
                 }


### PR DESCRIPTION
When referencing types from an authored component in a idl file, you can run into the error _runtime class without a default attribute cannot be used as a parameter_.  This seems to be due to the missing version attribute on the types.

Fixes #743 