### PR TITLE
GetObjectReferenceForInterface improvements

### DIFF
--- a/src/Benchmarks/Benchmarks.manifest
+++ b/src/Benchmarks/Benchmarks.manifest
@@ -11,6 +11,10 @@
         name="BenchmarkComponent.ClassWithMarshalingRoutines"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
+	<activatableClass
+		name="BenchmarkComponent.EventOperations"
+		threadingModel="both"
+		xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 
 </assembly>

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2335,8 +2335,9 @@ namespace UnitTest
 
             public void CallProxyObject()
             {
-                // Call to the proxy object after the apartment is gone should throw.
-                Assert.ThrowsAny<System.Exception>(() => proxyObject2.Commands);
+                // Call to a proxy object which we internally use an agile reference
+                // to resolve after the apartment is gone should throw.
+                Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands);
             }
 
             private Windows.UI.Popups.PopupMenu nonAgileObject, nonAgileObject2;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -2,6 +2,7 @@ Compat issues with assembly WinRT.Runtime:
 TypesMustExist : Type 'ABI.WinRT.Interop.IWeakReferenceSourceMethods' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Numerics.VectorExtensions' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.ComWrappersHelper' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ComWrappersSupport.GetObjectReferenceForInterface<T>(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Int32 WinRT.IObjectReference.TryAs(System.Guid, System.IntPtr)' does not exist in the reference but it does exist in the implementation.
@@ -12,4 +13,4 @@ MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi(WinRT
 TypesMustExist : Type 'WinRT.MarshalString.Pinnable' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-Total Issues: 13
+Total Issues: 15

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -50,7 +50,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface(nativeDelegate)?.As<IDelegateVftbl>(PIID);
+            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
             return abiDelegate is null ? null : (global::System.EventHandler<T>)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
         }
 
@@ -180,7 +180,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface(nativeDelegate)?.As<IDelegateVftbl>(GuidGenerator.GetIID(typeof(EventHandler)));
+            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
             return abiDelegate is null ? null : (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
         }
 

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -51,7 +51,7 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface(nativeDelegate)?.As<IDelegateVftbl>(GuidGenerator.GetIID(typeof(NotifyCollectionChangedEventHandler)));
+            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
             return abiDelegate is null ? null : (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
         }
 

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -50,7 +50,7 @@ namespace ABI.System.ComponentModel
 
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface(nativeDelegate)?.As<IDelegateVftbl>(GuidGenerator.GetIID(typeof(PropertyChangedEventHandler)));
+            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
             return abiDelegate is null ? null : (global::System.ComponentModel.PropertyChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
         }
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6321,7 +6321,7 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
-var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface(nativeDelegate)?.As<IDelegateVftbl>(GuidGenerator.GetIID(typeof(@%)));
+var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
 return abiDelegate is null ? null : (%)ComWrappersSupport.TryRegisterObjectForInterface(new %(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
 }
 
@@ -6456,8 +6456,6 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             type_name,
             // FromAbi
             type_name,
-            type.TypeName(),
-            type_params,
             type_name,
             type_name,
             // NativeDelegateWrapper.Invoke

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -170,8 +170,8 @@ namespace WinRT
                     int hr = _GetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId), &instancePtr);
                     if (hr == 0)
                     {
-                        using var objRef = ComWrappersSupport.GetObjectReferenceForInterface(instancePtr);
-                        return (objRef.As<IActivationFactoryVftbl>(), hr);
+                        var objRef = ComWrappersSupport.GetObjectReferenceForInterface<IActivationFactoryVftbl>(instancePtr);
+                        return (objRef, hr);
                     }
                     else
                     {
@@ -238,8 +238,8 @@ namespace WinRT
                     (instancePtr, hr) = GetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId));
                     if (hr == 0)
                     {
-                        using var objRef = ComWrappersSupport.GetObjectReferenceForInterface(instancePtr);
-                        return (objRef.As<IActivationFactoryVftbl>(), hr);
+                        var objRef = ComWrappersSupport.GetObjectReferenceForInterface<IActivationFactoryVftbl>(instancePtr);
+                        return (objRef, hr);
                     }
                     else
                     {
@@ -299,7 +299,7 @@ namespace WinRT
             Marshal.ThrowExceptionForHR(_IActivationFactory.Vftbl.ActivateInstance(_IActivationFactory.ThisPtr, &instancePtr));
             try
             {
-                return ComWrappersSupport.GetObjectReferenceForInterface(instancePtr).As<I>();
+                return ComWrappersSupport.GetObjectReferenceForInterface<I>(instancePtr);
             }
             finally
             {

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -338,82 +338,70 @@ namespace System
                 }
                 ctr.Dispose();
 
-                try
+                if (asyncStatus != AsyncStatus.Completed && asyncStatus != AsyncStatus.Canceled && asyncStatus != AsyncStatus.Error)
                 {
-                    if (asyncStatus != AsyncStatus.Completed && asyncStatus != AsyncStatus.Canceled && asyncStatus != AsyncStatus.Error)
-                    {
-                        Debug.Fail("The async operation should be in a terminal state.");
-                        throw new InvalidOperationException("The asynchronous operation could not be completed.");
-                    }
-
-                    TResult result = default(TResult);
-                    Exception error = null;
-                    if (asyncStatus == AsyncStatus.Error)
-                    {
-                        error = asyncInfo.ErrorCode;
-
-                        // Defend against a faulty IAsyncInfo implementation
-                        if (error is null)
-                        {
-                            Debug.Fail("IAsyncInfo.Status == Error, but ErrorCode returns a null Exception (implying S_OK).");
-                            error = new InvalidOperationException("The asynchronous operation could not be completed.");
-                        }
-                    }
-                    else if (asyncStatus == AsyncStatus.Completed && getResultsFunction != null)
-                    {
-                        try
-                        {
-                            result = getResultsFunction(asyncInfo);
-                        }
-                        catch (Exception resultsEx)
-                        {
-                            // According to the WinRT team, this can happen in some egde cases, such as marshalling errors in GetResults.
-                            error = resultsEx;
-                            asyncStatus = AsyncStatus.Error;
-                        }
-                    }
-
-                    // Complete the task based on the previously retrieved results:
-                    bool success = false;
-                    switch (asyncStatus)
-                    {
-                        case AsyncStatus.Completed:
-                            // TODO: AsyncCausality?
-                            success = base.TrySetResult(result);
-                            break;
-
-                        case AsyncStatus.Error:
-                            Debug.Assert(error != null, "The error should have been retrieved previously.");
-                            success = base.TrySetException(error);
-                            break;
-
-                        case AsyncStatus.Canceled:
-                            success = base.TrySetCanceled(_ct.IsCancellationRequested ? _ct : new CancellationToken(true));
-                            break;
-                    }
-
-                    Debug.Assert(success, "Expected the outcome to be successfully transfered to the task.");
+                    Debug.Fail("The async operation should be in a terminal state.");
+                    throw new InvalidOperationException("The asynchronous operation could not be completed.");
                 }
-                catch (Exception exc)
+
+                TResult result = default(TResult);
+                Exception error = null;
+                if (asyncStatus == AsyncStatus.Error)
                 {
-                    Debug.Fail($"Unexpected exception in Complete: {exc}");
+                    error = asyncInfo.ErrorCode;
 
-                    // TODO: AsyncCausality
-
-                    if (!base.TrySetException(exc))
+                    // Defend against a faulty IAsyncInfo implementation
+                    if (error is null)
                     {
-                        Debug.Fail("The task was already completed and thus the exception couldn't be stored.");
-                        throw;
+                        Debug.Fail("IAsyncInfo.Status == Error, but ErrorCode returns a null Exception (implying S_OK).");
+                        error = new InvalidOperationException("The asynchronous operation could not be completed.");
                     }
                 }
+                else if (asyncStatus == AsyncStatus.Completed && getResultsFunction != null)
+                {
+                    try
+                    {
+                        result = getResultsFunction(asyncInfo);
+                    }
+                    catch (Exception resultsEx)
+                    {
+                        // According to the WinRT team, this can happen in some egde cases, such as marshalling errors in GetResults.
+                        error = resultsEx;
+                        asyncStatus = AsyncStatus.Error;
+                    }
+                }
+
+                // Complete the task based on the previously retrieved results:
+                bool success = false;
+                switch (asyncStatus)
+                {
+                    case AsyncStatus.Completed:
+                        // TODO: AsyncCausality?
+                        success = base.TrySetResult(result);
+                        break;
+
+                    case AsyncStatus.Error:
+                        Debug.Assert(error != null, "The error should have been retrieved previously.");
+                        success = base.TrySetException(error);
+                        break;
+
+                    case AsyncStatus.Canceled:
+                        success = base.TrySetCanceled(_ct.IsCancellationRequested ? _ct : new CancellationToken(true));
+                        break;
+                }
+
+                Debug.Assert(success, "Expected the outcome to be successfully transfered to the task.");
             }
