### PR TITLE
Make DispatcherQueueSynchronizationContext faster and zero-alloc

### DIFF
--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
@@ -1,0 +1,243 @@
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using WinRT;
+
+#nullable enable
+#pragma warning disable CA1416
+
+namespace Microsoft.System
+{
+    /// <inheritdoc/>
+    public partial class DispatcherQueueSynchronizationContext
+    {
+        /// <summary>
+        /// A custom <c>IDispatcherQueueHandler</c> object, that internally stores a captured <see cref="SendOrPostCallback"/> instance and the
+        /// input captured state. This allows consumers to enqueue a state and a cached stateless delegate without any managed allocations.
+        /// </summary>
+        private unsafe struct DispatcherQueueProxyHandler
+        {
+            /// <summary>
+            /// The shared vtable pointer for <see cref="DispatcherQueueProxyHandler"/> instances.
+            /// </summary>
+            private static readonly void** Vtbl = InitVtbl();
+
+            /// <summary>
+            /// Setups the vtable pointer for <see cref="DispatcherQueueProxyHandler"/>.
+            /// </summary>
+            /// <returns>The initialized vtable pointer for <see cref="DispatcherQueueProxyHandler"/>.</returns>
+            /// <remarks>
+            /// The vtable itself is allocated with <see cref="RuntimeHelpers.AllocateTypeAssociatedMemory(Type, int)"/>,
+            /// which allocates memory in the high frequency heap associated with the input runtime type. This will be
+            /// automatically cleaned up when the type is unloaded, so there is no need to ever manually free this memory.
+            /// </remarks>
+            private static void** InitVtbl()
+            {
+                void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DispatcherQueueProxyHandler), sizeof(void*) * 4);
+
+                lpVtbl[0] = (delegate* unmanaged<DispatcherQueueProxyHandler*, Guid*, void**, int>)&Impl.QueryInterface;
+                lpVtbl[1] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.AddRef;
+                lpVtbl[2] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.Release;
+                lpVtbl[3] = (delegate* unmanaged<DispatcherQueueProxyHandler*, int>)&Impl.Invoke;
+
+                return lpVtbl;
+            }
+
+            /// <summary>
+            /// The vtable pointer for the current instance.
+            /// </summary>
+            private void** lpVtbl;
+
+            /// <summary>
+            /// The <see cref="GCHandle"/> to the captured <see cref="SendOrPostCallback"/>.
+            /// </summary>
+            private GCHandle callbackHandle;
+
+            /// <summary>
+            /// The <see cref="GCHandle"/> to the captured state (if present, or a <see langword="null"/> handle otherwise).
+            /// </summary>
+            private GCHandle stateHandle;
+
+            /// <summary>
+            /// The current reference count for the object (from <c>IUnknown</c>).
+            /// </summary>
+            private volatile uint referenceCount;
+
+            /// <summary>
+            /// Creates a new <see cref="DispatcherQueueProxyHandler"/> instance for the input callback and state.
+            /// </summary>
+            /// <param name="handler">The input <see cref="SendOrPostCallback"/> callback to enqueue.</param>
+            /// <param name="state">The input state to capture and pass to the callback.</param>
+            /// <returns>A pointer to the newly initialized <see cref="DispatcherQueueProxyHandler"/> instance.</returns>
+            public static DispatcherQueueProxyHandler* Create(SendOrPostCallback handler, object? state)
+            {
+#if NET6_0
+                DispatcherQueueProxyHandler* @this = (DispatcherQueueProxyHandler*)NativeMemory.Alloc((nuint)sizeof(DispatcherQueueProxyHandler));
+#else
+                DispatcherQueueProxyHandler* @this = (DispatcherQueueProxyHandler*)Marshal.AllocHGlobal(sizeof(DispatcherQueueProxyHandler));
+#endif
+
+                @this->lpVtbl = Vtbl;
+                @this->callbackHandle = GCHandle.Alloc(handler);
+                @this->stateHandle = state is not null ? GCHandle.Alloc(state) : default;
+                @this->referenceCount = 1;
+
+                return @this;
+            }
+
+            /// <summary>
+            /// Devirtualized API for <c>IUnknown.AddRef()</c>.
+            /// </summary>
+            /// <returns>The updated reference count for the current instance.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public uint AddRef()
+            {
+                return Interlocked.Increment(ref referenceCount);
+            }
+
+            /// <summary>
+            /// Devirtualized API for <c>IUnknown.Release()</c>.
+            /// </summary>
+            /// <returns>The updated reference count for the current instance.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public uint Release()
+            {
+                uint referenceCount = Interlocked.Decrement(ref this.referenceCount);
+
+                if (referenceCount == 0)
+                {
+                    callbackHandle.Free();
+                    
+                    if (stateHandle.IsAllocated)
+                    {
+                        stateHandle.Free();
+                    }
+
+#if NET6_0
+                    NativeMemory.Free(Unsafe.AsPointer(ref this));
+#else
+                    Marshal.FreeHGlobal((IntPtr)Unsafe.AsPointer(ref this));
+#endif
+                }
+
+                return referenceCount;
+            }
+
+            /// <summary>
+            /// A private type with the implementation of the unmanaged methods for <see cref="DispatcherQueueProxyHandler"/>.
+            /// These methods will be set into the shared vtable and invoked by WinRT from the object passed to it as an interface.
+            /// </summary>
+            private static class Impl
+            {
+                /// <summary>
+                /// The HRESULT for a successful operation.
+                /// </summary>
+                private const int S_OK = 0;
+
+                /// <summary>
+                /// The HRESULT for an invalid cast from <c>IUnknown.QueryInterface</c>.
+                /// </summary>
+                private const int E_NOINTERFACE = unchecked((int)0x80004002);
+
+                /// <summary>
+                /// The GUID for the <c>IUnknown</c> COM interface.
+                /// </summary>
+                private static readonly Guid GuidOfIUnknown = new(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
+
+                /// <summary>
+                /// The GUID for the <c>IAgileObject</c> WinRT interface.
+                /// </summary>
+                private static readonly Guid GuidOfIAgileObject = new(0x94EA2B94, 0xE9CC, 0x49E0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90);
+
+                /// <summary>
+                /// The GUID for the <c>IDispatcherQueueHandler</c> WinRT interface.
+                /// </summary>
+                private static readonly Guid GuidOfIDispatcherQueueHandler = new(0x2E0872A9, 0x4E29, 0x5F14, 0xB6, 0x88, 0xFB, 0x96, 0xD5, 0xF9, 0xD5, 0xF8);
+
+                /// <summary>
+                /// Implements <c>IUnknown.QueryInterface(REFIID, void**)</c>.
+                /// </summary>
+                [UnmanagedCallersOnly]
+                public static int QueryInterface(DispatcherQueueProxyHandler* @this, Guid* riid, void** ppvObject)
+                {
+                    if (riid->Equals(GuidOfIUnknown) ||
+                        riid->Equals(GuidOfIAgileObject) ||
+                        riid->Equals(GuidOfIDispatcherQueueHandler))
+                    {
+                        @this->AddRef();
+
+                        *ppvObject = @this;
+
+                        return S_OK;
+                    }
+
+                    return E_NOINTERFACE;
+                }
+
+                /// <summary>
+                /// Implements <c>IUnknown.AddRef()</c>.
+                /// </summary>
+                [UnmanagedCallersOnly]
+                public static uint AddRef(DispatcherQueueProxyHandler* @this)
+                {
+                    return Interlocked.Increment(ref @this->referenceCount);
+                }
+
+                /// <summary>
+                /// Implements <c>IUnknown.Release()</c>.
+                /// </summary>
+                [UnmanagedCallersOnly]
+                public static uint Release(DispatcherQueueProxyHandler* @this)
+                {
+                    uint referenceCount = Interlocked.Decrement(ref @this->referenceCount);
+
+                    if (referenceCount == 0)
+                    {
+                        @this->callbackHandle.Free();
+
+                        if (@this->stateHandle.IsAllocated)
+                        {
+                            @this->stateHandle.Free();
+                        }
+
+#if NET6_0
+                        NativeMemory.Free(@this);
+#else
+                        Marshal.FreeHGlobal((IntPtr)@this);
+#endif
+                    }
+
+                    return referenceCount;
+                }
+
+                /// <summary>
+                /// Implements <c>IDispatcherQueueHandler.Invoke()</c>.
+                /// </summary>
+                [UnmanagedCallersOnly]
+                public static int Invoke(DispatcherQueueProxyHandler* @this)
+                {
+                    object callback = @this->callbackHandle.Target!;
+                    object? state = @this->stateHandle.IsAllocated ? @this->stateHandle.Target! : null;
+
+                    try
+                    {
+                        Unsafe.As<SendOrPostCallback>(callback)(state);
+                    }
+                    catch (Exception e)
+                    {
+                        ExceptionHelpers.SetErrorInfo(e);
+
+                        return ExceptionHelpers.GetHRForException(e);
+                    }
+
+                    return S_OK;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
@@ -89,16 +89,6 @@ namespace Microsoft.System
             }
 
             /// <summary>
-            /// Devirtualized API for <c>IUnknown.AddRef()</c>.
-            /// </summary>
-            /// <returns>The updated reference count for the current instance.</returns>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public uint AddRef()
-            {
-                return Interlocked.Increment(ref referenceCount);
-            }
-
-            /// <summary>
             /// Devirtualized API for <c>IUnknown.Release()</c>.
             /// </summary>
             /// <returns>The updated reference count for the current instance.</returns>
@@ -167,7 +157,7 @@ namespace Microsoft.System
                         riid->Equals(GuidOfIAgileObject) ||
                         riid->Equals(GuidOfIDispatcherQueueHandler))
                     {
-                        @this->AddRef();
+                        Interlocked.Increment(ref @this->referenceCount);
 
                         *ppvObject = @this;
 

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
@@ -36,20 +36,20 @@ namespace Microsoft.System
             /// </remarks>
             private static void** InitVtbl()
             {
-                void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DispatcherQueueProxyHandler), sizeof(void*) * 4);
+                void** vtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DispatcherQueueProxyHandler), sizeof(void*) * 4);
 
