### PR TITLE
Restored ContractVersion attribution as Xaml Compiler relies on it

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1434,7 +1434,8 @@ remove => %.% -= value;
                 {
                     allow_multiple = true;
                 }
-                if (attribute_name != "DefaultOverload" && attribute_name != "Overload" && attribute_name != "AttributeUsage")
+                if (attribute_name != "DefaultOverload" && attribute_name != "Overload" && 
+                    attribute_name != "AttributeUsage" && attribute_name != "ContractVersion")
                 {
                     continue;
                 }


### PR DESCRIPTION
fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/32726656