### PR TITLE
Control ADO-Maestro job using variable

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
@@ -4,8 +4,8 @@ variables:
 name: $(MajorVersion).$(MinorVersion).$(PatchVersion)$(PrereleaseVersion).$(date:yyMMdd)$(rev:.r)
 
 stages:
-#- template: CsWinRT-BuildAndTest-Stage.yml
+- template: CsWinRT-BuildAndTest-Stage.yml
 
-#- template: CsWinRT-PublishToNuget-Stage.yml
+- template: CsWinRT-PublishToNuget-Stage.yml
 
 - template: CsWinRT-PublishToMaestro-Stage.yml

--- a/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
@@ -9,6 +9,3 @@ stages:
 - template: CsWinRT-PublishToNuget-Stage.yml
 
 - template: CsWinRT-PublishToMaestro-Stage.yml
-  parameters:
-    ${{ if eq(variables['PrereleaseVersion'], '') }}:
-      IsRelease: true

--- a/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Pipeline.yml
@@ -4,8 +4,8 @@ variables:
 name: $(MajorVersion).$(MinorVersion).$(PatchVersion)$(PrereleaseVersion).$(date:yyMMdd)$(rev:.r)
 
 stages:
-- template: CsWinRT-BuildAndTest-Stage.yml
+#- template: CsWinRT-BuildAndTest-Stage.yml
 
-- template: CsWinRT-PublishToNuget-Stage.yml
+#- template: CsWinRT-PublishToNuget-Stage.yml
 
 - template: CsWinRT-PublishToMaestro-Stage.yml

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -3,7 +3,7 @@ stages:
   displayName: Trigger Maestro Publish
   jobs:
   - job: TriggerMaestroPublish
-    condition: eq(variables['_isRelease'],'true')
+    condition: eq(variables['_IsRelease'],'true')
     variables:
       _DotNetCoreRuntimeVersion: 5.0.11        # matches with SDK v. 5.0.402
       _WindowsSdkPackageVersion: 10.0.18362.22 # matches with one consumed in WindowsAppSdk

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -1,12 +1,9 @@
-parameters:
-  IsRelease: ''
-
 stages:
 - stage: PublishToMaestro
   displayName: Trigger Maestro Publish
   jobs:
   - job: TriggerMaestroPublish
-    condition: eq('${{ parameters.IsRelease }}','true')
+    condition: eq(variables['_isRelease'],'true')
     variables:
       _DotNetCoreRuntimeVersion: 5.0.11        # matches with SDK v. 5.0.402
       _WindowsSdkPackageVersion: 10.0.18362.22 # matches with one consumed in WindowsAppSdk

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -10,3 +10,7 @@ variables:
   Net6.SDK.Version: '6.0.100-rc.2.21505.57'
   NoSamples: 'false'
 
+  # This 'coalesce' pattern allows the yml to define a default value for a variable but allows the value to be overridden at queue time.
+  # E.g. '_isRelease' defaults to empty string, but if 'isRelease' is set at queue time that value will be used.
+
+  _isRelease: $[coalesce(variables.isRelease, '')]

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -11,6 +11,6 @@ variables:
   NoSamples: 'false'
 
   # This 'coalesce' pattern allows the yml to define a default value for a variable but allows the value to be overridden at queue time.
-  # E.g. '_isRelease' defaults to empty string, but if 'isRelease' is set at queue time that value will be used.
+  # E.g. '_IsRelease' defaults to empty string, but if 'IsRelease' is set at queue time that value will be used.
 
-  _isRelease: $[coalesce(variables.isRelease, '')]
+  _IsRelease: $[coalesce(variables.IsRelease, '')]


### PR DESCRIPTION
Feeding a parameter thru was not working when the queue-time variable was set. To fix this we use the coalesce pattern and change the condition on the Maestro task.