### PR TITLE
Address memory leaks

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
@@ -1,2 +1,4 @@
+Compat issues with assembly WinRT.Runtime:
 MembersMustExist : Member 'public WinRT.MarshalString.HStringHeader WinRT.MarshalString.HStringHeader WinRT.MarshalString._header' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'WinRT.MarshalString.HStringHeader' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -316,7 +316,7 @@ namespace WinRT
             }
         }
 
-        public unsafe static void Init(IObjectReference objRef)
+        public unsafe static void Init(IObjectReference objRef, bool addRefFromTrackerSource = true)
         {
             if (objRef.ReferenceTrackerPtr == IntPtr.Zero)
             {
@@ -329,7 +329,16 @@ namespace WinRT
                     // Reference Tracker runtime whenever an AddRef()/Release()
                     // is performed on newInstance.
                     objRef.ReferenceTrackerPtr = referenceTracker;
-                    objRef.AddRefFromTrackerSource(); // ObjRef instance
+
+                    if (addRefFromTrackerSource)
+                    {
+                        objRef.AddRefFromTrackerSource(); // ObjRef instance
+                    }
+                    else
+                    {
+                        objRef.PreventReleaseFromTrackerSourceOnDispose = true;
+                    }
+
                     Marshal.Release(referenceTracker);
                 }
             }

--- a/src/WinRT.Runtime/Interop/IReferenceTracker.cs
+++ b/src/WinRT.Runtime/Interop/IReferenceTracker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WinRT.Interop
+{
+    [Guid("11D3B13A-180E-4789-A8BE-7712882893E6")]
+    internal unsafe struct IReferenceTrackerVftbl
+    {
+        public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+        private void* _ConnectFromTrackerSource_0;
+        private void* _DisconnectFromTrackerSource_1;
+        private void* _FindTrackerTargets_2;
+        private void* _GetReferenceTrackerManager_3;
+        private void* _AddRefFromTrackerSource_4;
+        public delegate* unmanaged[Stdcall]<IntPtr, int> AddRefFromTrackerSource { get => (delegate* unmanaged[Stdcall]<IntPtr, int>)_AddRefFromTrackerSource_4; set => _AddRefFromTrackerSource_4 = (void*)value; }
+        private void* _ReleaseFromTrackerSource_5;
+        public delegate* unmanaged[Stdcall]<IntPtr, int> ReleaseFromTrackerSource { get => (delegate* unmanaged[Stdcall]<IntPtr, int>)_ReleaseFromTrackerSource_5; set => _ReleaseFromTrackerSource_5 = (void*)value; }
+        private void* _PegFromTrackerSource_6;
+    }
+}

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1061,13 +1061,13 @@ namespace WinRT
         public static void DisposeAbi(IntPtr ptr) => MarshalInterfaceHelper<T>.DisposeAbi(ptr);
         public static IntPtr FromManaged(T o, bool unwrapObject = true)
         {
-            var objRef = CreateMarshaler(o, unwrapObject);
+            using var objRef = CreateMarshaler(o, unwrapObject);
             return objRef?.GetRef() ?? IntPtr.Zero;
         }
 
         public static unsafe void CopyManaged(T o, IntPtr dest, bool unwrapObject = true)
         {
-            var objRef = CreateMarshaler(o, unwrapObject);
+            using var objRef = CreateMarshaler(o, unwrapObject);
             *(IntPtr*)dest.ToPointer() = objRef?.GetRef() ?? IntPtr.Zero;
         }
 

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -1,3 +1,6 @@
 Compat issues with assembly WinRT.Runtime:
 TypesMustExist : Type 'System.Numerics.VectorExtensions' does not exist in the reference but it does exist in the implementation.
-Total Issues: 1
+TypesMustExist : Type 'WinRT.ComWrappersHelper' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 4

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -234,6 +234,7 @@ namespace WinRT
                     return false;
                 }
                 disposed = false;
+                ResurrectTrackerSource();
                 AddRef();
                 GC.ReRegisterForFinalize(this);
                 return true;
