### PR TITLE
Improvements to nullable / boxing

### DIFF
--- a/src/Benchmarks/ReflectionPerf.cs
+++ b/src/Benchmarks/ReflectionPerf.cs
@@ -203,6 +203,18 @@ namespace Benchmarks
         }
 
         [Benchmark]
+        public object GetNewIntDelegate()
+        {
+            return instance.NewIntDelegate;
+        }
+
+        [Benchmark]
+        public object GetExistingIntDelegate()
+        {
+            return instance.ExistingIntDelegate;
+        }
+
+        [Benchmark]
         public string CreateAndIterateList()
         {
             var list = instance.NewList();

--- a/src/Benchmarks/ReflectionPerf.cs
+++ b/src/Benchmarks/ReflectionPerf.cs
@@ -156,6 +156,19 @@ namespace Benchmarks
         }
 
         [Benchmark]
+        public object GetNullableTimeSpan()
+        {
+            return instance.NullableTimeSpan.Value;
+        }
+
+        [Benchmark]
+        public void SetNullableTimeSpan()
+        {
+            TimeSpan timeSpan = new TimeSpan(100);
+            instance.NullableTimeSpan = new Nullable<TimeSpan>(timeSpan);
+        }
+
+        [Benchmark]
         public object GetNullableNonBittableStruct()
         {
             return instance.NullableNonBlittableStruct.Value;

--- a/src/Benchmarks/ReflectionPerf.cs
+++ b/src/Benchmarks/ReflectionPerf.cs
@@ -190,6 +190,19 @@ namespace Benchmarks
         }
 
         [Benchmark]
+        public void SetNullableIntDelegate()
+        {
+            ProvideInt s = () => 4;
+            instance.BoxedDelegate = s;
+        }
+
+        [Benchmark]
+        public object GetNullableIntDelegate()
+        {
+            return instance.BoxedDelegate as ProvideInt;
+        }
+
+        [Benchmark]
         public string CreateAndIterateList()
         {
             var list = instance.NewList();

--- a/src/Benchmarks/ReflectionPerf.cs
+++ b/src/Benchmarks/ReflectionPerf.cs
@@ -67,6 +67,14 @@ namespace Benchmarks
         }
 
         [Benchmark]
+        public int ExecuteMarshalingForDelegate()
+        {
+            int y = 1;
+            instance.CallForInt(() => y);
+            return y;
+        }
+
+        [Benchmark]
         public void IntEventSource()
         {
             ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
@@ -120,6 +128,52 @@ namespace Benchmarks
         {
             var dict = instance.ExistingDictionary;
             return dict["a"];
+        }
+
+        [Benchmark]
+        public int GetNullableInt()
+        {
+            return instance.NullableInt.Value;
+        }
+
+        [Benchmark]
+        public void SetNullableInt()
+        {
+            instance.NullableInt = new Nullable<int>(4);
+        }
+
+        [Benchmark]
+        public object GetNullableBittableStruct()
+        {
+            return instance.NullableBlittableStruct.Value;
+        }
+
+        [Benchmark]
+        public void SetNullableBittableStruct()
+        {
+            BlittableStruct blittableStruct = new BlittableStruct() { i32 = 2 };
+            instance.NullableBlittableStruct = new Nullable<BlittableStruct>(blittableStruct);
+        }
+
+        [Benchmark]
+        public object GetNullableNonBittableStruct()
+        {
+            return instance.NullableNonBlittableStruct.Value;
+        }
+
+        [Benchmark]
+        public void SetNullableNonBittableStruct()
+        {
+            NonBlittable nonBlittable = new NonBlittable() { A = true, C = "beta" };
+            instance.NullableNonBlittableStruct = new Nullable<NonBlittable>(nonBlittable);
+        }
+
+        [Benchmark]
+        public void SetNullableDelegate()
+        {
+            int z;
+            System.EventHandler<int> s = (object sender, int value) => z = value;
+            instance.NewTypeErasedNullableObject = s;
         }
 
         [Benchmark]

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1407,6 +1407,11 @@ namespace winrt::TestComponentCSharp::implementation
         return winrt::unbox_value<hstring>(obj);
     }
 
+    winrt::TestComponentCSharp::ProvideInt Class::UnboxDelegate(WF::IInspectable const& obj)
+    {
+        return winrt::unbox_value<TestComponentCSharp::ProvideInt>(obj);
+    }
+
     com_array<int32_t> Class::UnboxInt32Array(WF::IInspectable const& obj)
     {
         return obj.as<IReferenceArray<int32_t>>().Value();

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1467,6 +1467,12 @@ namespace winrt::TestComponentCSharp::implementation
         return winrt::box_value(hstring{});
     }
 
+    WF::IInspectable Class::BoxedDelegate()
+    {
+        TestComponentCSharp::ProvideUri handler = [] { return Windows::Foundation::Uri(L"http://microsoft.com"); };
+        return winrt::box_value(handler);
+    }
+
     hstring Class::Catch(hstring const& /*params*/, hstring& /*lock*/)
     {
         // Compile-only test for keyword escaping

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -355,6 +355,7 @@ namespace winrt::TestComponentCSharp::implementation
         static int32_t UnboxInt32(IInspectable const& obj);
         static bool UnboxBoolean(IInspectable const& obj);
         static hstring UnboxString(IInspectable const& obj);
+        static TestComponentCSharp::ProvideInt UnboxDelegate(IInspectable const& obj);
         static com_array<int32_t> UnboxInt32Array(IInspectable const& obj);
         static com_array<bool> UnboxBooleanArray(IInspectable const& obj);
         static com_array<hstring> UnboxStringArray(IInspectable const& obj);

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -369,6 +369,7 @@ namespace winrt::TestComponentCSharp::implementation
         static hstring GetTypeNameForType(Windows::UI::Xaml::Interop::TypeName const& type);
 
         static Windows::Foundation::IInspectable EmptyString();
+        static Windows::Foundation::IInspectable BoxedDelegate();
 
         hstring Catch(hstring const& params, hstring& locks);
 

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -379,6 +379,7 @@ namespace TestComponentCSharp
         static Int32 UnboxInt32(Object obj);
         static Boolean UnboxBoolean(Object obj);
         static String UnboxString(Object obj);
+        static ProvideInt UnboxDelegate(Object obj);
         static Int32[] UnboxInt32Array(Object obj);
         static Boolean[] UnboxBooleanArray(Object obj);
         static String[] UnboxStringArray(Object obj);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -383,6 +383,7 @@ namespace TestComponentCSharp
         static Int32[] UnboxInt32Array(Object obj);
         static Boolean[] UnboxBooleanArray(Object obj);
         static String[] UnboxStringArray(Object obj);
+        static Object BoxedDelegate{ get; };
 
         // WUX.Interop.TypeName -> System.Type mapping
         static Windows.UI.Xaml.Interop.TypeName Int32Type { get; };

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2227,6 +2227,15 @@ namespace UnitTest
             Assert.Equal(string.Empty, (string)str2);
         }
 
+        [Fact]
+        public void TestDelegateUnboxing()
+        {
+            var del = Class.BoxedDelegate;
+            Assert.IsType<ProvideUri>(del);
+            var provideUriDel = (ProvideUri) del;
+            Assert.Equal(new Uri("http://microsoft.com"), provideUriDel());
+        }
+
         internal class ManagedType { }
 
         [Fact]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2153,6 +2153,9 @@ namespace UnitTest
 
             string s = "Hello World!";
             Assert.Equal(s, Class.UnboxString(s));
+
+            ProvideInt intHandler = () => 42;
+            Assert.Equal(intHandler, Class.UnboxDelegate(intHandler));
         }
 
         [Fact]

--- a/src/Tests/UnitTest/TestComponent_Tests.cs
+++ b/src/Tests/UnitTest/TestComponent_Tests.cs
@@ -974,6 +974,117 @@ namespace UnitTest
             Assert.True(composableObjects.GetRange(1, 3).SequenceEqual(interfaceSubset));
         }
 
