### PR TITLE
Fix GC issues with static events.

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2296,6 +2296,28 @@ namespace UnitTest
             Assert.True(TestObject.IterableOfObjectIterablesProperty.SequenceEqual(listOfListOfUris));
         }
 
+        [Fact]
+        public void TestStaticEventWithGC()
+        {
+            bool eventCalled = false;
+            void Class_StaticIntPropertyChanged(object sender, int e)
+            {
+                eventCalled = (e == 3);
+            }
+
+            Class.StaticIntPropertyChanged += Class_StaticIntPropertyChanged;
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            GC.WaitForPendingFinalizers();
+            Class.StaticIntPropertyChanged -= Class_StaticIntPropertyChanged;
+            Class.StaticIntProperty = 3;
+            Assert.False(eventCalled);
+            Class.StaticIntPropertyChanged += Class_StaticIntPropertyChanged;
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            GC.WaitForPendingFinalizers();
+            Class.StaticIntProperty = 3;
+            Assert.True(eventCalled);
+        }
+
 #if NET5_0
         [TestComponentCSharp.Warning]  // NO warning CA1416
         class WarningManaged { };


### PR DESCRIPTION
- When GC was ran, the static class instance gets cleaned up as it is a weak lazy reference  But that causes issues when the static class supports static events as any added events stay added and are associated with the previous instance.  Fixing this by making the static class instance not weak lazy if it it has static events which can be added to.  This has the effect of not cleaning up the instance on GC when there is no events added, but guarantees we are always adding to the same event source to replicate a static class behavior.

Fixes #753 