### PR TITLE
Fix typeof(Type) checks to account for RuntimeType

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -329,7 +329,7 @@ TEST(AuthoringTest, CustomTypes)
     EXPECT_EQ(type.Name, L"AuthoringTest.TestClass");
 
     auto erasedProjecteds = testClass.GetTypeErasedProjectedObjects();
-    EXPECT_EQ(erasedProjecteds.Size(), 4);
+    EXPECT_EQ(erasedProjecteds.Size(), 6);
     for (auto obj : erasedProjecteds)
     {
         auto pv = obj.try_as<IPropertyValue>();
@@ -342,6 +342,15 @@ TEST(AuthoringTest, CustomTypes)
     {
         auto pv = obj.try_as<IPropertyValue>();
         EXPECT_EQ(pv, nullptr);
+    }
+
+    auto erasedProjectedArrays = testClass.GetTypeErasedProjectedArrays();
+    EXPECT_EQ(erasedProjectedArrays.Size(), 8);
+    for (auto obj : erasedProjectedArrays)
+    {
+        auto ra = obj.try_as<IPropertyValue>();
+        EXPECT_NE(ra, nullptr);
+        auto type = ra.Type();
     }
 }
 

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -434,6 +434,8 @@ namespace AuthoringTest
                 BasicEnum.First,
                 new BasicStruct() { X = 1, Y = 2, Value = "Basic" },
                 new BasicDelegate((uint value) => {}),
+                typeof(TestClass),
+                new DisposableClass().GetType()
             };
         }
 
@@ -443,6 +445,20 @@ namespace AuthoringTest
                 PrivateEnum.PrivateFirst,
                 new PrivateStruct() { X = 1, Y = 2, Value = "Private" },
                 new PrivateDelegate((uint value) => { })
+            };
+        }
+
+        public IList<object> GetTypeErasedProjectedArrays()
+        {
+            return new List<object>() {
+                new int[] {42, 24, 12 },
+                new AsyncStatus[] { AsyncStatus.Canceled, AsyncStatus.Completed},
+                new BasicEnum[] {BasicEnum.First, BasicEnum.Fourth },
+                new BasicStruct[] {new BasicStruct() { X = 1, Y = 2, Value = "Basic" } },
+                new BasicDelegate[] { new BasicDelegate((uint value) => {}) },
+                new [] { new DisposableClass().GetType() , new NonProjectedDisposableClass().GetType() },
+                new Type[] { typeof(TestClass), typeof(DisposableClass) },
+                new PrivateEnum[] { PrivateEnum.PrivateFirst, PrivateEnum.PrivateSecond}
             };
         }
     }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -351,7 +351,7 @@ namespace WinRT
                 return false;
             }
 
-            if (type == typeof(string) || type == typeof(Type))
+            if (type == typeof(string) || type.IsTypeOfType())
                 return true;
             if (type.IsDelegate())
                 return IsWindowsRuntimeType(type);
@@ -497,7 +497,7 @@ namespace WinRT
                     Vtable = BoxedValueIReferenceImpl<object>.AbiToProjectionVftablePtr
                 };
             }
-            if (type == typeof(Type))
+            if (type.IsTypeOfType())
             {
                 return new ComInterfaceEntry
                 {
@@ -650,7 +650,7 @@ namespace WinRT
                     Vtable = BoxedArrayIReferenceArrayImpl<object>.AbiToProjectionVftablePtr
                 };
             }
-            if (type == typeof(Type))
+            if (type.IsTypeOfType())
             {
                 return new ComInterfaceEntry
                 {

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -84,9 +84,14 @@ namespace WinRT
             return typeof(Delegate).IsAssignableFrom(type);
         }
 
+        internal static bool IsTypeOfType(this Type type)
+        {
+            return typeof(Type).IsAssignableFrom(type);
+        }
+
         public static Type GetRuntimeClassCCWType(this Type type)
         {
-            return type.IsClass ? type.GetAuthoringMetadataType() : null;
+            return type.IsClass && !type.IsArray ? type.GetAuthoringMetadataType() : null;
         }
 
         internal static Type GetAuthoringMetadataType(this Type type)


### PR DESCRIPTION
The previous typeof(Type) checks don't work always as in some scenarios we can get a RuntimeType to represent the type which is an internal type that derives from Type.  To account for this, making use of assignable from instead.

Fixes #757 