### PR TITLE
Add support for calling non agile objects regardless of current context

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2186,8 +2186,8 @@ namespace UnitTest
                 objectAcquired.Set();
                 valueAcquired.WaitOne();
 
-                // Call to proxy object acquired from MTA which should throw
-                Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands.Count);
+                // Object gets proxied to apartment.
+                Assert.Equal(2, proxyObject.Commands.Count);
                 agileReference.Dispose();
             }
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2181,12 +2181,12 @@ namespace UnitTest
                 nonAgileObject.Commands.Add(new Windows.UI.Popups.UICommand("test"));
                 nonAgileObject.Commands.Add(new Windows.UI.Popups.UICommand("test2"));
                 Assert.ThrowsAny<System.Exception>(() => nonAgileObject.As<IAgileObject>());
-                agileReference = nonAgileObject.AsAgile();
 
+                agileReference = nonAgileObject.AsAgile();
                 objectAcquired.Set();
                 valueAcquired.WaitOne();
 
-                // Object gets proxied to apartment.
+                // Object gets proxied to the apartment.
                 Assert.Equal(2, proxyObject.Commands.Count);
                 agileReference.Dispose();
 
@@ -2197,7 +2197,6 @@ namespace UnitTest
             {
                 objectAcquired.WaitOne();
                 Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
-
                 proxyObject = agileReference.Get();
                 Assert.Equal(2, proxyObject.Commands.Count);
                 
@@ -2209,7 +2208,7 @@ namespace UnitTest
 
             public void CallProxyObject()
             {
-                // Call to proxy object after apartment is gone should throw
+                // Call to the proxy object after the apartment is gone should throw.
                 Assert.ThrowsAny<System.Exception>(() => proxyObject2.Commands);
             }
 

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -52,7 +52,14 @@ namespace WinRT
             {
                 if (_cookie != IntPtr.Zero)
                 {
-                    Git.Value.RevokeInterfaceFromGlobal(_cookie);
+                    try
+                    {
+                        Git.Value.RevokeInterfaceFromGlobal(_cookie);
+                    }
+                    catch(ArgumentException)
+                    {
+                        // Revoking cookie from GIT table may fail if apartment is gone.
+                    }
                 }
                 disposed = true;
             }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -69,7 +69,8 @@ namespace WinRT
             {
                 return new ObjectReferenceWithContext<IUnknownVftbl>(
                     unknownRef.GetRef(),
-                    Context.GetContextCallback());
+                    Context.GetContextCallback(),
+                    Context.GetContextToken());
             }
         }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -72,6 +72,8 @@ namespace WinRT
                     Context.GetContextToken());
             }
 
+            // If we are free threaded, we do not need to keep track of context.
+            // This can either be if the object implements IAgileObject or the free threaded marshaler.
             unsafe bool IsFreeThreaded()
             {
                 if (unknownRef.TryAs<IUnknownVftbl>(typeof(ABI.WinRT.Interop.IAgileObject.Vftbl).GUID, out var agileRef) >= 0)

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -7,6 +7,9 @@ namespace WinRT
     static class Context
     {
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+        private static extern unsafe int CoGetContextToken(IntPtr* contextToken);
+
+        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
 
         private static readonly Guid IID_ICallbackWithNoReentrancyToApplicationSTA = Guid.Parse("0A299774-3E4E-FC42-1D9D-72CEE105CA57");
@@ -21,7 +24,7 @@ namespace WinRT
         public unsafe static IntPtr GetContextToken()
         {
             IntPtr contextToken;
-            Marshal.ThrowExceptionForHR(Platform.CoGetContextToken(&contextToken));
+            Marshal.ThrowExceptionForHR(CoGetContextToken(&contextToken));
             return contextToken;
         }
 

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -25,6 +25,10 @@ namespace WinRT
             return contextToken;
         }
 
+        // Calls the given callback in the right context.
+        // On any exception, calls onFail callback if any set.
+        // If not set, exception is handled due to today we don't
+        // have any scenario to propagate it from here.
         public unsafe static void CallInContext(IntPtr contextCallbackPtr, IntPtr contextToken, Action callback, Action onFailCallback)
         {
             // Check if we are already on the same context, if so we do not need to switch.
@@ -45,9 +49,9 @@ namespace WinRT
                     return 0;
                 }, &data, IID_ICallbackWithNoReentrancyToApplicationSTA, 5);
             } 
-            catch(Exception) when (onFailCallback != null)
+            catch(Exception)
             {
-                onFailCallback();
+                onFailCallback?.Invoke();
             }
         }
 

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -9,11 +9,51 @@ namespace WinRT
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
 