+        private void Box_type<T>(T val, Func<T, object, object> boxFunc)
+        {
+            var boxedVal = boxFunc(val, val);
+            Assert.IsType<T>(boxedVal);
+            Assert.Equal((T)boxedVal, val);
+        }
+
+        [Fact]
+        public void Box_Byte()
+        {
+            Box_type<byte>(4, Tests.Box1);
+        }
+
+        [Fact]
+        public void Box_UShort()
+        {
+            Box_type<ushort>(4, Tests.Box2);
+        }
+
+        [Fact]
+        public void Box_UInt()
+        {
+            Box_type<uint>(4, Tests.Box3);
+        }
+
+        [Fact]
+        public void Box_ULong()
+        {
+            Box_type<ulong>(4, Tests.Box4);
+        }
+
+        [Fact]
+        public void Box_Short()
+        {
+            Box_type<short>(4, Tests.Box5);
+        }
+
+        [Fact]
+        public void Box_Int()
+        {
+            Box_type(4, Tests.Box6);
+        }
+
+        [Fact]
+        public void Box_Long()
+        {
+            Box_type<long>(4, Tests.Box7);
+        }
+
+        [Fact]
+        public void Box_Bool()
+        {
+            Box_type(true, Tests.Box8);
+        }
+
+        [Fact]
+        public void Box_Float()
+        {
+            Box_type<float>(4, Tests.Box9);
+        }
+
+        [Fact]
+        public void Box_Double()
+        {
+            Box_type(4.0, Tests.Box10);
+        }
+
+        [Fact]
+        public void Box_Guid()
+        {
+            Box_type(Guid.NewGuid(), Tests.Box11);
+        }
+
+        [Fact]
+        public void Box_Char()
+        {
+            Box_type('c', Tests.Box12);
+        }
+
+        [Fact]
+        public void Box_String()
+        {
+            Box_type("test", Tests.Box13);
+        }
+
+        [Fact]
+        public void Box_Timespan()
+        {
+            Box_type(TimeSpan.FromMilliseconds(4), Tests.Box14);
+        }
+
+        [Fact]
+        public void Box_Blittable()
+        {
+            Blittable blittable = new Blittable(3, 4, 5, 6, 7, 8, 9, 10, 11, typeof(ITests).GUID);
+            Box_type(blittable, Tests.Box15);
+        }
+
+        [Fact]
+        public void Box_NonBittable()
+        {
+            NonBlittable nonBlittable = new NonBlittable(true, 'a', "one", 1);
+            Box_type(nonBlittable, Tests.Box16);
+        }
+
+        [Fact]
+        public void Box_DateTime()
+        {
+            Box_type(DateTimeOffset.Now, Tests.Box17);
+        }
+
         // Nota Bene: this test case must always remain the final one
         [Fact]
         public void Z_Check_Coverage()

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -155,7 +155,7 @@ namespace WinRT
                         Vtable = (IntPtr)ifaceAbiType.GetAbiToProjectionVftblPtr()
                     });
 
-                    if(!hasCustomIMarshalInterface && iid == typeof(ABI.WinRT.Interop.IMarshal.Vftbl).GUID)
+                    if (!hasCustomIMarshalInterface && iid == typeof(ABI.WinRT.Interop.IMarshal.Vftbl).GUID)
                     {
                         hasCustomIMarshalInterface = true;
                     }
@@ -390,7 +390,7 @@ namespace WinRT
                     return CreateReferenceCachingFactory(CreateNullableTFactory(typeof(System.Nullable<>).MakeGenericType(implementationType)));
                 }
             }
-            else if(IsAbiNullableDelegate(implementationType))
+            else if (IsAbiNullableDelegate(implementationType))
             {
                 return CreateReferenceCachingFactory(CreateAbiNullableTFactory(implementationType));
             }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -286,15 +286,11 @@ namespace WinRT
         private static Func<IInspectable, object> CreateNullableTFactory(Type implementationType)
         {
             Type helperType = implementationType.GetHelperType();
-            Type vftblType = helperType.FindVftblType();
 
             ParameterExpression[] parms = new[] { Expression.Parameter(typeof(IInspectable), "inspectable") };
-            var createInterfaceInstanceExpression = Expression.New(helperType.GetConstructor(new[] { typeof(ObjectReference<>).MakeGenericType(vftblType) }),
-                    Expression.Call(parms[0],
-                        typeof(IInspectable).GetMethod(nameof(IInspectable.As)).MakeGenericMethod(vftblType)));
-
             return Expression.Lambda<Func<IInspectable, object>>(
-                Expression.Convert(Expression.Property(createInterfaceInstanceExpression, "Value"), typeof(object)), parms).Compile();
+                Expression.Convert(Expression.Call(helperType.GetMethod("GetValue", BindingFlags.Static | BindingFlags.NonPublic), 
+                    parms), typeof(object)), parms).Compile();
         }
 
         private static Func<IInspectable, object> CreateArrayFactory(Type implementationType)
@@ -476,143 +472,160 @@ namespace WinRT
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<int>)),
-                    Vtable = BoxedValueIReferenceImpl<int>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_int.IID,
+                    Vtable = ABI.System.Nullable_int.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(string))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<string>)),
-                    Vtable = BoxedValueIReferenceImpl<string>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_string.IID,
+                    Vtable = ABI.System.Nullable_string.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(byte))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<byte>)),
-                    Vtable = BoxedValueIReferenceImpl<byte>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_byte.IID,
+                    Vtable = ABI.System.Nullable_byte.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(short))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<short>)),
-                    Vtable = BoxedValueIReferenceImpl<short>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_short.IID,
+                    Vtable = ABI.System.Nullable_short.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(ushort))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<ushort>)),
-                    Vtable = BoxedValueIReferenceImpl<ushort>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_ushort.IID,
+                    Vtable = ABI.System.Nullable_ushort.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(uint))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<uint>)),
-                    Vtable = BoxedValueIReferenceImpl<uint>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_uint.IID,
+                    Vtable = ABI.System.Nullable_uint.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(long))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<long>)),
-                    Vtable = BoxedValueIReferenceImpl<long>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_long.IID,
+                    Vtable = ABI.System.Nullable_long.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(ulong))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<ulong>)),
-                    Vtable = BoxedValueIReferenceImpl<ulong>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_ulong.IID,
+                    Vtable = ABI.System.Nullable_ulong.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(float))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<float>)),
-                    Vtable = BoxedValueIReferenceImpl<float>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_float.IID,
+                    Vtable = ABI.System.Nullable_float.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(double))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<double>)),
-                    Vtable = BoxedValueIReferenceImpl<double>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_double.IID,
+                    Vtable = ABI.System.Nullable_double.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(char))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<char>)),
-                    Vtable = BoxedValueIReferenceImpl<char>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_char.IID,
+                    Vtable = ABI.System.Nullable_char.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(bool))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<bool>)),
-                    Vtable = BoxedValueIReferenceImpl<bool>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_bool.IID,
+                    Vtable = ABI.System.Nullable_bool.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(Guid))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<Guid>)),
-                    Vtable = BoxedValueIReferenceImpl<Guid>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_guid.IID,
+                    Vtable = ABI.System.Nullable_guid.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(DateTimeOffset))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<DateTimeOffset>)),
-                    Vtable = BoxedValueIReferenceImpl<DateTimeOffset>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_DateTimeOffset.IID,
+                    Vtable = ABI.System.Nullable_DateTimeOffset.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(TimeSpan))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<TimeSpan>)),
-                    Vtable = BoxedValueIReferenceImpl<TimeSpan>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_TimeSpan.IID,
+                    Vtable = ABI.System.Nullable_TimeSpan.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type == typeof(object))
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<object>)),
-                    Vtable = BoxedValueIReferenceImpl<object>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_Object.IID,
+                    Vtable = ABI.System.Nullable_Object.Vftbl.AbiToProjectionVftablePtr
                 };
             }
             if (type.IsTypeOfType())
             {
                 return new ComInterfaceEntry
                 {
-                    IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<Type>)),
-                    Vtable = BoxedValueIReferenceImpl<Type>.AbiToProjectionVftablePtr
+                    IID = ABI.System.Nullable_Type.IID,
+                    Vtable = ABI.System.Nullable_Type.Vftbl.AbiToProjectionVftablePtr
+                };
+            }
+            if (type == typeof(sbyte))
+            {
+                return new ComInterfaceEntry
+                {
+                    IID = ABI.System.Nullable_sbyte.IID,
+                    Vtable = ABI.System.Nullable_sbyte.Vftbl.AbiToProjectionVftablePtr
+                };
+            }
+            if (type.IsDelegate())
+            {
+                var delegateHelperType = typeof(ABI.System.Nullable_Delegate<>).MakeGenericType(type);
+                return new ComInterfaceEntry
+                {
+                    IID = global::WinRT.GuidGenerator.GetIID(delegateHelperType),
+                    Vtable = delegateHelperType.GetAbiToProjectionVftblPtr()
                 };
             }
 
             return new ComInterfaceEntry
             {
                 IID = global::WinRT.GuidGenerator.GetIID(typeof(ABI.System.Nullable<>).MakeGenericType(type)),
-                Vtable = (IntPtr)typeof(BoxedValueIReferenceImpl<>).MakeGenericType(type).GetAbiToProjectionVftblPtr()
+                Vtable = typeof(BoxedValueIReferenceImpl<>).MakeGenericType(type).GetAbiToProjectionVftblPtr()
             };
         }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -545,6 +545,10 @@ namespace WinRT
 
                     return new SingleInterfaceOptimizedObject(typeof(IWeakReference), iunknownObjRef, false);
                 }
