### PR TITLE
Perf improvements

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
@@ -1,4 +1,8 @@
 Compat issues with assembly WinRT.Runtime:
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.IInspectable.WinRT.IWinRTObject.get_AdditionalTypeData()' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.IInspectable.WinRT.IWinRTObject.get_QueryInterfaceCache()' in the contract but not the implementation.
 MembersMustExist : Member 'public WinRT.MarshalString.HStringHeader WinRT.MarshalString.HStringHeader WinRT.MarshalString._header' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'WinRT.MarshalString.HStringHeader' does not exist in the implementation but it does exist in the contract.
-Total Issues: 2
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.SingleInterfaceOptimizedObject.WinRT.IWinRTObject.get_AdditionalTypeData()' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.SingleInterfaceOptimizedObject.WinRT.IWinRTObject.get_QueryInterfaceCache()' in the contract but not the implementation.
+Total Issues: 6

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -58,9 +58,10 @@ namespace WinRT
             }
         }
 
-        public static void DisposeContextCallback(IntPtr contextCallbackPtr)
+        public unsafe static void DisposeContextCallback(IntPtr contextCallbackPtr)
         {
-            using var contextcallback = ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.Attach(ref contextCallbackPtr);
+            if (contextCallbackPtr == IntPtr.Zero) return;
+            (**(IUnknownVftbl**)contextCallbackPtr).Release(contextCallbackPtr);
         }
     }
 }

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -58,10 +58,9 @@ namespace WinRT
             }
         }
 
-        public unsafe static void DisposeContextCallback(IntPtr contextCallbackPtr)
+        public static void DisposeContextCallback(IntPtr contextCallbackPtr)
         {
-            if (contextCallbackPtr == IntPtr.Zero) return;
-            (**(IUnknownVftbl**)contextCallbackPtr).Release(contextCallbackPtr);
+            MarshalInspectable<object>.DisposeAbi(contextCallbackPtr);
         }
     }
 }

--- a/src/WinRT.Runtime/IInspectable.net5.cs
+++ b/src/WinRT.Runtime/IInspectable.net5.cs
@@ -8,8 +8,10 @@ namespace WinRT
         IObjectReference IWinRTObject.NativeObject => _obj;
         bool IWinRTObject.HasUnwrappableNativeObject => true;
 
-        ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+        private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+        ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+        private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
     }
 
 }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -358,25 +358,7 @@ namespace WinRT
         protected static readonly Type MarshalerType = typeof(T).GetMarshalerType();
         internal static readonly Type MarshalerArrayType = typeof(T).GetMarshalerArrayType();
 
-        static MarshalGeneric()
-        {
-            CreateMarshaler = (T value) => CreateMarshalerLazy.Value(value);
-            GetAbi = (object objRef) => GetAbiLazy.Value(objRef);
-            FromAbi = (object box) => FromAbiLazy.Value(box);
-            CopyAbi = (object box, IntPtr dest) => CopyAbiLazy.Value(box, dest);
-            FromManaged = (T value) => FromManagedLazy.Value(value);
-            CopyManaged = (T value, IntPtr dest) => CopyManagedLazy.Value(value, dest);
-            DisposeMarshaler = (object objRef) => DisposeMarshalerLazy.Value(objRef);
-            DisposeAbi = (object box) => DisposeAbiLazy.Value(box);
-            CreateMarshalerArray = (T[] array) => CreateMarshalerArrayLazy.Value(array);
-            GetAbiArray = (object box) => GetAbiArrayLazy.Value(box);
-            FromAbiArray = (object box) => FromAbiArrayLazy.Value(box);
-            FromManagedArray = (T[] array) => FromManagedArrayLazy.Value(array);
-            DisposeMarshalerArray = (object box) => DisposeMarshalerArrayLazy.Value(box);
-            DisposeAbiArray = (object box) => DisposeAbiArrayLazy.Value(box);
-        }
-
-        public static readonly Func<T, object> CreateMarshaler;
+        public static readonly Func<T, object> CreateMarshaler = (T value) => CreateMarshalerLazy.Value(value);
         private static readonly Lazy<Func<T, object>> CreateMarshalerLazy = new(BindCreateMarshaler);
         private static Func<T, object> BindCreateMarshaler()
         {
@@ -386,7 +368,7 @@ namespace WinRT
                     typeof(object)), parms).Compile();
         }
 
