### PR TITLE
Add workaround for issue in WinUI where they cast IBindableIterable to IIterable<object>

### DIFF
--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -27,6 +27,12 @@ namespace Microsoft.UI.Xaml.Interop
     internal interface IBindableIterator
     {
         bool MoveNext();
+        // GetMany is not implemented by IBindableIterator, but it is here
+        // for compat purposes with WinUI where there are scenarios they do
+        // reinterpret_cast from IBindableIterator to IIterable<object>.  It is
+        // the last function in the vftable and shouldn't be called by anyone.
+        // If called, it will return NotImplementedException.
+        uint GetMany(ref object[] items);
         object Current { get; }
         bool HasCurrent { get; }
     }
@@ -78,6 +84,8 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
             private void* _MoveNext_2;
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> MoveNext_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
+            private void* _GetMany_3;
+            public delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int> GetMany_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>)_GetMany_3; set => _GetMany_3 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
@@ -90,10 +98,10 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
                     _get_Current_0 = (delegate* unmanaged<IntPtr, IntPtr*, int>)&Do_Abi_get_Current_0,
                     _get_HasCurrent_1 = (delegate* unmanaged<IntPtr, byte*, int>)&Do_Abi_get_HasCurrent_1,
-                    _MoveNext_2 = (delegate* unmanaged<IntPtr, byte*, int>)&Do_Abi_MoveNext_2
-
+                    _MoveNext_2 = (delegate* unmanaged<IntPtr, byte*, int>)&Do_Abi_MoveNext_2,
+                    _GetMany_3 = (delegate* unmanaged<IntPtr, int, IntPtr, uint*, int>)&Do_Abi_GetMany_3
                 };
-                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 3);
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 4);
                 Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
                 AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
             }
@@ -116,6 +124,24 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
+            }
+
+            [UnmanagedCallersOnly]
+
+            private static unsafe int Do_Abi_GetMany_3(IntPtr thisPtr, int __itemsSize, IntPtr items, uint* result)
+            {
+                *result = default;
+
+                try
+                {
+                    // Should never be called.
+                    throw new NotImplementedException();
+                }
+                catch (Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
             }
 
             [UnmanagedCallersOnly]
@@ -167,6 +193,12 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             return __retval != 0;
         }
 
+        unsafe uint global::Microsoft.UI.Xaml.Interop.IBindableIterator.GetMany(ref object[] items)
+        {
+            // Should never be called.
+            throw new NotImplementedException();
+        }
+
         unsafe object global::Microsoft.UI.Xaml.Interop.IBindableIterator.Current
         {
             get
@@ -205,6 +237,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         public unsafe delegate int get_Current_0(IntPtr thisPtr, IntPtr* result);
         public unsafe delegate int get_HasCurrent_1(IntPtr thisPtr, byte* result);
         public unsafe delegate int MoveNext_2(IntPtr thisPtr, byte* result);
+        public unsafe delegate int GetMany_3(IntPtr thisPtr, int itemSize, IntPtr items, uint* result);
     }
 
     [DynamicInterfaceCastableImplementation]

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -84,6 +84,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
             private void* _MoveNext_2;
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> MoveNext_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
+            // Note this may not be a valid address and should not be called.
             private void* _GetMany_3;
             public delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int> GetMany_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>)_GetMany_3; set => _GetMany_3 = value; }
 

--- a/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
@@ -27,6 +27,12 @@ namespace Microsoft.UI.Xaml.Interop
     internal interface IBindableIterator
     {
         bool MoveNext();
+        // GetMany is not implemented by IBindableIterator, but it is here
+        // for compat purposes with WinUI where there are scenarios they do
+        // reinterpret_cast from IBindableIterator to IIterable<object>.  It is
+        // the last function in the vftable and shouldn't be called by anyone.
+        // If called, it will return NotImplementedException.
+        uint GetMany(ref object[] items);
         object Current { get; }
         bool HasCurrent { get; }
     }
@@ -71,11 +77,13 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
             private void* _MoveNext_2;
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> MoveNext_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
+            private void* _GetMany_3;
+            public delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int> GetMany_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>)_GetMany_3; set => _GetMany_3 = value; }
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
 
