### PR TITLE
Update dotnet SDK to to address VS 16.10 regressions

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRT.SourceGenerator.csproj
+++ b/src/Authoring/WinRT.SourceGenerator/WinRT.SourceGenerator.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0-4.20472.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />    
   </ItemGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,8 +4,6 @@
     <LangVersion>preview</LangVersion>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
@@ -19,10 +17,6 @@
     <Compile Remove="$(GeneratedFilesRootDir)**/*.cs" />
     <None Include="$(GeneratedFilesRootDir)**/*.cs" />
     <Compile Condition="'$(GeneratedFilesDir)' != '$(GeneratedFilesRootDir)'" Include="$(GeneratedFilesDir)*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/DiagnosticTests/DiagnosticTests.csproj
+++ b/src/Tests/DiagnosticTests/DiagnosticTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0-4.20472.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />    
   </ItemGroup>
 

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 if /i "%cswinrt_echo%" == "on" @echo on
 
-set CsWinRTNet5SdkVersion=5.0.100
+set CsWinRTNet5SdkVersion=5.0.300
 
 set this_dir=%~dp0
 


### PR DESCRIPTION
- Updated to dotnet 300 series to address pipeline failure after recent VS update
- Removed dependency on older rosyln compilers package as a couple VS version have shipped with the minimum that we require and adding this package forces a downgrade on the compilers package which we use compared to the default one in VS
- Updating versions of source generator package to use release ones from nuget rather than one from dotnet feeds