### PR TITLE
Stop VS error for patcher tool

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -182,7 +182,7 @@ $(GuidPatchTargetAssemblyReferences)
   <!-- When the IIDOptimizer succeeds, replace the input .dll with the patched version -->
   <Target Name="CsWinRTReplaceForPatchedRuntime" 
           Condition="$(CsWinRTGuidPatchExitCode) == 0"
-          AfterTargets="CsWinRTInvokeGuidPatcher"
+          DependsOnTargets="CsWinRTInvokeGuidPatcher"
           BeforeTargets="Link">
 
     <ItemGroup>


### PR DESCRIPTION
One of the build targets for the IIDOptimizer was set to always run, so we change it to run depending on the one it should follow. 
This PR fixes a VS bug where it prompts that the patched files do not exist, before the project has been built. 