### PR TITLE
Run IIDOptimizer on WinRT.Runtime

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.IIDOptimizer.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.IIDOptimizer.targets
@@ -1,0 +1,79 @@
+<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+
+  <!-- For the IIDOptimizer to work, it needs to be given all the (reference) assemblies used during compilation 
+       This target consolidates them based on an item group output by the CoreCompile target,  
+       so they may be passed as an option to the IIDOptimizer in the target that invokes the tool -->
+  <Target Name="CsWinRTGenerateIIDOptimizerResponseFile" AfterTargets="Compile" BeforeTargets="CsWinRTInvokeGuidPatcher"
+          Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'">
+    
+    <PropertyGroup> 
+      <!-- CsWinRTIIDOptimizerPath: If building in the CsWinRT Repo, then this is set already via Directory.Build.props  --> 
+      <CsWinRTIIDOptimizerPath Condition="'$(CsWinRTIIDOptimizerPath)' == ''">$(CsWinRTPath)build\tools\IIDOptimizer\</CsWinRTIIDOptimizerPath>
+      <!-- CsWinRTIIDOptimizerTargetAssembly: First argument to the IIDOptimizer. 
+            We are using the output's .dll from the *obj* folder. 
+            After linking, the output's .dll gets copied to the bin folder. These targets run before linking. --> 
+      <CsWinRTIIDOptimizerTargetAssembly>@(BuiltProjectOutputGroupKeyOutput->'%(Identity)')</CsWinRTIIDOptimizerTargetAssembly>
+      <!-- IIDOptimizerInterimDir: Second argument to the IIDOptimizer.
+             The folder used by the IIDOptimizer to save output files --> 
+      <IIDOptimizerInterimDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'IIDOptimizer'))</IIDOptimizerInterimDir>
+      <!-- GuidPatchTargetAssemblyReferences: third argument to the IIDOptimizer. 
+            We use ReferencePathWithRefAssemblies as this is passed to Csc (C# Compile Task) for the TargetAssembly's References --> 
+      <GuidPatchTargetAssemblyReferences>@(ReferencePathWithRefAssemblies->'--refs &#x0d;&#x0a; %(Identity)', '&#x0d;&#x0a;')</GuidPatchTargetAssemblyReferences>
+      <!-- GuidPatchParams: Used to write the response file (.rsp) when executing IIDOptimizer.
+            include the current dll, the folder to winrt.runtime, and the reference assemblies --> 
+      <GuidPatchParams>
+--target
+$(CsWinRTIIDOptimizerTargetAssembly)
+--outdir
+$(IIDOptimizerInterimDir)
+$(GuidPatchTargetAssemblyReferences)
+      </GuidPatchParams>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(IIDOptimizerInterimDir)"/>
+
+    <PropertyGroup>
+      <CsWinRTIIDOptimizerResponseFile>$(IIDOptimizerInterimDir)cswinrt_iidoptimizer.rsp</CsWinRTIIDOptimizerResponseFile>
+	    <CsWinRTIIDOptimizerCommand>"$(CsWinRTIIDOptimizerPath)IIDOptimizer.exe" %40"$(CsWinRTIIDOptimizerResponseFile)"</CsWinRTIIDOptimizerCommand>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(CsWinRTIIDOptimizerResponseFile)" Lines="$(GuidPatchParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <!-- Run the IIDOptimizer on the projection .dll -->
+  <Target Name="CsWinRTInvokeGuidPatcher" AfterTargets="Compile" BeforeTargets="Link" DependsOnTargets="CsWinRTGenerateIIDOptimizerResponseFile"
+          Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'">  
+    <Message Text="$(CsWinRTIIDOptimizerCommand)" Importance="$(CsWinRTMessageImportance)" />
+    <Exec Command="$(CsWinRTIIDOptimizerCommand)" ConsoleToMsBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CsWinRTGuidPatchOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="CsWinRTGuidPatchExitCode"/>
+    </Exec>
+  </Target>
+
+  <!-- When the IIDOptimizer succeeds, replace the input .dll with the patched version -->
+  <Target Name="CsWinRTReplaceForPatchedRuntime" 
+          Condition="$(CsWinRTGuidPatchExitCode) == 0"
+          AfterTargets="CsWinRTInvokeGuidPatcher"
+          BeforeTargets="Link">
+
+    <ItemGroup>
+      <CsWinRTGuidPatchedFiles Include="$(IIDOptimizerInterimDir)$(AssemblyName).dll;$(IIDOptimizerInterimDir)$(AssemblyName).pdb" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- Use the above .dll to find the directory we should copy to when we finish (usually "obj")-->
+      <CsWinRTIIDOptimizerOutputDir>$([System.IO.Directory]::GetParent($(CsWinRTIIDOptimizerTargetAssembly))) </CsWinRTIIDOptimizerOutputDir>
+    </PropertyGroup>
+
+    <!--  Replace the .dll in the output folder with the optimized version we just made -->
+    <Copy SourceFiles="@(CsWinRTGuidPatchedFiles)" DestinationFolder="$(CsWinRTIIDOptimizerOutputDir)" />
+  </Target>
+
+
+</Project>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -128,78 +128,9 @@ $(CsWinRTIncludeWinRTInterop)
       <Compile Include="$(CsWinRTGeneratedFilesDir)*.cs" Exclude="@(Compile)" />
     </ItemGroup>
   </Target>
-
-  <!-- For the IIDOptimizer to work, it needs to be given all the (reference) assemblies used during compilation 
-       This target consolidates them based on an item group output by the CoreCompile target,  
-       so they may be passed as an option to the IIDOptimizer in the target that invokes the tool -->
-  <Target Name="CsWinRTGenerateIIDOptimizerResponseFile" AfterTargets="Compile" BeforeTargets="CsWinRTInvokeGuidPatcher"
-          Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'">
-    
-    <PropertyGroup> 
-      <!-- CsWinRTIIDOptimizerPath: If building in the CsWinRT Repo, then this is set already via Directory.Build.props  --> 
-      <CsWinRTIIDOptimizerPath Condition="'$(CsWinRTIIDOptimizerPath)' == ''">$(CsWinRTPath)build\tools\IIDOptimizer\</CsWinRTIIDOptimizerPath>
-      <!-- CsWinRTIIDOptimizerTargetAssembly: First argument to the IIDOptimizer. 
-            We are using the output's .dll from the *obj* folder. 
-            After linking, the output's .dll gets copied to the bin folder. These targets run before linking. --> 
-      <CsWinRTIIDOptimizerTargetAssembly>@(BuiltProjectOutputGroupKeyOutput->'%(Identity)')</CsWinRTIIDOptimizerTargetAssembly>
-      <!-- IIDOptimizerInterimDir: Second argument to the IIDOptimizer.
-             The folder used by the IIDOptimizer to save output files --> 
-      <IIDOptimizerInterimDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'IIDOptimizer'))</IIDOptimizerInterimDir>
-      <!-- GuidPatchTargetAssemblyReferences: third argument to the IIDOptimizer. 
-            We use ReferencePathWithRefAssemblies as this is passed to Csc (C# Compile Task) for the TargetAssembly's References --> 
-      <GuidPatchTargetAssemblyReferences>@(ReferencePathWithRefAssemblies->'--refs &#x0d;&#x0a; %(Identity)', '&#x0d;&#x0a;')</GuidPatchTargetAssemblyReferences>
-      <!-- GuidPatchParams: Used to write the response file (.rsp) when executing IIDOptimizer.
-            include the current dll, the folder to winrt.runtime, and the reference assemblies --> 
-      <GuidPatchParams>
---target
-$(CsWinRTIIDOptimizerTargetAssembly)
---outdir
-$(IIDOptimizerInterimDir)
-$(GuidPatchTargetAssemblyReferences)
-      </GuidPatchParams>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(IIDOptimizerInterimDir)"/>
-
-    <PropertyGroup>
-      <CsWinRTIIDOptimizerResponseFile>$(IIDOptimizerInterimDir)cswinrt_iidoptimizer.rsp</CsWinRTIIDOptimizerResponseFile>
-	    <CsWinRTIIDOptimizerCommand>"$(CsWinRTIIDOptimizerPath)IIDOptimizer.exe" %40"$(CsWinRTIIDOptimizerResponseFile)"</CsWinRTIIDOptimizerCommand>
-    </PropertyGroup>
-
-    <WriteLinesToFile File="$(CsWinRTIIDOptimizerResponseFile)" Lines="$(GuidPatchParams)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-  </Target>
-
-  <!-- Run the IIDOptimizer on the projection .dll -->
-  <Target Name="CsWinRTInvokeGuidPatcher" AfterTargets="Compile" BeforeTargets="Link" DependsOnTargets="CsWinRTGenerateIIDOptimizerResponseFile"
-          Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'">  
-    <Message Text="$(CsWinRTIIDOptimizerCommand)" Importance="$(CsWinRTMessageImportance)" />
-    <Exec Command="$(CsWinRTIIDOptimizerCommand)" ConsoleToMsBuild="true" IgnoreExitCode="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="CsWinRTGuidPatchOutput" />
-      <Output TaskParameter="ExitCode" PropertyName="CsWinRTGuidPatchExitCode"/>
-    </Exec>
-  </Target>
-
-  <!-- When the IIDOptimizer succeeds, replace the input .dll with the patched version -->
-  <Target Name="CsWinRTReplaceForPatchedRuntime" 
-          Condition="$(CsWinRTGuidPatchExitCode) == 0"
-          AfterTargets="CsWinRTInvokeGuidPatcher"
-          DependsOnTargets="CsWinRTInvokeGuidPatcher"
-          BeforeTargets="Link">
-
-    <ItemGroup>
-      <CsWinRTGuidPatchedFiles Include="$(IIDOptimizerInterimDir)$(AssemblyName).dll;$(IIDOptimizerInterimDir)$(AssemblyName).pdb" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <!-- Use the above .dll to find the directory we should copy to when we finish (usually "obj")-->
-      <CsWinRTIIDOptimizerOutputDir>$([System.IO.Directory]::GetParent($(CsWinRTIIDOptimizerTargetAssembly))) </CsWinRTIIDOptimizerOutputDir>
-    </PropertyGroup>
-
-    <!--  Replace the .dll in the output folder with the optimized version we just made -->
-    <Copy SourceFiles="@(CsWinRTGuidPatchedFiles)" DestinationFolder="$(CsWinRTIIDOptimizerOutputDir)" />
-  </Target>
   
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets')"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" />
 
 </Project>

--- a/src/Perf/IIDOptimizer/GuidPatcher.cs
+++ b/src/Perf/IIDOptimizer/GuidPatcher.cs
@@ -78,15 +78,16 @@ namespace GuidPatch
                 guidGeneratorType = winRTRuntimeAssembly.MainModule.Types.Where(typeDef => typeDef.Name == "GuidGenerator").First(); 
                 typeExtensionsType = winRTRuntimeAssembly.MainModule.Types.Where(typeDef => typeDef.Name == "TypeExtensions").First();
             }
