### PR TITLE
Event handler optimizations

### DIFF
--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1541,6 +1541,28 @@ namespace winrt::TestComponentCSharp::implementation
         _dataErrorsChanged(*this, args);
     }
 
+    // ICommand
+    winrt::event_token Class::CanExecuteChanged(winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable> const& handler)
+    {
+        return _canExecuteChanged.add(handler);
+    }
+    void Class::CanExecuteChanged(winrt::event_token const& token) noexcept
+    {
+        return _canExecuteChanged.remove(token);
+    }
+    bool Class::CanExecute(winrt::Windows::Foundation::IInspectable const& parameter)
+    {
+        return true;
+    }
+    void Class::Execute(winrt::Windows::Foundation::IInspectable const& parameter)
+    {
+    }
+    void Class::RaiseCanExecuteChanged()
+    {
+        _canExecuteChanged(*this, *this);
+    }
+
+
     WF::IInspectable Class::BadRuntimeClassName()
     {
         struct bad_runtime_classname : winrt::implements<bad_runtime_classname, WF::IInspectable>

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -392,6 +392,13 @@ namespace winrt::TestComponentCSharp::implementation
         Windows::Foundation::Collections::IIterable<Windows::Foundation::IInspectable> GetErrors(hstring const& propertyName);
         void RaiseDataErrorChanged();
 
+        winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::IInspectable>> _canExecuteChanged;
+        winrt::event_token CanExecuteChanged(Windows::Foundation::EventHandler<Windows::Foundation::IInspectable> const& handler);
+        void CanExecuteChanged(winrt::event_token const& token) noexcept;
+        bool CanExecute(Windows::Foundation::IInspectable const& parameter);
+        void Execute(Windows::Foundation::IInspectable const& parameter);
+        void RaiseCanExecuteChanged();
+
         static Windows::Foundation::IInspectable BadRuntimeClassName();
     };
 }

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -138,6 +138,7 @@ namespace TestComponentCSharp
         , IProperties1
         , IProperties2
         , Microsoft.UI.Xaml.Data.INotifyDataErrorInfo
+        , Microsoft.UI.Xaml.Input.ICommand 
         //, Windows.Foundation.Collections.IVector<String>
         //, Windows.Foundation.Collections.IMap<Int32, String>
     {
@@ -390,6 +391,9 @@ namespace TestComponentCSharp
 
         // INotifyDataErrorInfo
         void RaiseDataErrorChanged();
+
+        // ICommand
+        void RaiseCanExecuteChanged();
 
         static Object BadRuntimeClassName{ get; };
     }

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -140,4 +140,173 @@ namespace ABI.System
             return 0;
         }
     }
