### PR TITLE
Support net6

### DIFF
--- a/nuget/NOTICE.txt
+++ b/nuget/NOTICE.txt
@@ -40,3 +40,33 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+System.CommandLine 2.0.0-beta1.21308.1 - MIT
+
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining 
+a copy of this software and associated documentation files (the 
+"Software"), to deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to 
+ permit persons to whom the Software is furnished to do so, subject to 
+ the following conditions:
+
+The above copyright notice and this permission notice shall be 
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE 
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+---------------------------------------------------------

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Platforms>x64;x86</Platforms>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <UseWinmd>false</UseWinmd>
     <BenchmarkWinmdSupport Condition="'$(BenchmarkWinmdSupport)' == ''">false</BenchmarkWinmdSupport>
     <!-- Controls whether to build using WinMDs or the projection. -->

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -9,8 +9,8 @@
     <!-- Controls whether to build using WinMDs or the projection. -->
     <UseWinmd Condition="'$(TargetFramework)' == 'netcoreapp3.1' And $(BenchmarkWinmdSupport) == true">true</UseWinmd>
     <ApplicationManifest Condition="$(UseWinmd) == true">Benchmarks.manifest</ApplicationManifest>
-    <BenchmarkTargetFramework>$(TargetFramework)</BenchmarkTargetFramework>
-    <BenchmarkTargetFramework Condition="'$(BenchmarkTargetFramework)' != 'net5.0'">netstandard2.0</BenchmarkTargetFramework>
+    <BenchmarkTargetFramework>netstandard2.0</BenchmarkTargetFramework>
+    <BenchmarkTargetFramework Condition="$(IsTargetFrameworkNet5OrGreater)">$(TargetFramework)</BenchmarkTargetFramework>
     <IsDotnetBuild Condition="'$(IsDotnetBuild)' == ''">false</IsDotnetBuild>
     <LangVersion Condition="$(IsDotnetBuild) == true">9.0</LangVersion>
   </PropertyGroup>

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -9,7 +9,7 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Characteristics;
 using System.IO;
 