-                lpVtbl[0] = (delegate* unmanaged<DispatcherQueueProxyHandler*, Guid*, void**, int>)&Impl.QueryInterface;
-                lpVtbl[1] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.AddRef;
-                lpVtbl[2] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.Release;
-                lpVtbl[3] = (delegate* unmanaged<DispatcherQueueProxyHandler*, int>)&Impl.Invoke;
+                vtbl[0] = (delegate* unmanaged<DispatcherQueueProxyHandler*, Guid*, void**, int>)&Impl.QueryInterface;
+                vtbl[1] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.AddRef;
+                vtbl[2] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.Release;
+                vtbl[3] = (delegate* unmanaged<DispatcherQueueProxyHandler*, int>)&Impl.Invoke;
 
-                return lpVtbl;
+                return vtbl;
             }
 
             /// <summary>
             /// The vtable pointer for the current instance.
             /// </summary>
-            private void** lpVtbl;
+            private void** vtbl;
 
             /// <summary>
             /// The <see cref="GCHandle"/> to the captured <see cref="SendOrPostCallback"/>.
@@ -80,7 +80,7 @@ namespace Microsoft.System
                 DispatcherQueueProxyHandler* @this = (DispatcherQueueProxyHandler*)Marshal.AllocHGlobal(sizeof(DispatcherQueueProxyHandler));
 #endif
 