+
+    [Guid("c50898f6-c536-5f47-8583-8b2c2438a13b")]
+    internal static class EventHandler
+    {
+        private delegate int Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args);
+
+        private static readonly global::WinRT.Interop.IDelegateVftbl AbiToProjectionVftable;
+        public static readonly IntPtr AbiToProjectionVftablePtr;
+
+        static EventHandler()
+        {
+            AbiInvokeDelegate = (Abi_Invoke)Do_Abi_Invoke;
+            AbiToProjectionVftable = new global::WinRT.Interop.IDelegateVftbl
+            {
+                IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
+                Invoke = Marshal.GetFunctionPointerForDelegate(AbiInvokeDelegate)
+            };
+            var nativeVftbl = ComWrappersSupport.AllocateVtableMemory(typeof(EventHandler), Marshal.SizeOf<global::WinRT.Interop.IDelegateVftbl>());
+            Marshal.StructureToPtr(AbiToProjectionVftable, nativeVftbl, false);
+            AbiToProjectionVftablePtr = nativeVftbl;
+        }
+
+        public static global::System.Delegate AbiInvokeDelegate { get; }
+
+        public static unsafe IObjectReference CreateMarshaler(global::System.EventHandler managedDelegate) =>
+            managedDelegate is null ? null : ComWrappersSupport.CreateCCWForObject(managedDelegate).As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(EventHandler)));
+
+        public static IntPtr GetAbi(IObjectReference value) =>
+            value is null ? IntPtr.Zero : MarshalInterfaceHelper<global::System.EventHandler<object>>.GetAbi(value);
+
+        public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
+        {
+            var abiDelegate = ObjectReference<IDelegateVftbl>.FromAbi(nativeDelegate);
+            return (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+        }
+
+        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
+#if NETSTANDARD2_0
+        private class NativeDelegateWrapper
+#else
+        private class NativeDelegateWrapper : IWinRTObject
+#endif
+        {
+            private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
+#if NETSTANDARD2_0
+            private readonly AgileReference _agileReference = default;
+#endif
+            public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
+            {
+                _nativeDelegate = nativeDelegate;
+                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
+                {
+                    var agileReference = new AgileReference(_nativeDelegate);
+#if NETSTANDARD2_0
+                    _agileReference = agileReference;
+#else
+                    ((IWinRTObject)this).AdditionalTypeData.TryAdd(typeof(AgileReference).TypeHandle, agileReference);
+#endif
+                }
+                else
+                {
+                    objRef.Dispose();
+                }
+            }
+
+#if !NETSTANDARD2_0
+            IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
+            bool IWinRTObject.HasUnwrappableNativeObject => true;
+            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+#endif
+
+            public void Invoke(object sender, EventArgs args)
+            {
+#if NETSTANDARD2_0
+                var agileReference = _agileReference;
+#else
+                var agileReference = ((IWinRTObject)this).AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj) ? 
+                    (AgileReference)agileObj : null;
+#endif
+                using var agileDelegate = agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(EventHandler)));
+                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
+                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
+                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
+                IObjectReference __sender = default;
+                IObjectReference __args = default;
+                var __params = new object[] { ThisPtr, null, null };
+                try
+                {
+                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
+                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
+                    __args = MarshalInspectable<EventArgs>.CreateMarshaler(args);
+                    __params[2] = MarshalInspectable<EventArgs>.GetAbi(__args);
+                    abiInvoke.DynamicInvokeAbi(__params);
+                }
+                finally
+                {
+                    MarshalInspectable<object>.DisposeMarshaler(__sender);
+                    MarshalInspectable<EventArgs>.DisposeMarshaler(__args);
+                }
+
+            }
+        }
+
+        public static IntPtr FromManaged(global::System.EventHandler managedDelegate) =>
+            CreateMarshaler(managedDelegate)?.GetRef() ?? IntPtr.Zero;
+
+        public static void DisposeMarshaler(IObjectReference value) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeMarshaler(value);
+
+        public static void DisposeAbi(IntPtr abi) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeAbi(abi);
+
+        private static unsafe int Do_Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args)
+        {
+            try
+            {
+                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
+                {
+                    invoke.DynamicInvoke(
+                        MarshalInspectable<object>.FromAbi(sender),
+                        MarshalInspectable<object>.FromAbi(args) as EventArgs ?? EventArgs.Empty);
+                });
+            }
+            catch (global::System.Exception __exception__)
+            {
+                global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+            }
+            return 0;
+        }
+    }
+
+    internal sealed unsafe class EventHandlerEventSource : EventSource<global::System.EventHandler>
+    {
+        private global::System.EventHandler handler;
+
+        internal EventHandlerEventSource(IObjectReference obj,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
+            : base(obj, addHandler, removeHandler)
+        {
+        }
+
+        protected override IObjectReference CreateMarshaler(global::System.EventHandler del) =>
+            del is null ? null : EventHandler.CreateMarshaler(del);
+
+        protected override void DisposeMarshaler(IObjectReference marshaler) =>
+            EventHandler.DisposeMarshaler(marshaler);
+
+        protected override IntPtr GetAbi(IObjectReference marshaler) =>
+            marshaler is null ? IntPtr.Zero : EventHandler.GetAbi(marshaler);
+
+        protected override global::System.Delegate EventInvoke
+        {
+            // This is synchronized from the base class
+            get
+            {
+                if (handler == null)
+                {
+                    handler = (global::System.Object obj, global::System.EventArgs e) =>
+                    {
+                        var localDel = _event;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
+                    };
+                }
+                return handler;
+            }
+        }
+    }
 }

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -127,6 +127,8 @@ namespace ABI.System.Windows.Input
 
     internal sealed unsafe class CanExecuteChangedEventSource : EventSource<global::System.EventHandler>
     {
+        private global::System.EventHandler handler;
+
         internal CanExecuteChangedEventSource(IObjectReference obj,
             delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
             delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
@@ -142,6 +144,24 @@ namespace ABI.System.Windows.Input
 
         protected override IntPtr GetAbi(IObjectReference marshaler) =>
             marshaler is null ? IntPtr.Zero : CanExecuteChangedEventHandler.GetAbi(marshaler);
+
+        protected override global::System.Delegate EventInvoke
+        {
+            // This is synchronized from the base class
+            get
+            {
+                if (handler == null)
+                {
+                    handler = (global::System.Object obj, global::System.EventArgs e) =>
+                    {
+                        var localDel = _event;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
+                    };
+                }
+                return handler;
+            }
+        }
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -12,158 +12,6 @@ using WinRT.Interop;
 
 namespace ABI.System.Windows.Input
 {
-    [Guid("c50898f6-c536-5f47-8583-8b2c2438a13b")]
-    internal static class CanExecuteChangedEventHandler
-    {
-        private delegate int Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args);
-
-        private static readonly global::WinRT.Interop.IDelegateVftbl AbiToProjectionVftable;
-        public static readonly IntPtr AbiToProjectionVftablePtr;
-
-        static CanExecuteChangedEventHandler()
-        {
-            AbiInvokeDelegate = (Abi_Invoke)Do_Abi_Invoke;
-            AbiToProjectionVftable = new global::WinRT.Interop.IDelegateVftbl
-            {
-                IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
-                Invoke = Marshal.GetFunctionPointerForDelegate(AbiInvokeDelegate)
-            };
-            var nativeVftbl = ComWrappersSupport.AllocateVtableMemory(typeof(CanExecuteChangedEventHandler), Marshal.SizeOf<global::WinRT.Interop.IDelegateVftbl>());
-            Marshal.StructureToPtr(AbiToProjectionVftable, nativeVftbl, false);
-            AbiToProjectionVftablePtr = nativeVftbl;
-        }
-
-        public static global::System.Delegate AbiInvokeDelegate { get; }
-
-        public static unsafe IObjectReference CreateMarshaler(global::System.EventHandler managedDelegate) =>
-            managedDelegate is null ? null : ComWrappersSupport.CreateCCWForObject(managedDelegate).As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(CanExecuteChangedEventHandler)));
-
-        public static IntPtr GetAbi(IObjectReference value) => 
-            value is null ? IntPtr.Zero : MarshalInterfaceHelper<global::System.EventHandler<object>>.GetAbi(value);
-
-        public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
-        {
-            var abiDelegate = ObjectReference<IDelegateVftbl>.FromAbi(nativeDelegate);
-            return (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
-        }
-
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
-        private class NativeDelegateWrapper : IWinRTObject
-        {
-            private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
-
-            public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
-            {
-                _nativeDelegate = nativeDelegate;
-                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
-                {
-                    var agileReference = new AgileReference(_nativeDelegate);
-                    ((IWinRTObject)this).AdditionalTypeData.TryAdd(typeof(AgileReference).TypeHandle, agileReference);
-                }
-                else
-                {
-                    objRef.Dispose();
-                }
-            }
-
-            IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
-            bool IWinRTObject.HasUnwrappableNativeObject => true;
-            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
-
-            public void Invoke(object sender, EventArgs args)
-            {
-                var agileReference = ((IWinRTObject)this).AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj) ? (AgileReference)agileObj : null;
-                using var agileDelegate = agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(CanExecuteChangedEventHandler)));
-                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
-                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
-                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
-                IObjectReference __sender = default;
-                IObjectReference __args = default;
-                var __params = new object[] { ThisPtr, null, null };
-                try
-                {
-                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
-                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
-                    __args = MarshalInspectable<EventArgs>.CreateMarshaler(args);
-                    __params[2] = MarshalInspectable<EventArgs>.GetAbi(__args);
-                    abiInvoke.DynamicInvokeAbi(__params);
-                }
-                finally
-                {
-                    MarshalInspectable<object>.DisposeMarshaler(__sender);
-                    MarshalInspectable<EventArgs>.DisposeMarshaler(__args);
-                }
-
-            }
-        }
-
-        public static IntPtr FromManaged(global::System.EventHandler managedDelegate) =>
-            CreateMarshaler(managedDelegate)?.GetRef() ?? IntPtr.Zero;
-
-        public static void DisposeMarshaler(IObjectReference value) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeMarshaler(value);
-
-        public static void DisposeAbi(IntPtr abi) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeAbi(abi);
-
-        private static unsafe int Do_Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args)
-        {
-            try
-            {
-                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
-                {
-                    invoke.DynamicInvoke(
-                        MarshalInspectable<object>.FromAbi(sender),
-                        MarshalInspectable<EventArgs>.FromAbi(args) ?? EventArgs.Empty);
-                });
-            }
-            catch (global::System.Exception __exception__)
-            {
-                global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
-                return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
-            }
-            return 0;
-        }
-    }
-
-    internal sealed unsafe class CanExecuteChangedEventSource : EventSource<global::System.EventHandler>
-    {
-        private global::System.EventHandler handler;
-
-        internal CanExecuteChangedEventSource(IObjectReference obj,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
-            : base(obj, addHandler, removeHandler)
-        {
-        }
-
-        protected override IObjectReference CreateMarshaler(EventHandler del) =>
-            del is null ? null : CanExecuteChangedEventHandler.CreateMarshaler(del);
-
-        protected override void DisposeMarshaler(IObjectReference marshaler) =>
-            CanExecuteChangedEventHandler.DisposeMarshaler(marshaler);
-
-        protected override IntPtr GetAbi(IObjectReference marshaler) =>
-            marshaler is null ? IntPtr.Zero : CanExecuteChangedEventHandler.GetAbi(marshaler);
-
-        protected override global::System.Delegate EventInvoke
-        {
-            // This is synchronized from the base class
-            get
-            {
-                if (handler == null)
-                {
-                    handler = (global::System.Object obj, global::System.EventArgs e) =>
-                    {
-                        var localDel = _event;
-                        if (localDel != null)
-                            localDel.Invoke(obj, e);
-                    };
-                }
-                return handler;
-            }
-        }
-    }
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Guid("E5AF3542-CA67-4081-995B-709DD13792DF")]
     [DynamicInterfaceCastableImplementation]