-#if NET5_0
+#if NET
 [assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
 #endif
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,8 @@
     <PlatformToolset>v142</PlatformToolset>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <AssetTargetFallback>netcoreapp5.0</AssetTargetFallback>
+    <IsTargetFrameworkNet5OrGreater>false</IsTargetFrameworkNet5OrGreater>
+    <IsTargetFrameworkNet5OrGreater Condition="'$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">true</IsTargetFrameworkNet5OrGreater>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">

--- a/src/Projections/Benchmark/Benchmark.csproj
+++ b/src/Projections/Benchmark/Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
 

--- a/src/Projections/Benchmark/Module.cs
+++ b/src/Projections/Benchmark/Module.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0
+﻿#if NET
 using System.Runtime.Versioning;
 [assembly: SupportedOSPlatform("Windows")]
 #endif

--- a/src/Projections/Directory.Build.props
+++ b/src/Projections/Directory.Build.props
@@ -4,10 +4,10 @@
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0' AND '$(TargetFramework)' != ''">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup Condition="!$(IsTargetFrameworkNet5OrGreater) AND '$(TargetFramework)' != ''">
     <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
   </PropertyGroup>
     
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
 </Project>

--- a/src/Projections/Reunion/Reunion.csproj
+++ b/src/Projections/Reunion/Reunion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <AssemblyName>Microsoft.WinUI</AssemblyName>
     <AssemblyVersion>9.9.9.9</AssemblyVersion>

--- a/src/Projections/Test/Test.csproj
+++ b/src/Projections/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
   

--- a/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.csproj
+++ b/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
 

--- a/src/Projections/WinUI/Module.cs
+++ b/src/Projections/WinUI/Module.cs
@@ -1,3 +1,3 @@
-﻿#if NET5_0
+﻿#if NET
 [assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
 #endif

--- a/src/Projections/WinUI/WinUI.csproj
+++ b/src/Projections/WinUI/WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
 

--- a/src/Projections/Windows/Windows.csproj
+++ b/src/Projections/Windows/Windows.csproj
@@ -13,10 +13,6 @@
     <InternalsVisibleTo Include="UnitTest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Generated Files\" />
-  </ItemGroup>
-
   <PropertyGroup>
     <CsWinRTFilters>
 -include Windows

--- a/src/Projections/Windows/Windows.csproj
+++ b/src/Projections/Windows/Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <AssemblyName>Microsoft.Windows.SDK.NET</AssemblyName>
   </PropertyGroup>
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\WinRT.Runtime\WinRT.Runtime.csproj" />
     <ProjectReference Include="..\..\cswinrt\cswinrt.vcxproj" />
     <InternalsVisibleTo Include="UnitTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Generated Files\" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Tests/DiagnosticTests/DiagnosticTests.csproj
+++ b/src/Tests/DiagnosticTests/DiagnosticTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFrameworks>net5.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+        <TargetFrameworks>net5.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
         <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
         <RootNamespace>ObjectLifetimeTests.Lifted</RootNamespace>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -29,13 +29,13 @@ using Windows.Security.Cryptography;
 using Windows.Security.Cryptography.Core;
 using System.Reflection;
 
-#if NET5_0
+#if NET
 using WeakRefNS = System;
 #else
 using WeakRefNS = WinRT;
 #endif
 
-#if NET5_0
+#if NET
 // Test SupportedOSPlatform warnings for APIs targeting 10.0.19041.0:
 [assembly: global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.18362.0")]
 #endif
@@ -403,7 +403,7 @@ namespace UnitTest
             Assert.True(LookupPorts().Wait(5000));
         }
 
-#if NET5_0
+#if NET
         async Task InvokeStreamWriteZeroBytes()
         {
             var random = new Random(42);
@@ -2483,7 +2483,7 @@ namespace UnitTest
             Assert.True(eventCalled);
         }
 
-#if NET5_0
+#if NET
         [TestComponentCSharp.Warning]  // NO warning CA1416
         class WarningManaged { };
 

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--Target .NET Core 2.0 to test .NET Standard 2.0 projection -->
-    <TargetFrameworks>netcoreapp2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <ProjectName>UnitTest</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
@@ -36,7 +36,7 @@
     <None Include="**/*.net5.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="$(IsTargetFrameworkNet5OrGreater)">
     <Compile Remove="**/*.netcoreapp2.0.cs" />
     <None Include="**/*.netcoreapp2.0.cs" />
   </ItemGroup>

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -28,7 +28,7 @@ namespace WinRT
                     ref iid,
                     instance.ThisPtr,
                     &agileReference));
-#if NET5_0
+#if NET
                 _agileReference = (IAgileReference)new SingleInterfaceOptimizedObject(typeof(IAgileReference), ObjectReference<ABI.WinRT.Interop.IAgileReference.Vftbl>.Attach(ref agileReference));
 #else
                 _agileReference = ABI.WinRT.Interop.IAgileReference.FromAbi(agileReference).AsType<ABI.WinRT.Interop.IAgileReference>();

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+  <PropertyGroup> 
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>WinRT</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9</LangVersion>
@@ -32,7 +32,7 @@
     <None Include="**/*.net5.cs" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="$(IsTargetFrameworkNet5OrGreater)">
     <Compile Remove="**/*.netstandard2.0.cs" />
     <None Include="**/*.netstandard2.0.cs" />
   </ItemGroup>
@@ -52,7 +52,7 @@
     <CsWinRTApiCompatVersion>1.0.1</CsWinRTApiCompatVersion>
     <ApiCompatArgs>$(ApiCompatArgs) --allow-default-interface-methods</ApiCompatArgs>
     <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) --allow-default-interface-methods</MatchingRefApiCompatArgs>
