### PR TITLE
Remove duplicate file from the CsWinRT NuGet package.

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -169,7 +169,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </Content> 
 
       <!-- Custom targets that copy DLLs for consumers of the authored component. -->
-      <Content Include="$(CsWinRTPath)buildTransitive\Microsoft.Windows.CsWinRT.Authoring.Transitive.targets">
+      <Content Include="$(CsWinRTPath)build\Microsoft.Windows.CsWinRT.Authoring.Transitive.targets">
         <Pack>true</Pack>
         <PackagePath>buildTransitive\$(AssemblyName).targets;build\$(AssemblyName).targets</PackagePath>
       </Content>

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -25,7 +25,6 @@
     <file src="Microsoft.Windows.CsWinRT.Authoring.targets" target="build"/>
     <file src="Microsoft.Windows.CsWinRT.Prerelease*.targets" target="build"/>
     <file src="Microsoft.Windows.CsWinRT.Authoring.Transitive.targets" target="build"/>
-    <file src="Microsoft.Windows.CsWinRT.Authoring.Transitive.targets" target="buildTransitive"/>
     <file src="$interop_winmd$" target="metadata"/>
     <file src="readme.txt"/>
     <file src="$net5_runtime$" target="lib\net5.0\"/>


### PR DESCRIPTION
This PR fixes #908 by simply using the Microsoft.Windows.CsWinRT.Authoring.Transitive.targets file from the build folder and removing the one from buildTransitive.