### PR TITLE
Fix prerelease variable getting overriden by YAML

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -1,6 +1,6 @@
 variables:
   MajorVersion: 1
-  MinorVersion: 5
+  MinorVersion: 4
   PatchVersion: 0
   WinRT.Runtime.AssemblyVersion: '1.5.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -2,7 +2,6 @@ variables:
   MajorVersion: 1
   MinorVersion: 5
   PatchVersion: 0
-  PrereleaseVersion: '-prerelease'
   WinRT.Runtime.AssemblyVersion: '1.5.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
   Net5.SDK.Version: '5.0.402'

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -4,7 +4,7 @@ variables:
   PatchVersion: 0
   WinRT.Runtime.AssemblyVersion: '1.5.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
-  Net5.SDK.Version: '5.0.402'
+  Net5.SDK.Version: '5.0.404'
   Net6.SDK.Version: '6.0.100-rc.2.21505.57'
   NoSamples: 'false'
   
@@ -13,4 +13,4 @@ variables:
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
   _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
-  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '23-preview')]  
+  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersion, '23')]  

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -1,6 +1,6 @@
 variables:
   MajorVersion: 1
-  MinorVersion: 4
+  MinorVersion: 5
   PatchVersion: 0
   WinRT.Runtime.AssemblyVersion: '1.5.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -2,7 +2,7 @@
 if /i "%cswinrt_echo%" == "on" @echo on
 
 set CsWinRTBuildNetSDKVersion=6.0.100-rc.2.21505.57
-set CsWinRTNet5SdkVersion=5.0.402
+set CsWinRTNet5SdkVersion=5.0.404
 set this_dir=%~dp0
 
 :dotnet


### PR DESCRIPTION
Variable is set in pipeline variables, but this YAML file seems to override that causing for release builds to build as prerelease.