### PR TITLE
Improve the performance of invoking events

### DIFF
--- a/src/Benchmarks/EventPerf.cs
+++ b/src/Benchmarks/EventPerf.cs
@@ -103,20 +103,5 @@ namespace Benchmarks
             return instance;
             GC.KeepAlive(s);
         }
-
-//        [Benchmark]
-        public void AddIntEvent()
-        {
-            int z;
-            instance.IntPropertyChanged += (object sender, int value) => z = value;
-        }
-
-//        [Benchmark]
-        public void AddAndInvokeIntEvent()
-        {
-            int z;
-            instance.IntPropertyChanged += (object sender, int value) => z = value;
-            instance.RaiseIntChanged();
-        }
     }
 }

--- a/src/Benchmarks/EventPerf.cs
+++ b/src/Benchmarks/EventPerf.cs
@@ -1,0 +1,122 @@
+﻿using BenchmarkComponent;
+using BenchmarkDotNet.Attributes;
+using System;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    public class EventPerf
+    {
+        ClassWithMarshalingRoutines instance;
+        int z2;
+        ClassWithMarshalingRoutines instance2;
+        int z4;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            instance = new ClassWithMarshalingRoutines();
+            System.EventHandler<int> s = (object sender, int value) => z2 = value;
+            instance.IntPropertyChanged += s;
+
+            instance2 = new ClassWithMarshalingRoutines();
+            System.EventHandler<int> s2 = (object sender, int value) =>
+            {
+                if (sender == this)
+                    z4 = value;
+                else
+                    z4 = value * 3;
+            };
+            instance2.IntPropertyChanged += s2;
+        }
+
+        [Benchmark]
+        public object IntEventOverhead()
+        {
+            ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
+            int z;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            return instance;
+            GC.KeepAlive(s);
+        }
+
+        [Benchmark]
+        public object AddIntEventToNewEventSource()
+        {
+            ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
+            int z;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            instance.IntPropertyChanged += s;
+            return instance;
+            GC.KeepAlive(s);
+        }
+
+        [Benchmark]
+        public object AddMultipleEventsToNewEventSource()
+        {
+            ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
+            int z;
+            double y;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            instance.IntPropertyChanged += s;
+            System.EventHandler<double> t = (object sender, double value) => y = value;
+            instance.DoublePropertyChanged += t;
+            return instance;
+            GC.KeepAlive(s);
+            GC.KeepAlive(t);
+        }
+
+        [Benchmark]
+        public object AddAndInvokeIntEventOnNewEventSource()
+        {
+            ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
+            int z;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            instance.IntPropertyChanged += s;
+            instance.RaiseIntChanged();
+            return instance;
+            GC.KeepAlive(s);
+        }
+
+        [Benchmark]
+        public int InvokeIntEvent()
+        {
+            instance.RaiseIntChanged();
+            return z2;
+        }
+
+        [Benchmark]
+        public int InvokeIntEventWithSenderCheck()
+        {
+            instance2.RaiseIntChanged();
+            return z4;
+        }
+
+        [Benchmark]
+        public object AddAndRemoveIntEventOnNewEventSource()
+        {
+            ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
+            int z;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            instance.IntPropertyChanged += s;
+            instance.IntPropertyChanged -= s;
+            return instance;
+            GC.KeepAlive(s);
+        }
+
+//        [Benchmark]
+        public void AddIntEvent()
+        {
+            int z;
+            instance.IntPropertyChanged += (object sender, int value) => z = value;
+        }
+
+//        [Benchmark]
+        public void AddAndInvokeIntEvent()
+        {
+            int z;
+            instance.IntPropertyChanged += (object sender, int value) => z = value;
+            instance.RaiseIntChanged();
+        }
+    }
+}

--- a/src/Benchmarks/EventPerf.cs
+++ b/src/Benchmarks/EventPerf.cs
@@ -48,7 +48,6 @@ namespace Benchmarks
             System.EventHandler<int> s = (object sender, int value) => z = value;
             instance.IntPropertyChanged += s;
             return instance;