-                @this->lpVtbl = Vtbl;
+                @this->vtbl = Vtbl;
                 @this->callbackHandle = GCHandle.Alloc(handler);
                 @this->stateHandle = state is not null ? GCHandle.Alloc(state) : default;
                 @this->referenceCount = 1;

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
@@ -135,44 +135,17 @@ namespace Microsoft.System
                 /// <summary>
                 /// The GUID for the <c>IUnknown</c> COM interface.
                 /// </summary>
-                private static ref readonly Guid GuidOfIUnknown
-                {
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get
-                    {
-                        ReadOnlySpan<byte> data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 };
-
-                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
-                    }
-                }
+                private static readonly Guid GuidOfIUnknown = new(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
 
                 /// <summary>
                 /// The GUID for the <c>IAgileObject</c> WinRT interface.
                 /// </summary>
-                private static ref readonly Guid GuidOfIAgileObject
-                {
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get
-                    {
-                        ReadOnlySpan<byte> data = new byte[] { 0x94, 0xEA, 0x2B, 0x94, 0xE9, 0xCC, 0x49, 0xE0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90 };
-
-                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
-                    }
-                }
+                private static readonly Guid GuidOfIAgileObject = new(0x94EA2B94, 0xE9CC, 0x49E0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90);
 
                 /// <summary>
                 /// The GUID for the <c>IDispatcherQueueHandler</c> WinRT interface.
                 /// </summary>
-                private static ref readonly Guid GuidOfIDispatcherQueueHandler
-                {
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get
-                    {
-                        ReadOnlySpan<byte> data = new byte[] { 0x2E, 0x08, 0x72, 0xA9, 0x4E, 0x29, 0x5F, 0x14, 0xB6, 0x88, 0xFB, 0x96, 0xD5, 0xF9, 0xD5, 0xF8 };
-
-                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
-                    }
-                }
+                private static readonly Guid GuidOfIDispatcherQueueHandler = new(0x2E0872A9, 0x4E29, 0x5F14, 0xB6, 0x88, 0xFB, 0x96, 0xD5, 0xF9, 0xD5, 0xF8);
 
                 /// <summary>
                 /// Implements <c>IUnknown.QueryInterface(REFIID, void**)</c>.

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.DispatcherQueueProxyHandler.cs
@@ -135,17 +135,44 @@ namespace Microsoft.System
                 /// <summary>
                 /// The GUID for the <c>IUnknown</c> COM interface.
                 /// </summary>
-                private static readonly Guid GuidOfIUnknown = new(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
+                private static ref readonly Guid GuidOfIUnknown
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get
+                    {
+                        ReadOnlySpan<byte> data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 };
+
+                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+                    }
+                }
 
                 /// <summary>
                 /// The GUID for the <c>IAgileObject</c> WinRT interface.
                 /// </summary>
