### PR TITLE
Add explicit dependency info to enable FastUpToDateCheck feature in VS

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -107,6 +107,13 @@ $(CsWinRTFilters)
     <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
     <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
     <Exec Command="$(CsWinRTCommand)" />
+    <ItemGroup>
+      <CsWinRTOutputs Include="$(CsWinRTGeneratedFilesDir)/*.cs"/>
+      <UpToDateCheckInput Include="@(CsWinRTInputs)" Set="CsWinRTInputs" />
+      <UpToDateCheckOutput Include="$(CsWinRTResponseFile)" Set="CsWinRTInputs" />
+      <UpToDateCheckInput Include="$(CsWinRTResponseFile)" Set="CsWinRTOutputs" />
+      <UpToDateCheckOutput Include="@(CsWinRTOutputs)" Set="CsWinRTOutputs" />
+    </ItemGroup>
   </Target>
   
   <Target Name="CsWinRTIncludeProjection" BeforeTargets="BeforeCompile" DependsOnTargets="CsWinRTGenerateProjection" Condition="$(CsWinRTEnabled)">


### PR DESCRIPTION
fixes #804 