### PR TITLE
Return IIDOptimizer exit code

### DIFF
--- a/src/Perf/IIDOptimizer/Program.cs
+++ b/src/Perf/IIDOptimizer/Program.cs
@@ -143,7 +143,7 @@ namespace GuidPatch
             }
             catch (Exception e)
             {
-                Console.WriteLine("Application failed with unexpected exception.");
+                Console.WriteLine("Failed with unexpected exception.");
                 Console.WriteLine($"{e}");
                 return -1; 
             }

--- a/src/Perf/IIDOptimizer/Program.cs
+++ b/src/Perf/IIDOptimizer/Program.cs
@@ -141,6 +141,12 @@ namespace GuidPatch
                 Console.WriteLine($"\tAssembly : {e.AssemblyReference.Name}"); 
                 return -1; 
             }
+            catch (Exception e)
+            {
+                Console.WriteLine("Application failed with unexpected exception.");
+                Console.WriteLine($"{e}");
+                return -1; 
+            }
         }
     }
 }


### PR DESCRIPTION
This PR corrects an error in the iidoptimizer where the intended exit codes were forgotten on termination. Given that we have a helper for resolving winrt.runtime, I made sure we exit early if anything goes wrong. 

Fixes #953 