-                private static readonly Guid GuidOfIAgileObject = new(0x94EA2B94, 0xE9CC, 0x49E0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90);
+                private static ref readonly Guid GuidOfIAgileObject
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get
+                    {
+                        ReadOnlySpan<byte> data = new byte[] { 0x94, 0xEA, 0x2B, 0x94, 0xE9, 0xCC, 0x49, 0xE0, 0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90 };
+
+                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+                    }
+                }
 
                 /// <summary>
                 /// The GUID for the <c>IDispatcherQueueHandler</c> WinRT interface.
                 /// </summary>
-                private static readonly Guid GuidOfIDispatcherQueueHandler = new(0x2E0872A9, 0x4E29, 0x5F14, 0xB6, 0x88, 0xFB, 0x96, 0xD5, 0xF9, 0xD5, 0xF8);
+                private static ref readonly Guid GuidOfIDispatcherQueueHandler
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get
+                    {
+                        ReadOnlySpan<byte> data = new byte[] { 0x2E, 0x08, 0x72, 0xA9, 0x4E, 0x29, 0x5F, 0x14, 0xB6, 0x88, 0xFB, 0x96, 0xD5, 0xF9, 0xD5, 0xF8 };
+
+                        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+                    }
+                }
 
                 /// <summary>
                 /// Implements <c>IUnknown.QueryInterface(REFIID, void**)</c>.

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
@@ -17,7 +17,7 @@ namespace Microsoft.System
             /// <summary>
             /// The vtable pointer for the current instance.
             /// </summary>
-            private readonly void** lpVtbl;
+            private readonly void** vtbl;
 
             /// <summary>
             /// Native API for <see cref="DispatcherQueue.TryEnqueue(DispatcherQueueHandler)"/>.