-  </PropertyGroup>
+  </PropertyGroup> 
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20560.3" PrivateAssets="All" />

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -90,8 +90,8 @@ set prerelease_targets=%this_dir%..\nuget\Microsoft.Windows.CsWinRT.Prerelease.t
 rem Create default %prerelease_targets%
 echo ^<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="CsWinRTVerifyPrerelease"^> > %prerelease_targets%
 echo   ^<Target Name="CsWinRTVerifyPrerelease" >> %prerelease_targets%
-echo     Condition="'$(NetCoreSdkVersion)' ^!= '%CsWinRTBuildNetSDKVersion%' and '$(Net5SdkVersion)' ^!= '%CsWinRTBuildNetSDKVersion%'"^> >> %prerelease_targets%
-echo     ^<Warning Text="This C#/WinRT prerelease is designed for .Net SDK %CsWinRTBuildNetSDKVersion%. Other prereleases may be incompatible due to breaking changes." /^> >> %prerelease_targets%
+echo     Condition="'$(NetCoreSdkVersion)' ^!= '%CsWinRTNet5SdkVersion%' and '$(Net5SdkVersion)' ^!= '%CsWinRTNet5SdkVersion%'"^> >> %prerelease_targets%
+echo     ^<Warning Text="This C#/WinRT prerelease is designed for .Net SDK %CsWinRTNet5SdkVersion%. Other prereleases may be incompatible due to breaking changes." /^> >> %prerelease_targets%
 echo   ^</Target^> >> %prerelease_targets%
 echo ^</Project^> >> %prerelease_targets%
 

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -2,7 +2,7 @@
 if /i "%cswinrt_echo%" == "on" @echo on
 
 set CsWinRTBuildNetSDKVersion=6.0.100-preview.6.21355.2
-set CsWinRTNet5SdkVersion=5.0.300
+set CsWinRTNet5SdkVersion=5.0.302
 set this_dir=%~dp0
 
 :dotnet

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -1,16 +1,17 @@
 @echo off
 if /i "%cswinrt_echo%" == "on" @echo on
 
-set CsWinRTNet5SdkVersion=6.0.100-preview.6.21355.2
+set CsWinRTBuildNetSDKVersion=6.0.100-preview.6.21355.2
+set CsWinRTNet5SdkVersion=5.0.300
 set this_dir=%~dp0
 
 :dotnet
-rem Install required .NET 5 SDK version and add to environment
+rem Install required .NET SDK version and add to environment
 set DOTNET_ROOT=%LocalAppData%\Microsoft\dotnet
 set DOTNET_ROOT(86)=%LocalAppData%\Microsoft\dotnet\x86
 set path=%DOTNET_ROOT%;%path%
 
-
+rem Install .net5 to run our projects  targeting it
 powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
@@ -21,13 +22,24 @@ powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
 -Version '%CsWinRTNet5SdkVersion%' -InstallDir '%DOTNET_ROOT(86)%' -Architecture 'x86' ^
 -AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
