### PR TITLE
Update IIDOptimizer Target

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -182,6 +182,7 @@ $(GuidPatchTargetAssemblyReferences)
   <!-- When the IIDOptimizer succeeds, replace the input .dll with the patched version -->
   <Target Name="CsWinRTReplaceForPatchedRuntime" 
           Condition="$(CsWinRTGuidPatchExitCode) == 0"
+          AfterTargets="CsWinRTInvokeGuidPatcher"
           DependsOnTargets="CsWinRTInvokeGuidPatcher"
           BeforeTargets="Link">
 


### PR DESCRIPTION
MSBuild does not always build a target just because it "DependsOn" another target, we need to force a target to run by using "After". We keep "Depends" so that we only run the target after the one it depends on. 