@@ -29,7 +29,7 @@ namespace Microsoft.System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int TryEnqueue(void* callback, bool* result)
             {
-                return ((delegate* unmanaged<IDispatcherQueue*, void*, byte*, int>)lpVtbl[7])((IDispatcherQueue*)Unsafe.AsPointer(ref this), callback, (byte*)result);
+                return ((delegate* unmanaged<IDispatcherQueue*, void*, byte*, int>)vtbl[7])((IDispatcherQueue*)Unsafe.AsPointer(ref this), callback, (byte*)result);
             }
         }
     }

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
@@ -1,0 +1,36 @@
+#if NET5_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.System
+{
+    /// <inheritdoc/>
+    public partial class DispatcherQueueSynchronizationContext
+    {
+        /// <summary>
+        /// A struct mapping the native WinRT <c>IDispatcherQueue</c> interface.
+        /// </summary>
+        internal unsafe struct IDispatcherQueue
+        {
+            /// <summary>
+            /// The vtable pointer for the current instance.
+            /// </summary>
+            private readonly void** lpVtbl;
+
+            /// <summary>
+            /// Native API for <see cref="DispatcherQueue.TryEnqueue(DispatcherQueueHandler)"/>.
+            /// </summary>
+            /// <param name="callback">A pointer to an <c>IDispatcherQueueHandler</c> object.</param>
+            /// <param name="result">The result of the operation (the <see cref="bool"/> WinRT retval).</param>
+            /// <returns>The <c>HRESULT</c> for the operation.</returns>
+            /// <remarks>The <paramref name="callback"/> parameter is assumed to be a pointer to an <c>IDispatcherQueueHandler</c> object.</remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int TryEnqueue(void* callback, byte* result)
+            {
+                return ((delegate* unmanaged<IDispatcherQueue*, void*, byte*, int>)lpVtbl[7])((IDispatcherQueue*)Unsafe.AsPointer(ref this), callback, result);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
@@ -1,5 +1,7 @@
 #if NET5_0_OR_GREATER
 
+#pragma warning disable CS0649
+
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.System

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.IDispatcherQueue.cs
@@ -27,9 +27,9 @@ namespace Microsoft.System
             /// <returns>The <c>HRESULT</c> for the operation.</returns>
             /// <remarks>The <paramref name="callback"/> parameter is assumed to be a pointer to an <c>IDispatcherQueueHandler</c> object.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int TryEnqueue(void* callback, byte* result)
+            public int TryEnqueue(void* callback, bool* result)
             {
-                return ((delegate* unmanaged<IDispatcherQueue*, void*, byte*, int>)lpVtbl[7])((IDispatcherQueue*)Unsafe.AsPointer(ref this), callback, result);
+                return ((delegate* unmanaged<IDispatcherQueue*, void*, byte*, int>)lpVtbl[7])((IDispatcherQueue*)Unsafe.AsPointer(ref this), callback, (byte*)result);
             }
         }
     }

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -3,6 +3,9 @@ using System.Threading;
 using WinRT;
 
 #nullable enable
+
+// CA1416 is "validate platform compatibility". This suppresses the warnings for IWinRTObject.NativeObject and
+// IObjectReference.ThisPtr only being supported on Windows (since WASDK as a whole only works on Windows anyway).
 #pragma warning disable CA1416
 
 namespace Microsoft.System

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -47,7 +47,7 @@ namespace Microsoft.System
             try
             {
                 IDispatcherQueue* dispatcherQueue = (IDispatcherQueue*)((IWinRTObject)m_dispatcherQueue).NativeObject.ThisPtr;
-                byte success;
+                bool success;
 
                 hResult = dispatcherQueue->TryEnqueue(dispatcherQueueProxyHandler, &success);
 

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using Microsoft.System;
 
 namespace Microsoft.System
 {
@@ -17,19 +16,33 @@ namespace Microsoft.System
             m_dispatcherQueue = dispatcherQueue;
         }
 
+        /// <inheritdoc/>
         public override void Post(SendOrPostCallback d, object state)
         {
-            if (d == null)
+#if NET6_0
+            ArgumentNullException.ThrowIfNull(d, nameof(d));
+#else
+            static void ThrowArgumentNullException()
+            {
                 throw new ArgumentNullException(nameof(d));
+            }
+
+            if (d is null)
+            {
+                ThrowArgumentNullException();
+            }
+#endif
 
             m_dispatcherQueue.TryEnqueue(() => d(state));
         }
 
+        /// <inheritdoc/>
         public override void Send(SendOrPostCallback d, object state)
         {
             throw new NotSupportedException("Send not supported");
         }
 
+        /// <inheritdoc/>
         public override SynchronizationContext CreateCopy()
         {
             return new DispatcherQueueSynchronizationContext(m_dispatcherQueue);

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -39,14 +39,14 @@ namespace Microsoft.System
 
 #if NET5_0_OR_GREATER
             DispatcherQueueProxyHandler* dispatcherQueueProxyHandler = DispatcherQueueProxyHandler.Create(d!, state);
-            bool success;
             int hResult;
 
             try
             {
                 IDispatcherQueue* dispatcherQueue = (IDispatcherQueue*)((IWinRTObject)m_dispatcherQueue).NativeObject.ThisPtr;
+                byte success;
 
-                hResult = dispatcherQueue->TryEnqueue(dispatcherQueueProxyHandler, (byte*)&success);
+                hResult = dispatcherQueue->TryEnqueue(dispatcherQueueProxyHandler, &success);
 
                 GC.KeepAlive(this);
             }
@@ -60,7 +60,7 @@ namespace Microsoft.System
                 ExceptionHelpers.ThrowExceptionForHR(hResult);
             }
 #else
-            m_dispatcherQueue.TryEnqueue(() => d!(state));
+            _ = m_dispatcherQueue.TryEnqueue(() => d!(state));
 #endif
         }
 

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -26,19 +26,15 @@ namespace Microsoft.System
         /// <inheritdoc/>
         public override unsafe void Post(SendOrPostCallback d, object? state)
         {
-#if NET6_0
-            ArgumentNullException.ThrowIfNull(d, nameof(d));
-#else
-            static void ThrowArgumentNullException()
-            {
-                throw new ArgumentNullException(nameof(d));
-            }
-
             if (d is null)
             {
+                static void ThrowArgumentNullException()
+                {
+                    throw new ArgumentNullException(nameof(d));
+                }
+
                 ThrowArgumentNullException();
             }
-#endif
 
 #if NET5_0_OR_GREATER
             DispatcherQueueProxyHandler* dispatcherQueueProxyHandler = DispatcherQueueProxyHandler.Create(d!, state);

--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -28,16 +28,11 @@ namespace Microsoft.System
         {
             if (d is null)
             {
-                static void ThrowArgumentNullException()
-                {
-                    throw new ArgumentNullException(nameof(d));
-                }
-
-                ThrowArgumentNullException();
+                throw new ArgumentNullException(nameof(d));
             }
 
 #if NET5_0_OR_GREATER
-            DispatcherQueueProxyHandler* dispatcherQueueProxyHandler = DispatcherQueueProxyHandler.Create(d!, state);
+            DispatcherQueueProxyHandler* dispatcherQueueProxyHandler = DispatcherQueueProxyHandler.Create(d, state);
             int hResult;
 
             try

--- a/src/Projections/Reunion/Reunion.csproj
+++ b/src/Projections/Reunion/Reunion.csproj
@@ -5,6 +5,7 @@
     <Platforms>x64;x86</Platforms>
     <AssemblyName>Microsoft.WinUI</AssemblyName>
     <AssemblyVersion>9.9.9.9</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Overview

The current `DispatcherQueueSynchronizationContext` implementation is rather inefficient, for two reasons:
- It's creating a delegate with closure every single time (!), capturing both the callback and the state
- There's also additional overhead in general due to how the actual callback is then scheduled internally

Here's the specific line that's troubling:

https://github.com/microsoft/CsWinRT/blob/31a191d0e9b557e3732f93d86cf626defbb8d009/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs#L25

This type is used extremely frequently in applications, especially for those that eg. rely on portable libraries for things such as MVVM support etc. that also deal with proper dispatching. The way that works is by capturing the synchronization context during setup and then dispatch through that, meaning this `Post` method will get invoked every time.

## The proposed solution

This PR optimizes the `Post` implementation by making it faster and zero-alloc.
There are no public API changes.
Opening this as draft as I'm not entirely sure of the procedure to add tests for this for this specific repo.
Pinging @jkoritzinsky as we discussed this feature idea previously on Discord as well 😄

I run some benchmarks for this a while back, got some nice numbers:

|                 Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|  TryEnqueueWithClosure | 7.062 us | 0.1353 us | 0.1852 us |  1.00 | 0.0687 |     - |     - |     312 B |
|    **TryEnqueueWithState** | **1.139 us** | 0.0229 us | 0.0676 us |  **0.15** |      - |     - |     - |         **-** |

In this scenario dispatching with this system was about 7x faster, and also completely allocation free.
I'd argue it'd be nice to have such a basic building block like this one to be as efficient as possible.

I'm sure it might be a good idea to setup up some new ones in this repo as well, though I'd need guidance on that 😅

Opening as draft for now because of this, can switch this once everyone's happy with coverage and overall setup.

## Related issues/PRs

- https://github.com/CommunityToolkit/WindowsCommunityToolkit/pull/4097
- https://github.com/microsoft/microsoft-ui-xaml/issues/3321