-            GC.KeepAlive(s);
         }
 
         [Benchmark]
@@ -62,8 +61,6 @@ namespace Benchmarks
             System.EventHandler<double> t = (object sender, double value) => y = value;
             instance.DoublePropertyChanged += t;
             return instance;
-            GC.KeepAlive(s);
-            GC.KeepAlive(t);
         }
 
         [Benchmark]
@@ -75,7 +72,6 @@ namespace Benchmarks
             instance.IntPropertyChanged += s;
             instance.RaiseIntChanged();
             return instance;
-            GC.KeepAlive(s);
         }
 
         [Benchmark]

--- a/src/Benchmarks/QueryInterface.cs
+++ b/src/Benchmarks/QueryInterface.cs
@@ -75,5 +75,11 @@ namespace Benchmarks
             ClassWithMultipleInterfaces instance2 = new ClassWithMultipleInterfaces();
             return instance2.IntProperty;
         }
+
+        [Benchmark]
+        public int StaticPropertyCall()
+        {
+            return Windows.System.Power.PowerManager.RemainingChargePercent;
+        }
     }
 }

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -172,6 +172,20 @@ namespace WinRT
             return ObjectReference<IUnknownVftbl>.Attach(ref ccw);
         }
 
+        internal static ObjectReference<T> CreateCCWForObject<T>(object obj, Guid iid)
+        {
+            IntPtr ccw = ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.TrackerSupport);
+            try
+            {
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(ccw, ref iid, out var iidCcw));
+                return ObjectReference<T>.Attach(ref iidCcw);
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeAbi(ccw);
+            }
+        }
+
         public static unsafe T FindObject<T>(IntPtr ptr)
             where T : class => ComInterfaceDispatch.GetInstance<T>((ComInterfaceDispatch*)ptr);
 

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -162,6 +162,14 @@ namespace WinRT
             return objRef;
         }
 
+        internal static ObjectReference<T> CreateCCWForObject<T>(object obj, Guid iid)
+        {
+            var wrapper = ComWrapperCache.GetValue(obj, _ => new ComCallableWrapper(obj));
+            Marshal.ThrowExceptionForHR(Marshal.QueryInterface(wrapper.IdentityPtr, ref iid, out var iidCcw));
+            GC.KeepAlive(wrapper); // This GC.KeepAlive ensures that a newly created wrapper is alive until objRef is created and has AddRef'd the CCW.
+            return ObjectReference<T>.Attach(ref iidCcw);
+        }
+
         public static T FindObject<T>(IntPtr thisPtr)
             where T : class =>
             (T)UnmanagedObject.FindObject<ComCallableWrapper>(thisPtr).ManagedObject;

--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -25,6 +25,7 @@ namespace WinRT.Interop
 
         internal static readonly Guid IID = new(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
 
+        // Avoids boxing when using default Equals.
         internal bool Equals(IUnknownVftbl other)
         {
             return _QueryInterface == other._QueryInterface && _AddRef == other._AddRef && _Release == other._Release;

--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -24,5 +24,15 @@ namespace WinRT.Interop
         public static IntPtr AbiToProjectionVftblPtr => ComWrappersSupport.IUnknownVftblPtr;
 
         internal static readonly Guid IID = new(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+
+        internal bool Equals(IUnknownVftbl other)
+        {
+            return _QueryInterface == other._QueryInterface && _AddRef == other._AddRef && _Release == other._Release;
+        }
+
+        internal unsafe static bool IsReferenceToManagedObject(IntPtr ptr)
+        {
+            return (**(IUnknownVftbl**)ptr).Equals(AbiToProjectionVftbl);
+        }
     }
 }

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -44,10 +44,7 @@ namespace WinRT.Interop
                 return null;
             }
 
