### PR TITLE
More queue-time variables

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -4,9 +4,6 @@ stages:
   jobs:
   - job: TriggerMaestroPublish
     condition: eq(variables['_IsRelease'],'true')
-    variables:
-      _DotNetCoreRuntimeVersion: 5.0.11        # matches with SDK v. 5.0.402
-      _WindowsSdkPackageVersion: 10.0.18362.22 # matches with one consumed in WindowsAppSdk
     pool: 
       vmImage: windows-2019
     steps:
@@ -47,4 +44,4 @@ stages:
     - template: ..\..\eng\common\AzurePipelineTemplates\Maestro-PublishBuildToMaestro-Steps.yml 
       parameters:
         AssetNames: Microsoft.Windows.CsWinRT;CsWinRT.Dependency.DotNetCoreSdk;CsWinRT.Dependency.DotNetCoreRuntime;CsWinRT.Dependency.WindowsSdkPackage
-        AssetVersions: $(NugetVersion);$(Net5.Sdk.Version);$(_DotNetCoreRuntimeVersion);$(_WindowsSdkPackageVersion)
+        AssetVersions: $(NugetVersion);$(Net5.Sdk.Version);$(_DotNetRuntimeVersion);$(_WindowsSdkPackageVersion)

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -13,5 +13,5 @@ variables:
   # E.g. '_IsRelease' defaults to empty string, but if 'IsRelease' is set at queue time that value will be used.
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
-  _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.11')]  
+  _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
   _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '10.0.18362.23-preview')]  

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -1,5 +1,4 @@
 variables:
-  DotNetRuntimeVersion: '5.0.11'
   MajorVersion: 1
   MinorVersion: 5
   PatchVersion: 0
@@ -9,8 +8,10 @@ variables:
   Net5.SDK.Version: '5.0.402'
   Net6.SDK.Version: '6.0.100-rc.2.21505.57'
   NoSamples: 'false'
-
+  
   # This 'coalesce' pattern allows the yml to define a default value for a variable but allows the value to be overridden at queue time.
   # E.g. '_IsRelease' defaults to empty string, but if 'IsRelease' is set at queue time that value will be used.
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
+  _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.11')]  
+  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '10.0.18362.23-preview')]  

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -14,4 +14,4 @@ variables:
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
   _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
-  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '10.0.18362.23-preview')]  
+  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '23-preview')]  


### PR DESCRIPTION
Allows us to set the version dependencies communicated to Maestro at queue-time. 
Note that the WindowsSdkPackageVersion is no longer a full windows version, but just the suffix used to get the latest projection -- e.g. "10.0.17763.22" -> "22"