### PR TITLE
Ujjwalchadha/fix value type caching 2

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -28,7 +28,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Security.Cryptography;
 using Windows.Security.Cryptography.Core;
 using System.Reflection;
-using Windows.Devices.Enumeration.Pnp;
 
 #if NET
 using WeakRefNS = System;
@@ -2628,49 +2627,5 @@ namespace UnitTest
             WarningStatic.WarningEvent += (object s, Int32 v) => { }; // warning CA1416
         }
 #endif
-
-        [Fact]
-        private async Task TestPnpPropertiesAsync()
-        {
-            var requestedDeviceProperties = new List<string>()
-                {
-                    "System.Devices.ClassGuid",
-                    "System.Devices.ContainerId",
-                    "System.Devices.DeviceHasProblem",
-                    "System.Devices.DeviceInstanceId",
-                    "System.Devices.Parent",
-                    "System.Devices.Present",
-                    "System.ItemNameDisplay",
-                    "System.Devices.Children",
-                };
-            var devicefilter = "System.Devices.Present:System.StructuredQueryType.Boolean#True";
-            var presentDevices = (await PnpObject.FindAllAsync(PnpObjectType.Device, requestedDeviceProperties, devicefilter).AsTask().ConfigureAwait(false)).Select(pnpObject => {
-                var prop = pnpObject.Properties;
-                // Iterating through each key is necessary for this test even though we do not use each key directly
-                // This makes it more probable for a native pointer to get repeated and a value type to be cached and seen again.
-                foreach (var key in prop.Keys)
-                {
-                    var val = prop[key];
-                    if (key == "System.Devices.ContainerId" && val != null)
-                    {
-                        var val4 = pnpObject.Properties[key];
-                        if (val is not Guid || val4 is not Guid)
-                        {
-                            throw new Exception("Incorrect value type Guid");
-                        }
-                    }
-                    if (key == "System.Devices.Parent" && val != null)
-                    {
-                        var val4 = pnpObject.Properties[key];
-                        if (val is not string || val4 is not string)
-                        {
-                            throw new Exception("Incorrect value type string");
-                        }
-                    }
-
-                }
-                return pnpObject;
-            }).ToList();
-        }
     }
 }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -282,9 +282,8 @@ namespace WinRT
                     Expression.Call(parms[0],
                         typeof(IInspectable).GetMethod(nameof(IInspectable.As)).MakeGenericMethod(vftblType)));
 
-            var getValueExpression = Expression.Convert(Expression.Property(createInterfaceInstanceExpression, "Value"), typeof(object));
-            var setValueInWrapperexpression = Expression.New(typeof(ValueTypeWrapper).GetConstructor(new[] { typeof(object) }), getValueExpression);
-            return Expression.Lambda<Func<IInspectable, object>>(setValueInWrapperexpression, parms).Compile();
+            return Expression.Lambda<Func<IInspectable, object>>(
+                Expression.Convert(Expression.Property(createInterfaceInstanceExpression, "Value"), typeof(object)), parms).Compile();
         }
 
         private static Func<IInspectable, object> CreateArrayFactory(Type implementationType)
@@ -297,9 +296,8 @@ namespace WinRT
                     Expression.Call(parms[0],
                         typeof(IInspectable).GetMethod(nameof(IInspectable.As)).MakeGenericMethod(vftblType)));
 
-            var getValueExpression = Expression.Property(createInterfaceInstanceExpression, "Value");
-            var setValueInWrapperexpression = Expression.New(typeof(ValueTypeWrapper).GetConstructor(new[] { typeof(object) }), getValueExpression);
-            return Expression.Lambda<Func<IInspectable, object>>(setValueInWrapperexpression, parms).Compile();
+            return Expression.Lambda<Func<IInspectable, object>>(
+                Expression.Property(createInterfaceInstanceExpression, "Value"), parms).Compile();
         }
 
         internal static Func<IInspectable, object> CreateTypedRcwFactory(string runtimeClassName)
@@ -727,21 +725,6 @@ namespace WinRT
                 IIDs = iids;
             }
 
-        }
-
-        internal class ValueTypeWrapper
-        {
-            private readonly object value;
-
-            public ValueTypeWrapper(object value)
-            {
-                this.value = value;
-            }
-
-            public object Value
-            {
-                get => this.value;
-            }
         }
     }
 }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -324,11 +324,11 @@ namespace WinRT
             // PropertySet and ValueSet can return IReference<String> but Nullable<String> is illegal
             if (runtimeClassName == "Windows.Foundation.IReference`1<String>")
             {
-                return (IInspectable obj) => new ABI.System.Nullable<String>(obj.ObjRef);
+                return CreateReferenceCachingFactory((IInspectable obj) => new ABI.System.Nullable<String>(obj.ObjRef));
             }
             else if (runtimeClassName == "Windows.Foundation.IReference`1<Windows.UI.Xaml.Interop.TypeName>")
             {
-                return (IInspectable obj) => new ABI.System.Nullable<Type>(obj.ObjRef);
+                return CreateReferenceCachingFactory((IInspectable obj) => new ABI.System.Nullable<Type>(obj.ObjRef));
             }
 
             Type implementationType = TypeNameSupport.FindTypeByNameCached(runtimeClassName);

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -92,13 +92,6 @@ namespace WinRT
             var flags = tryUseCache ? CreateObjectFlags.TrackerObject : CreateObjectFlags.TrackerObject | CreateObjectFlags.UniqueInstance;
             var rcw = ComWrappers.GetOrCreateObjectForComInstance(ptr, flags);
             CreateRCWType.Value = null;