-            using (IObjectReference objReference = ComWrappersSupport.CreateCCWForObject(target))
-            {
-                return objReference.As(riid);
-            }
+            return ComWrappersSupport.CreateCCWForObject<IUnknownVftbl>(target, riid);
         }
     }
 }

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
@@ -44,10 +44,7 @@ namespace WinRT.Interop
                 return null;
             }
 
-            using (IObjectReference objReference = ComWrappersSupport.CreateCCWForObject(target))
-            {
-                return objReference.As(riid);
-            }
+            return ComWrappersSupport.CreateCCWForObject<IUnknownVftbl>(target, riid);
         }
     }
 }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1173,20 +1173,13 @@ namespace WinRT
             {
                 return default;
             }
-            using var objRef = ObjectReference<IUnknownVftbl>.FromAbi(ptr);
-            using var unknownObjRef = objRef.As<IUnknownVftbl>(IUnknownVftbl.IID);
+
+            Guid iid_iunknown = IUnknownVftbl.IID;
+            Marshal.QueryInterface(ptr, ref iid_iunknown, out var iunknownPtr);
+            using var unknownObjRef = ObjectReference<IUnknownVftbl>.Attach(ref iunknownPtr);
             if (unknownObjRef.IsReferenceToManagedObject)
             {
                 return (T) ComWrappersSupport.FindObject<object>(unknownObjRef.ThisPtr);
-            }
-            else if (Projections.TryGetMarshalerTypeForProjectedRuntimeClass<T>(objRef, out Type type))
-            {
-                var fromAbiMethod = type.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-                if (fromAbiMethod is null)
-                {
-                    throw new MissingMethodException();
-                }
-                return (T) fromAbiMethod.Invoke(null, new object[] { ptr });
             }
             else
             {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1150,7 +1150,7 @@ namespace WinRT
             }
             var publicType = o.GetType();
             Type helperType = Projections.FindCustomHelperTypeMapping(publicType, true);
-            if(helperType != null)
+            if (helperType != null)
             {
                 var parms = new[] { Expression.Parameter(typeof(object), "arg") };
                 var createMarshaler = Expression.Lambda<Func<object, IObjectReference>>(
@@ -1158,10 +1158,8 @@ namespace WinRT
                         new[] { Expression.Convert(parms[0], publicType) }), parms).Compile();
                 return createMarshaler(o);
             }
-            using (var ccw = ComWrappersSupport.CreateCCWForObject(o))
-            {
-                return ccw.As<IInspectable.Vftbl>(IInspectable.IID);
-            }
+
+            return ComWrappersSupport.CreateCCWForObject<IInspectable.Vftbl>(o, IInspectable.IID);
         }
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
@@ -1251,10 +1249,8 @@ namespace WinRT
             {
                 return objRef.As<global::WinRT.Interop.IDelegateVftbl>(delegateIID);
             }
