### PR TITLE
removed assembly-level SupportedOSPlatformAttribute to enable projection authors to apply a more restricted (later) version

### DIFF
--- a/src/Tests/AuthoringTest/Module.cs
+++ b/src/Tests/AuthoringTest/Module.cs
@@ -1,0 +1,3 @@
+﻿#if !NETSTANDARD2_0
+[assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows")]
+#endif

--- a/src/WinRT.Runtime/Module.cs
+++ b/src/WinRT.Runtime/Module.cs
@@ -1,0 +1,3 @@
+﻿#if !NETSTANDARD2_0
+[assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows")]
+#endif

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -16,10 +16,6 @@ using System.Linq.Expressions;
 #pragma warning disable 0649 // Field 'xxx' is never assigned to, and will always have its default value
 #pragma warning disable CA1060
 
-#if !NETSTANDARD2_0
-[assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows")]
-#endif
-
 namespace WinRT
 {
     using System.Diagnostics;


### PR DESCRIPTION
fixes #792 