### PR TITLE
Don't use exceptions for flow control when loading dlls.

### DIFF
--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -136,7 +136,7 @@ namespace WinRT
                 return false;
             }
 
-            var getActivationFactory = Platform.GetProcAddress(_moduleHandle, nameof(DllGetActivationFactory));
+            var getActivationFactory = Platform.GetProcAddress(moduleHandle, nameof(DllGetActivationFactory));
             if (getActivationFactory == IntPtr.Zero)
             {
                 module = null;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -46,6 +46,15 @@ namespace WinRT
 
         [DllImport("kernel32.dll", SetLastError = true, BestFitMapping = false)]
         internal static extern IntPtr GetProcAddress(IntPtr moduleHandle, [MarshalAs(UnmanagedType.LPStr)] string functionName);
+        internal static T GetProcAddress<T>(IntPtr moduleHandle)
+        {
+            IntPtr functionPtr = Platform.GetProcAddress(moduleHandle, typeof(T).Name);
+            if (functionPtr == IntPtr.Zero)
+            {
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+            return Marshal.GetDelegateForFunctionPointer<T>(functionPtr);
+        }
 
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern IntPtr LoadLibraryExW([MarshalAs(UnmanagedType.LPWStr)] string fileName, IntPtr fileHandle, uint flags);


### PR DESCRIPTION
This PR changes the way CsWinRT loads dlls to use the Try* pattern. Currently lookup throws an exception when a specific dll is not found resulting in a lot of first chance exceptions being thrown slowing down debugging.