-            using (var ccw = ComWrappersSupport.CreateCCWForObject(o))
-            {
-                return ccw.As<global::WinRT.Interop.IDelegateVftbl>(delegateIID);
-            }
+
+            return ComWrappersSupport.CreateCCWForObject<global::WinRT.Interop.IDelegateVftbl>(o, delegateIID);
         }
     }
 

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -123,10 +123,15 @@ namespace ABI.System
         {
             try
             {
+#if NET
+                var invoke = ComWrappersSupport.FindObject<global::System.EventHandler<T>>(new IntPtr(thisPtr));
+                invoke.Invoke(MarshalInspectable<object>.FromAbi(sender), Marshaler<T>.FromAbi(args));
+#else
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(new IntPtr(thisPtr), (global::System.EventHandler<T> invoke) =>
                 {
                     invoke.Invoke(MarshalInspectable<object>.FromAbi(sender), Marshaler<T>.FromAbi(args));
                 });
+#endif
             }
             catch (global::System.Exception __exception__)
             {
@@ -254,12 +259,19 @@ namespace ABI.System
         {
             try
             {
+#if NET
+                var invoke = ComWrappersSupport.FindObject<global::System.EventHandler>(thisPtr);
+                invoke.Invoke(
+                    MarshalInspectable<object>.FromAbi(sender),
+                    MarshalInspectable<object>.FromAbi(args) as EventArgs ?? EventArgs.Empty);
+#else
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.EventHandler invoke) =>
                 {
                     invoke.Invoke(
                         MarshalInspectable<object>.FromAbi(sender),
                         MarshalInspectable<object>.FromAbi(args) as EventArgs ?? EventArgs.Empty);
                 });
+#endif
             }
             catch (global::System.Exception __exception__)
             {

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -123,9 +123,9 @@ namespace ABI.System
         {
             try
             {
-                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(new IntPtr(thisPtr), (global::System.Delegate invoke) =>
+                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(new IntPtr(thisPtr), (global::System.EventHandler<T> invoke) =>
                 {
-                    invoke.DynamicInvoke(MarshalInspectable<object>.FromAbi(sender), Marshaler<T>.FromAbi(args));
+                    invoke.Invoke(MarshalInspectable<object>.FromAbi(sender), Marshaler<T>.FromAbi(args));
                 });
             }
             catch (global::System.Exception __exception__)
@@ -254,9 +254,9 @@ namespace ABI.System
         {
             try
             {
-                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Delegate invoke) =>
+                global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.EventHandler invoke) =>
                 {
-                    invoke.DynamicInvoke(
+                    invoke.Invoke(
                         MarshalInspectable<object>.FromAbi(sender),
                         MarshalInspectable<object>.FromAbi(args) as EventArgs ?? EventArgs.Empty);
                 });

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -39,7 +39,7 @@ namespace ABI.System.Collections.Generic
     interface IDictionary<K, V> : global::System.Collections.Generic.IDictionary<K, V>, global::Windows.Foundation.Collections.IMap<K, V>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IDictionary<K, V> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IDictionary<K, V>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IDictionary<K, V>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -41,7 +41,7 @@ namespace ABI.System.Collections.Generic
     class IDictionary<K, V> : global::System.Collections.Generic.IDictionary<K, V>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IDictionary<K, V> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IDictionary<K, V>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IDictionary<K, V>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -53,7 +53,7 @@ namespace ABI.System.Collections.Generic
     interface IEnumerable<T> : global::System.Collections.Generic.IEnumerable<T>, global::Windows.Foundation.Collections.IIterable<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IEnumerable<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IEnumerable<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IEnumerable<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;
@@ -202,7 +202,7 @@ namespace ABI.System.Collections.Generic
     class IEnumerator<T> : global::System.Collections.Generic.IEnumerator<T>, global::Windows.Foundation.Collections.IIterator<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IEnumerator<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IEnumerator<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IEnumerator<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -47,7 +47,7 @@ namespace ABI.System.Collections.Generic
     class IEnumerable<T> : global::System.Collections.Generic.IEnumerable<T>, global::Windows.Foundation.Collections.IIterable<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IEnumerable<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IEnumerable<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IEnumerable<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;
@@ -212,7 +212,7 @@ namespace ABI.System.Collections.Generic
     class IEnumerator<T> : global::System.Collections.Generic.IEnumerator<T>, global::Windows.Foundation.Collections.IIterator<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IEnumerator<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IEnumerator<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IEnumerator<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -43,7 +43,7 @@ namespace ABI.System.Collections.Generic
     interface IList<T> : global::System.Collections.Generic.IList<T>, global::Windows.Foundation.Collections.IVector<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IList<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IList<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IList<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -50,7 +50,7 @@ namespace ABI.System.Collections.Generic
     class IList<T> : global::System.Collections.Generic.IList<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IList<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IList<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IList<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -35,7 +35,7 @@ namespace ABI.System.Collections.Generic
     interface IReadOnlyDictionary<K, V> : global::System.Collections.Generic.IReadOnlyDictionary<K, V>, global::Windows.Foundation.Collections.IMapView<K, V>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IReadOnlyDictionary<K, V> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IReadOnlyDictionary<K, V>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IReadOnlyDictionary<K, V>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -41,7 +41,7 @@ namespace ABI.System.Collections.Generic
     class IReadOnlyDictionary<K, V> : global::System.Collections.Generic.IReadOnlyDictionary<K, V>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IReadOnlyDictionary<K, V> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IReadOnlyDictionary<K, V>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IReadOnlyDictionary<K, V>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -34,7 +34,7 @@ namespace ABI.System.Collections.Generic
     interface IReadOnlyList<T> : global::System.Collections.Generic.IReadOnlyList<T>, global::Windows.Foundation.Collections.IVectorView<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IReadOnlyList<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IReadOnlyList<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IReadOnlyList<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -38,7 +38,7 @@ namespace ABI.System.Collections.Generic
     class IReadOnlyList<T> : global::System.Collections.Generic.IReadOnlyList<T>
     {
         public static IObjectReference CreateMarshaler(global::System.Collections.Generic.IReadOnlyList<T> obj) =>
-            obj is null ? null : ComWrappersSupport.CreateCCWForObject(obj).As<Vftbl>(GuidGenerator.GetIID(typeof(IReadOnlyList<T>)));
+            obj is null ? null : ComWrappersSupport.CreateCCWForObject<Vftbl>(obj, GuidGenerator.GetIID(typeof(IReadOnlyList<T>)));
 
         public static IntPtr GetAbi(IObjectReference objRef) =>
             objRef?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -64,11 +64,7 @@ namespace ABI.Windows.Foundation
     {
         public static IObjectReference CreateMarshaler(object value)
         {
-            if (value is null)
-            {
-                return null;
-            }
-            return ComWrappersSupport.CreateCCWForObject(value).As(PIID);
+            return value is null ? null : ComWrappersSupport.CreateCCWForObject<IUnknownVftbl>(value, PIID);
         }
 
         public static IntPtr GetAbi(IObjectReference m) => m?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -68,7 +68,7 @@ namespace ABI.Windows.Foundation
             {
                 return null;
             }
-            return ComWrappersSupport.CreateCCWForObject(value).As(PIID);
+            return ComWrappersSupport.CreateCCWForObject<IUnknownVftbl>(value, PIID);
         }
 
         public static IntPtr GetAbi(IObjectReference m) => m?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -128,10 +128,15 @@ namespace ABI.System.Collections.Specialized
         {
             try
             {
+#if NET
+                var invoke = ComWrappersSupport.FindObject<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(thisPtr);
+                invoke.Invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.FromAbi(e));
+#else
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler invoke) =>
                 {
                     invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.FromAbi(e));
                 });
+#endif
             }
             catch (global::System.Exception __exception__)
             {

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -64,11 +64,7 @@ namespace ABI.System
     {
         public static IObjectReference CreateMarshaler(object value)
         {
-            if (value is null)
-            {
-                return null;
-            }
-            return ComWrappersSupport.CreateCCWForObject(value).As(PIID);
+            return value is null ? null : ComWrappersSupport.CreateCCWForObject<IUnknownVftbl>(value, PIID);
         }
 
         public static IntPtr GetAbi(IObjectReference m) => m?.ThisPtr ?? IntPtr.Zero;

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -127,10 +127,15 @@ namespace ABI.System.ComponentModel
         {
             try
             {
+#if NET
+                var invoke = ComWrappersSupport.FindObject<global::System.ComponentModel.PropertyChangedEventHandler>(thisPtr);
+                invoke.Invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.FromAbi(e));
+#else
                 global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(thisPtr, (global::System.ComponentModel.PropertyChangedEventHandler invoke) =>
                 {
                     invoke(MarshalInspectable<object>.FromAbi(sender), global::ABI.System.ComponentModel.PropertyChangedEventArgs.FromAbi(e));
                 });
+#endif
             }
             catch (global::System.Exception __exception__)
             {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6567,7 +6567,8 @@ global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(%, (% invoke) =>
 global::WinRT.ComWrappersSupport.FindObject<%>(%).Invoke(%)
 )",
                             type_name,
-                            is_generic ? "new IntPtr(thisPtr)" : "thisPtr"
+                            is_generic ? "new IntPtr(thisPtr)" : "thisPtr",
+                            "%"
                         ));
                 }
             });

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6536,25 +6536,41 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
                 }
                 w.write(")");
             },