-        public static readonly Func<object, object> GetAbi;
+        public static readonly Func<object, object> GetAbi = (object objRef) => GetAbiLazy.Value(objRef);
         private static readonly Lazy<Func<object, object>> GetAbiLazy = new(BindGetAbi);
         private static Func<object, object> BindGetAbi()
         {
@@ -397,7 +379,7 @@ namespace WinRT
                         typeof(object)), parms).Compile();
         }
 
-        public static readonly Action<object, IntPtr> CopyAbi;
+        public static readonly Action<object, IntPtr> CopyAbi = (object box, IntPtr dest) => CopyAbiLazy.Value(box, dest);
         private static readonly Lazy<Action<object, IntPtr>> CopyAbiLazy = new(BindCopyAbi);
         private static Action<object, IntPtr> BindCopyAbi()
         {
@@ -409,7 +391,7 @@ namespace WinRT
                     new Expression[] { Expression.Convert(parms[0], MarshalerType), parms[1] }), parms).Compile();
         }
 
-        public static readonly Func<object, T> FromAbi;
+        public static readonly Func<object, T> FromAbi = (object box) => FromAbiLazy.Value(box);
         private static readonly Lazy<Func<object, T>> FromAbiLazy = new(BindFromAbi);
         private static Func<object, T> BindFromAbi()
         {
@@ -419,7 +401,7 @@ namespace WinRT
                     new[] { Expression.Convert(parms[0], AbiType) }), parms).Compile();
         }
 
-        public static readonly Func<T, object> FromManaged;
+        public static readonly Func<T, object> FromManaged = (T value) => FromManagedLazy.Value(value);
         private static readonly Lazy<Func<T, object>> FromManagedLazy = new(BindFromManaged);
         private static Func<T, object> BindFromManaged()
         {
@@ -429,7 +411,7 @@ namespace WinRT
                     typeof(object)), parms).Compile();
         }
 
-        public static readonly Action<T, IntPtr> CopyManaged;
+        public static readonly Action<T, IntPtr> CopyManaged = (T value, IntPtr dest) => CopyManagedLazy.Value(value, dest);
         private static readonly Lazy<Action<T, IntPtr>> CopyManagedLazy = new(BindCopyManaged);
         private static Action<T, IntPtr> BindCopyManaged()
         {
@@ -440,7 +422,7 @@ namespace WinRT
                 Expression.Call(copyManaged, parms), parms).Compile();
         }
 
-        public static readonly Action<object> DisposeMarshaler;
+        public static readonly Action<object> DisposeMarshaler = (object objRef) => DisposeMarshalerLazy.Value(objRef);
         private static readonly Lazy<Action<object>> DisposeMarshalerLazy = new(BindDisposeMarshaler);
         private static Action<object> BindDisposeMarshaler()
         {
@@ -450,7 +432,7 @@ namespace WinRT
                     new[] { Expression.Convert(parms[0], MarshalerType) }), parms).Compile();
         }
 
-        internal static readonly Action<object> DisposeAbi;
+        internal static readonly Action<object> DisposeAbi = (object box) => DisposeAbiLazy.Value(box);
         private static readonly Lazy<Action<object>> DisposeAbiLazy = new(BindDisposeAbi);
         private static Action<object> BindDisposeAbi()
         {
@@ -461,7 +443,7 @@ namespace WinRT
                 Expression.Call(disposeAbi, new[] { Expression.Convert(parms[0], AbiType) }), parms).Compile();
         }
 
-        internal static readonly Func<T[], object> CreateMarshalerArray;
+        internal static readonly Func<T[], object> CreateMarshalerArray = (T[] array) => CreateMarshalerArrayLazy.Value(array);
         private static readonly Lazy<Func<T[], object>> CreateMarshalerArrayLazy = new(BindCreateMarshalerArray);
         private static Func<T[], object> BindCreateMarshalerArray()
         {
@@ -472,7 +454,7 @@ namespace WinRT
                 Expression.Convert(Expression.Call(createMarshalerArray, parms), typeof(object)), parms).Compile();
         }
 
