### PR TITLE
Eliminate an ObjectReference object in a couple custom types

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -1,10 +1,10 @@
 variables:
   DotNetRuntimeVersion: '5.0.11'
   MajorVersion: 1
-  MinorVersion: 4
-  PatchVersion: 2
+  MinorVersion: 5
+  PatchVersion: 0
   PrereleaseVersion: '-prerelease'
-  WinRT.Runtime.AssemblyVersion: '1.4.0.0'
+  WinRT.Runtime.AssemblyVersion: '1.5.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
   Net5.SDK.Version: '5.0.402'
   Net6.SDK.Version: '6.0.100-rc.2.21505.57'

--- a/src/Benchmarks/ReflectionPerf.cs
+++ b/src/Benchmarks/ReflectionPerf.cs
@@ -228,5 +228,23 @@ namespace Benchmarks
             }
             return sentence;
         }
+
+        [Benchmark]
+        public object GetUri()
+        {
+            return instance.NewUri;
+        }
+
+        [Benchmark]
+        public void SetUri()
+        {
+            instance.NewUri = new Uri("https://github.com");
+        }
+
+        [Benchmark]
+        public object GetExistingUri()
+        {
+            return instance.ExistingUri;
+        }
     }
 }

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -109,11 +109,10 @@ namespace ABI.System.ComponentModel
                 return null;
             }
 
-            using var args = ObjectReference<ABI.Microsoft.UI.Xaml.Data.IDataErrorsChangedEventArgsVftbl>.FromAbi(ptr);
             IntPtr propertyName = IntPtr.Zero;
             try
             {
-                ExceptionHelpers.ThrowExceptionForHR(args.Vftbl.get_PropertyName_0(args.ThisPtr, &propertyName));
+                ExceptionHelpers.ThrowExceptionForHR((**(ABI.Microsoft.UI.Xaml.Data.IDataErrorsChangedEventArgsVftbl**)ptr).get_PropertyName_0(ptr, &propertyName));
                 return new global::System.ComponentModel.DataErrorsChangedEventArgs(MarshalString.FromAbi(propertyName));
             }
             finally

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -24,16 +24,18 @@ namespace ABI.Windows.Foundation
     {
         private static readonly IReferenceArray<T>.Vftbl AbiToProjectionVftable;
         public static readonly IntPtr AbiToProjectionVftablePtr;
+        private static readonly Delegate DelegateCache;
+
         static unsafe BoxedArrayIReferenceArrayImpl()
         {
             AbiToProjectionVftable = new IReferenceArray<T>.Vftbl
             {
                 IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
-                get_Value_0 = Do_Abi_get_Value_0
+                _get_Value_0 = (void*)Marshal.GetFunctionPointerForDelegate(DelegateCache = new IReferenceArray_Delegates.get_Value_0(Do_Abi_get_Value_0))
             };
             var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(BoxedArrayIReferenceArrayImpl<T>), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
             Marshal.StructureToPtr(AbiToProjectionVftable.IInspectableVftbl, (IntPtr)nativeVftbl, false);
-            nativeVftbl[6] = Marshal.GetFunctionPointerForDelegate(AbiToProjectionVftable.get_Value_0);
+            nativeVftbl[6] = (IntPtr)AbiToProjectionVftable.GetValue_0;
 
             AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
         }
@@ -102,18 +104,20 @@ namespace ABI.Windows.Foundation
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IReferenceArray<T>));
 
         [Guid("61C17707-2D65-11E0-9AE8-D48564015472")]
-        public struct Vftbl
+        public unsafe struct Vftbl
         {
             internal IInspectable.Vftbl IInspectableVftbl;
-            public IReferenceArray_Delegates.get_Value_0 get_Value_0;
+            internal void* _get_Value_0;
+            internal delegate* unmanaged[Stdcall]<IntPtr, out int, out IntPtr, int> GetValue_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, out int, out IntPtr, int>)_get_Value_0; set => _get_Value_0 = (void*)value; }
+
             public static Guid PIID = GuidGenerator.CreateIID(typeof(IReferenceArray<T>));
 
