### PR TITLE
Clean intermediate dirs in pipeline builds to manage disk space

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,7 +34,7 @@
     <BuildOutDir Condition="'$(BuildOutDir)'==''">$([MSBuild]::NormalizeDirectory('$(SolutionDir)_build', '$(BuildPlatform)', '$(Configuration)'))</BuildOutDir>
     <CsWinRTPath>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', 'cswinrt', 'bin'))</CsWinRTPath>
     <CsWinRTPath Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([MSBuild]::NormalizeDirectory('$(SolutionDir)_build', 'x86', '$(Configuration)', 'cswinrt', 'bin'))</CsWinRTPath>
-    <CsWinRTInteropMetadata Condition="'$(CsWinRTInteropMetadata)' == ''">$(CsWinRTPath)..\obj\merged\WinRT.Interop.winmd</CsWinRTInteropMetadata>
+    <CsWinRTInteropMetadata Condition="'$(CsWinRTInteropMetadata)' == ''">$(CsWinRTPath)WinRT.Interop.winmd</CsWinRTInteropMetadata>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.wapproj'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -29,7 +29,7 @@
     <Error Condition="!Exists('$(SolutionDir)TestWinRT')" Text="This solution requires the TestWinRT repo, which is missing. Please run build.cmd from a Visual Studio command prompt." />
   </Target>
 
-  <Target Name="CleanIntermediateDir" AfterTargets="Build">
+  <Target Name="CleanIntermediateDirs" Condition="'$(CleanIntermediateDirs)'=='true'" AfterTargets="Build">
     <RemoveDir Directories="$(IntDir)" />
   </Target>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -29,4 +29,8 @@
     <Error Condition="!Exists('$(SolutionDir)TestWinRT')" Text="This solution requires the TestWinRT repo, which is missing. Please run build.cmd from a Visual Studio command prompt." />
   </Target>
 
+  <Target Name="CleanIntermediateDir" AfterTargets="Build">
+    <RemoveDir Directories="$(IntDir)" />
+  </Target>
+
 </Project>

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -110,9 +110,9 @@ if not "%cswinrt_label%"=="" goto %cswinrt_label%
 :restore
 rem When a preview nuget is required, update -self doesn't work, so manually update 
 if exist %nuget_dir%\nuget.exe (
-  %nuget_dir%\nuget.exe | findstr 5.8.0 >nul
+  %nuget_dir%\nuget.exe | findstr 5.9 >nul
   if ErrorLevel 1 (
-    echo Updating to nuget 5.8.0
+    echo Updating to nuget 5.9
     rd /s/q %nuget_dir% >nul 2>&1
   )
 )

--- a/src/cswinrt/Directory.Build.targets
+++ b/src/cswinrt/Directory.Build.targets
@@ -5,11 +5,15 @@
     </PropertyGroup>
 
     <!--Workaround for MidlRT nupkg expecting project to publish $(RootNamespace).winmd-->
-    <Target Name="CopyWinRTInteropWinMD" Inputs="$(CsWinRTInteropMetadata)" Outputs="$(MidlRTProjectWinMD)">
+    <Target Name="CopyWinRTInteropWinMD" Inputs="$(CsWinRTPath)..\obj\merged\WinRT.Interop.winmd" Outputs="$(MidlRTProjectWinMD);$(CsWinRTInteropMetadata)">
         <Copy UseHardlinksIfPossible="$(MidlRTUseHardlinksIfPossible)"
             SkipUnchangedFiles="$(MidlRTSkipUnchangedFiles)"
-            SourceFiles="$(CsWinRTInteropMetadata)"
+            SourceFiles="$(CsWinRTPath)..\obj\merged\WinRT.Interop.winmd"
             DestinationFiles="$(MidlRTProjectWinMD)" />
+        <Copy UseHardlinksIfPossible="$(MidlRTUseHardlinksIfPossible)"
+            SkipUnchangedFiles="$(MidlRTSkipUnchangedFiles)"
+            SourceFiles="$(CsWinRTPath)..\obj\merged\WinRT.Interop.winmd"
+            DestinationFiles="$(CsWinRTInteropMetadata)" />
     </Target>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />


### PR DESCRIPTION
Hosted agents are limited to 10GB of disk space, and we just started running out.  Added a post-build target to delete the obj dir of each project.