-            bind<write_managed_method_call>(signature,
-                w.write_temp(R"(global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(%, (% invoke) =>
+            [&](writer& w) {
+                if (settings.netstandard_compat)
+                {
+                    write_managed_method_call(w, signature,
+                        w.write_temp(R"(
+global::WinRT.ComWrappersSupport.MarshalDelegateInvoke(%, (% invoke) =>
 {
     %
 }))",
-                    is_generic ? "new IntPtr(thisPtr)" : "thisPtr",
-                    type_name,
-                    bind([&](writer& w)
-                    {
-                        if (signature.return_signature())
-                        {
-                            w.write("return invoke(%);", "%");
-                        }
-                        else
-                        {
-                            w.write("invoke(%);");
-                        }
-                    })
-        )));
+                            is_generic ? "new IntPtr(thisPtr)" : "thisPtr",
+                            type_name,
+                            bind([&](writer& w)
+                            {
+                                if (signature.return_signature())
+                                {
+                                    w.write("return invoke(%);", "%");
+                                }
+                                else
+                                {
+                                    w.write("invoke(%);");
+                                }
+                            })
+                        ));
+                }
+                else
+                {
+                    write_managed_method_call(w, signature,
+                        w.write_temp(R"(
+global::WinRT.ComWrappersSupport.FindObject<%>(%).Invoke(%)
+)",
+                            type_name,
+                            is_generic ? "new IntPtr(thisPtr)" : "thisPtr"
+                        ));
+                }
+            });
     }
 
     void write_constant(writer& w, Constant const& value)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6542,14 +6542,10 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
     %
 }))",
                     is_generic ? "new IntPtr(thisPtr)" : "thisPtr",