-            finally
+            catch (Exception exc)
             {
-                // We may be called on an STA thread which we don't own, so make sure that the RCW is released right
-                // away. Otherwise, if we leave it up to the finalizer, the apartment may already be gone.
-                if (ComWrappersSupport.TryUnwrapObject(asyncInfo, out var objRef))
+                Debug.Fail($"Unexpected exception in Complete: {exc}");
+
+                // TODO: AsyncCausality
+
+                if (!base.TrySetException(exc))
                 {
-                    objRef.Dispose();
+                    Debug.Fail("The task was already completed and thus the exception couldn't be stored.");
+                    throw;
                 }
             }
         }

--- a/src/get_testwinrt.cmd
+++ b/src/get_testwinrt.cmd
@@ -14,7 +14,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard 26177a8cca2486acfd1c52cc2602dfab81e836a4
+git reset -q --hard 1db1f31510edfa4a578e070d5792bcc2efa3243e
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 %this_dir%.nuget\nuget.exe restore


### PR DESCRIPTION
- Added a bunch of native events benchmarks
- Added a new version of GetObjectReferenceForInterface which allows to get the object reference with the right vftbl already set to eliminate the need for doing a QI to get the right version of ObjectReference.  Made use of it throughout.
- Fixed a bug discovered with agile references where they can refer to ones which had their IObjectReference disposed when we were sharing them across instances.
- Fixed a bug that got exposed after the agile reference fix where we were disposing the IObjectReference on the IAsyncAction RCW before the RCW was collected and thereby allowing for the ptr to be reused and running into issues with the cached RCW being returned when it shouldn't.  That code was trying to do safe cleanup on STA, but runs into issues with getting disconnected from the RCW and the pointer being reused, so I left it to our typical code path to dispose which won't run into that issue.  But it can run into the scenario where the apartment can be gone which we should monitor if it becomes an issue with regards to any leaks.