-        internal static readonly Func<object, (int, IntPtr)> GetAbiArray;
+        internal static readonly Func<object, (int, IntPtr)> GetAbiArray = (object box) => GetAbiArrayLazy.Value(box);
         private static readonly Lazy<Func<object, (int, IntPtr)>> GetAbiArrayLazy = new(BindGetAbiArray);
         private static Func<object, (int, IntPtr)> BindGetAbiArray()
         {
@@ -483,7 +465,7 @@ namespace WinRT
                 Expression.Convert(Expression.Call(getAbiArray, parms), typeof((int, IntPtr))), parms).Compile();
         }
 
-        internal static readonly Func<object, T[]> FromAbiArray;
+        internal static readonly Func<object, T[]> FromAbiArray = (object box) => FromAbiArrayLazy.Value(box);
         private static readonly Lazy<Func<object, T[]>> FromAbiArrayLazy = new(BindFromAbiArray);
         private static Func<object, T[]> BindFromAbiArray()
         {
@@ -494,7 +476,7 @@ namespace WinRT
                 Expression.Call(fromAbiArray, parms), parms).Compile();
         }
 
-        internal static readonly Func<T[], (int, IntPtr)> FromManagedArray;
+        internal static readonly Func<T[], (int, IntPtr)> FromManagedArray = (T[] array) => FromManagedArrayLazy.Value(array);
         private static readonly Lazy<Func<T[], (int, IntPtr)>> FromManagedArrayLazy = new(BindFromManagedArray);
         private static Func<T[], (int, IntPtr)> BindFromManagedArray()
         {
@@ -505,7 +487,7 @@ namespace WinRT
                 Expression.Convert(Expression.Call(fromManagedArray, parms), typeof((int, IntPtr))), parms).Compile();
         }
 
-        internal static readonly Action<object> DisposeMarshalerArray;
+        internal static readonly Action<object> DisposeMarshalerArray = (object box) => DisposeMarshalerArrayLazy.Value(box);
         private static readonly Lazy<Action<object>> DisposeMarshalerArrayLazy = new(BindDisposeMarshalerArray);
         private static Action<object> BindDisposeMarshalerArray()
         {
@@ -516,7 +498,7 @@ namespace WinRT
                 Expression.Call(disposeMarshalerArray, Expression.Convert(parms[0], MarshalerArrayType)), parms).Compile();
         }
 