-            private static readonly Delegate[] DelegateCache = new Delegate[3];
+            private static readonly Delegate[] DelegateCache = new Delegate[4];
 
             static unsafe Vftbl()
             {
@@ -86,9 +94,9 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                     _get_Current_0 = Marshal.GetFunctionPointerForDelegate(DelegateCache[0] = new IBindableIterator_Delegates.get_Current_0(Do_Abi_get_Current_0)).ToPointer(),
                     _get_HasCurrent_1 = Marshal.GetFunctionPointerForDelegate(DelegateCache[1] = new IBindableIterator_Delegates.get_HasCurrent_1(Do_Abi_get_HasCurrent_1)).ToPointer(),
                     _MoveNext_2 = Marshal.GetFunctionPointerForDelegate(DelegateCache[2] = new IBindableIterator_Delegates.MoveNext_2(Do_Abi_MoveNext_2)).ToPointer(),
-
+                    _GetMany_3 = Marshal.GetFunctionPointerForDelegate(DelegateCache[3] = new IBindableIterator_Delegates.GetMany_3(Do_Abi_GetMany_3)).ToPointer(),
                 };
-                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 3);
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 4);
                 Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
                 AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
             }
@@ -110,6 +118,23 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 }
                 return 0;
             }
+
+            private static unsafe int Do_Abi_GetMany_3(IntPtr thisPtr, int __itemsSize, IntPtr items, uint* result)
+            {
+                *result = default;
+
+                try
+                {
+                    // Should never be called.
+                    throw new NotImplementedException();
+                }
+                catch (Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+            }
+
 
             private static unsafe int Do_Abi_get_Current_0(IntPtr thisPtr, IntPtr* value)
             {
@@ -193,6 +218,12 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             }
         }
 
+        public unsafe uint GetMany(ref object[] items)
+        {
+            // Should never be called.
+            throw new NotImplementedException();
+        }
+
     }
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal static class IBindableIterator_Delegates
@@ -200,6 +231,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         public unsafe delegate int get_Current_0(IntPtr thisPtr, IntPtr* result);
         public unsafe delegate int get_HasCurrent_1(IntPtr thisPtr, byte* result);
         public unsafe delegate int MoveNext_2(IntPtr thisPtr, byte* result);
+        public unsafe delegate int GetMany_3(IntPtr thisPtr, int itemSize, IntPtr items, uint* result);
     }
 
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]

--- a/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
@@ -77,6 +77,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> get_HasCurrent_1 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_get_HasCurrent_1; set => _get_HasCurrent_1 = value; }
             private void* _MoveNext_2;
             public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> MoveNext_2 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_MoveNext_2; set => _MoveNext_2 = value; }
+            // Note this may not be a valid address and should not be called.
             private void* _GetMany_3;
             public delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int> GetMany_3 { get => (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>)_GetMany_3; set => _GetMany_3 = value; }
 

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -410,6 +410,12 @@ namespace ABI.System.Collections.Generic
             public object Current => _Current;
 
             public bool MoveNext() => _MoveNext();
+
+            uint IBindableIterator.GetMany(ref object[] items)
+            {
+                // Should not be called.
+                throw new NotImplementedException();
+            }
         }
 
         [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]

--- a/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -415,6 +415,12 @@ namespace ABI.System.Collections.Generic
             public object Current => _Current;
 
             public bool MoveNext() => _MoveNext();
+
+            uint IBindableIterator.GetMany(ref object[] items)
+            {
+                // Should not be called.
+                throw new NotImplementedException();
+            }
         }
 
         [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]


### PR DESCRIPTION
Recent changes in CsWinRT around memory management exposed a bug where WinUI has an IBindableIterable and tries to treat it as an IIterable<Object>.  This for the most part worked fine until now as there is only one additional function in IIterable (GetMany) and that function was somehow getting an invalid address that was accepted by the function pointer delegate marshaling code.  Calling that function would indeed still error, but that function is also rarely used.  But after our recent memory management updates in the vftable optimization, the invalid address is more random and no longer accepted by the function pointer delegate marshaling code.

In order to unblock WinUI apps until the WinUI bug is fixed, adding a GetMany function to our IBindableIterable implementation which allows the function pointer delegate marshaling code to not error in these scenarios.  Calling the function would still error, but it won't crash when the vftable is generated.