### PR TITLE
Support DispatcherQueueSynchronizationContext.Send.

### DIFF
--- a/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Reunion/Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs
@@ -27,7 +27,20 @@ namespace Microsoft.System
 
         public override void Send(SendOrPostCallback d, object state)
         {
-            throw new NotSupportedException("Send not supported");
+            if (m_dispatcherQueue.HasThreadAccess)
+            {
+                d(state);
+            }
+            else
+            {
+                var m = new ManualResetEvent(false);
+                m_dispatcherQueue.TryEnqueue(() =>
+                {
+                    d(state);
+                    m.Set();
+                });
+                m.WaitOne();
+            }
         }
 
         public override SynchronizationContext CreateCopy()


### PR DESCRIPTION
In various places in .NET, the runtime calls SynchronizationContext.Send. For example in the SystemEvents class Send is used: https://github.com/dotnet/runtime/blob/6de7147b9266d7730b0d73ba67632b0c198cb11e/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs#L1326

This means that subscribing to events on the SystemEvents class from the UI thread in a WinUI3 app works, but the event is never fired, because Send throws an exception. There are likely other places where Send is used and where this causes problems for WinUI3 apps.

This PR adds support for Send in a similar to how Xamarin Android does this for the Android main thread: https://github.com/xamarin/xamarin-android/blob/main/src/Mono.Android/Android.App/SyncContext.cs and MAUI for GtkSynchronizationContext: https://github.com/dotnet/maui/blob/18e0f4ebbcca7c904ccdb67e6439cb72382e2a40/src/Compatibility/Core/src/GTK/GtkSynchronizationContext.cs