### PR TITLE
Prioritize the assembly where the projected type is to look up the helper type

### DIFF
--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -31,7 +31,7 @@ namespace WinRT
                 }
 
                 var helper = $"ABI.{fullTypeName}";
-                return Type.GetType(helper) ?? type.Assembly.GetType(helper);
+                return type.Assembly.GetType(helper) ?? Type.GetType(helper);
             });
         }
 
@@ -100,7 +100,7 @@ namespace WinRT
         internal static Type GetAuthoringMetadataType(this Type type)
         {
             var ccwTypeName = $"ABI.Impl.{type.FullName}";
-            return Type.GetType(ccwTypeName, false) ?? type.Assembly.GetType(ccwTypeName, false);
+            return type.Assembly.GetType(ccwTypeName, false) ?? Type.GetType(ccwTypeName, false);
         }
 
     }


### PR DESCRIPTION
There is 2 versions of the ICustomProperty type (one in WinRT.Runtime, one in WinUI).  The first is internal while the other is public.  If someone tries to cast using the public one, they can run into issues where IDIC will fail to cast as it tries to use the helper type from the internal one.  This change priorities looking at the helper type in the same assembly as the projected type which avoids this issue hitting.

Fixes #856 