@@ -253,7 +101,7 @@ namespace ABI.System.Windows.Input
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr);
-                    var __handler = CanExecuteChangedEventHandler.FromAbi(handler);
+                    var __handler = EventHandler.FromAbi(handler);
                     *token = _CanExecuteChanged_TokenTables.GetOrCreateValue(__this).AddEventHandler(__handler);
                     __this.CanExecuteChanged += __handler;
                     return 0;
@@ -286,12 +134,12 @@ namespace ABI.System.Windows.Input
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static CanExecuteChangedEventSource _CanExecuteChanged(IWinRTObject _this)
+        private static EventHandlerEventSource _CanExecuteChanged(IWinRTObject _this)
         {
             var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle));
 
-            return (CanExecuteChangedEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.Windows.Input.ICommand).TypeHandle,
-                () => new CanExecuteChangedEventSource(_obj, _obj.Vftbl.add_CanExecuteChanged_0, _obj.Vftbl.remove_CanExecuteChanged_1));
+            return (EventHandlerEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.Windows.Input.ICommand).TypeHandle,
+                () => new EventHandlerEventSource(_obj, _obj.Vftbl.add_CanExecuteChanged_0, _obj.Vftbl.remove_CanExecuteChanged_1));
         }
 
         unsafe bool global::System.Windows.Input.ICommand.CanExecute(object parameter)