-            internal unsafe Vftbl(IntPtr thisPtr)
+            internal unsafe Vftbl(IntPtr thisPtr) : this()
             {
                 var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
                 var vftbl = (IntPtr*)vftblPtr.Vftbl;
                 IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
-                get_Value_0 = Marshal.GetDelegateForFunctionPointer<IReferenceArray_Delegates.get_Value_0>(vftbl[6]);
+                GetValue_0 = (delegate* unmanaged[Stdcall]<IntPtr, out int, out IntPtr, int>)vftbl[6];
             }
         }
 
@@ -140,7 +144,7 @@ namespace ABI.Windows.Foundation
                 IntPtr __retval_data = default;
                 try
                 {
-                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Value_0(ThisPtr, out __retval_length, out __retval_data));
+                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetValue_0(ThisPtr, out __retval_length, out __retval_data));
                     return Marshaler<T>.FromAbiArray((__retval_length, __retval_data));
                 }
                 finally

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -111,11 +111,10 @@ namespace ABI.System.ComponentModel
                 return null;
             }
 
-            using var args = ObjectReference<ABI.Microsoft.UI.Xaml.Data.IPropertyChangedEventArgsVftbl>.FromAbi(ptr);
             IntPtr propertyName = IntPtr.Zero;
             try
             {
-                ExceptionHelpers.ThrowExceptionForHR(args.Vftbl.get_PropertyName_0(args.ThisPtr, &propertyName));
+                ExceptionHelpers.ThrowExceptionForHR((**(ABI.Microsoft.UI.Xaml.Data.IPropertyChangedEventArgsVftbl**)ptr).get_PropertyName_0(ptr, &propertyName));
                 return new global::System.ComponentModel.PropertyChangedEventArgs(MarshalString.FromAbi(propertyName));
             }
             finally

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -114,11 +114,10 @@ namespace ABI.System
                 return null;
             }
 
-            using var uri = ObjectReference<ABI.Windows.Foundation.IUriRuntimeClassVftbl>.FromAbi(ptr);
             IntPtr rawUri = IntPtr.Zero;
             try
             {
-                ExceptionHelpers.ThrowExceptionForHR(uri.Vftbl.get_RawUri_10(uri.ThisPtr, &rawUri));
+                ExceptionHelpers.ThrowExceptionForHR((**(ABI.Windows.Foundation.IUriRuntimeClassVftbl**)ptr).get_RawUri_10(ptr, &rawUri));
                 return new global::System.Uri(MarshalString.FromAbi(rawUri));
             }
             finally

--- a/src/get_testwinrt.cmd
+++ b/src/get_testwinrt.cmd
@@ -14,7 +14,7 @@ git checkout -f master
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 git fetch -f
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
-git reset -q --hard c08bbd40da7f93e29ca2ed683e32121a4692535d
+git reset -q --hard 1071d8ee25b8dcb0a1874f6f2b6de2e97fb4c74c
 if ErrorLevel 1 popd & exit /b !ErrorLevel!
 echo Restoring Nuget
 %this_dir%.nuget\nuget.exe restore


### PR DESCRIPTION
- Replaced a couple ObjectReference objects in a couple custom types where we don't need it outside the function and can directly call the vtable function.
- Also updated IReferenceArray to use function pointers similar to my previous PR which did it for some other types.

Master

| Method |       Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------- |-----------:|--------:|--------:|-------:|----------:|
| GetUri | 1,101.8 ns | 7.82 ns | 7.32 ns | 0.0896 |     376 B |
| SetUri |   845.3 ns | 9.10 ns | 8.07 ns | 0.0362 |     152 B |

PR

| Method |     Mean |   Error |   StdDev |  Gen 0 | Allocated |
|------- |---------:|--------:|---------:|-------:|----------:|
| GetUri | 884.3 ns | 8.56 ns | 10.51 ns | 0.0286 |     120 B |
| SetUri | 840.8 ns | 5.89 ns |  5.22 ns | 0.0362 |     152 B |

.NET Core 3.1 built-in support

| Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------- |---------:|---------:|---------:|-------:|----------:|
| GetUri | 970.1 ns | 19.14 ns | 15.98 ns | 0.0305 |     136 B |
| SetUri | 831.4 ns | 13.41 ns | 13.78 ns | 0.0172 |      72 B |

