### PR TITLE
Fully qualify attribute types

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -519,4 +519,29 @@ And this is another one"
       void f();
     }
 
+    // Compile time test for sub windows namespace
+    namespace Windows
+    {
+        runtimeclass Class
+        {
+            Class();
+            static void StaticMethod();
+            void Method();
+            void Method2(Windows.Foundation.IStringable stringable);
+        }
+
+        [contract(Windows.Foundation.UniversalApiContract, 8)]
+        interface IWarning
+        {
+            Int32 WarningInterfacePropertySetter{ get; };
+            event Windows.Foundation.TypedEventHandler<Class, String> StringPropertyChanged;
+        }
+
+        [contract(Windows.Foundation.UniversalApiContract, 10)]
+        [attributeusage(target_all)]
+        [attributename("warning2")]
+        attribute Warning2Attribute
+        {
+        };
+    }
 }

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -5,6 +5,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTVerbosity>high</CppWinRTVerbosity>
     <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <ProjectGuid>{7e3a9ab3-8cbb-4b9c-ba76-0fe7108dcaeb}</ProjectGuid>
     <ProjectName>TestComponentCSharp</ProjectName>
@@ -73,6 +74,7 @@
     <ClInclude Include="Singleton.h" />
     <ClInclude Include="WarningClass.h" />
     <ClInclude Include="WarningStatic.h" />
+    <ClInclude Include="Windows.Class.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
@@ -88,6 +90,7 @@
     <ClCompile Include="Singleton.cpp" />
     <ClCompile Include="WarningClass.cpp" />
     <ClCompile Include="WarningStatic.cpp" />
+    <ClCompile Include="Windows.Class.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClCompile Include="WarningClass.cpp" />
     <ClCompile Include="WarningStatic.cpp" />
     <ClCompile Include="Singleton.cpp" />
+    <ClCompile Include="Windows.Class.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -25,6 +26,7 @@
     <ClInclude Include="WarningStatic.h" />
     <ClInclude Include="WarningClass.h" />
     <ClInclude Include="Singleton.h" />
+    <ClInclude Include="Windows.Class.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/Tests/TestComponentCSharp/Windows.Class.cpp
+++ b/src/Tests/TestComponentCSharp/Windows.Class.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "Windows.Class.h"
+#include "Windows.Class.g.cpp"
+
+namespace winrt::TestComponentCSharp::Windows::implementation
+{
+    void Class::StaticMethod()
+    {
+    }
+
+    void Class::Method()
+    {
+    }
+
+    void Class::Method2(winrt::Windows::Foundation::IStringable const& stringable)
+    {
+    }
+}

--- a/src/Tests/TestComponentCSharp/Windows.Class.h
+++ b/src/Tests/TestComponentCSharp/Windows.Class.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "Windows.Class.g.h"
+
+namespace winrt::TestComponentCSharp::Windows::implementation
+{
+    struct Class : ClassT<Class>
+    {
+        Class() = default;
+
+        static void StaticMethod();
+        void Method();
+        void Method2(winrt::Windows::Foundation::IStringable const& stringable);
+    };
+}
+namespace winrt::TestComponentCSharp::Windows::factory_implementation
+{
+    struct Class : ClassT<Class, implementation::Class>
+    {
+    };
+}

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1304,7 +1304,7 @@ remove => %.% -= value;
                             }
                         }
                         w.write("%",
-                            bind_list([](writer& w, auto&& value) { w.write("AttributeTargets.%", value); },
+                            bind_list([](writer& w, auto&& value) { w.write("global::System.AttributeTargets.%", value); },
                                 " | ", values));
                     }
                     else for (auto field : enum_value.type.m_typedef.FieldList())
@@ -1471,7 +1471,7 @@ remove => %.% -= value;
             // GCPressure, Guid, Flags, ProjectionInternal are handled separately
             if (attribute_name == "GCPressure" || attribute_name == "Guid" || 
                 attribute_name == "Flags" || attribute_name == "ProjectionInternal") continue;
-            auto attribute_full = (attribute_name == "AttributeUsage") ? "AttributeUsage" :
+            auto attribute_full = (attribute_name == "AttributeUsage") ? "System.AttributeUsage" :
                 w.write_temp("%.%", attribute_namespace, attribute_name);
             auto signature = attribute.Value();
             auto params = write_custom_attribute_args(w, attribute, signature);
@@ -1481,7 +1481,7 @@ remove => %.% -= value;
                 auto platform = get_platform(w, signature, params);
                 if (!platform.empty())
                 {
-                    attributes["global::System.Runtime.Versioning.SupportedOSPlatform"].push_back(platform);
+                    attributes["System.Runtime.Versioning.SupportedOSPlatform"].push_back(platform);
                 }
             }
             // Skip metadata attributes without a projection
@@ -1499,18 +1499,14 @@ remove => %.% -= value;
             }
             attributes[attribute_full] = std::move(params);
         }
-        if (auto&& usage = attributes.find("AttributeUsage"); usage != attributes.end())
+        if (auto&& usage = attributes.find("System.AttributeUsage"); usage != attributes.end())
         {
             usage->second.push_back(w.write_temp("AllowMultiple = %", allow_multiple ? "true" : "false"));
         }
 
         for (auto&& attribute : attributes)
         {
-            w.write("[");
-            if (w._in_abi_impl_namespace)
-            {
-                w.write("global::");
-            }
+            w.write("[global::");
             w.write(attribute.first);
             if (!attribute.second.empty())
             {


### PR DESCRIPTION
Attributes weren't fully qualified which causes issues if one of the sub namespaces matches with the namespace of the attribute.

Fixes #850   