### PR TITLE
Revert "Fix InvalidCastExceptions from RCW reuse (#833)"

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2254,14 +2254,6 @@ namespace UnitTest
         [Fact]
         unsafe public void TestComImports()
         {
-            TestObject();
-            GCCollect();
-            Assert.Equal(0, ComImports.NumObjects);
-
-            TestImports();
-            GCCollect();
-            Assert.Equal(0, ComImports.NumObjects);
-
             static Object MakeObject()
             {
                 Assert.Equal(0, ComImports.NumObjects);
@@ -2283,24 +2275,24 @@ namespace UnitTest
             static void TestImports()
             {
                 var (initializeWithWindow, windowNative) = MakeImports();
-
-                GCCollect();
+                
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
 
                 var hwnd = new IntPtr(0x12345678);
                 initializeWithWindow.Initialize(hwnd);
                 Assert.Equal(windowNative.WindowHandle, hwnd);
             }
 
-            static void GCCollect()
-            {
-                // Require multiple GC collects due to
-                // the final release is not done immediately.
-                for(int idx = 0; idx < 3; idx++)
-                {
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                }
-            }
+            TestObject();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Assert.Equal(0, ComImports.NumObjects);
+
+            TestImports();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Assert.Equal(0, ComImports.NumObjects);
         }
 
         [Fact]

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -101,9 +101,9 @@ namespace WinRT
 
             return rcw switch
             {
-                ABI.System.Nullable<string> ns => (T)(object)ns.Value,
-                ABI.System.Nullable<Type> nt => (T)(object)nt.Value,
-                _ => (T)rcw
+                ABI.System.Nullable<string> ns => (T)(object) ns.Value,
+                ABI.System.Nullable<Type> nt => (T)(object) nt.Value,
+                _ => (T) rcw
             };
         }
 
@@ -143,7 +143,6 @@ namespace WinRT
             if (target is IWinRTObject winrtObj)
             {
                 winrtObj.Resurrect();
-                winrtObj.NativeObject.MarkCleanupRCW();
             }
             return rcw;
         }
@@ -207,7 +206,6 @@ namespace WinRT
             out IObjectReference objRef)
         {
             objRef = ComWrappersSupport.GetObjectReferenceForInterface(isAggregation ? inner : newInstance);
-            objRef.MarkCleanupRCW();
 
             IntPtr referenceTracker;
             {
@@ -466,7 +464,6 @@ namespace WinRT
                 // on destruction as the CLR would do it.
                 winrtObj.NativeObject.ReleaseFromTrackerSource();
                 winrtObj.NativeObject.PreventReleaseFromTrackerSourceOnDispose = true;
-                winrtObj.NativeObject.MarkCleanupRCW();
             }
 
             return obj;

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -169,7 +169,6 @@ namespace WinRT
         {
             if (NativeObject.Resurrect())
             {
-                NativeObject.MarkCleanupRCW();
                 foreach (var cached in QueryInterfaceCache)
                 {
                     cached.Value.Resurrect();

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -18,7 +18,6 @@ namespace WinRT
         private readonly IntPtr _thisPtr;
         private object _disposedLock = new object();
         private IntPtr _referenceTrackerPtr;
-        private byte _rcwCleanupCounter;
 
         public IntPtr ThisPtr
         {
@@ -197,13 +196,6 @@ namespace WinRT
 
         public void Dispose()
         {
-            // If this is the object reference associated with the RCW,
-            // defer dispose to after the RCW has been finalized for .NET 5.
-            if (!Cleanup)
-            {
-                return;
-            }
-
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -216,20 +208,6 @@ namespace WinRT
                 {
                     return;
                 }
-
-                // If the object reference is associated with the RCW, we need to
-                // defer the final release on the ThisPtr until after the RCW has been
-                // finalized and it has been removed from the ComWrappers cache.
-                // In .NET 6, there will be a new API for us to use, but until then
-                // in .NET 5, we defer the finalization of this object until it
-                // has reached Gen 2 by reregistering for finalization.
-                if(!Cleanup)
-                {
-                    _rcwCleanupCounter--;
-                    GC.ReRegisterForFinalize(this);
-                    return;
-                }
-
 #if DEBUG
                 if (BreakOnDispose && System.Diagnostics.Debugger.IsAttached)
                 {
@@ -330,10 +308,6 @@ namespace WinRT
                 ReferenceTracker.IUnknownVftbl.Release(ReferenceTrackerPtr);
             }
         }
-        
-        internal void MarkCleanupRCW() => _rcwCleanupCounter = 2;
-
-        private bool Cleanup { get => _rcwCleanupCounter == 0; }
     }
 
     public class ObjectReference<T> : IObjectReference


### PR DESCRIPTION
This reverts commit 3f5dd34a6ae93df1d9229385468fe772a904028e.

There seems to have been issues from this change discovered in WinUI checked builds.  Until we have a better understanding of the issue and a fix for it, undoing this change to unblock upcoming release.

#762 