@@ -281,6 +282,18 @@ namespace WinRT
             if (ReferenceTrackerPtr != IntPtr.Zero)
             {
                 ReferenceTracker.ReleaseFromTrackerSource(ReferenceTrackerPtr);
+            }
+        }
+
+        private unsafe void ResurrectTrackerSource()
+        {
+            if (ReferenceTrackerPtr != IntPtr.Zero)
+            {
+                ReferenceTracker.IUnknownVftbl.AddRef(ReferenceTrackerPtr);
+                if (!PreventReleaseFromTrackerSourceOnDispose)
+                {
+                    ReferenceTracker.AddRefFromTrackerSource(ReferenceTrackerPtr);
+                }
             }
         }
 

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -17,6 +17,7 @@ namespace WinRT
         protected bool disposed;
         private readonly IntPtr _thisPtr;
         private object _disposedLock = new object();
+        private IntPtr _referenceTrackerPtr;
 
         public IntPtr ThisPtr
         {
@@ -24,6 +25,52 @@ namespace WinRT
             {
                 ThrowIfDisposed();
                 return _thisPtr;
+            }
+        }
+
+#if DEBUG
+        private unsafe uint RefCount
+        {
+            get
+            {
+                VftblIUnknown.AddRef(ThisPtr);
+                return VftblIUnknown.Release(ThisPtr);
+            }
+        }
+
+        private bool BreakOnDispose { get; set; }
+#endif
+
+        internal bool IsAggregated { get; set; }
+
+        internal bool PreventReleaseOnDispose { get; set; }
+
+        internal bool PreventReleaseFromTrackerSourceOnDispose { get; set; }
+
+        internal unsafe IntPtr ReferenceTrackerPtr
+        {
+            get
+            {
+                return _referenceTrackerPtr;
+            }
+
+            set
+            {
+                _referenceTrackerPtr = value;
+                if (_referenceTrackerPtr != IntPtr.Zero)
+                {
+                    ReferenceTracker.IUnknownVftbl.AddRef(_referenceTrackerPtr);
+                    AddRefFromTrackerSource();
+                }
+            }
+        }
+
+        internal unsafe IReferenceTrackerVftbl ReferenceTracker
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return **(IReferenceTrackerVftbl**)ReferenceTrackerPtr;
             }
         }
 
@@ -55,7 +102,17 @@ namespace WinRT
         {
             ThrowIfDisposed();
             Marshal.ThrowExceptionForHR(VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr));
-            return ObjectReference<T>.Attach(ref thatPtr);
+            if (IsAggregated)
+            {
+                Marshal.Release(thatPtr);
+            }
+            AddRefFromTrackerSource();
+
+            var objRef = ObjectReference<T>.Attach(ref thatPtr);
+            objRef.IsAggregated = IsAggregated;
+            objRef.PreventReleaseOnDispose = IsAggregated;
+            objRef.ReferenceTrackerPtr = ReferenceTrackerPtr;
+            return objRef;
         }
 
         public unsafe TInterface AsInterface<TInterface>()
@@ -92,7 +149,16 @@ namespace WinRT
             int hr = VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr);
             if (hr >= 0)
             {
-                objRef = ObjectReference<T>.Attach(ref thatPtr); 
+                if (IsAggregated)
+                {
+                    Marshal.Release(thatPtr);
+                }
+                AddRefFromTrackerSource();
+
+                objRef = ObjectReference<T>.Attach(ref thatPtr);
+                objRef.IsAggregated = IsAggregated;
+                objRef.PreventReleaseOnDispose = IsAggregated;
+                objRef.ReferenceTrackerPtr = ReferenceTrackerPtr;
             }
             return hr;
         }
@@ -113,7 +179,7 @@ namespace WinRT
         public IntPtr GetRef()
         {
             ThrowIfDisposed();
-            AddRef();
+            AddRef(false);
             return ThisPtr;
         }
 
@@ -142,7 +208,19 @@ namespace WinRT
                 {
                     return;
                 }
-                Release();
+#if DEBUG
+                if (BreakOnDispose && System.Diagnostics.Debugger.IsAttached)
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+#endif
+
+                if (!PreventReleaseOnDispose)
+                {
+                    Release();
+                }
+
+                DisposeTrackerSource();
                 disposed = true;
             }
         }
@@ -162,13 +240,23 @@ namespace WinRT
             }
         }
 