-            else
-            { 
-                guidGeneratorType = new TypeReference("WinRT", "GuidGenerator", assembly.MainModule, assembly.Name).Resolve();
-                typeExtensionsType = new TypeReference("WinRT", "TypeExtensions", assembly.MainModule, assembly.Name).Resolve();
-            }
 
             foreach (var asm in assembly.MainModule.AssemblyReferences)
             {
-                if (asm.Name == "System.Runtime.InteropServices")
+                if (asm.Name == "WinRT.Runtime")
+                {
+                    guidGeneratorType =
+                        new TypeReference("WinRT", "GuidGenerator", assembly.MainModule, asm).Resolve();
+                    typeExtensionsType = new TypeReference("WinRT", "TypeExtensions", assembly.MainModule, asm).Resolve();
+                }
+                else if (asm.Name == "System.Runtime.InteropServices")
                 {
                     guidAttributeType = new TypeReference("System.Runtime.InteropServices", "GuidAttribute", assembly.MainModule, asm).Resolve();
                 }

--- a/src/Perf/IIDOptimizer/GuidPatcher.cs
+++ b/src/Perf/IIDOptimizer/GuidPatcher.cs
@@ -68,19 +68,25 @@ namespace GuidPatch
 
             getTypeFromHandleMethod = systemType.Methods.First(m => m.Name == "GetTypeFromHandle");
 
-            guidGeneratorType = null;
+            guidGeneratorType = null; 
 
-            TypeDefinition? typeExtensionsType = null;
+            TypeDefinition? typeExtensionsType = null; 
+
+            // Use the type definition if we are patching WinRT.Runtime, otherwise lookup the types as references 
+            if (assembly.Name.Name == "WinRT.Runtime")
+            {
+                guidGeneratorType = winRTRuntimeAssembly.MainModule.Types.Where(typeDef => typeDef.Name == "GuidGenerator").First(); 
+                typeExtensionsType = winRTRuntimeAssembly.MainModule.Types.Where(typeDef => typeDef.Name == "TypeExtensions").First();
+            }
+            else
+            { 
+                guidGeneratorType = new TypeReference("WinRT", "GuidGenerator", assembly.MainModule, assembly.Name).Resolve();
+                typeExtensionsType = new TypeReference("WinRT", "TypeExtensions", assembly.MainModule, assembly.Name).Resolve();
+            }
 
             foreach (var asm in assembly.MainModule.AssemblyReferences)
             {
-                if (asm.Name == "WinRT.Runtime")
-                {
-                    guidGeneratorType =
-                        new TypeReference("WinRT", "GuidGenerator", assembly.MainModule, asm).Resolve();
-                    typeExtensionsType = new TypeReference("WinRT", "TypeExtensions", assembly.MainModule, asm).Resolve();
-                }
-                else if (asm.Name == "System.Runtime.InteropServices")
+                if (asm.Name == "System.Runtime.InteropServices")
                 {
                     guidAttributeType = new TypeReference("System.Runtime.InteropServices", "GuidAttribute", assembly.MainModule, asm).Resolve();
                 }

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -66,6 +66,32 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestEventArgsVector()
+        { 
+            var eventArgsVector = TestObject.GetEventArgsVector();
+            Assert.Equal(1, eventArgsVector.Count);
+            foreach (var dataErrorChangedEventArgs in eventArgsVector)
+            {
+                var propName  = dataErrorChangedEventArgs.PropertyName;
+                Assert.Equal("name", propName);
+            }
+        }
+
+        [Fact]
+        public void TestNonGenericDelegateVector()
+        {
+            var provideUriVector = TestObject.GetNonGenericDelegateVector();
+
+            Assert.Equal(1, provideUriVector.Count);
+            
+            foreach (var provideUri in provideUriVector)
+            {
+                Uri delegateTarget = provideUri.Invoke();
+                Assert.Equal("http://microsoft.com", delegateTarget.OriginalString);
+            }
+        }
+
+        [Fact]
         public void TestEnums()
         {
             // Enums

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -9,9 +9,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
     <CsWinRTEnabled>false</CsWinRTEnabled>
-    <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\Projections\Windows\Windows.csproj" />
     <ProjectReference Include="..\..\Projections\WinUI\WinUI.csproj" />

--- a/src/WinRT.Runtime/Directory.Build.targets
+++ b/src/WinRT.Runtime/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)../../nuget/Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(TargetFramework)' != 'netstandard2.0'"/> 
+</Project>

--- a/src/cswinrt.sln
+++ b/src/cswinrt.sln
@@ -36,6 +36,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestComponent", "TestWinRT\
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinRT.Runtime", "WinRT.Runtime\WinRT.Runtime.csproj", "{25244CED-966E-45F2-9711-1F51E951FF89}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AE3B0611-2FBB-42AB-A245-B4E79868A5F9} = {AE3B0611-2FBB-42AB-A245-B4E79868A5F9}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinUIDesktopSample", "Samples\WinUIDesktopSample\WinUIDesktopSample.csproj", "{8E6FBCB2-B0C1-4E92-8AEB-2A11564E6E0D}"
 EndProject
@@ -53,6 +56,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{967889B0-4C40-4EA2-8F11-26ECB88205FF}"
 	ProjectSection(SolutionItems) = preProject
 		..\nuget\LICENSE = ..\nuget\LICENSE
+		..\nuget\Microsoft.Windows.CsWinRT.IIDOptimizer.targets = ..\nuget\Microsoft.Windows.CsWinRT.IIDOptimizer.targets
 		..\nuget\Microsoft.Windows.CsWinRT.nuspec = ..\nuget\Microsoft.Windows.CsWinRT.nuspec
 		..\nuget\Microsoft.Windows.CsWinRT.props = ..\nuget\Microsoft.Windows.CsWinRT.props
 		..\nuget\Microsoft.Windows.CsWinRT.targets = ..\nuget\Microsoft.Windows.CsWinRT.targets
@@ -108,9 +112,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Perf", "Perf", "{539DBDEF-3B49-4503-9BD3-7EB83C2179CB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IIDOptimizer", "Perf\IIDOptimizer\IIDOptimizer.csproj", "{AE3B0611-2FBB-42AB-A245-B4E79868A5F9}"
-	ProjectSection(ProjectDependencies) = postProject
-		{25244CED-966E-45F2-9711-1F51E951FF89} = {25244CED-966E-45F2-9711-1F51E951FF89}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Reunion", "Projections\Reunion\Reunion.csproj", "{B6312AD1-A59E-4F3B-AA39-20B780FE9E15}"
 EndProject


### PR DESCRIPTION
Fixes #862 

We patch WinRT.Runtime by using the target assembly for patching to resolve the WinRT types. 
I moved the targets related to the IIDOptimizer to their own file, and now we can use a Directory.Build.targets file in WinRT.Runtime project to import these targets. The `cswinrt.sln` change is to add a build dependency for WinRT.Runtime to IIDOptimizer project.

FYI @jkoritzinsky 