### PR TITLE
Fix scenarios where event handler is detached after managed object is cleaned up

### DIFF
--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -252,7 +252,7 @@ namespace ABI.System.Windows.Input
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr);
-                    if (_CanExecuteChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _CanExecuteChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.CanExecuteChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
@@ -237,7 +237,7 @@ namespace ABI.System.Windows.Input
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr);
-                    if (_CanExecuteChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _CanExecuteChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.CanExecuteChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
@@ -67,7 +67,7 @@ namespace ABI.System.Collections.Specialized
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Collections.Specialized.INotifyCollectionChanged>(thisPtr);
-                    if (_CollectionChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _CollectionChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.CollectionChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.netstandard2.0.cs
@@ -74,7 +74,7 @@ namespace ABI.System.Collections.Specialized
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Collections.Specialized.INotifyCollectionChanged>(thisPtr);
-                    if (_CollectionChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _CollectionChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.CollectionChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -108,7 +108,7 @@ namespace ABI.System.ComponentModel
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.ComponentModel.INotifyDataErrorInfo>(thisPtr);
-                    if (_ErrorsChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _ErrorsChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.ErrorsChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
@@ -134,7 +134,7 @@ namespace ABI.System.ComponentModel
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.ComponentModel.INotifyDataErrorInfo>(thisPtr);
-                    if (_ErrorsChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _ErrorsChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.ErrorsChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
@@ -66,7 +66,7 @@ namespace ABI.System.ComponentModel
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.ComponentModel.INotifyPropertyChanged>(thisPtr);
-                    if (_PropertyChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _PropertyChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.PropertyChanged -= __handler;
                     }

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.netstandard2.0.cs
@@ -74,7 +74,7 @@ namespace ABI.System.ComponentModel
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.ComponentModel.INotifyPropertyChanged>(thisPtr);
-                    if (_PropertyChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
+                    if (__this != null && _PropertyChanged_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(token, out var __handler))
                     {
                         __this.PropertyChanged -= __handler;
                     }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -4428,7 +4428,7 @@ private static unsafe int Do_Abi_%%
 try
 {
 var __this = global::WinRT.ComWrappersSupport.FindObject<%>(thisPtr);
-if(_%_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(%, out var __handler))
+if(__this != null && _%_TokenTables.TryGetValue(__this, out var __table) && __table.RemoveEventHandler(%, out var __handler))
 {
 __this.% -= __handler;
 }


### PR DESCRIPTION
After fixing the memory leaks, we are seeing in WinUI chk builds that there are asserts getting triggered during detach handler calls. From investigation, it seems like we are running into scenarios where after the object no longer has any rooted references (only non rooted WinUI references), WinUI is trying to do cleanup and detach its registered handlers.  But .NET has already decided to go ahead and GC the managed object, but keep its CCW for it in a destroyed state that isn't cleaned up until WinUI lets go of its non rooted references.  Given when the managed object gets cleaned up, its event sources also get cleaned up, it is safe to say the handlers at that point have already been unregistered.  So when WinUI does its remove handler call during cleanup, it really has already been removed.  Currently that is failing due to being unable to find the managed object, but we can safely handle that scenario saying if the managed object is not found, there is nothing to remove.