--- a/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
@@ -11,152 +11,6 @@ using WinRT.Interop;
 
 namespace ABI.System.Windows.Input
 {
-    [Guid("c50898f6-c536-5f47-8583-8b2c2438a13b")]
-    internal static class CanExecuteChangedEventHandler
-    {
-        private delegate int Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args);
-
-        private static readonly global::WinRT.Interop.IDelegateVftbl AbiToProjectionVftable;
-        public static readonly IntPtr AbiToProjectionVftablePtr;
-
-        static CanExecuteChangedEventHandler()
-        {
-            AbiInvokeDelegate = (Abi_Invoke)Do_Abi_Invoke;
-            AbiToProjectionVftable = new global::WinRT.Interop.IDelegateVftbl
-            {
-                IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
-                Invoke = Marshal.GetFunctionPointerForDelegate(AbiInvokeDelegate)
-            };
-            var nativeVftbl = ComWrappersSupport.AllocateVtableMemory(typeof(CanExecuteChangedEventHandler), Marshal.SizeOf<global::WinRT.Interop.IDelegateVftbl>());
-            Marshal.StructureToPtr(AbiToProjectionVftable, nativeVftbl, false);
-            AbiToProjectionVftablePtr = nativeVftbl;
-        }
-
-        public static global::System.Delegate AbiInvokeDelegate { get; }
-
-        public static unsafe IObjectReference CreateMarshaler(global::System.EventHandler managedDelegate) =>
-            managedDelegate is null ? null : ComWrappersSupport.CreateCCWForObject(managedDelegate).As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(CanExecuteChangedEventHandler)));
-
-        public static IntPtr GetAbi(IObjectReference value) => 
-            value is null ? IntPtr.Zero : MarshalInterfaceHelper<global::System.EventHandler<object>>.GetAbi(value);
-
-        public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
-        {
-            var abiDelegate = ObjectReference<IDelegateVftbl>.FromAbi(nativeDelegate);
-            return (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
-        }
-
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
-        private class NativeDelegateWrapper
-        {
-            private readonly ObjectReference<global::WinRT.Interop.IDelegateVftbl> _nativeDelegate;
-            private readonly AgileReference _agileReference = default;
-
-            public NativeDelegateWrapper(ObjectReference<global::WinRT.Interop.IDelegateVftbl> nativeDelegate)
-            {
-                _nativeDelegate = nativeDelegate;
-                if (_nativeDelegate.TryAs<ABI.WinRT.Interop.IAgileObject.Vftbl>(out var objRef) < 0)
-                {
-                    _agileReference = new AgileReference(_nativeDelegate);
-                }
-                else
-                {
-                    objRef.Dispose();
-                }
-            }
-
-            public void Invoke(object sender, EventArgs args)
-            {
-                using var agileDelegate = _agileReference?.Get()?.As<global::WinRT.Interop.IDelegateVftbl>(GuidGenerator.GetIID(typeof(CanExecuteChangedEventHandler)));
-                var delegateToInvoke = agileDelegate ?? _nativeDelegate;
-                IntPtr ThisPtr = delegateToInvoke.ThisPtr;
-                var abiInvoke = Marshal.GetDelegateForFunctionPointer<Abi_Invoke>(delegateToInvoke.Vftbl.Invoke);
-                IObjectReference __sender = default;
-                IObjectReference __args = default;
-                var __params = new object[] { ThisPtr, null, null };
-                try
-                {
-                    __sender = MarshalInspectable<object>.CreateMarshaler(sender);
-                    __params[1] = MarshalInspectable<object>.GetAbi(__sender);
-                    __args = MarshalInspectable<EventArgs>.CreateMarshaler(args);
-                    __params[2] = MarshalInspectable<EventArgs>.GetAbi(__args);
-                    abiInvoke.DynamicInvokeAbi(__params);
-                }
-                finally
-                {
-                    MarshalInspectable<object>.DisposeMarshaler(__sender);
-                    MarshalInspectable<EventArgs>.DisposeMarshaler(__args);
-                }
-
-            }
-        }
-
-        public static IntPtr FromManaged(global::System.EventHandler managedDelegate) =>
-            CreateMarshaler(managedDelegate)?.GetRef() ?? IntPtr.Zero;
-
-        public static void DisposeMarshaler(IObjectReference value) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeMarshaler(value);
-
-        public static void DisposeAbi(IntPtr abi) => MarshalInterfaceHelper<global::System.EventHandler<object>>.DisposeAbi(abi);
-
-        private static unsafe int Do_Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr args)
-        {
-            try
-            {
-                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
-                {
-                    invoke.DynamicInvoke(
-                        MarshalInspectable<object>.FromAbi(sender),
-                        MarshalInspectable<EventArgs>.FromAbi(args) ?? EventArgs.Empty);
-                });
-            }
-            catch (global::System.Exception __exception__)
-            {
-                global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
-                return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
-            }
-            return 0;
-        }
-    }
-
-    internal sealed unsafe class CanExecuteChangedEventSource : EventSource<global::System.EventHandler>
-    {
-        private global::System.EventHandler handler;
-
-        internal CanExecuteChangedEventSource(IObjectReference obj,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
-            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
-            : base(obj, addHandler, removeHandler)
-        {
-        }
-
-        protected override IObjectReference CreateMarshaler(EventHandler del) =>
-            del is null ? null : CanExecuteChangedEventHandler.CreateMarshaler(del);
-
-        protected override void DisposeMarshaler(IObjectReference marshaler) =>
-            CanExecuteChangedEventHandler.DisposeMarshaler(marshaler);
-
-        protected override IntPtr GetAbi(IObjectReference marshaler) =>
-            marshaler is null ? IntPtr.Zero : CanExecuteChangedEventHandler.GetAbi(marshaler);
-
-        protected override global::System.Delegate EventInvoke
-        {
-            // This is synchronized from the base class
-            get
-            {
-                if (handler == null)
-                {
-                    handler = (global::System.Object obj, global::System.EventArgs e) =>
-                    {
-                        var localDel = _event;
-                        if (localDel != null)
-                            localDel.Invoke(obj, e);
-                    };
-                }
-                return handler;
-            }
-        }
-    }
-
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj)), EditorBrowsable(EditorBrowsableState.Never)]
     [Guid("E5AF3542-CA67-4081-995B-709DD13792DF")]
     public unsafe class ICommand : global::System.Windows.Input.ICommand
