### PR TITLE
Fix GC hole in string marshaling

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
@@ -1,1 +1,2 @@
-Total Issues: 0
+MembersMustExist : Member 'public WinRT.MarshalString.HStringHeader WinRT.MarshalString.HStringHeader WinRT.MarshalString._header' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'WinRT.MarshalString.HStringHeader' does not exist in the implementation but it does exist in the contract.

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -32,19 +32,15 @@ namespace WinRT
     // as well as passing marshalers to FromAbi by ref so they can be conditionally disposed.
     public class MarshalString
     {
-        public unsafe struct HStringHeader // sizeof(HSTRING_HEADER)
-        {
-            public fixed byte Reserved[24];
-        };
-        public HStringHeader _header;
+        private IntPtr _header;
         public GCHandle _gchandle;
-        private GCHandle _gchandleSelf;
         public IntPtr _handle;
 
         public void Dispose()
         {
             _gchandle.Dispose();
-            _gchandleSelf.Dispose();
+            Marshal.FreeHGlobal(_header);
+            _header = IntPtr.Zero;
         }
 
         public static unsafe MarshalString CreateMarshaler(string value)
@@ -56,11 +52,11 @@ namespace WinRT
             try
             {
                 m._gchandle = GCHandle.Alloc(value, GCHandleType.Pinned);
-                m._gchandleSelf = GCHandle.Alloc(m, GCHandleType.Pinned);
-                fixed (void* chars = value, header = &m._header, handle = &m._handle)
+                m._header = Marshal.AllocHGlobal(24); // sizeof(HSTRING_HEADER)
+                fixed (void* chars = value, handle = &m._handle)
                 {
                     Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(
-                        (char*)chars, value.Length, (IntPtr*)header, (IntPtr*)handle));
+                        (char*)chars, value.Length, (IntPtr*)m._header, (IntPtr*)handle));
                 };
                 return m;
             }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -38,11 +38,13 @@ namespace WinRT
         };
         public HStringHeader _header;
         public GCHandle _gchandle;
+        private GCHandle _gchandleHeader;
         public IntPtr _handle;
 
         public void Dispose()
         {
             _gchandle.Dispose();
+            _gchandleHeader.Dispose();
         }
 
         public static unsafe MarshalString CreateMarshaler(string value)
@@ -54,6 +56,7 @@ namespace WinRT
             try
             {
                 m._gchandle = GCHandle.Alloc(value, GCHandleType.Pinned);
+                m._gchandleHeader = GCHandle.Alloc(m._header, GCHandleType.Pinned);
                 fixed (void* chars = value, header = &m._header, handle = &m._handle)
                 {
                     Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -38,13 +38,13 @@ namespace WinRT
         };
         public HStringHeader _header;
         public GCHandle _gchandle;
-        private GCHandle _gchandleHeader;
+        private GCHandle _gchandleSelf;
         public IntPtr _handle;
 
         public void Dispose()
         {
             _gchandle.Dispose();
-            _gchandleHeader.Dispose();
+            _gchandleSelf.Dispose();
         }
 
         public static unsafe MarshalString CreateMarshaler(string value)
@@ -56,7 +56,7 @@ namespace WinRT
             try
             {
                 m._gchandle = GCHandle.Alloc(value, GCHandleType.Pinned);
-                m._gchandleHeader = GCHandle.Alloc(m._header, GCHandleType.Pinned);
+                m._gchandleSelf = GCHandle.Alloc(m, GCHandleType.Pinned);
                 fixed (void* chars = value, header = &m._header, handle = &m._handle)
                 {
                     Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -237,7 +237,6 @@ namespace WinRT
         {
             // TODO: "using var" with ref struct and remove the try/catch below
             var m = MarshalString.CreateMarshaler(runtimeClassId);
-            Func<bool> dispose = () => { m.Dispose(); return false; };
             try
             {
                 IntPtr instancePtr;
@@ -245,10 +244,9 @@ namespace WinRT
                 (instancePtr, hr) = GetActivationFactory(MarshalString.GetAbi(m));
                 return (hr == 0 ? ObjectReference<IActivationFactoryVftbl>.Attach(ref instancePtr) : null, hr);
             }
-            catch (Exception) when (dispose())
+            finally
             {
-                // Will never execute
-                return default;
+                m.Dispose();
             }
         }
         


### PR DESCRIPTION
Fixes #768

Fix GC hole where the whole `MarshalString` object gets moved and makes the `HSTRING` reference invalid
Fix memory leak and possible memory corruption in exception handling in GetActivationFactory

The implementation of `WindowsCreateStringReference` takes the header buffer, fills it and then the returned handle is a pointer to the header buffer. It is thus absolutely essential that the header buffer is not moved while the HSTRING instance is alive. This is explicitly called out in the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/winstring/nf-winstring-windowscreatestringreference):

> The caller must ensure that sourceString and the contents of hstringHeader remain unchanged during the lifetime of the attached HSTRING.

The code was storing the header buffer in unpinned GC memory so the GC was free to move it and it occasionally did so which caused accesses from native code into invalid memory.

Now the solution in the PR is not the most optimal one but it's one that is least disruptive and easy to review. From performance point of view it would make sense to use `ref struct` and rely on the stack being unmovable.

