### PR TITLE
Address potential races in recent event changes

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6488,11 +6488,12 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
                 {
                     handler = (%) =>
                     {
-                        if (_state.del == null)
+                        % localDel = _state.del;
+                        if (localDel == null)
                         {
                             return %;
                         }
-                        %_state.del.Invoke(%);
+                        %localDel.Invoke(%);
                     };
                 }
                 return handler;
@@ -6506,6 +6507,7 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
                     eventTypeCode,
                     bind<write_event_source_type_name>(eventTypeSemantics), 
                     bind<write_event_invoke_params>(invokeMethodSig),
+                    eventTypeCode,
                     bind<write_event_invoke_return_default>(invokeMethodSig),
                     bind<write_event_invoke_return>(invokeMethodSig),
                     bind<write_event_invoke_args>(invokeMethodSig));

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6488,7 +6488,7 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
                 {
                     handler = (%) =>
                     {
-                        % localDel = _state.del;
+                        var localDel = _state.del;
                         if (localDel == null)
                         {
                             return %;
@@ -6507,7 +6507,6 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
                     eventTypeCode,
                     bind<write_event_source_type_name>(eventTypeSemantics), 
                     bind<write_event_invoke_params>(invokeMethodSig),
-                    eventTypeCode,
                     bind<write_event_invoke_return_default>(invokeMethodSig),
                     bind<write_event_invoke_return>(invokeMethodSig),
                     bind<write_event_invoke_args>(invokeMethodSig));

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -581,8 +581,9 @@ namespace WinRT
                 {
                     handler = (System.Object obj, T e) =>
                     {
-                        if (_state.del != null)
-                            _state.del.Invoke(obj, e);
+                        System.EventHandler<T> delLocal = _state.del;
+                        if (delLocal != null)
+                            delLocal.Invoke(obj, e);
                     };
                 }
                 return handler;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -370,7 +370,10 @@ namespace WinRT
         {
             lock (this)
             {
-                if (_state.del is null)
+                bool registerHandler = _state.del is null;
+                
+                _state.del = (TDelegate)global::System.Delegate.Combine(_state.del, del);
+                if (registerHandler)
                 {
                     var marshaler = CreateMarshaler((TDelegate)EventInvoke);
                     try
@@ -385,7 +388,6 @@ namespace WinRT
                         DisposeMarshaler(marshaler);
                     }
                 }
-                _state.del = (TDelegate)global::System.Delegate.Combine(_state.del, del);
             }
         }
 
@@ -445,10 +447,10 @@ namespace WinRT
             }
 
             private IWeakReference target;
-            private ConcurrentDictionary<int, EventSource<TDelegate>.State> states = new ConcurrentDictionary<int, EventSource<TDelegate>.State>();
+            private readonly ConcurrentDictionary<int, EventSource<TDelegate>.State> states = new ConcurrentDictionary<int, EventSource<TDelegate>.State>();
 
-            private static ReaderWriterLockSlim cachesLock = new ReaderWriterLockSlim();
-            private static ConcurrentDictionary<IntPtr, Cache> caches = new ConcurrentDictionary<IntPtr, Cache>();
+            private static readonly ReaderWriterLockSlim cachesLock = new ReaderWriterLockSlim();
+            private static readonly ConcurrentDictionary<IntPtr, Cache> caches = new ConcurrentDictionary<IntPtr, Cache>();
 
             private Cache Update(IWeakReference target, EventSource<TDelegate> source, int index)
             {

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -581,9 +581,9 @@ namespace WinRT
                 {
                     handler = (System.Object obj, T e) =>
                     {
-                        System.EventHandler<T> delLocal = _state.del;
-                        if (delLocal != null)
-                            delLocal.Invoke(obj, e);
+                        var localDel = _state.del;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
                     };
                 }
                 return handler;


### PR DESCRIPTION
- If an event source tries to invoke a handler right after it is added, it won't invoke any registered handlers as we set them up after.  Fixing the ordering for it.
- Previously before the event handler optimizations, we stored the delegate in a local before invoking it to prevent races with it being removed.  Putting that back in to avoid that race.