@@ -240,7 +94,7 @@ namespace ABI.System.Windows.Input
                 try
                 {
                     var __this = global::WinRT.ComWrappersSupport.FindObject<global::System.Windows.Input.ICommand>(thisPtr);
-                    var __handler = CanExecuteChangedEventHandler.FromAbi(handler);
+                    var __handler = EventHandler.FromAbi(handler);
                     *token = _CanExecuteChanged_TokenTables.GetOrCreateValue(__this).AddEventHandler(__handler);
                     __this.CanExecuteChanged += __handler;
                     return 0;
@@ -283,7 +137,7 @@ namespace ABI.System.Windows.Input
             _obj = obj;
 
             _CanExecuteChanged =
-                new CanExecuteChangedEventSource(_obj,
+                new EventHandlerEventSource(_obj,
                 _obj.Vftbl.add_CanExecuteChanged_0,
                 _obj.Vftbl.remove_CanExecuteChanged_1);
         }
@@ -319,7 +173,7 @@ namespace ABI.System.Windows.Input
             }
         }
 
-        private readonly EventSource<global::System.EventHandler> _CanExecuteChanged;
+        private readonly EventHandlerEventSource _CanExecuteChanged;
 
         public event global::System.EventHandler CanExecuteChanged
         {

--- a/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
@@ -120,6 +120,8 @@ namespace ABI.System.Windows.Input
 
     internal sealed unsafe class CanExecuteChangedEventSource : EventSource<global::System.EventHandler>
     {
+        private global::System.EventHandler handler;
+
         internal CanExecuteChangedEventSource(IObjectReference obj,
             delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
             delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
@@ -135,6 +137,24 @@ namespace ABI.System.Windows.Input
 
         protected override IntPtr GetAbi(IObjectReference marshaler) =>
             marshaler is null ? IntPtr.Zero : CanExecuteChangedEventHandler.GetAbi(marshaler);
+
+        protected override global::System.Delegate EventInvoke
+        {
+            // This is synchronized from the base class
+            get
+            {
+                if (handler == null)
+                {
+                    handler = (global::System.Object obj, global::System.EventArgs e) =>
+                    {
+                        var localDel = _event;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
+                    };
+                }
+                return handler;
+            }
+        }
     }
 
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj)), EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
@@ -81,12 +81,12 @@ namespace ABI.System.Collections.Specialized
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler> _CollectionChanged(IWinRTObject _this)
+        private static NotifyCollectionChangedEventSource _CollectionChanged(IWinRTObject _this)
         {
             var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle));
             