+                else if (ComWrappersSupport.CreateRCWType != null && ComWrappersSupport.CreateRCWType.IsDelegate())
+                {
+                    return ComWrappersSupport.CreateDelegateFactory(ComWrappersSupport.CreateRCWType)(externalComObject);
+                }
                 else
                 {
                     // If the external COM object isn't IInspectable or IWeakReference, we can't handle it.
@@ -555,7 +559,10 @@ namespace WinRT
             }
             finally
             {
-                Marshal.Release(ptr);
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.Release(ptr);
+                }
             }
         }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -119,8 +119,7 @@ namespace WinRT
 
             return rcw switch
             {
-                ABI.System.Nullable<string> ns => (T)(object)ns.Value,
-                ABI.System.Nullable<Type> nt => (T)(object)nt.Value,
+                ABI.System.Nullable nt => (T)nt.Value,
                 T castRcw => castRcw,
                 _ when tryUseCache => CreateRcwForComObject<T>(ptr, false),
                 _ => throw new ArgumentException(string.Format("Unable to create a wrapper object. The WinRT object {0} has type {1} which cannot be assigned to type {2}", ptr, rcw.GetType(), typeof(T)))

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -51,6 +51,11 @@ namespace WinRT
                 {
                     runtimeWrapper = new ABI.WinRT.Interop.IWeakReference(weakRef);
                 }
+                else if (typeof(T).IsDelegate())
+                {
+                    runtimeWrapper = CreateDelegateFactory(typeof(T))(ptr);
+                }
+
                 keepAliveSentinel = runtimeWrapper; // We don't take a strong reference on runtimeWrapper at any point, so we need to make sure it lives until it can get assigned to rcw.
                 var runtimeWrapperReference = new System.WeakReference<object>(runtimeWrapper);
                 var cleanupSentinel = new RuntimeWrapperCleanup(identity.ThisPtr, runtimeWrapperReference);

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -80,8 +80,7 @@ namespace WinRT
             // for a single System.Type.
             return rcw switch
             {
-                ABI.System.Nullable<string> ns => (T)(object)ns.Value,
-                ABI.System.Nullable<Type> nt => (T)(object)nt.Value,
+                ABI.System.Nullable nt => (T)nt.Value,
                 _ => (T)rcw
             };
         }

--- a/src/WinRT.Runtime/Interop/StandardDelegates.cs
+++ b/src/WinRT.Runtime/Interop/StandardDelegates.cs
@@ -231,4 +231,16 @@ namespace WinRT.Interop
     public 
 #endif 
     delegate int _remove_EventHandler(IntPtr thisPtr, EventRegistrationToken token);
+
+    // IDelegate
+#if EMBED
+    internal
+#else
+    public
+#endif
+    struct IDelegateVftbl
+    {
+        public IUnknownVftbl IUnknownVftbl;
+        public IntPtr Invoke;
+    }
 }

--- a/src/WinRT.Runtime/Interop/StandardDelegates.cs
+++ b/src/WinRT.Runtime/Interop/StandardDelegates.cs
@@ -231,16 +231,4 @@ namespace WinRT.Interop
     public 
 #endif 
     delegate int _remove_EventHandler(IntPtr thisPtr, EventRegistrationToken token);
-
-    // IDelegate
-#if EMBED
-    internal
-#else
-    public
-#endif
-    struct IDelegateVftbl
-    {
-        public IUnknownVftbl IUnknownVftbl;
-        public IntPtr Invoke;
-    }
 }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1261,7 +1261,7 @@ namespace WinRT
             return ComWrappersSupport.CreateCCWForObject<global::WinRT.Interop.IDelegateVftbl>(o, delegateIID);
         }
 
-        public static T FromAbi<T>(IntPtr nativeDelegate, Func<ObjectReference<IDelegateVftbl>, T> createCallback)
+        public static T FromAbi<T>(IntPtr nativeDelegate, Func<IntPtr, T> createCallback)
             where T : System.Delegate
         {
             if (nativeDelegate == IntPtr.Zero)
@@ -1274,8 +1274,7 @@ namespace WinRT
             }
             else
             {
-                var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-                return (T) ComWrappersSupport.TryRegisterObjectForInterface(createCallback(abiDelegate), nativeDelegate);
+                return (T) ComWrappersSupport.TryRegisterObjectForInterface(createCallback(nativeDelegate), nativeDelegate);
             }
         }
     }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1261,7 +1261,7 @@ namespace WinRT
             return ComWrappersSupport.CreateCCWForObject<global::WinRT.Interop.IDelegateVftbl>(o, delegateIID);
         }
 
-        public static T FromAbi<T>(IntPtr nativeDelegate, Func<IntPtr, T> createCallback)
+        public static T FromAbi<T>(IntPtr nativeDelegate)
             where T : System.Delegate
         {
             if (nativeDelegate == IntPtr.Zero)
@@ -1274,7 +1274,7 @@ namespace WinRT
             }
             else
             {
-                return (T) ComWrappersSupport.TryRegisterObjectForInterface(createCallback(nativeDelegate), nativeDelegate);
+                return ComWrappersSupport.CreateRcwForComObject<T>(nativeDelegate);
             }
         }
     }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1260,6 +1260,24 @@ namespace WinRT
 
             return ComWrappersSupport.CreateCCWForObject<global::WinRT.Interop.IDelegateVftbl>(o, delegateIID);
         }
+
+        public static unsafe T FromAbi<T>(IntPtr nativeDelegate, Func<ObjectReference<IDelegateVftbl>, T> createCallback)
+            where T : System.Delegate
+        {
+            if (nativeDelegate == IntPtr.Zero)
+            {
+                return null;
+            }
+            else if (IUnknownVftbl.IsReferenceToManagedObject(nativeDelegate))
+            {
+                return ComWrappersSupport.FindObject<T>(nativeDelegate);
+            }
+            else
+            {
+                var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
+                return (T) ComWrappersSupport.TryRegisterObjectForInterface(createCallback(abiDelegate), nativeDelegate);
+            }
+        }
     }
 
 #if EMBED

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1261,7 +1261,7 @@ namespace WinRT
             return ComWrappersSupport.CreateCCWForObject<global::WinRT.Interop.IDelegateVftbl>(o, delegateIID);
         }
 
