### PR TITLE
Correct embedded sample

### DIFF
--- a/src/Samples/TestEmbedded/Net5App.Bootstrap/Net5App.Bootstrap.csproj
+++ b/src/Samples/TestEmbedded/Net5App.Bootstrap/Net5App.Bootstrap.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <LangVersion>9</LangVersion>
     <CsWinRTEmbedded>true</CsWinRTEmbedded>
-    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>sdk</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/TestEmbedded/Net5App/Net5App.csproj
+++ b/src/Samples/TestEmbedded/Net5App/Net5App.csproj
@@ -10,7 +10,7 @@
 <!-- CsWinRT reference needed for the target that blocks NETSDK1130 for the C++/WinRT components 
              (transitive project reference asset) -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.4.0-prerelease.211109.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.4.0-prerelease.211109.3" IncludeAssets="build"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestLib.cs
+++ b/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestLib.cs
@@ -24,21 +24,8 @@ namespace TestEmbeddedLibrary
 
     public class TestLib 
     {
-        Geolocator g;
         public TestLib()
         {
-            WinRT.ComWrappersSupport.RegisterProjectionAssembly(typeof(TestLib).Assembly);
-            g = new();
-        }
-
-        public void SetDesiredAccuracy()
-        {
-            g.DesiredAccuracy = PositionAccuracy.Default;
-        }
-
-        public void ShowDesiredAccuracy()
-        {
-            Console.WriteLine("Desired accuracy = " + g.DesiredAccuracy);
         }
 
         internal int Test1_Helper(IAlpha alpha) { return alpha.Five(); }
@@ -49,8 +36,6 @@ namespace TestEmbeddedLibrary
             MyGreek g = new();
             return Test1_Helper(a) + Test1_Helper(g);
         }
-
-        internal IBeta Test2_Helper(IBeta beta) { return beta; }
 
         public int Test2()
         {
@@ -78,9 +63,12 @@ namespace TestEmbeddedLibrary
 
         async System.Threading.Tasks.Task CallGeoAsyncApi()
         {
+            Console.WriteLine("Making a Microsoft.Devices.Geolocation.Geolocator object...");
             Geolocator g = new();
+            Console.WriteLine("Setting the Desired Accuracy to Default on the Geolocator object...");
             g.DesiredAccuracy = PositionAccuracy.Default;
-            Console.WriteLine("Desired accuracy " + g.DesiredAccuracy);
+            Console.WriteLine("Accessing the Desired Accuracy, shows: " + g.DesiredAccuracy);
+            Console.WriteLine("Calling GetGeopositionAsync...");
             Geoposition pos = await g.GetGeopositionAsync();
         }
 


### PR DESCRIPTION
There was some commit rewriting done that I didnt realized had happened when merging up topic branches. And then was missed in code review. But the sample library for embedded support is out of date in master, so this PR updates it. The main issue was in the main of the lib, it was registering the assembly unnecessarily. The rest is cutting unused code.

Also, in the code review we decided to take out some IncludeAssets metadata in the sample, and this was a mistake. We needed that metadata as it prevented runtime assets being resolved when they shouldn't have been. 