-            return (EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle,
-                () => new EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(_obj, _obj.Vftbl.add_CollectionChanged_0, _obj.Vftbl.remove_CollectionChanged_1));
+            return (NotifyCollectionChangedEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle,
+                () => new NotifyCollectionChangedEventSource(_obj, _obj.Vftbl.add_CollectionChanged_0, _obj.Vftbl.remove_CollectionChanged_1));
         }
 
         event global::System.Collections.Specialized.NotifyCollectionChangedEventHandler global::System.Collections.Specialized.INotifyCollectionChanged.CollectionChanged
@@ -94,6 +94,5 @@ namespace ABI.System.Collections.Specialized
             add => _CollectionChanged((IWinRTObject)this).Subscribe(value);
             remove => _CollectionChanged((IWinRTObject)this).Unsubscribe(value);
         }
-
     }
 }

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.netstandard2.0.cs
@@ -100,7 +100,7 @@ namespace ABI.System.Collections.Specialized
             _obj = obj;
 
             _CollectionChanged =
-                new EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(_obj,
+                new NotifyCollectionChangedEventSource(_obj,
                 _obj.Vftbl.add_CollectionChanged_0,
                 _obj.Vftbl.remove_CollectionChanged_1);
         }
@@ -111,6 +111,6 @@ namespace ABI.System.Collections.Specialized
             remove => _CollectionChanged.Unsubscribe(value);
         }
 
-        private EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler> _CollectionChanged;
+        private NotifyCollectionChangedEventSource _CollectionChanged;
     }
 }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -122,12 +122,12 @@ namespace ABI.System.ComponentModel
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static EventSource<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>> _ErrorsChanged(IWinRTObject _this)
+        private static EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> _ErrorsChanged(IWinRTObject _this)
         {
             var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle));
             var ThisPtr = _obj.ThisPtr;
-            return (EventSource<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle,
-                () => new EventSource<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>(_obj,
+            return (EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle,
+                () => new EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>(_obj,
                     (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>)_obj.Vftbl.add_ErrorsChanged_1,
                     _obj.Vftbl.remove_ErrorsChanged_2));
         }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
@@ -160,7 +160,7 @@ namespace ABI.System.ComponentModel
             _obj = obj;
 
             _ErrorsChanged =
-                new EventSource<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>(_obj,
+                new EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>(_obj,
                 (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out global::WinRT.EventRegistrationToken, int>)(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>)_obj.Vftbl.add_ErrorsChanged_1,
                 _obj.Vftbl.remove_ErrorsChanged_2);
         }
@@ -198,7 +198,7 @@ namespace ABI.System.ComponentModel
             remove => _ErrorsChanged.Unsubscribe(value);
         }
 
-        private EventSource<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>> _ErrorsChanged;
+        private EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> _ErrorsChanged;
     }
     
     internal static class INotifyDataErrorInfo_Delegates

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
@@ -80,12 +80,12 @@ namespace ABI.System.ComponentModel
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static EventSource<global::System.ComponentModel.PropertyChangedEventHandler> _PropertyChanged(IWinRTObject _this)
+        private static PropertyChangedEventSource _PropertyChanged(IWinRTObject _this)
         {
             var _obj = (ObjectReference<Vftbl>)_this.GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle);
             
-            return (EventSource<global::System.ComponentModel.PropertyChangedEventHandler>)_this.GetOrCreateTypeHelperData(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle,
-                () => new EventSource<global::System.ComponentModel.PropertyChangedEventHandler>(_obj, _obj.Vftbl.add_PropertyChanged_0, _obj.Vftbl.remove_PropertyChanged_1));
+            return (PropertyChangedEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle,
+                () => new PropertyChangedEventSource(_obj, _obj.Vftbl.add_PropertyChanged_0, _obj.Vftbl.remove_PropertyChanged_1));
         }
 
         event global::System.ComponentModel.PropertyChangedEventHandler global::System.ComponentModel.INotifyPropertyChanged.PropertyChanged

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.netstandard2.0.cs
@@ -99,7 +99,7 @@ namespace ABI.System.ComponentModel
             _obj = obj;
 
             _PropertyChanged =
-                new EventSource<global::System.ComponentModel.PropertyChangedEventHandler>(_obj,
+                new PropertyChangedEventSource(_obj,
                 _obj.Vftbl.add_PropertyChanged_0,
                 _obj.Vftbl.remove_PropertyChanged_1);
         }
@@ -111,6 +111,6 @@ namespace ABI.System.ComponentModel
             remove => _PropertyChanged.Unsubscribe(value);
         }
 
