### PR TITLE
Handle case where event source may remove event and any other added events don't fire

### DIFF
--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -346,7 +346,9 @@ namespace winrt::TestComponentCSharp::implementation
     }
     winrt::event_token Class::IntPropertyChanged(EventHandler<int32_t> const& handler)
     {
-        return _intChanged.add(handler);
+        auto eventToken = _intChanged.add(handler);
+        _lastIntChangedEventToken = eventToken;
+        return eventToken;
     }
     void Class::IntPropertyChanged(winrt::event_token const& token) noexcept
     {
@@ -355,6 +357,10 @@ namespace winrt::TestComponentCSharp::implementation
     void Class::RaiseIntChanged()
     {
         _intChanged(*this, _int);
+    }
+    void Class::RemoveLastIntPropertyChangedHandler()
+    {
+        _intChanged.remove(_lastIntChangedEventToken);
     }
     void Class::CallForInt(TestComponentCSharp::ProvideInt const& provideInt)
     {

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -28,6 +28,7 @@ namespace winrt::TestComponentCSharp::implementation
 
         int32_t _int = 0;
         winrt::event<Windows::Foundation::EventHandler<int32_t>> _intChanged;
+        winrt::event_token _lastIntChangedEventToken;
         bool _bool = false;
         winrt::event<Windows::Foundation::EventHandler<bool>> _boolChanged;
         EnumValue _enumValue;
@@ -138,6 +139,7 @@ namespace winrt::TestComponentCSharp::implementation
         winrt::event_token IntPropertyChanged(Windows::Foundation::EventHandler<int32_t> const& handler);
         void IntPropertyChanged(winrt::event_token const& token) noexcept;
         void RaiseIntChanged();
+        void RemoveLastIntPropertyChangedHandler();
         void CallForInt(TestComponentCSharp::ProvideInt const& provideInt);
         bool BoolProperty();
         void BoolProperty(bool value);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -195,6 +195,7 @@ namespace TestComponentCSharp
         Int32 IntProperty;
         event Windows.Foundation.EventHandler<Int32> IntPropertyChanged;
         void RaiseIntChanged();
+        void RemoveLastIntPropertyChangedHandler();
         void CallForInt(ProvideInt provideInt);
 
         Boolean BoolProperty;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -484,7 +484,8 @@ namespace WinRT
                 bool registerHandler =
                     _state is null ||
                     !_state.TryGetTarget(out state) ||
-                    !state.HasComReferences(); // We have a wrapper delegate we created, but no longer has any references from any event source.
+                    // We have a wrapper delegate, but no longer has any references from any event source.
+                    !state.HasComReferences();
                 if (registerHandler)
                 {
                     state = CreateEventState();

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -604,8 +604,12 @@ namespace WinRT
 #if NETSTANDARD2_0
                     var weakRefSource = (IWeakReferenceSource)typeof(IWeakReferenceSource).GetHelperType().GetConstructor(new[] { typeof(IObjectReference) }).Invoke(new object[] { obj });
 #else
-                    var weakRefSource = (IWeakReferenceSource)(object)new WinRT.IInspectable(obj);
+                    var weakRefSource = ((object)new WinRT.IInspectable(obj)) as IWeakReferenceSource;
 #endif
+                    if (weakRefSource == null)
+                    {
+                        return;
+                    }
                     target = weakRefSource.GetWeakReference();
                 }
                 catch (Exception)

--- a/src/cswinrt/strings/WinRT_Interop.cs
+++ b/src/cswinrt/strings/WinRT_Interop.cs
@@ -30,4 +30,17 @@ namespace WinRT.Interop
         public IUnknownVftbl IUnknownVftbl;
         public IntPtr Invoke;
     }
+
+    [Guid("64BD43F8-bFEE-4EC4-B7EB-2935158DAE21")]
+    internal unsafe struct IReferenceTrackerTargetVftbl
+    {
+        public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+        private void* _AddRefFromReferenceTracker;
+        public delegate* unmanaged[Stdcall]<IntPtr, uint> AddRefFromReferenceTracker => (delegate* unmanaged[Stdcall]<IntPtr, uint>)_AddRefFromReferenceTracker;
+        private void* _ReleaseFromReferenceTracker;
+        public delegate* unmanaged[Stdcall]<IntPtr, uint> ReleaseFromReferenceTracker => (delegate* unmanaged[Stdcall]<IntPtr, uint>)_ReleaseFromReferenceTracker;
+        private void* _Peg;
+        private void* _Unpeg;
+    }
+
 }


### PR DESCRIPTION
Checking for any COM references when subscribing events to ensure our registered wrapper handler is still being held by an event source.  If there isn't any, we create a new event wrapper delegate to hold onto the event being subscribed.  This seems to fix #626 , but there is technically a scenario which this doesn't handle which is if the delegate is being removed as one is being added on another thread.  Handling that scenario will require 1-1 mappings which we will need to consider if that becomes a concern.

Fixes #626 