-        public static unsafe T FromAbi<T>(IntPtr nativeDelegate, Func<ObjectReference<IDelegateVftbl>, T> createCallback)
+        public static T FromAbi<T>(IntPtr nativeDelegate, Func<ObjectReference<IDelegateVftbl>, T> createCallback)
             where T : System.Delegate
         {
             if (nativeDelegate == IntPtr.Zero)

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -10,6 +10,7 @@ TypesMustExist : Type 'WinRT.ComWrappersHelper' does not exist in the reference 
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ComWrappersSupport.GetObjectReferenceForInterface<T>(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsReferenceToManagedObject.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Int32 WinRT.IObjectReference.TryAs(System.Guid, System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalString..ctor(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalString.Pinnable WinRT.MarshalString.CreatePinnable(System.String)' does not exist in the reference but it does exist in the implementation.

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -10,14 +10,15 @@ TypesMustExist : Type 'WinRT.ComWrappersHelper' does not exist in the reference 
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ComWrappersSupport.GetObjectReferenceForInterface<T>(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsReferenceToManagedObject.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Int32 WinRT.IObjectReference.TryAs(System.Guid, System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr, System.Func<WinRT.ObjectReference<WinRT.Interop.IDelegateVftbl>, T>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalString..ctor(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalString.Pinnable WinRT.MarshalString.CreatePinnable(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi(WinRT.MarshalString.Pinnable)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.IObjectReference WinRT.MarshalInspectable<T>.CreateMarshaler<V>(T, System.Guid, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.MarshalString.Pinnable' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.Interop.IDelegateVftbl' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-Total Issues: 20
+Total Issues: 22

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -4,6 +4,9 @@ TypesMustExist : Type 'ABI.System.Collections.Generic.IEnumerableMethods<T>' doe
 TypesMustExist : Type 'ABI.System.Collections.Generic.IListMethods<T>' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.System.Collections.Generic.IReadOnlyDictionaryMethods<K, V>' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.System.Collections.Generic.IReadOnlyListMethods<T>' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.EventHandler<T> ABI.System.EventHandler<T>.CreateRcw(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Collections.Specialized.NotifyCollectionChangedEventHandler ABI.System.Collections.Specialized.NotifyCollectionChangedEventHandler.CreateRcw(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.ComponentModel.PropertyChangedEventHandler ABI.System.ComponentModel.PropertyChangedEventHandler.CreateRcw(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.WinRT.Interop.IWeakReferenceSourceMethods' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Numerics.VectorExtensions' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.ComWrappersHelper' does not exist in the reference but it does exist in the implementation.
@@ -11,7 +14,7 @@ MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ComWrappersSupp
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Int32 WinRT.IObjectReference.TryAs(System.Guid, System.IntPtr)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr, System.Func<System.IntPtr, T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalString..ctor(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalString.Pinnable WinRT.MarshalString.CreatePinnable(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi()' does not exist in the reference but it does exist in the implementation.
@@ -20,4 +23,4 @@ MembersMustExist : Member 'public WinRT.IObjectReference WinRT.MarshalInspectabl
 TypesMustExist : Type 'WinRT.MarshalString.Pinnable' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-Total Issues: 22
+Total Issues: 24

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -11,14 +11,13 @@ MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ComWrappersSupp
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterObjectForInterface(System.Object, System.IntPtr, System.Runtime.InteropServices.CreateObjectFlags)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Int32 WinRT.IObjectReference.TryAs(System.Guid, System.IntPtr)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr, System.Func<WinRT.ObjectReference<WinRT.Interop.IDelegateVftbl>, T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr, System.Func<System.IntPtr, T>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalString..ctor(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalString.Pinnable WinRT.MarshalString.CreatePinnable(System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalString.GetAbi(WinRT.MarshalString.Pinnable)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.IObjectReference WinRT.MarshalInspectable<T>.CreateMarshaler<V>(T, System.Guid, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.MarshalString.Pinnable' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.Interop.IDelegateVftbl' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
 Total Issues: 22

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -298,7 +298,7 @@ namespace WinRT
             VftblIUnknownFromOriginalContext.Release(ThisPtrFromOriginalContext);
         }
 
-        internal unsafe bool IsReferenceToManagedObject
+        public unsafe bool IsReferenceToManagedObject
         {
             get
             {

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -298,7 +298,7 @@ namespace WinRT
             VftblIUnknownFromOriginalContext.Release(ThisPtrFromOriginalContext);
         }
 
-        public unsafe bool IsReferenceToManagedObject
+        internal unsafe bool IsReferenceToManagedObject
         {
             get
             {

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -49,7 +49,7 @@ namespace WinRT
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<ulong>), typeof(ABI.System.Nullable_ulong), "Windows.Foundation.IReference`1<UInt64>");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<float>), typeof(ABI.System.Nullable_float), "Windows.Foundation.IReference`1<Single>");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<double>), typeof(ABI.System.Nullable_double), "Windows.Foundation.IReference`1<Double>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<char>), typeof(ABI.System.Nullable_char), "Windows.Foundation.IReference`1<Char>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<char>), typeof(ABI.System.Nullable_char), "Windows.Foundation.IReference`1<Char16>");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<bool>), typeof(ABI.System.Nullable_bool), "Windows.Foundation.IReference`1<Boolean>");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<Guid>), typeof(ABI.System.Nullable_guid), "Windows.Foundation.IReference`1<Guid>");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<DateTimeOffset>), typeof(ABI.System.Nullable_DateTimeOffset), "Windows.Foundation.IReference`1<Windows.Foundation.DateTime>");

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -40,6 +40,21 @@ namespace WinRT
             
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<>), typeof(ABI.System.Nullable<>), "Windows.Foundation.IReference`1");
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<int>), typeof(ABI.System.Nullable_int), "Windows.Foundation.IReference`1<Int32>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<byte>), typeof(ABI.System.Nullable_byte), "Windows.Foundation.IReference`1<UInt8>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<sbyte>), typeof(ABI.System.Nullable_sbyte), "Windows.Foundation.IReference`1<Int8>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<short>), typeof(ABI.System.Nullable_short), "Windows.Foundation.IReference`1<Int16>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<ushort>), typeof(ABI.System.Nullable_ushort), "Windows.Foundation.IReference`1<UInt16>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<uint>), typeof(ABI.System.Nullable_uint), "Windows.Foundation.IReference`1<UInt32>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<long>), typeof(ABI.System.Nullable_long), "Windows.Foundation.IReference`1<Int64>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<ulong>), typeof(ABI.System.Nullable_ulong), "Windows.Foundation.IReference`1<UInt64>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<float>), typeof(ABI.System.Nullable_float), "Windows.Foundation.IReference`1<Single>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<double>), typeof(ABI.System.Nullable_double), "Windows.Foundation.IReference`1<Double>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<char>), typeof(ABI.System.Nullable_char), "Windows.Foundation.IReference`1<Char>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<bool>), typeof(ABI.System.Nullable_bool), "Windows.Foundation.IReference`1<Boolean>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<Guid>), typeof(ABI.System.Nullable_guid), "Windows.Foundation.IReference`1<Guid>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<DateTimeOffset>), typeof(ABI.System.Nullable_DateTimeOffset), "Windows.Foundation.IReference`1<Windows.Foundation.DateTime>");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<TimeSpan>), typeof(ABI.System.Nullable_TimeSpan), "Windows.Foundation.IReference`1<TimeSpan>");
+
             RegisterCustomAbiTypeMappingNoLock(typeof(DateTimeOffset), typeof(ABI.System.DateTimeOffset), "Windows.Foundation.DateTime");
             RegisterCustomAbiTypeMappingNoLock(typeof(Exception), typeof(ABI.System.Exception), "Windows.Foundation.HResult");
             RegisterCustomAbiTypeMappingNoLock(typeof(TimeSpan), typeof(ABI.System.TimeSpan), "Windows.Foundation.TimeSpan");

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -39,6 +39,7 @@ namespace WinRT
             RegisterCustomAbiTypeMappingNoLock(typeof(EventRegistrationToken), typeof(ABI.WinRT.EventRegistrationToken), "Windows.Foundation.EventRegistrationToken");
             
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<>), typeof(ABI.System.Nullable<>), "Windows.Foundation.IReference`1");
+            RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<int>), typeof(ABI.System.Nullable_int), "Windows.Foundation.IReference`1<Int32>");
             RegisterCustomAbiTypeMappingNoLock(typeof(DateTimeOffset), typeof(ABI.System.DateTimeOffset), "Windows.Foundation.DateTime");
             RegisterCustomAbiTypeMappingNoLock(typeof(Exception), typeof(ABI.System.Exception), "Windows.Foundation.HResult");
             RegisterCustomAbiTypeMappingNoLock(typeof(TimeSpan), typeof(ABI.System.TimeSpan), "Windows.Foundation.TimeSpan");
@@ -124,6 +125,11 @@ namespace WinRT
 
                 if (publicType.IsGenericType)
                 {
+                    if (CustomTypeToHelperTypeMappings.TryGetValue(publicType, out Type specializedAbiType))
+                    {
+                        return specializedAbiType;
+                    }
+
                     return CustomTypeToHelperTypeMappings.TryGetValue(publicType.GetGenericTypeDefinition(), out Type abiTypeDefinition)
                         ? abiTypeDefinition.MakeGenericType(publicType.GetGenericArguments())
                         : null;
@@ -143,6 +149,11 @@ namespace WinRT
             {
                 if (abiType.IsGenericType)
                 {
+                    if (CustomAbiTypeToTypeMappings.TryGetValue(abiType, out Type specializedPublicType))
+                    {
+                        return specializedPublicType;
+                    }
+
                     return CustomAbiTypeToTypeMappings.TryGetValue(abiType.GetGenericTypeDefinition(), out Type publicTypeDefinition)
                         ? publicTypeDefinition.MakeGenericType(abiType.GetGenericArguments())
                         : null;

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -51,18 +51,11 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            if (abiDelegate is null)
+            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
+
+            static global::System.EventHandler<T> CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
             {
-                return null;
-            }
-            else if (abiDelegate.IsReferenceToManagedObject)
-            {
-                return ComWrappersSupport.FindObject<global::System.EventHandler<T>>(nativeDelegate);
-            }
-            else
-            {
-                return (global::System.EventHandler<T>)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+                return new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke);
             }
         }
 
@@ -120,7 +113,6 @@ namespace ABI.System
                     MarshalInspectable<object>.DisposeMarshaler(__sender);
                     Marshaler<T>.DisposeMarshaler(__args);
                 }
-
             }
         }
 
@@ -192,18 +184,11 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            if (abiDelegate is null)
+            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
+
+            static global::System.EventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
             {
-                return null;
-            }
-            else if (abiDelegate.IsReferenceToManagedObject)
-            {
-                return ComWrappersSupport.FindObject<global::System.EventHandler>(nativeDelegate);
-            }
-            else
-            {
-                return (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+                return new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
             }
         }
 

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -51,7 +51,12 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.EventHandler<T>(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
+            return MarshalDelegate.FromAbi<global::System.EventHandler<T>>(nativeDelegate);
+        }
+
+        public static global::System.EventHandler<T> CreateRcw(IntPtr ptr)
+        {
+            return new global::System.EventHandler<T>(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke);
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -179,7 +184,12 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.EventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
+            return MarshalDelegate.FromAbi<global::System.EventHandler>(nativeDelegate);
+        }
+
+        public static global::System.EventHandler CreateRcw(IntPtr ptr)
+        {
+            return new global::System.EventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke);
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -51,12 +51,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
-
-            static global::System.EventHandler<T> CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
-            {
-                return new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke);
-            }
+            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.EventHandler<T>(new NativeDelegateWrapper(objRef).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -184,12 +179,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
-
-            static global::System.EventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
-            {
-                return new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
-            }
+            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.EventHandler(new NativeDelegateWrapper(objRef).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -51,7 +51,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.EventHandler<T>(new NativeDelegateWrapper(objRef).Invoke));
+            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.EventHandler<T>(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -179,7 +179,7 @@ namespace ABI.System
 
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.EventHandler(new NativeDelegateWrapper(objRef).Invoke));
+            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.EventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -52,7 +52,18 @@ namespace ABI.System
         public static unsafe global::System.EventHandler<T> FromAbi(IntPtr nativeDelegate)
         {
             var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            return abiDelegate is null ? null : (global::System.EventHandler<T>)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            if (abiDelegate is null)
+            {
+                return null;
+            }
+            else if (abiDelegate.IsReferenceToManagedObject)
+            {
+                return ComWrappersSupport.FindObject<global::System.EventHandler<T>>(nativeDelegate);
+            }
+            else
+            {
+                return (global::System.EventHandler<T>)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler<T>(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            }
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -182,7 +193,18 @@ namespace ABI.System
         public static unsafe global::System.EventHandler FromAbi(IntPtr nativeDelegate)
         {
             var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            return abiDelegate is null ? null : (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            if (abiDelegate is null)
+            {
+                return null;
+            }
+            else if (abiDelegate.IsReferenceToManagedObject)
+            {
+                return ComWrappersSupport.FindObject<global::System.EventHandler>(nativeDelegate);
+            }
+            else
+            {
+                return (global::System.EventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.EventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            }
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -52,7 +52,7 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(objRef).Invoke));
+            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -52,7 +52,12 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
+            return MarshalDelegate.FromAbi<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(nativeDelegate);
+        }
+
+        public static global::System.Collections.Specialized.NotifyCollectionChangedEventHandler CreateRcw(IntPtr ptr)
+        {
+            return new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke);
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -52,18 +52,11 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            if (abiDelegate is null)
+            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
+
+            static global::System.Collections.Specialized.NotifyCollectionChangedEventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
             {
-                return null;
-            }
-            else if (abiDelegate.IsReferenceToManagedObject)
-            {
-                return ComWrappersSupport.FindObject<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(nativeDelegate);
-            }
-            else
-            {
-                return (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+                return new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
             }
         }
 

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -53,7 +53,18 @@ namespace ABI.System.Collections.Specialized
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
             var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            return abiDelegate is null ? null : (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            if (abiDelegate is null)
+            {
+                return null;
+            }
+            else if (abiDelegate.IsReferenceToManagedObject)
+            {
+                return ComWrappersSupport.FindObject<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>(nativeDelegate);
+            }
+            else
+            {
+                return (global::System.Collections.Specialized.NotifyCollectionChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            }
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -52,12 +52,7 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe global::System.Collections.Specialized.NotifyCollectionChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
-
-            static global::System.Collections.Specialized.NotifyCollectionChangedEventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
-            {
-                return new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
-            }
+            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(objRef).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -158,8 +158,8 @@ namespace ABI.System
 
     // Used to handle boxing of strings and types where the C# compiler will de-duplicate them
     // causing for the same instance to be reused with multiple different box instances.
-    // This is also used for delegates which are objects themselves in C# and are associated with their own
-    // ptr and can not be also associated with the ptr for the box / nullable.
+    // This is also used for delegates which are objects themselves in C# and are associated with
+    // their own ptr and thereby can not be associated with the ptr for the box / nullable.
     internal sealed class Nullable
     {
         public Nullable(object boxedObject)

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -156,6 +156,20 @@ namespace ABI.System
         }
     }
 
+    // Used to handle boxing of strings and types where the C# compiler will de-duplicate them
+    // causing for the same instance to be reused with multiple different box instances.
+    // This is also used for delegates which are objects themselves in C# and are associated with their own
+    // ptr and can not be also associated with the ptr for the box / nullable.
+    internal sealed class Nullable
+    {
+        public Nullable(object boxedObject)
+        {
+            Value = boxedObject;
+        }
+
+        public object Value { get; }
+    }
+
     [Guid("548cefbd-bc8a-5fa0-8df2-957440fc8bf4")]
     internal static class Nullable_int
     {
@@ -293,7 +307,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static string GetValue(IInspectable inspectable)
+        unsafe internal static Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;
@@ -301,7 +315,7 @@ namespace ABI.System
             {
                 ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return MarshalString.FromAbi(__retval);
+                return new Nullable(MarshalString.FromAbi(__retval));
             }
             finally
             {
@@ -1450,23 +1464,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        unsafe internal static object GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            IntPtr __retval = default;
-            try
-            {
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return MarshalInspectable<object>.FromAbi(__retval);
-            }
-            finally
-            {
-                MarshalInspectable<object>.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("3830ad99-d8da-53f3-989b-fc92ad222778")]
@@ -1529,7 +1526,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static global::System.Type GetValue(IInspectable inspectable)
+        unsafe internal static Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             Type __retval = default;
@@ -1537,7 +1534,7 @@ namespace ABI.System
             {
                 ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Type*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return Type.FromAbi(__retval);
+                return new Nullable(Type.FromAbi(__retval));
             }
             finally
             {
@@ -1598,7 +1595,7 @@ namespace ABI.System
 
         public static Guid PIID = Vftbl.PIID;
 
-        unsafe internal static T GetValue(IInspectable inspectable)
+        unsafe internal static Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;
@@ -1606,7 +1603,7 @@ namespace ABI.System
             {
                 ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref PIID, out nullablePtr));
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return Marshaler<T>.FromAbi(__retval);
+                return new Nullable(Marshaler<T>.FromAbi(__retval));
             }
             finally
             {

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -1556,26 +1556,23 @@ namespace ABI.System
         public unsafe struct Vftbl
         {
             internal IInspectable.Vftbl IInspectableVftbl;
-            private void* _Get_Value_0;
-            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+            private Nullable_Delegates.GetValueDelegate _Get_Value_0;
 
             public static Guid PIID = GuidGenerator.CreateIID(typeof(Nullable<T>));
 
             private static readonly Vftbl AbiToProjectionVftable;
             public static readonly IntPtr AbiToProjectionVftablePtr;
 
-            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
-            private static readonly GetValueDelegate delegateCache;
-
             static Vftbl()
             {
                 AbiToProjectionVftable = new Vftbl
                 {
                     IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
-                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+                    _Get_Value_0 = Do_Abi_get_Value_0
                 };
                 var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
-                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                Marshal.StructureToPtr(AbiToProjectionVftable.IInspectableVftbl, (IntPtr)nativeVftbl, false);
+                nativeVftbl[6] = Marshal.GetFunctionPointerForDelegate(AbiToProjectionVftable._Get_Value_0);
                 AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
             }
 
@@ -1617,5 +1614,10 @@ namespace ABI.System
                 Marshal.Release(nullablePtr);
             }
         }
+    }
+
+    internal static class Nullable_Delegates
+    {
+        public unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
     }
 }

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -126,10 +126,16 @@ namespace ABI.System
         public IntPtr ThisPtr => _obj.ThisPtr;
         public ObjectReference<I> AsInterface<I>() => _obj.As<I>();
         public A As<A>() => _obj.AsType<A>();
-        public Nullable(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public Nullable(IObjectReference obj) : this(obj.As<Vftbl>(Vftbl.PIID)) { }
         public Nullable(ObjectReference<Vftbl> obj)
         {
             _obj = obj;
+        }
+
+        internal static T GetValue(IInspectable inspectable)
+        {
+            var nullable = new Nullable<T>(inspectable.ObjRef);
+            return nullable.Value;
         }
 
         public unsafe T Value
@@ -146,6 +152,1469 @@ namespace ABI.System
                 {
                     Marshaler<T>.DisposeAbi(__params[1]);
                 }
+            }
+        }
+    }
+
+    [Guid("548cefbd-bc8a-5fa0-8df2-957440fc8bf4")]
+    internal static class Nullable_int
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};i4)";
+        internal static Guid IID = new(0x548cefbd, 0xbc8a, 0x5fa0, 0x8d, 0xf2, 0x95, 0x74, 0x40, 0xfc, 0x8b, 0xf4);
+
+        [Guid("548cefbd-bc8a-5fa0-8df2-957440fc8bf4")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, int*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, int*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, int* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, int*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, int* __return_value__)
+            {
+                int ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (int)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static int GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                int __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("fd416dfb-2a07-52eb-aae3-dfce14116c05")]
+    internal static class Nullable_string
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};string)";
+        internal static Guid IID = new(0xfd416dfb, 0x2a07, 0x52eb, 0xaa, 0xe3, 0xdf, 0xce, 0x14, 0x11, 0x6c, 0x05);
+
+        [Guid("fd416dfb-2a07-52eb-aae3-dfce14116c05")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, IntPtr*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, IntPtr* __return_value__)
+            {
+                string ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (string)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = MarshalString.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static string GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            IntPtr __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return MarshalString.FromAbi(__retval);
+            }
+            finally
+            {
+                MarshalString.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")]
+    internal static class Nullable_byte
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};u1)";
+        internal static Guid IID = new(0xe5198cc8, 0x2873, 0x55f5, 0xb0, 0xa1, 0x84, 0xff, 0x9e, 0x4a, 0xad, 0x62);
+
+        [Guid("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, byte*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, byte* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, byte*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, byte* __return_value__)
+            {
+                byte ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (byte)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static byte GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                byte __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("95500129-fbf6-5afc-89df-70642d741990")]
+    internal static class Nullable_sbyte
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};i1)";
+        internal static Guid IID = new(0x95500129, 0xfbf6, 0x5afc, 0x89, 0xdf, 0x70, 0x64, 0x2d, 0x74, 0x19, 0x90);
+
+        [Guid("95500129-fbf6-5afc-89df-70642d741990")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, sbyte*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, sbyte*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, sbyte* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, sbyte*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, sbyte* __return_value__)
+            {
+                sbyte ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (sbyte)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static sbyte GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                sbyte __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, sbyte*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("6ec9e41b-6709-5647-9918-a1270110fc4e")]
+    internal static class Nullable_short
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};i2)";
+        internal static Guid IID = new(0x6ec9e41b, 0x6709, 0x5647, 0x99, 0x18, 0xa1, 0x27, 0x01, 0x10, 0xfc, 0x4e);
+
+        [Guid("6ec9e41b-6709-5647-9918-a1270110fc4e")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, short*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, short*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, short* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, short*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, short* __return_value__)
+            {
+                short ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (short)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static short GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                short __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, short*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("5ab7d2c3-6b62-5e71-a4b6-2d49c4f238fd")]
+    internal static class Nullable_ushort
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};u2)";
+        internal static Guid IID = new(0x5ab7d2c3, 0x6b62, 0x5e71, 0xa4, 0xb6, 0x2d, 0x49, 0xc4, 0xf2, 0x38, 0xfd);
+
+        [Guid("5ab7d2c3-6b62-5e71-a4b6-2d49c4f238fd")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, ushort*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, ushort*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, ushort* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, ushort*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, ushort* __return_value__)
+            {
+                ushort ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (ushort)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static ushort GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                ushort __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, ushort*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("513ef3af-e784-5325-a91e-97c2b8111cf3")]
+    internal static class Nullable_uint
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};u4)";
+        internal static Guid IID = new(0x513ef3af, 0xe784, 0x5325, 0xa9, 0x1e, 0x97, 0xc2, 0xb8, 0x11, 0x1c, 0xf3);
+
+        [Guid("513ef3af-e784-5325-a91e-97c2b8111cf3")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, uint*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, uint* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, uint*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, uint* __return_value__)
+            {
+                uint ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (uint)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static uint GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                uint __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("4dda9e24-e69f-5c6a-a0a6-93427365af2a")]
+    internal static class Nullable_long
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};i8)";
+        internal static Guid IID = new(0x4dda9e24, 0xe69f, 0x5c6a, 0xa0, 0xa6, 0x93, 0x42, 0x73, 0x65, 0xaf, 0x2a);
+
+        [Guid("4dda9e24-e69f-5c6a-a0a6-93427365af2a")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, long*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, long*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, long* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, long*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, long* __return_value__)
+            {
+                long ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (long)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static long GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                long __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, long*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("6755e376-53bb-568b-a11d-17239868309e")]
+    internal static class Nullable_ulong
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};u8)";
+        internal static Guid IID = new(0x6755e376, 0x53bb, 0x568b, 0xa1, 0x1d, 0x17, 0x23, 0x98, 0x68, 0x30, 0x9e);
+
+        [Guid("6755e376-53bb-568b-a11d-17239868309e")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, ulong*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, ulong*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, ulong* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, ulong*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, ulong* __return_value__)
+            {
+                ulong ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (ulong)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static ulong GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                ulong __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, ulong*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("719cc2ba-3e76-5def-9f1a-38d85a145ea8")]
+    internal static class Nullable_float
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};f4)";
+        internal static Guid IID = new(0x719cc2ba, 0x3e76, 0x5def, 0x9f, 0x1a, 0x38, 0xd8, 0x5a, 0x14, 0x5e, 0xa8);
+
+        [Guid("719cc2ba-3e76-5def-9f1a-38d85a145ea8")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, float*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, float*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, float* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, float*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, float* __return_value__)
+            {
+                float ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (float)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static float GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                float __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, float*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("2f2d6c29-5473-5f3e-92e7-96572bb990e2")]
+    internal static class Nullable_double
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};f8)";
+        internal static Guid IID = new(0x2f2d6c29, 0x5473, 0x5f3e, 0x92, 0xe7, 0x96, 0x57, 0x2b, 0xb9, 0x90, 0xe2);
+
+        [Guid("2f2d6c29-5473-5f3e-92e7-96572bb990e2")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, double*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, double*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, double* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, double*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, double* __return_value__)
+            {
+                double ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (double)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static double GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                double __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, double*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("fb393ef3-bbac-5bd5-9144-84f23576f415")]
+    internal static class Nullable_char
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};c2)";
+        internal static Guid IID = new(0xfb393ef3, 0xbbac, 0x5bd5, 0x91, 0x44, 0x84, 0xf2, 0x35, 0x76, 0xf4, 0x15);
+
+        [Guid("fb393ef3-bbac-5bd5-9144-84f23576f415")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, char*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, char*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, char* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, char*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, char* __return_value__)
+            {
+                char ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (char)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static char GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                char __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, char*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("3c00fd60-2950-5939-a21a-2d12c5a01b8a")]
+    internal static class Nullable_bool
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};b1)";
+        internal static Guid IID = new(0x3c00fd60, 0x2950, 0x5939, 0xa2, 0x1a, 0x2d, 0x12, 0xc5, 0xa0, 0x1b, 0x8a);
+
+        [Guid("3c00fd60-2950-5939-a21a-2d12c5a01b8a")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, bool*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, bool*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, bool* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, bool*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, bool* __return_value__)
+            {
+                bool ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (bool)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static bool GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                bool __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, bool*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("7d50f649-632c-51f9-849a-ee49428933ea")]
+    internal static class Nullable_guid
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};g16)";
+        internal static Guid IID = new(0x7d50f649, 0x632c, 0x51f9, 0x84, 0x9a, 0xee, 0x49, 0x42, 0x89, 0x33, 0xea);
+
+        [Guid("7d50f649-632c-51f9-849a-ee49428933ea")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, Guid*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, Guid*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, Guid* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, Guid*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, Guid* __return_value__)
+            {
+                Guid ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (Guid)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = ____return_value__;
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static Guid GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                Guid __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("5541d8a7-497c-5aa4-86fc-7713adbf2a2c")]
+    internal static class Nullable_DateTimeOffset
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};struct(Windows.Foundation.DateTime;i8))";
+        internal static Guid IID = new(0x5541d8a7, 0x497c, 0x5aa4, 0x86, 0xfc, 0x77, 0x13, 0xad, 0xbf, 0x2a, 0x2c);
+
+        [Guid("5541d8a7-497c-5aa4-86fc-7713adbf2a2c")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, DateTimeOffset*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, DateTimeOffset*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, DateTimeOffset* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, DateTimeOffset*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, DateTimeOffset* __return_value__)
+            {
+                global::System.DateTimeOffset ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (global::System.DateTimeOffset)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = DateTimeOffset.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static global::System.DateTimeOffset GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            DateTimeOffset __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, DateTimeOffset*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return DateTimeOffset.FromAbi(__retval);
+            }
+            finally
+            {
+                DateTimeOffset.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("604d0c4c-91de-5c2a-935f-362f13eaf800")]
+    internal static class Nullable_TimeSpan
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};struct(Windows.Foundation.TimeSpan;i8))";
+        internal static Guid IID = new(0x604d0c4c, 0x91de, 0x5c2a, 0x93, 0x5f, 0x36, 0x2f, 0x13, 0xea, 0xf8, 0x00);
+
+        [Guid("604d0c4c-91de-5c2a-935f-362f13eaf800")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, TimeSpan*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, TimeSpan*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, TimeSpan* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, TimeSpan*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, TimeSpan* __return_value__)
+            {
+                global::System.TimeSpan ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (global::System.TimeSpan)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = TimeSpan.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static global::System.TimeSpan GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            TimeSpan __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, TimeSpan*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return TimeSpan.FromAbi(__retval);
+            }
+            finally
+            {
+                TimeSpan.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("06dccc90-a058-5c88-87b7-6f3360a2fc16")]
+    internal static class Nullable_Object
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};cinterface(IInspectable))";
+        internal static Guid IID = new(0x06dccc90, 0xa058, 0x5c88, 0x87, 0xb7, 0x6f, 0x33, 0x60, 0xa2, 0xfc, 0x16);
+
+        [Guid("06dccc90-a058-5c88-87b7-6f3360a2fc16")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, IntPtr*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, IntPtr* __return_value__)
+            {
+                object ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = MarshalInspectable<object>.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static object GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            IntPtr __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return MarshalInspectable<object>.FromAbi(__retval);
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("3830ad99-d8da-53f3-989b-fc92ad222778")]
+    internal static class Nullable_Type
+    {
+        public static string GetGuidSignature() => "pinterface({61c17706-2d65-11e0-9ae8-d48564015472};struct(Windows.UI.Xaml.Interop.TypeName;string;enum(Windows.UI.Xaml.Interop.TypeKind;i4)))";
+        internal static Guid IID = new(0x3830ad99, 0xd8da, 0x53f3, 0x98, 0x9b, 0xfc, 0x92, 0xad, 0x22, 0x27, 0x78);
+
+        [Guid("3830ad99-d8da-53f3-989b-fc92ad222778")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, Type*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, Type*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+#if NETSTANDARD2_0
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, Type* value);
+            private static readonly GetValueDelegate delegateCache;
+#endif
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+#if NETSTANDARD2_0
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+#else
+                    _Get_Value_0 = (delegate* unmanaged<IntPtr, Type*, int>)&Do_Abi_get_Value_0
+#endif
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+#if !NETSTANDARD2_0
+            [UnmanagedCallersOnly]
+#endif
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, Type* __return_value__)
+            {
+                global::System.Type ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = (global::System.Type)global::WinRT.ComWrappersSupport.FindObject<object>(thisPtr);
+                    *__return_value__ = Type.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        unsafe internal static global::System.Type GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            Type __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref IID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Type*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return Type.FromAbi(__retval);
+            }
+            finally
+            {
+                Type.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    [Guid("61C17706-2D65-11E0-9AE8-D48564015472")]
+    internal static class Nullable_Delegate<T> where T : global::System.Delegate
+    {
+        public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(Nullable<T>));
+
+        [Guid("61C17706-2D65-11E0-9AE8-D48564015472")]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _Get_Value_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> Get_Value_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_Get_Value_0; set => _Get_Value_0 = value; }
+
+            public static Guid PIID = GuidGenerator.CreateIID(typeof(Nullable<T>));
+
+            private static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+            private unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
+            private static readonly GetValueDelegate delegateCache;
+
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
+                    _Get_Value_0 = Marshal.GetFunctionPointerForDelegate(delegateCache = Do_Abi_get_Value_0).ToPointer()
+                };
+                var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
+                Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
+                AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
+            }
+
+            private static unsafe int Do_Abi_get_Value_0(IntPtr thisPtr, IntPtr* __return_value__)
+            {
+                T ____return_value__ = default;
+
+                *__return_value__ = default;
+
+                try
+                {
+                    ____return_value__ = global::WinRT.ComWrappersSupport.FindObject<T>(thisPtr);
+                    *__return_value__ = (IntPtr)Marshaler<T>.FromManaged(____return_value__);
+                }
+                catch (global::System.Exception __exception__)
+                {
+                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+                }
+                return 0;
+            }
+        }
+
+        public static Guid PIID = Vftbl.PIID;
+
+        unsafe internal static T GetValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            IntPtr __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref PIID, out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return Marshaler<T>.FromAbi(__retval);
+            }
+            finally
+            {
+                Marshaler<T>.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
             }
         }
     }

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -51,7 +51,7 @@ namespace ABI.System.ComponentModel
 
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(objRef).Invoke));
+            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -51,12 +51,7 @@ namespace ABI.System.ComponentModel
 
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
-
-            static global::System.ComponentModel.PropertyChangedEventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
-            {
-                return new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
-            }
+            return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(objRef).Invoke));
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -51,7 +51,12 @@ namespace ABI.System.ComponentModel
 
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
+            return MarshalDelegate.FromAbi<global::System.ComponentModel.PropertyChangedEventHandler>(nativeDelegate);
+        }
+
+        public static global::System.ComponentModel.PropertyChangedEventHandler CreateRcw(IntPtr ptr)
+        {
+            return new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke);
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -51,18 +51,11 @@ namespace ABI.System.ComponentModel
 
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
-            var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            if (abiDelegate is null)
+            return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
+
+            static global::System.ComponentModel.PropertyChangedEventHandler CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
             {
-                return null;
-            }
-            else if (abiDelegate.IsReferenceToManagedObject)
-            {
-                return ComWrappersSupport.FindObject<global::System.ComponentModel.PropertyChangedEventHandler>(nativeDelegate);
-            }
-            else
-            {
-                return (global::System.ComponentModel.PropertyChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+                return new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke);
             }
         }
 

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -52,7 +52,18 @@ namespace ABI.System.ComponentModel
         public static unsafe global::System.ComponentModel.PropertyChangedEventHandler FromAbi(IntPtr nativeDelegate)
         {
             var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-            return abiDelegate is null ? null : (global::System.ComponentModel.PropertyChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            if (abiDelegate is null)
+            {
+                return null;
+            }
+            else if (abiDelegate.IsReferenceToManagedObject)
+            {
+                return ComWrappersSupport.FindObject<global::System.ComponentModel.PropertyChangedEventHandler>(nativeDelegate);
+            }
+            else
+            {
+                return (global::System.ComponentModel.PropertyChangedEventHandler)ComWrappersSupport.TryRegisterObjectForInterface(new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+            }
         }
 
         [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -160,6 +160,7 @@ namespace WinRT
                 "Boolean" => typeof(bool),
                 "String" => typeof(string),
                 "Char" => typeof(char),
+                "Char16" => typeof(char),
                 "Single" => typeof(float),
                 "Double" => typeof(double),
                 "Guid" => typeof(Guid),

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -133,6 +133,10 @@ namespace WinRT
             {
                 if (genericTypes != null)
                 {
+                    if(resolvedType == typeof(global::System.Nullable<>) && genericTypes[0].IsDelegate())
+                    {
+                        return typeof(ABI.System.Nullable_Delegate<>).MakeGenericType(genericTypes);
+                    }
                     resolvedType = resolvedType.MakeGenericType(genericTypes);
                 }
                 return resolvedType;

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6559,7 +6559,7 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
-return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new %(new NativeDelegateWrapper(objRef).Invoke));
+return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new %(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
 }
 
 [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6559,12 +6559,7 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
-return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
-
-static % CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
-{
-    return new %(new NativeDelegateWrapper(abiDelegate).Invoke);
-}
+return MarshalDelegate.FromAbi(nativeDelegate, (objRef) => new %(new NativeDelegateWrapper(objRef).Invoke));
 }
 
 [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -6697,7 +6692,6 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             // GetAbi
             type_name,
             // FromAbi
-            type_name,
             type_name,
             type_name,
             // NativeDelegateWrapper.Invoke

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6559,18 +6559,11 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
-var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-if (abiDelegate is null)
+return MarshalDelegate.FromAbi(nativeDelegate, CreateDelegate);
+
+static % CreateDelegate(ObjectReference<global::WinRT.Interop.IDelegateVftbl> abiDelegate)
 {
-return null;
-}
-else if (abiDelegate.IsReferenceToManagedObject)
-{
-return ComWrappersSupport.FindObject<%>(nativeDelegate);
-}
-else
-{
-return (%)ComWrappersSupport.TryRegisterObjectForInterface(new %(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+    return new %(new NativeDelegateWrapper(abiDelegate).Invoke);
 }
 }
 
@@ -6704,7 +6697,6 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             // GetAbi
             type_name,
             // FromAbi
-            type_name,
             type_name,
             type_name,
             type_name,

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6559,7 +6559,12 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
-return MarshalDelegate.FromAbi(nativeDelegate, (ptr) => new %(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke));
+return MarshalDelegate.FromAbi<%>(nativeDelegate);
+}
+
+public static % CreateRcw(IntPtr ptr)
+{
+return new %(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr)).Invoke);
 }
 
 [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -6692,6 +6697,8 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             // GetAbi
             type_name,
             // FromAbi
+            type_name,
+            type_name,
             type_name,
             type_name,
             // NativeDelegateWrapper.Invoke

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6560,7 +6560,18 @@ public static IntPtr GetAbi(IObjectReference value) => MarshalInterfaceHelper<%>
 public static unsafe % FromAbi(IntPtr nativeDelegate)
 {
 var abiDelegate = ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(nativeDelegate);
-return abiDelegate is null ? null : (%)ComWrappersSupport.TryRegisterObjectForInterface(new %(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+if (abiDelegate is null)
+{
+return null;
+}
+else if (abiDelegate.IsReferenceToManagedObject)
+{
+return ComWrappersSupport.FindObject<%>(nativeDelegate);
+}
+else
+{
+return (%)ComWrappersSupport.TryRegisterObjectForInterface(new %(new NativeDelegateWrapper(abiDelegate).Invoke), nativeDelegate);
+}
 }
 
 [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
@@ -6693,6 +6704,7 @@ public static Guid PIID = GuidGenerator.CreateIID(typeof(%));)",
             // GetAbi
             type_name,
             // FromAbi
+            type_name,
             type_name,
             type_name,
             type_name,

--- a/src/cswinrt/strings/WinRT_Interop.cs
+++ b/src/cswinrt/strings/WinRT_Interop.cs
@@ -20,13 +20,6 @@ namespace WinRT.Interop
         internal static readonly Guid IID = new(0x00000035, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
     }
 
-    // IDelegate
-    internal struct IDelegateVftbl
-    {
-        public IUnknownVftbl IUnknownVftbl;
-        public IntPtr Invoke;
-    }
-
     [Guid("64BD43F8-bFEE-4EC4-B7EB-2935158DAE21")]
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct IReferenceTrackerTargetVftbl

--- a/src/cswinrt/strings/WinRT_Interop.cs
+++ b/src/cswinrt/strings/WinRT_Interop.cs
@@ -20,6 +20,13 @@ namespace WinRT.Interop
         internal static readonly Guid IID = new(0x00000035, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
     }
 
+    // IDelegate
+    internal struct IDelegateVftbl
+    {
+        public IUnknownVftbl IUnknownVftbl;
+        public IntPtr Invoke;
+    }
+
     [Guid("64BD43F8-bFEE-4EC4-B7EB-2935158DAE21")]
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct IReferenceTrackerTargetVftbl

--- a/src/get_testwinrt.cmd
+++ b/src/get_testwinrt.cmd
@@ -14,7 +14,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard d448f7cf94b5376b2ef7af9ad78b7c5077ff0473
+git reset -q --hard c08bbd40da7f93e29ca2ed683e32121a4692535d
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 %this_dir%.nuget\nuget.exe restore


### PR DESCRIPTION
Created specialized versions of some of the common nullable types to make use of function pointers rather than delegates and avoid generic marshalers.

Fixed issue with nullable delegates where we can't associate them with 2 different pointers (delegate ptr and nullable ptr) and as part of that also improved how we return back wrapped nullable objects which were used for types and strings and now also used for delegates.

Fixes #87 