-        private EventSource<global::System.ComponentModel.PropertyChangedEventHandler> _PropertyChanged;
+        private PropertyChangedEventSource _PropertyChanged;
     }
 }

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -134,4 +134,43 @@ namespace ABI.System.Collections.Specialized
             return 0;
         }
     }
+
+    internal sealed unsafe class NotifyCollectionChangedEventSource : EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>
+    {
+        private global::System.Collections.Specialized.NotifyCollectionChangedEventHandler handler;
+
+        internal NotifyCollectionChangedEventSource(IObjectReference obj,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
+            : base(obj, addHandler, removeHandler)
+        {
+        }
+
+        protected override IObjectReference CreateMarshaler(global::System.Collections.Specialized.NotifyCollectionChangedEventHandler del) =>
+            del is null ? null : NotifyCollectionChangedEventHandler.CreateMarshaler(del);
+
+        protected override void DisposeMarshaler(IObjectReference marshaler) =>
+            NotifyCollectionChangedEventHandler.DisposeMarshaler(marshaler);
+
+        protected override IntPtr GetAbi(IObjectReference marshaler) =>
+            marshaler is null ? IntPtr.Zero : NotifyCollectionChangedEventHandler.GetAbi(marshaler);
+
+        protected override global::System.Delegate EventInvoke
+        {
+            // This is synchronized from the base class
+            get
+            {
+                if (handler == null)
+                {
+                    handler = (global::System.Object obj, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
+                    {
+                        var localDel = _event;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
+                    };
+                }
+                return handler;
+            }
+        }
+    }
 }

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -135,4 +135,43 @@ namespace ABI.System.ComponentModel
             return 0;
         }
     }
