### PR TITLE
Recreate agile reference for delegate when delegate is resurrect

### DIFF
--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -173,6 +173,13 @@ namespace WinRT
                 {
                     cached.Value.Resurrect();
                 }
+
+                // Delegates store their agile reference as an additional type data.
+                // These should be recreated when instances are resurrect.
+                if (AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj))
+                {
+                    AdditionalTypeData.TryUpdate(typeof(AgileReference).TypeHandle, new AgileReference(NativeObject), agileObj);
+                }
             }
         }
     }

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -56,14 +56,20 @@ namespace ABI.System
 #endif
         {
             private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+#if NETSTANDARD2_0
             private readonly AgileReference _agileReference = default;
-
+#endif
             public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
             {
                 _nativeDelegate = nativeDelegate;
                 if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
                 {
-                    _agileReference = new AgileReference(_nativeDelegate);
+                    var agileReference = new AgileReference(_nativeDelegate);
+#if NETSTANDARD2_0
+                    _agileReference = agileReference;
+#else
+                    ((IWinRTObject)this).AdditionalTypeData.TryAdd(typeof(AgileReference).TypeHandle, agileReference);
+#endif
                 }
                 else
                 {
@@ -80,7 +86,13 @@ namespace ABI.System
 
             public void Invoke(object sender, T args)
             {
-                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(EventHandler<T>)));
+#if NETSTANDARD2_0
+                var agileReference = _agileReference;
+#else
+                var agileReference = ((IWinRTObject)this).AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj) ? 
+                    (AgileReference)agileObj : null;
+#endif
+                using var agileDelegate = agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(EventHandler<T>)));
                 var delegateToInvoke = agileDelegate ?? _nativeDelegate;
                 IntPtr ThisPtr = delegateToInvoke.ThisPtr;
                 var abiInvoke = Marshal.GetDelegateForFunctionPointer(delegateToInvoke.Vftbl.Invoke, Abi_Invoke_Type);

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -52,14 +52,21 @@ namespace ABI.System.Collections.Specialized
 #endif
         {
             private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+#if NETSTANDARD2_0
             private readonly AgileReference _agileReference = default;
+#endif
 
             public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
             {
                 _nativeDelegate = nativeDelegate;
                 if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
                 {
-                    _agileReference = new AgileReference(_nativeDelegate);
+                    var agileReference = new AgileReference(_nativeDelegate);
+#if NETSTANDARD2_0
+                    _agileReference = agileReference;
+#else
+                    ((IWinRTObject)this).AdditionalTypeData.TryAdd(typeof(AgileReference).TypeHandle, agileReference);
+#endif
                 }
                 else
                 {
@@ -76,7 +83,13 @@ namespace ABI.System.Collections.Specialized
 
             public void Invoke(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
             {
-                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(NotifyCollectionChangedEventHandler)));
+#if NETSTANDARD2_0
+                var agileReference = _agileReference;
+#else
+                var agileReference = ((IWinRTObject)this).AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj) ?
+                    (AgileReference)agileObj : null;
+#endif
+                using var agileDelegate = agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(NotifyCollectionChangedEventHandler)));
                 var delegateToInvoke = agileDelegate ?? _nativeDelegate;
                 IntPtr ThisPtr = delegateToInvoke.ThisPtr;
                 var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);


### PR DESCRIPTION
- We previously addressed an issue where we got back an RCW for a delegate that was already disposed and we had made changes to resurrect it.  But there is an additional scenario where both the delegate and the agile reference it stores are disposed and we ended up with a ObjectDisposedException when we invoked such a delegate.
- I am taking advantage of AdditionalTypeData to hold the AgileReference object for delegates allowing us to update it in the scenarios where we resurrect the NativeObject for the delegate.  This also allows us to avoid API surface changes and be compatible with existing versions.

Fixes #682 