-        protected virtual unsafe void AddRef()
+        protected virtual unsafe void AddRef(bool refFromTrackerSource)
         {
             VftblIUnknown.AddRef(ThisPtr);
+            if(refFromTrackerSource)
+            {
+                AddRefFromTrackerSource();
+            }
+        }
+
+        protected virtual unsafe void AddRef()
+        {
+            AddRef(true);
         }
 
         protected virtual unsafe void Release()
         {
+            ReleaseFromTrackerSource();
             VftblIUnknown.Release(ThisPtr);
         }
 
@@ -177,6 +265,34 @@ namespace WinRT
             get
             {
                 return VftblIUnknown.Equals(IUnknownVftbl.AbiToProjectionVftbl);
+            }
+        }
+
+        internal unsafe void AddRefFromTrackerSource()
+        {
+            if (ReferenceTrackerPtr != IntPtr.Zero)
+            {
+                ReferenceTracker.AddRefFromTrackerSource(ReferenceTrackerPtr);
+            }
+        }
+
+        internal unsafe void ReleaseFromTrackerSource()
+        {
+            if (ReferenceTrackerPtr != IntPtr.Zero)
+            {
+                ReferenceTracker.ReleaseFromTrackerSource(ReferenceTrackerPtr);
+            }
+        }
+
+        private unsafe void DisposeTrackerSource()
+        {
+            if (ReferenceTrackerPtr != IntPtr.Zero)
+            {
+                if (!PreventReleaseFromTrackerSourceOnDispose)
+                {
+                    ReferenceTracker.ReleaseFromTrackerSource(ReferenceTrackerPtr);
+                }
+                ReferenceTracker.IUnknownVftbl.Release(ReferenceTrackerPtr);
             }
         }
     }
@@ -294,9 +410,20 @@ namespace WinRT
             int hr = VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr);
             if (hr >= 0)
             {
+                if (IsAggregated)
+                {
+                    Marshal.Release(thatPtr);
+                }
+                AddRefFromTrackerSource();
+
                 using (var contextCallbackReference = ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.FromAbi(_contextCallbackPtr))
                 {
-                    objRef = new ObjectReferenceWithContext<U>(thatPtr, contextCallbackReference.GetRef());
+                    objRef = new ObjectReferenceWithContext<U>(thatPtr, contextCallbackReference.GetRef())
+                    {
+                        IsAggregated = IsAggregated,
+                        PreventReleaseOnDispose = IsAggregated,
+                        ReferenceTrackerPtr = ReferenceTrackerPtr
+                    };
                 }
             }
             return hr;

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1660,7 +1660,8 @@ MarshalInspectable<object>.DisposeAbi(ptr);
 }
 }))())
 {
-    ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
+ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
+%
 }
 )",
                     platform_attribute, 
@@ -1670,7 +1671,8 @@ MarshalInspectable<object>.DisposeAbi(ptr);
                     cache_object,
                     method.Name(),
                     bind_list<write_parameter_name_with_modifier>(", ", signature.params()),
-                    settings.netstandard_compat ? "new " + default_interface_name : "");
+                    settings.netstandard_compat ? "new " + default_interface_name : "",
+                    settings.netstandard_compat ? "" : "ComWrappersHelper.Init(_inner, false);");
             }
         }
         else
@@ -1679,11 +1681,13 @@ MarshalInspectable<object>.DisposeAbi(ptr);
 public %() : this(%(ActivationFactory<%>.ActivateInstance<IUnknownVftbl>()))
 {
 ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
+%
 }
 )",
                 class_type.TypeName(),
                 settings.netstandard_compat ? "new " + default_interface_name : "",
-                class_type.TypeName());
+                class_type.TypeName(),
+                settings.netstandard_compat ? "" : "ComWrappersHelper.Init(_inner, false);");
         }
     }
 


### PR DESCRIPTION
The changes in this PR addresses the memory leaks observed in the samples from #781.  It is a variant of the changes attempted initially in #673 , but addresses some of the concerns about finalizers on the RCW handling release by moving that to the IObjectReference itself which owns the lifetime.  In addition, it makes sure in aggregated scenarios, any QIs don't increment the COM ref count maintained by the CLR and that for non aggregated scenarios XAML is informed of those references.

From testing, these changes seem to demonstrate an improvement and no leaks are observed in the samples in #781 