+
+    internal sealed unsafe class PropertyChangedEventSource : EventSource<global::System.ComponentModel.PropertyChangedEventHandler>
+    {
+        private global::System.ComponentModel.PropertyChangedEventHandler handler;
+
+        internal PropertyChangedEventSource(IObjectReference obj,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, out global::WinRT.EventRegistrationToken, int> addHandler,
+            delegate* unmanaged[Stdcall]<global::System.IntPtr, global::WinRT.EventRegistrationToken, int> removeHandler)
+            : base(obj, addHandler, removeHandler)
+        {
+        }
+
+        protected override IObjectReference CreateMarshaler(global::System.ComponentModel.PropertyChangedEventHandler del) =>
+            del is null ? null : PropertyChangedEventHandler.CreateMarshaler(del);
+
+        protected override void DisposeMarshaler(IObjectReference marshaler) =>
+            PropertyChangedEventHandler.DisposeMarshaler(marshaler);
+
+        protected override IntPtr GetAbi(IObjectReference marshaler) =>
+            marshaler is null ? IntPtr.Zero : PropertyChangedEventHandler.GetAbi(marshaler);
+
+        protected override global::System.Delegate EventInvoke
+        {
+            // This is synchronized from the base class
+            get
+            {
+                if (handler == null)
+                {
+                    handler = (global::System.Object obj, global::System.ComponentModel.PropertyChangedEventArgs e) =>
+                    {
+                        var localDel = _event;
+                        if (localDel != null)
+                            localDel.Invoke(obj, e);
+                    };
+                }
+                return handler;
+            }
+        }
+    }
 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6453,6 +6453,7 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
 
     void write_event_source_subclass(writer& w, cswinrt::type_semantics eventTypeSemantics)
     {
+        auto abiTypeName = w.write_temp("%", bind<write_type_name>(eventTypeSemantics, typedef_name_type::ABI, true));
         for_typedef(w, eventTypeSemantics, [&](TypeDef const& eventType)
             {
                 if ((eventType.TypeNamespace() == "Windows.Foundation" || eventType.TypeNamespace() == "System") && eventType.TypeName() == "EventHandler`1")
@@ -6472,7 +6473,16 @@ delegate* unmanaged[Stdcall]<System.IntPtr, WinRT.EventRegistrationToken, int> r
 {
 }
 
-override protected System.Delegate EventInvoke
+protected override IObjectReference CreateMarshaler(% del) =>
+del is null ? null : %.CreateMarshaler(del);
+
+protected override void DisposeMarshaler(IObjectReference marshaler) =>
+%.DisposeMarshaler(marshaler);
+
+protected override System.IntPtr GetAbi(IObjectReference marshaler) =>
+marshaler is null ? System.IntPtr.Zero : %.GetAbi(marshaler);
+
+protected override System.Delegate EventInvoke
 {
 get
 {
@@ -6498,6 +6508,10 @@ return handler;
                     eventTypeCode, 
                     eventTypeCode,
                     bind<write_event_source_type_name>(eventTypeSemantics), 
+                    eventTypeCode,
+                    abiTypeName,
+                    abiTypeName,
+                    abiTypeName,
                     bind<write_event_invoke_params>(invokeMethodSig),
                     bind<write_event_out_defaults>(invokeMethodSig),
                     bind<write_event_invoke_return_default>(invokeMethodSig),

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6463,7 +6463,7 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
                 auto eventTypeCode = w.write_temp("%", bind<write_type_name>(eventType, typedef_name_type::Projected, false));
                 auto invokeMethodSig = get_event_invoke_method(eventType);
                 w.write(R"(
-internal unsafe class %% : EventSource<%>
+internal sealed unsafe class %% : EventSource<%>
 {
 private % handler;
 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -334,7 +334,7 @@ namespace WinRT
 
 #pragma warning disable CA2002
 
-    internal unsafe class EventSource<TDelegate>
+    internal unsafe abstract class EventSource<TDelegate>
         where TDelegate : class, MulticastDelegate
     {
         readonly IObjectReference _obj;
@@ -344,20 +344,11 @@ namespace WinRT
         private EventRegistrationToken _token;
         protected TDelegate _event;
 
-        protected virtual IObjectReference CreateMarshaler(TDelegate del)
-        {
-            return (IObjectReference)Marshaler<TDelegate>.CreateMarshaler((TDelegate)EventInvoke);
-        }
+        protected abstract IObjectReference CreateMarshaler(TDelegate del);
 
-        protected virtual IntPtr GetAbi(IObjectReference marshaler)
-        {
-            return (IntPtr)Marshaler<TDelegate>.GetAbi(marshaler);
-        }
+        protected abstract IntPtr GetAbi(IObjectReference marshaler);
 
-        protected virtual void DisposeMarshaler(IObjectReference marshaler)
-        {
-            Marshaler<TDelegate>.DisposeMarshaler(marshaler);
-        }
+        protected abstract void DisposeMarshaler(IObjectReference marshaler);
 
         public void Subscribe(TDelegate del)
         {
@@ -397,42 +388,9 @@ namespace WinRT
             }
         }
 
-        private System.Delegate _eventInvoke;
-        protected virtual System.Delegate EventInvoke
-        {
-            get
-            {
-                if (_eventInvoke is object)
-                {
-                    return _eventInvoke;
-                }
+        protected abstract System.Delegate EventInvoke { get; }
 
-                MethodInfo invoke = typeof(TDelegate).GetMethod("Invoke");
-                ParameterInfo[] invokeParameters = invoke.GetParameters();
-                ParameterExpression[] parameters = new ParameterExpression[invokeParameters.Length];
-                for (int i = 0; i < invokeParameters.Length; i++)
-                {
-                    parameters[i] = Expression.Parameter(invokeParameters[i].ParameterType, invokeParameters[i].Name);
-                }
-
-                ParameterExpression delegateLocal = Expression.Parameter(typeof(TDelegate), "event");
-
-                _eventInvoke = Expression.Lambda(typeof(TDelegate),
-                    Expression.Block(
-                        invoke.ReturnType,
-                        new[] { delegateLocal },
-                        Expression.Assign(delegateLocal, Expression.Field(Expression.Constant(this), typeof(EventSource<TDelegate>).GetField(nameof(_event), BindingFlags.Instance | BindingFlags.NonPublic))),
-                        Expression.Condition(
-                            Expression.ReferenceNotEqual(delegateLocal, Expression.Constant(null, typeof(TDelegate))),
-                            Expression.Call(delegateLocal, invoke, parameters),
-                            Expression.Default(invoke.ReturnType))),
-                    parameters).Compile();
-
-                return _eventInvoke;
-            }
-        }
-
-        internal EventSource(IObjectReference obj,
+        protected EventSource(IObjectReference obj,
             delegate* unmanaged[Stdcall]<System.IntPtr, System.IntPtr, out WinRT.EventRegistrationToken, int> addHandler,
             delegate* unmanaged[Stdcall]<System.IntPtr, WinRT.EventRegistrationToken, int> removeHandler)
         {
@@ -448,7 +406,7 @@ namespace WinRT
         }
     }
 
-    internal unsafe class EventSource__EventHandler<T> : EventSource<System.EventHandler<T>>
+    internal sealed unsafe class EventSource__EventHandler<T> : EventSource<System.EventHandler<T>>
     {
         private System.EventHandler<T> handler;
 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -458,7 +458,16 @@ namespace WinRT
         {
         }
 
-        override protected System.Delegate EventInvoke
+        protected override IObjectReference CreateMarshaler(System.EventHandler<T> del) =>
+            del is null ? null : ABI.System.EventHandler<T>.CreateMarshaler(del);
+
+        protected override void DisposeMarshaler(IObjectReference marshaler) =>
+            ABI.System.EventHandler<T>.DisposeMarshaler(marshaler);
+
+        protected override IntPtr GetAbi(IObjectReference marshaler) =>
+            marshaler is null ? IntPtr.Zero : ABI.System.EventHandler<T>.GetAbi(marshaler);
+
+        protected override System.Delegate EventInvoke
         {
             // This is synchronized from the base class
             get


### PR DESCRIPTION
- Apply previous optimizations done to generated code to the manual ones in WinRT.Runtime
- Avoid using reflection for delegate marshaling functions and instead use type information from previous optimizations

Fixes #890 
Fixes #891 