-                    is_generic ? "global::System.Delegate" : type_name,
+                    type_name,
                     bind([&](writer& w)
                     {
-                        if (is_generic)
-                        {
-                            w.write(R"(invoke.DynamicInvoke(%);)", "%");
-                        }
-                        else if (signature.return_signature())
+                        if (signature.return_signature())
                         {
                             w.write("return invoke(%);", "%");
                         }

--- a/src/get_testwinrt.cmd
+++ b/src/get_testwinrt.cmd
@@ -14,7 +14,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard 62c15ff0014e8c4e9e6a8bc2446909146337c685
+git reset -q --hard 26177a8cca2486acfd1c52cc2602dfab81e836a4
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 %this_dir%.nuget\nuget.exe restore


### PR DESCRIPTION
- Reduced the # of allocations on the event invoke code path.
- Move the custom type mapping logic in FromABI to CreateObject which allows for better caching of both the RCW for the ptr and the factory function used to create the RCW.
- Removed the use of Action via MarshalDelegateInvoke in the event invoke code path on .NET 5.
- Moved to using ThreadStatic rather than ThreadLocal for the variable which stores the RCW type as it looks to be more performant according to benchmarks.
- Avoid boxing when checking if it is a reference to a managed object and also avoid the need to create a IObjectReference to do so.
- Reduce the # of IObjectReferences created by creating a specialized version of CreateCCW which gives you the ObjectReference with the right vftbl and does a QI.
- Added a set of benchmarks that helped evaluate the improvements