+        private static readonly Guid IID_ICallbackWithNoReentrancyToApplicationSTA = Guid.Parse("0A299774-3E4E-FC42-1D9D-72CEE105CA57");
+
         public static IntPtr GetContextCallback()
         {
             Guid riid = typeof(IContextCallback).GUID;
             Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
             return contextCallbackPtr;
+        }
+
+        public unsafe static IntPtr GetContextToken()
+        {
+            IntPtr contextToken;
+            Marshal.ThrowExceptionForHR(Platform.CoGetContextToken(&contextToken));
+            return contextToken;
+        }
+
+        public unsafe static void CallInContext(IntPtr contextCallbackPtr, IntPtr contextToken, Action callback, Action onFailCallback)
+        {
+            // Check if we are already on the same context, if so we do not need to switch.
+            if(contextCallbackPtr == IntPtr.Zero || GetContextToken() == contextToken)
+            {
+                callback();
+                return;
+            }
+
+            ComCallData data = default;
+            var contextCallback = new ABI.WinRT.Interop.IContextCallback(ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.FromAbi(contextCallbackPtr));
+
+            try
+            {
+                contextCallback.ContextCallback(_ =>
+                {
+                    callback();
+                    return 0;
+                }, &data, IID_ICallbackWithNoReentrancyToApplicationSTA, 5);
+            } 
+            catch(Exception) when (onFailCallback != null)
+            {
+                onFailCallback();
+            }
+        }
+
+        public static void DisposeContextCallback(IntPtr contextCallbackPtr)
+        {
+            using var contextcallback = ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.Attach(ref contextCallbackPtr);
         }
     }
 }

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -117,7 +117,7 @@ namespace WinRT
                     var qiObjRef = objRef.As<IUnknownVftbl>(GuidGenerator.GetIID(helperType));
                     if (!QueryInterfaceCache.TryAdd(interfaceType, qiObjRef))
                     {
-                        objRef.Dispose();
+                        qiObjRef.Dispose();
                     }
                     return true;
                 }

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -74,6 +74,7 @@ namespace ABI.WinRT.Interop
             var callback = Marshal.GetFunctionPointerForDelegate(pfnCallback);
             var result = _obj.Vftbl.ContextCallback_4(ThisPtr, callback, pParam, &riid, iMethod, IntPtr.Zero);
             GC.KeepAlive(pfnCallback);
+            Marshal.ThrowExceptionForHR(result);
         }
     }
 }

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -69,17 +69,11 @@ namespace ABI.WinRT.Interop
             public ComCallData* userData;
         }
 
-        private const int RPC_E_DISCONNECTED = unchecked((int)0x80010108);
-
         public unsafe void ContextCallback(global::WinRT.Interop.PFNCONTEXTCALL pfnCallback, ComCallData* pParam, Guid riid, int iMethod)
         {
             var callback = Marshal.GetFunctionPointerForDelegate(pfnCallback);
             var result = _obj.Vftbl.ContextCallback_4(ThisPtr, callback, pParam, &riid, iMethod, IntPtr.Zero);
             GC.KeepAlive(pfnCallback);
-            if (result != RPC_E_DISCONNECTED)
-            {
-                Marshal.ThrowExceptionForHR(result);
-            }
         }
     }
 }

--- a/src/WinRT.Runtime/Interop/IMarshal.cs
+++ b/src/WinRT.Runtime/Interop/IMarshal.cs
@@ -37,6 +37,8 @@ namespace ABI.WinRT.Interop
 
         private static readonly string NotImplemented_NativeRoutineNotFound = "A native library routine was not found: {0}.";
 
+        internal static Lazy<Guid> IID_InProcFreeThreadedMarshaler = new Lazy<Guid>(Vftbl.GetInProcFreeThreadedMarshalerIID);
+
         [Guid("00000003-0000-0000-c000-000000000046")]
         public unsafe struct Vftbl
         {
@@ -119,6 +121,16 @@ namespace ABI.WinRT.Interop
                 {
                     throw new NotImplementedException(string.Format(NotImplemented_NativeRoutineNotFound, "CoCreateFreeThreadedMarshaler"), ex);
                 }
+            }
+
+            internal static Guid GetInProcFreeThreadedMarshalerIID()
+            {
+                EnsureHasFreeThreadedMarshaler();
+
+                Guid iid_IUnknown = typeof(IUnknownVftbl).GUID;
+                Guid iid_unmarshalClass;
+                t_freeThreadedMarshaler.GetUnmarshalClass(&iid_IUnknown, IntPtr.Zero, MSHCTX.InProc, IntPtr.Zero, MSHLFLAGS.Normal, &iid_unmarshalClass);
+                return iid_unmarshalClass;
             }
 
             public Vftbl(IntPtr ptr)

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -486,9 +486,8 @@ namespace WinRT
             ObjectReference<T> GetForCurrentContext(IntPtr _)
             {
                 var agileReference = _agileReference.Value;
-                // During process termination, we may fail to switch context
-                // and thereby not get an agile reference.  In these cases,
-                // fallback to using the current context.
+                // We may fail to switch context and thereby not get an agile reference.
+                // In these cases, fallback to using the current context.
                 if (agileReference == null)
                 {
                     return null;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -46,9 +46,6 @@ namespace WinRT
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         internal static extern unsafe int CoIncrementMTAUsage(IntPtr* cookie);
 
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        internal static extern unsafe int CoGetContextToken(IntPtr* contextToken);
-
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool FreeLibrary(IntPtr moduleHandle);

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -46,6 +46,9 @@ namespace WinRT
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         internal static extern unsafe int CoIncrementMTAUsage(IntPtr* cookie);
 
+        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+        internal static extern unsafe int CoGetContextToken(IntPtr* contextToken);
+
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool FreeLibrary(IntPtr moduleHandle);


### PR DESCRIPTION
Previously in .NET native, apps were able to call APIs on non agile objects regardless of the context / apartment they were in.  .NET marshaled the ptr to the current context and then used that to call the API via a proxy.  This PR achieves something similar where whenever the ThisPtr is retrieved on an non agile object, we check if we are in the context when it was originally retrieved in and if so we use it, otherwise we switch back to the original context and get an agile reference to the object and then use the agile reference to get a proxy for it in the current context.  To avoid doing this each time, the Ptrs retrieved are cached.  If we fail to switch context, we just use the original ptr given that is the best we can do.

In addition, we previously checked whether an object implements IAgileObject as a way to determine whether it is agile or not.  But not all objects implement that but can still be agile such as if they aggregate the free threaded marshaler.  Now we have a check for that too and those who do are considered agile.  This seems to include WinUI types.

Fixes #844 
Fixes #814 