-            
-            // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
-            if (rcw is IWinRTObject winrtObj)
-            {
-                winrtObj.Resurrect();
-            }
-
             // Because .NET will de-duplicate strings and WinRT doesn't,
             // our RCW factory returns a wrapper of our string instance.
             // This ensures that ComWrappers never sees the same managed object for two different
@@ -106,11 +99,17 @@ namespace WinRT
             // and consumers get a string object for a Windows.Foundation.IReference<String>.
             // We need to do the same thing for System.Type because there can be multiple WUX.Interop.TypeName's
             // for a single System.Type.
+
+            // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
+            if (rcw is IWinRTObject winrtObj)
+            {
+                winrtObj.Resurrect();
+            }
+
             return rcw switch
             {
                 ABI.System.Nullable<string> ns => (T)(object)ns.Value,
                 ABI.System.Nullable<Type> nt => (T)(object)nt.Value,
-                ValueTypeWrapper vt => (T) vt.Value,
                 T castRcw => castRcw,
                 _ when tryUseCache => CreateRcwForComObject<T>(ptr, false),
                 _ => throw new ArgumentException(string.Format("Unable to create a wrapper object. The WinRT object {0} has type {1} which cannot be assigned to type {2}", ptr, rcw.GetType(), typeof(T)))

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -432,10 +432,6 @@ namespace WinRT
             return isRcw;
         }
 
-        // This is used to hold the reference to the native value type object (IReference) until the actual value in it (boxed as an object) gets cleaned up by GC
-        // This is done to avoid pointer reuse until GC cleans up the boxed object
-        private static ConditionalWeakTable<object, IObjectReference> valueTypeRefHolder = new ConditionalWeakTable<object, IObjectReference>();
-
         private static object CreateObject(IObjectReference objRef)
         {
             if (objRef.TryAs<IInspectable.Vftbl>(out var inspectableRef) == 0)
@@ -450,13 +446,7 @@ namespace WinRT
                     return inspectable;
                 }
 
-                var obj = ComWrappersSupport.GetTypedRcwFactory(runtimeClassName)(inspectable);
-                var type = obj.GetType();
-                if (type != null && (type.IsValueType || type.IsArray))
-                {
-                    valueTypeRefHolder.Add(obj, objRef);
-                }
-                return obj;
+                return ComWrappersSupport.GetTypedRcwFactory(runtimeClassName)(inspectable);
             }
             else if (objRef.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)
             {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -438,7 +438,6 @@ namespace WinRT
 
         private static object CreateObject(IObjectReference objRef)
         {
-            Console.WriteLine("Creating object");
             if (objRef.TryAs<IInspectable.Vftbl>(out var inspectableRef) == 0)
             {
                 IInspectable inspectable = new IInspectable(inspectableRef);
@@ -452,8 +451,8 @@ namespace WinRT
                 }
 
                 var obj = ComWrappersSupport.GetTypedRcwFactory(runtimeClassName)(inspectable);
-                var type = TypeNameSupport.FindTypeByNameCached(runtimeClassName);
-                if (type != null && (type.IsValueType || runtimeClassName.StartsWith("Windows.Foundation.IReferenceArray`1")))
+                var type = obj.GetType();
+                if (type != null && (type.IsValueType || type.IsArray))
                 {
                     valueTypeRefHolder.Add(obj, objRef);
                 }

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -74,7 +74,6 @@ namespace WinRT
             {
                 ABI.System.Nullable<string> ns => (T)(object)ns.Value,
                 ABI.System.Nullable<Type> nt => (T)(object)nt.Value,
-                ValueTypeWrapper vt => (T)vt.Value,
                 _ => (T)rcw
             };
         }

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -19,10 +19,6 @@ namespace WinRT
 
         internal static InspectableInfo GetInspectableInfo(IntPtr pThis) => UnmanagedObject.FindObject<ComCallableWrapper>(pThis).InspectableInfo;
 
-        // This is used to hold the reference to the native value type object (IReference) until the actual value in it (boxed as an object) gets cleaned up by GC
-        // This is done to avoid pointer reuse until GC cleans up the boxed object
-        private static ConditionalWeakTable<object, IObjectReference> valueTypeRefHolder = new ConditionalWeakTable<object, IObjectReference>();
-
         public static T CreateRcwForComObject<T>(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
@@ -42,11 +38,6 @@ namespace WinRT
                     var inspectable = new IInspectable(identity);
                     string runtimeClassName = GetRuntimeClassForTypeCreation(inspectable, typeof(T));
                     runtimeWrapper = string.IsNullOrEmpty(runtimeClassName) ? inspectable : TypedObjectFactoryCache.GetOrAdd(runtimeClassName, className => CreateTypedRcwFactory(className))(inspectable);
-                    var type = TypeNameSupport.FindTypeByNameCached(runtimeClassName);
-                    if (type != null && (type.IsValueType || runtimeClassName.StartsWith("Windows.Foundation.IReferenceArray`1")))
-                    {
-                        valueTypeRefHolder.Add(runtimeWrapper, identity);
-                    }
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)
                 {


### PR DESCRIPTION
This PR reverts the [previous fix](https://github.com/microsoft/CsWinRT/pull/932) to value type caching issue.
The actual cause of the issue is: not holding on to the native value type (coming in as IReference or IReferenceArrsy) when it gets stored in the dotnet cache. Thus, the pointer is allowed to be reused before GC cleans it. 
We fix it by adding a ConditionalWeakTable which holds on to the native reference until the boxed value is alive. Thus not allowing pointer reuse before it should be.