+rem Install .NET Version used to build projection
+powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+&([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
+-Version '%CsWinRTBuildNetSDKVersion%' -InstallDir '%DOTNET_ROOT%' -Architecture 'x64' ^
+-AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
+powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+&([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
+-Version '%CsWinRTBuildNetSDKVersion%' -InstallDir '%DOTNET_ROOT(86)%' -Architecture 'x86' ^
+-AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
 
 :globaljson
 rem Create global.json for current .NET SDK, and with allowPrerelease=true
 set global_json=%this_dir%global.json
 echo { > %global_json%
 echo   "sdk": { >> %global_json%
-echo     "version": "%CsWinRTNet5SdkVersion%", >> %global_json%
+echo     "version": "%CsWinRTBuildNetSDKVersion%", >> %global_json%
 echo     "allowPrerelease": true >> %global_json%
 echo   } >> %global_json%
 echo } >> %global_json%
@@ -78,8 +90,8 @@ set prerelease_targets=%this_dir%..\nuget\Microsoft.Windows.CsWinRT.Prerelease.t
 rem Create default %prerelease_targets%
 echo ^<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="CsWinRTVerifyPrerelease"^> > %prerelease_targets%
 echo   ^<Target Name="CsWinRTVerifyPrerelease" >> %prerelease_targets%
-echo     Condition="'$(NetCoreSdkVersion)' ^!= '%CsWinRTNet5SdkVersion%' and '$(Net5SdkVersion)' ^!= '%CsWinRTNet5SdkVersion%'"^> >> %prerelease_targets%
-echo     ^<Warning Text="This C#/WinRT prerelease is designed for .Net SDK %CsWinRTNet5SdkVersion%. Other prereleases may be incompatible due to breaking changes." /^> >> %prerelease_targets%
+echo     Condition="'$(NetCoreSdkVersion)' ^!= '%CsWinRTBuildNetSDKVersion%' and '$(Net5SdkVersion)' ^!= '%CsWinRTBuildNetSDKVersion%'"^> >> %prerelease_targets%
+echo     ^<Warning Text="This C#/WinRT prerelease is designed for .Net SDK %CsWinRTBuildNetSDKVersion%. Other prereleases may be incompatible due to breaking changes." /^> >> %prerelease_targets%
 echo   ^</Target^> >> %prerelease_targets%
 echo ^</Project^> >> %prerelease_targets%
 

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 if /i "%cswinrt_echo%" == "on" @echo on
 
-set CsWinRTNet5SdkVersion=5.0.300
+set CsWinRTNet5SdkVersion=6.0.100-preview.6.21355.2
 set this_dir=%~dp0
 
 :dotnet

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -32,7 +32,7 @@ namespace cswinrt
         { "output", 0, 1, "<path>", "Location of generated projection" },
         { "include", 0, option::no_max, "<prefix>", "One or more prefixes to include in projection" },
         { "exclude", 0, option::no_max, "<prefix>", "One or more prefixes to exclude from projection" },
-        { "target", 0, 1, "<net5.0|netstandard2.0>", "Target TFM for projection. Omit for compatibility with newest TFM (net5.0)." },
+        { "target", 0, 1, "<net6.0|net5.0|netstandard2.0>", "Target TFM for projection. Omit for compatibility with newest TFM (net5.0)." },
         { "component", 0, 0, {}, "Generate component projection." },
         { "verbose", 0, 0, {}, "Show detailed progress information" },
         { "help", 0, option::no_max, {}, "Show detailed help" },
@@ -86,7 +86,7 @@ Where <spec> is one or more of:
 
         settings.verbose = args.exists("verbose");
         auto target = args.value("target");
-        if (!target.empty() && target != "netstandard2.0" && !starts_with(target, "net5.0"))
+        if (!target.empty() && target != "netstandard2.0" && !starts_with(target, "net5.0") && !starts_with(target, "net6.0"))
         {
             throw usage_exception();
         }
@@ -386,6 +386,7 @@ Where <spec> is one or more of:
         }
         catch (usage_exception const&)
         {
+            result = 1;
             print_usage(w);
         }
         catch (std::exception const& e)

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -8,7 +8,7 @@ namespace System
     using global::System.Threading.Tasks;
     using global::Windows.Foundation;
 
-#if NET5_0
+#if NET
     [global::System.Runtime.Versioning.SupportedOSPlatform("windows10.0.10240.0")]
 #endif
     public static class WindowsRuntimeSystemExtensions
@@ -232,7 +232,7 @@ namespace System
     /// using <code>VoidValueTypeParameter</code> offers better performance.</summary>
     internal class VoidReferenceTypeParameter { }
 
-#if NET5_0
+#if NET
     [global::System.Runtime.Versioning.SupportedOSPlatform("windows10.0.10240.0")]
 #endif
     sealed class AsyncInfoToTaskBridge<TResult, TProgress> : TaskCompletionSource<TResult>


### PR DESCRIPTION
This updates CsWinRT to be able to generate .net6 projections when net6.0 is targeted,
This PR also updates other projects to target net6.0 along with net5.0 including WinRT.Runtime and test projects.