### PR TITLE
Fix codegen when custom attributes have embedded newlines

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -500,4 +500,23 @@ namespace TestComponentCSharp
             //overridable event Windows.Foundation.EventHandler<Int32> WarningOverridableEvent;
         }
     }
+
+    [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
+    [attributename("attr_string")]
+    attribute MyStringAttribute
+    {
+        String Content;
+    }
+
+    [attr_string(
+"This is line one
+This is line two
+
+And this is another one"
+    )]
+    runtimeclass MultiLineStringAttributeTest
+    {
+      void f();
+    }
+
 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1321,7 +1321,7 @@ remove => %.% -= value;
                 },
                 [&](std::string_view type_name)
                 {
-                    w.write("\"%\"", type_name);
+                    w.write("^@\"%\"", type_name);
                 },
                 [&](auto&&)
                 {


### PR DESCRIPTION
Fixes #818 

When stamping out custom attributes, the codegen was not considering that string-typed custom attribute parameters might contain newlines. This results in invalid C# generated code.
The fix is to prepend the string with the "raw string" C# token `@` so that newlines are embedded in the string as intended.