-        internal static readonly Action<object> DisposeAbiArray;
+        internal static readonly Action<object> DisposeAbiArray = (object box) => DisposeAbiArrayLazy.Value(box);
         private static readonly Lazy<Action<object>> DisposeAbiArrayLazy = new(BindDisposeAbiArray);
         private static Action<object> BindDisposeAbiArray()
         {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -360,23 +360,24 @@ namespace WinRT
 
         static MarshalGeneric()
         {
-            CreateMarshaler = BindCreateMarshaler();
-            GetAbi = BindGetAbi();
-            FromAbi = BindFromAbi();
-            CopyAbi = BindCopyAbi();
-            FromManaged = BindFromManaged();
-            CopyManaged = BindCopyManaged();
-            DisposeMarshaler = BindDisposeMarshaler();
-            DisposeAbi = BindDisposeAbi();
-            CreateMarshalerArray = BindCreateMarshalerArray();
-            GetAbiArray = BindGetAbiArray();
-            FromAbiArray = BindFromAbiArray();
-            FromManagedArray = BindFromManagedArray();
-            DisposeMarshalerArray = BindDisposeMarshalerArray();
-            DisposeAbiArray = BindDisposeAbiArray();
+            CreateMarshaler = (T value) => CreateMarshalerLazy.Value(value);
+            GetAbi = (object objRef) => GetAbiLazy.Value(objRef);
+            FromAbi = (object box) => FromAbiLazy.Value(box);
+            CopyAbi = (object box, IntPtr dest) => CopyAbiLazy.Value(box, dest);
+            FromManaged = (T value) => FromManagedLazy.Value(value);
+            CopyManaged = (T value, IntPtr dest) => CopyManagedLazy.Value(value, dest);
+            DisposeMarshaler = (object objRef) => DisposeMarshalerLazy.Value(objRef);
+            DisposeAbi = (object box) => DisposeAbiLazy.Value(box);
+            CreateMarshalerArray = (T[] array) => CreateMarshalerArrayLazy.Value(array);
+            GetAbiArray = (object box) => GetAbiArrayLazy.Value(box);
+            FromAbiArray = (object box) => FromAbiArrayLazy.Value(box);
+            FromManagedArray = (T[] array) => FromManagedArrayLazy.Value(array);
+            DisposeMarshalerArray = (object box) => DisposeMarshalerArrayLazy.Value(box);
+            DisposeAbiArray = (object box) => DisposeAbiArrayLazy.Value(box);
         }
 
         public static readonly Func<T, object> CreateMarshaler;
+        private static readonly Lazy<Func<T, object>> CreateMarshalerLazy = new(BindCreateMarshaler);
         private static Func<T, object> BindCreateMarshaler()
         {
             var parms = new[] { Expression.Parameter(typeof(T), "arg") };
@@ -386,6 +387,7 @@ namespace WinRT
         }
 
         public static readonly Func<object, object> GetAbi;
+        private static readonly Lazy<Func<object, object>> GetAbiLazy = new(BindGetAbi);
         private static Func<object, object> BindGetAbi()
         {
             var parms = new[] { Expression.Parameter(typeof(object), "arg") };
@@ -396,6 +398,7 @@ namespace WinRT
         }
 
         public static readonly Action<object, IntPtr> CopyAbi;
+        private static readonly Lazy<Action<object, IntPtr>> CopyAbiLazy = new(BindCopyAbi);
         private static Action<object, IntPtr> BindCopyAbi()
         {
             var copyAbi = HelperType.GetMethod("CopyAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -407,6 +410,7 @@ namespace WinRT
         }
 
         public static readonly Func<object, T> FromAbi;
+        private static readonly Lazy<Func<object, T>> FromAbiLazy = new(BindFromAbi);
         private static Func<object, T> BindFromAbi()
         {
             var parms = new[] { Expression.Parameter(typeof(object), "arg") };
@@ -416,6 +420,7 @@ namespace WinRT
         }
 
         public static readonly Func<T, object> FromManaged;
+        private static readonly Lazy<Func<T, object>> FromManagedLazy = new(BindFromManaged);
         private static Func<T, object> BindFromManaged()
         {
             var parms = new[] { Expression.Parameter(typeof(T), "arg") };
@@ -425,6 +430,7 @@ namespace WinRT
         }
 
         public static readonly Action<T, IntPtr> CopyManaged;
+        private static readonly Lazy<Action<T, IntPtr>> CopyManagedLazy = new(BindCopyManaged);
         private static Action<T, IntPtr> BindCopyManaged()
         {
             var copyManaged = HelperType.GetMethod("CopyManaged", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -435,6 +441,7 @@ namespace WinRT
         }
 
         public static readonly Action<object> DisposeMarshaler;
+        private static readonly Lazy<Action<object>> DisposeMarshalerLazy = new(BindDisposeMarshaler);
         private static Action<object> BindDisposeMarshaler()
         {
             var parms = new[] { Expression.Parameter(typeof(object), "arg") };
@@ -444,6 +451,7 @@ namespace WinRT
         }
 
         internal static readonly Action<object> DisposeAbi;
+        private static readonly Lazy<Action<object>> DisposeAbiLazy = new(BindDisposeAbi);
         private static Action<object> BindDisposeAbi()
         {
             var disposeAbi = HelperType.GetMethod("DisposeAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -454,6 +462,7 @@ namespace WinRT
         }
 
         internal static readonly Func<T[], object> CreateMarshalerArray;
+        private static readonly Lazy<Func<T[], object>> CreateMarshalerArrayLazy = new(BindCreateMarshalerArray);
         private static Func<T[], object> BindCreateMarshalerArray()
         {
             var createMarshalerArray = HelperType.GetMethod("CreateMarshalerArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -464,6 +473,7 @@ namespace WinRT
         }
 
         internal static readonly Func<object, (int, IntPtr)> GetAbiArray;
+        private static readonly Lazy<Func<object, (int, IntPtr)>> GetAbiArrayLazy = new(BindGetAbiArray);
         private static Func<object, (int, IntPtr)> BindGetAbiArray()
         {
             var getAbiArray = HelperType.GetMethod("GetAbiArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -474,6 +484,7 @@ namespace WinRT
         }
 
         internal static readonly Func<object, T[]> FromAbiArray;
+        private static readonly Lazy<Func<object, T[]>> FromAbiArrayLazy = new(BindFromAbiArray);
         private static Func<object, T[]> BindFromAbiArray()
         {
             var fromAbiArray = HelperType.GetMethod("FromAbiArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -484,6 +495,7 @@ namespace WinRT
         }
 
         internal static readonly Func<T[], (int, IntPtr)> FromManagedArray;
+        private static readonly Lazy<Func<T[], (int, IntPtr)>> FromManagedArrayLazy = new(BindFromManagedArray);
         private static Func<T[], (int, IntPtr)> BindFromManagedArray()
         {
             var fromManagedArray = HelperType.GetMethod("FromManagedArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -494,6 +506,7 @@ namespace WinRT
         }
 
         internal static readonly Action<object> DisposeMarshalerArray;
+        private static readonly Lazy<Action<object>> DisposeMarshalerArrayLazy = new(BindDisposeMarshalerArray);
         private static Action<object> BindDisposeMarshalerArray()
         {
             var disposeMarshalerArray = HelperType.GetMethod("DisposeMarshalerArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -504,6 +517,7 @@ namespace WinRT
         }
 
         internal static readonly Action<object> DisposeAbiArray;
+        private static readonly Lazy<Action<object>> DisposeAbiArrayLazy = new(BindDisposeAbiArray);
         private static Action<object> BindDisposeAbiArray()
         {
             var disposeAbiArray = HelperType.GetMethod("DisposeAbiArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -519,7 +533,7 @@ namespace WinRT
                 (value is null) ? IntPtr.Zero : ((IObjectReference) CreateMarshaler(value)).GetRef();
         }
 
-        internal static unsafe void CopyManagedArray(T[] array, IntPtr data) => MarshalInterfaceHelper<T>.CopyManagedArray(array, data, CopyManaged ?? CopyManagedFallback);
+        internal static unsafe void CopyManagedArray(T[] array, IntPtr data) => MarshalInterfaceHelper<T>.CopyManagedArray(array, data, CopyManagedLazy.Value ?? CopyManagedFallback);
     }
 
     public class MarshalNonBlittable<T> : MarshalGeneric<T>
@@ -1186,10 +1200,10 @@ namespace WinRT
                 CopyManaged = MarshalGeneric<T>.CopyManaged;
                 DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
                 DisposeAbi = MarshalGeneric<T>.DisposeAbi;
-                CreateMarshalerArray = (T[] array) => MarshalGeneric<T>.CreateMarshalerArray(array);
-                GetAbiArray = (object box) => MarshalGeneric<T>.GetAbiArray(box);
-                FromAbiArray = (object box) => MarshalGeneric<T>.FromAbiArray(box);
-                FromManagedArray = (T[] array) => MarshalGeneric<T>.FromManagedArray(array);
+                CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
+                GetAbiArray = MarshalGeneric<T>.GetAbiArray;
+                FromAbiArray = MarshalGeneric<T>.FromAbiArray;
+                FromManagedArray = MarshalGeneric<T>.FromManagedArray;
                 CopyManagedArray = (T[] array, IntPtr data) => MarshalGeneric<T>.CopyManagedArray(array, data);
                 DisposeMarshalerArray = (object box) => MarshalInterface<T>.DisposeMarshalerArray(box);
                 DisposeAbiArray = (object box) => MarshalInterface<T>.DisposeAbiArray(box);
@@ -1304,13 +1318,13 @@ namespace WinRT
                 CopyManaged = MarshalGeneric<T>.CopyManaged;
                 DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
                 DisposeAbi = MarshalGeneric<T>.DisposeAbi;
-                CreateMarshalerArray = (T[] array) => MarshalGeneric<T>.CreateMarshalerArray(array);
-                GetAbiArray = (object box) => MarshalGeneric<T>.GetAbiArray(box);
-                FromAbiArray = (object box) => MarshalGeneric<T>.FromAbiArray(box);
-                FromManagedArray = (T[] array) => MarshalGeneric<T>.FromManagedArray(array);
+                CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
+                GetAbiArray = MarshalGeneric<T>.GetAbiArray;
+                FromAbiArray = MarshalGeneric<T>.FromAbiArray;
+                FromManagedArray = MarshalGeneric<T>.FromManagedArray;
                 CopyManagedArray = (T[] array, IntPtr data) => MarshalGeneric<T>.CopyManagedArray(array, data);
-                DisposeMarshalerArray = (object box) => MarshalGeneric<T>.DisposeMarshalerArray(box);
-                DisposeAbiArray = (object box) => MarshalGeneric<T>.DisposeAbiArray(box);
+                DisposeMarshalerArray = MarshalGeneric<T>.DisposeMarshalerArray;
+                DisposeAbiArray = MarshalGeneric<T>.DisposeAbiArray;
             }
             RefAbiType = AbiType.MakeByRefType();
         }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -894,8 +894,10 @@ namespace WinRT
         public static void DisposeAbi(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero) return;
-            // TODO: this should be a direct v-table call when function pointers are a thing
-            ObjectReference<WinRT.Interop.IUnknownVftbl>.Attach(ref ptr).Dispose();
+            unsafe
+            {
+                (**(IUnknownVftbl**)ptr).Release(ptr);
+            }
         }
     }
 

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1023,8 +1023,7 @@ namespace WinRT
 
         private static Func<IObjectReference, IObjectReference> BindAs()
         {
-            var helperType = typeof(T).GetHelperType();
-            var vftblType = helperType.FindVftblType();
+            var vftblType = HelperType.FindVftblType();
             if (vftblType is not null)
             {
                 var parms = new[] { Expression.Parameter(typeof(IObjectReference), "arg") };
@@ -1036,7 +1035,7 @@ namespace WinRT
             }
             else
             {
-                Guid iid = GuidGenerator.GetIID(helperType);
+                Guid iid = GuidGenerator.GetIID(HelperType);
                 return obj => obj.As<IUnknownVftbl>(iid);
             }
         }

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -132,7 +132,7 @@ namespace ABI.System.ComponentModel
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature()
         {

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -66,8 +66,10 @@ namespace ABI.System
 #if !NETSTANDARD2_0
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
-            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
 #endif
 
             public void Invoke(object sender, T args)
@@ -178,8 +180,10 @@ namespace ABI.System
 #if !NETSTANDARD2_0
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
-            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
 #endif
 
             public unsafe void Invoke(object sender, EventArgs args)

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -100,7 +100,7 @@ namespace ABI.Windows.Foundation
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IReferenceArray<T>));
 

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -100,7 +100,7 @@ namespace ABI.Windows.Foundation
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IReferenceArray<T>));
 

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -232,7 +232,7 @@ namespace ABI.System.Collections.Specialized
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature()
         {

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -67,8 +67,10 @@ namespace ABI.System.Collections.Specialized
 #if !NETSTANDARD2_0
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
-            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
 #endif
 
             public unsafe void Invoke(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -95,7 +95,7 @@ namespace ABI.System
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(Nullable<T>));
 

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -133,7 +133,7 @@ namespace ABI.System.ComponentModel
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature()
         {

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -66,8 +66,10 @@ namespace ABI.System.ComponentModel
 #if !NETSTANDARD2_0
             IObjectReference IWinRTObject.NativeObject => _nativeDelegate;
             bool IWinRTObject.HasUnwrappableNativeObject => true;
-            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+            ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+            private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+            ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
 #endif
 
             public unsafe void Invoke(object sender, global::System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -141,7 +141,7 @@ namespace ABI.System
         }
 
         public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
-        public static void DisposeAbi(IntPtr abi) { using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref abi); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
 
         public static string GetGuidSignature()
         {

--- a/src/WinRT.Runtime/SingleInterfaceOptimizedObject.net5.cs
+++ b/src/WinRT.Runtime/SingleInterfaceOptimizedObject.net5.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 using WinRT.Interop;
 
 namespace WinRT
@@ -30,8 +28,10 @@ namespace WinRT
         IObjectReference IWinRTObject.NativeObject => _obj;
         bool IWinRTObject.HasUnwrappableNativeObject => false;
 
-        ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache { get; } = new();
-        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData { get; } = new();
+        private Lazy<ConcurrentDictionary<RuntimeTypeHandle, IObjectReference>> _lazyQueryInterfaceCache = new();
+        ConcurrentDictionary<RuntimeTypeHandle, IObjectReference> IWinRTObject.QueryInterfaceCache => _lazyQueryInterfaceCache.Value;
+        private Lazy<ConcurrentDictionary<RuntimeTypeHandle, object>> _lazyAdditionalTypeData = new();
+        ConcurrentDictionary<RuntimeTypeHandle, object> IWinRTObject.AdditionalTypeData => _lazyAdditionalTypeData.Value;
 
         bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
         {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1656,10 +1656,7 @@ remove => %.% -= value;
                 cache_type_name);
         auto cache_interface =
             w.write_temp(
-                R"((new BaseActivationFactory("%", "%.%"))._As<%>)",
-                class_type.TypeNamespace(),
-                class_type.TypeNamespace(),
-                class_type.TypeName(),
+                R"(_factory._As<%>)",
                 cache_vftbl_type);
             w.write(R"(
 internal class _% : ABI.%.%
@@ -1686,7 +1683,7 @@ internal class _% : IWinRTObject
 private IObjectReference _obj;
 public _%()
 {
-_obj = (new BaseActivationFactory("%", "%.%"))._As(GuidGenerator.GetIID(typeof(%.%).GetHelperType()));
+_obj = _factory._As(GuidGenerator.GetIID(typeof(%.%).GetHelperType()));
 }
 
 %
@@ -1702,9 +1699,6 @@ global::System.Collections.Concurrent.ConcurrentDictionary<global::System.Runtim
 )",
                 cache_type_name,
                 cache_type_name,
-                class_type.TypeNamespace(),
-                class_type.TypeNamespace(),
-                class_type.TypeName(),
                 class_type.TypeNamespace(),
                 cache_type_name,
                 instance,

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -176,8 +176,15 @@ namespace WinRT
         {
             IntPtr instancePtr;
             var hstrRuntimeClassId = MarshalString.CreateMarshaler(runtimeClassId);
-            int hr = _GetActivationFactory(MarshalString.GetAbi(hstrRuntimeClassId), out instancePtr);
-            return (hr == 0 ? ObjectReference<IActivationFactoryVftbl>.Attach(ref instancePtr) : null, hr);
+            try
+            {
+                int hr = _GetActivationFactory(MarshalString.GetAbi(hstrRuntimeClassId), out instancePtr);
+                return (hr == 0 ? ObjectReference<IActivationFactoryVftbl>.Attach(ref instancePtr) : null, hr);
+            }
+            finally
+            {
+                hstrRuntimeClassId.Dispose();
+            }
         }
 
         ~DllModule()


### PR DESCRIPTION
This PR makes several changes to improve the perf of CsWinRT projections based on what is seen in profiling:

- Avoid constructing an ObjectReference when doing a release
- Make all the MarshalGeneric reflection lambdas lazy as we do not use all the helper types in every scenario but rather a couple in most cases.  This reduces JIT cost too.
- Make all the concurrent dictionaries used as part of IDIC support lazy initialized as we don't use the caches in all scenarios and we are seeing a large # of empty ones on the finalizer.
-  Fix issue where activation factories were initialized multiple times for factory and statics when we needed only one instance
- Remove creating lazy interface dictionary when there are no members and setting size in constructor

Fixes #987 
Fixes #988 
Fixes #825 
Fixes #1000 