### PR TITLE
Skip projection generation during design-time build if inputs are missing

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -67,12 +67,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
   </Target>
 
+  <!-- 
+      During a design-time build, input WinMDs may not exist yet if a full build has not been completed.
+      If that is the case, generation of the CsWinRT projection will fail. To avoid causing a design-time
+      build break (which can put the design-time build results of dependent projects into a bad state),
+      we want to skip projection generation if a) this is a design-time build, and b) any of the inputs
+      do not exist.
+  -->
+  <Target Name="CsWinRTCalculateSkipDesignTimeGenerateProjection" 
+          DependsOnTargets="CsWinRTRemoveWinMDReferences">
+    <ItemGroup>
+      <_CsWinRTNonexistentInputs Include="@(CsWinRTInputs)" Condition="!Exists('%(CsWinRTInputs.Identity)')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <CsWinRTSkipDesignTimeGenerateProjection Condition="('$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true') and '@(_CsWinRTNonexistentInputs)'!=''">true</CsWinRTSkipDesignTimeGenerateProjection>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="CsWinRTCleanGenerateProjectionOutputs">
     <Delete Files="$(CsWinRTGeneratedFilesDir)cswinrt.rsp" />
   </Target>
 
   <Target Name="CsWinRTGenerateProjection"
-          DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences"
+          DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences;CsWinRTCalculateSkipDesignTimeGenerateProjection"
           Condition="'$(CsWinRTGenerateProjection)' == 'true'"
           Inputs="$(MSBuildAllProjects);@(CsWinRTInputs);$(CsWinRTExcludes);$(CsWinRTIncludes);$(CsWinRTFilters);$(CsWinRTWindowsMetadata)"
           Outputs="$(CsWinRTGeneratedFilesDir)cswinrt.rsp">
@@ -123,10 +141,17 @@ $(CsWinRTIncludeWinRTInterop)
 $(CsWinRTEmbeddedParam)
       </CsWinRTParams>
     </PropertyGroup>
-    <MakeDir Directories="$(CsWinRTGeneratedFilesDir)" />
-    <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" />
-    <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
-    <Exec Command="$(CsWinRTCommand)" />
+
+  <!-- The following tasks should only be executed if design-time generation of the projection
+       is not being skipped. -->
+    <MakeDir Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'" 
+      Directories="$(CsWinRTGeneratedFilesDir)" />
+    <WriteLinesToFile Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
+      File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" />
+    <Message Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
+      Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
+    <Exec Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
+      Command="$(CsWinRTCommand)" />
 
     <ItemGroup Condition="'$(CsWinRTComponent)' != 'true' and Exists('$(CsWinRTGeneratedFilesDir)WinRT.cs')">
       <UpToDateCheckInput Include="$(CsWinRTGeneratedFilesDir)WinRT.cs" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -67,30 +67,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <!-- 
-      During a design-time build, input WinMDs may not exist yet if a full build has not been completed.
-      If that is the case, generation of the CsWinRT projection will fail. To avoid causing a design-time
-      build break (which can put the design-time build results of dependent projects into a bad state),
-      we want to skip projection generation if a) this is a design-time build, and b) any of the inputs
-      do not exist.
-  -->
-  <Target Name="CsWinRTCalculateSkipDesignTimeGenerateProjection" 
-          DependsOnTargets="CsWinRTRemoveWinMDReferences">
-    <ItemGroup>
-      <_CsWinRTNonexistentInputs Include="@(CsWinRTInputs)" Condition="!Exists('%(CsWinRTInputs.Identity)')" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <CsWinRTSkipDesignTimeGenerateProjection Condition="('$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true') and '@(_CsWinRTNonexistentInputs)'!=''">true</CsWinRTSkipDesignTimeGenerateProjection>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="CsWinRTCleanGenerateProjectionOutputs">
     <Delete Files="$(CsWinRTGeneratedFilesDir)cswinrt.rsp" />
   </Target>
 
   <Target Name="CsWinRTGenerateProjection"
-          DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences;CsWinRTCalculateSkipDesignTimeGenerateProjection"
+          DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences"
           Condition="'$(CsWinRTGenerateProjection)' == 'true'"
           Inputs="$(MSBuildAllProjects);@(CsWinRTInputs);$(CsWinRTExcludes);$(CsWinRTIncludes);$(CsWinRTFilters);$(CsWinRTWindowsMetadata)"
           Outputs="$(CsWinRTGeneratedFilesDir)cswinrt.rsp">
@@ -142,16 +124,21 @@ $(CsWinRTEmbeddedParam)
       </CsWinRTParams>
     </PropertyGroup>
 
-  <!-- The following tasks should only be executed if design-time generation of the projection
-       is not being skipped. -->
-    <MakeDir Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'" 
-      Directories="$(CsWinRTGeneratedFilesDir)" />
-    <WriteLinesToFile Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
-      File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" />
-    <Message Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
-      Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
-    <Exec Condition="'$(CsWinRTSkipDesignTimeGenerateProjection)'!='true'"
-      Command="$(CsWinRTCommand)" />
+    <!-- 
+      During a design-time build, generation of the CsWinRT projection might fail (e.g. input .winmds might
+      not exist if a full build hasn't completed yet). To avoid causing a design-time build break, which can 
+      put the design-time build results of dependent projects into a bad state, we want the build to continue
+      if cswinrt.exe encounters an error during a design-time build.
+    -->
+    <PropertyGroup>
+      <CsWinRTContinueOnError>false</CsWinRTContinueOnError>
+      <CsWinRTContinueOnError Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">true</CsWinRTContinueOnError>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(CsWinRTGeneratedFilesDir)" />
+    <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" />
+    <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
+    <Exec Command="$(CsWinRTCommand)" ContinueOnError="$(CsWinRTContinueOnError)" />
 
     <ItemGroup Condition="'$(CsWinRTComponent)' != 'true' and Exists('$(CsWinRTGeneratedFilesDir)WinRT.cs')">
       <UpToDateCheckInput Include="$(CsWinRTGeneratedFilesDir)WinRT.cs" />


### PR DESCRIPTION
Although it is generally desirable for CsWinRT projection generation to explicitly fail if input `.winmd`s are missing, we *don't* want this to happen during a design-time build. Due to Visual Studio's architecture, failures in a project's design-time build can leave the results of dependent projects' design-time builds in an inconsistent state (this was determined to be one of the primary root causes of https://task.ms/37142724). An example of this scenario would be a CsWinRT project that depends on a C++/CX Windows Runtime Component project: the latter produces its output `.winmd` during the `Link` target and so the `.winmd` does not exist for the former to consume until a normal build has completed.

This change modifies the `CsWinRTGenerateProjection` target to skip the `cswinrt.exe` command if it is determined that (a) it is currently running in the context of a design-time build, and (b) one or more of the input `.winmd`s does not exist. This allows the design-time build to succeed while still allowing for the possibility of a legitimate failure during a normal build.