### PR TITLE
Improve non agile object performance

### DIFF
--- a/src/Benchmarks/NonAgileObjectPerf.cs
+++ b/src/Benchmarks/NonAgileObjectPerf.cs
@@ -1,0 +1,61 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    public class NonAgileObjectPerf
+    {
+        AutoResetEvent createObject;
+        AutoResetEvent exitThread;
+        AutoResetEvent objectCreated;
+        Thread staThread;
+        private Windows.UI.Popups.PopupMenu nonAgileObject;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            createObject = new AutoResetEvent(false);
+            exitThread = new AutoResetEvent(false);
+            objectCreated = new AutoResetEvent(false);
+            staThread = new Thread(new ThreadStart(ObjectAllocationLoop));
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            exitThread.Set();
+            createObject.Set();
+        }
+
+        private void ObjectAllocationLoop()
+        {
+            while (createObject.WaitOne() && !exitThread.WaitOne(1))
+            {
+                createObject.Reset();
+                nonAgileObject = new Windows.UI.Popups.PopupMenu();
+                _ = nonAgileObject.Commands.Count;
+                objectCreated.Set();
+            }
+        }
+
+        private int CallObject()
+        {
+            return nonAgileObject.Commands.Count;
+        }
+
+        [Benchmark]
+        public void ConstructAndQueryNonAgileObject()
+        {
+            createObject.Set();
+            objectCreated.WaitOne();
+            CallObject();
+            objectCreated.Reset();
+        }
+    }
+}

--- a/src/Benchmarks/NonAgileObjectPerf.cs
+++ b/src/Benchmarks/NonAgileObjectPerf.cs
@@ -1,7 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace Benchmarks
@@ -55,6 +52,14 @@ namespace Benchmarks
             createObject.Set();
             objectCreated.WaitOne();
             CallObject();
+            objectCreated.Reset();
+        }
+
+        [Benchmark]
+        public void ConstructNonAgileObject()
+        {
+            createObject.Set();
+            objectCreated.WaitOne();
             objectCreated.Reset();
         }
     }

--- a/src/Benchmarks/NonAgileObjectPerf.cs
+++ b/src/Benchmarks/NonAgileObjectPerf.cs
@@ -10,7 +10,7 @@ namespace Benchmarks
         AutoResetEvent exitThread;
         AutoResetEvent objectCreated;
         Thread staThread;
-        private Windows.UI.Popups.PopupMenu nonAgileObject;
+        private volatile Windows.UI.Popups.PopupMenu nonAgileObject;
 
         [GlobalSetup]
         public void Setup()
@@ -36,7 +36,7 @@ namespace Benchmarks
             {
                 createObject.Reset();
                 nonAgileObject = new Windows.UI.Popups.PopupMenu();
-                _ = nonAgileObject.Commands.Count;
+                CallObject();
                 objectCreated.Set();
             }
         }

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -16,7 +16,7 @@ namespace WinRT
     {
         private readonly static Guid CLSID_StdGlobalInterfaceTable = new(0x00000323, 0, 0, 0xc0, 0, 0, 0, 0, 0, 0, 0x46);
         private readonly static Lazy<IGlobalInterfaceTable> Git = new Lazy<IGlobalInterfaceTable>(() => GetGitTable());
-        private readonly IAgileReference _agileReference;
+        private readonly IObjectReference _agileReference;
         private readonly IntPtr _cookie;
         private bool disposed;
 
@@ -36,11 +36,7 @@ namespace WinRT
                     ref iid,
                     instance.ThisPtr,
                     &agileReference));
-#if NET
-                _agileReference = (IAgileReference)new SingleInterfaceOptimizedObject(typeof(IAgileReference), ObjectReference<ABI.WinRT.Interop.IAgileReference.Vftbl>.Attach(ref agileReference));
-#else
-                _agileReference = ABI.WinRT.Interop.IAgileReference.FromAbi(agileReference).AsType<ABI.WinRT.Interop.IAgileReference>();
-#endif
+                _agileReference = ObjectReference<IUnknownVftbl>.Attach(ref agileReference);
             }
             catch(TypeLoadException)
             {
@@ -51,7 +47,10 @@ namespace WinRT
                 MarshalInterface<IAgileReference>.DisposeAbi(agileReference);
             }
         }
-        public IObjectReference Get() => _cookie == IntPtr.Zero ? _agileReference?.Resolve(IUnknownVftbl.IID) : Git.Value?.GetInterfaceFromGlobal(_cookie, IUnknownVftbl.IID);
+
+        public IObjectReference Get() => _cookie == IntPtr.Zero ? ABI.WinRT.Interop.IAgileReferenceMethods.Resolve(_agileReference, IUnknownVftbl.IID) : Git.Value?.GetInterfaceFromGlobal(_cookie, IUnknownVftbl.IID);
+
+        internal ObjectReference<T> Get<T>(Guid iid) => _cookie == IntPtr.Zero ? ABI.WinRT.Interop.IAgileReferenceMethods.Resolve<T>(_agileReference, iid) : Git.Value?.GetInterfaceFromGlobal(_cookie, IUnknownVftbl.IID)?.As<T>(iid);
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -39,69 +39,16 @@ namespace ABI.WinRT.Interop
 {
     using global::WinRT;
 
-    [DynamicInterfaceCastableImplementation]
-    [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
-    internal unsafe interface IAgileReference : global::WinRT.Interop.IAgileReference
+    internal static class IAgileReferenceMethods
     {
-        [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
-        public struct Vftbl
+        public static unsafe IObjectReference Resolve(IObjectReference _obj, Guid riid)
         {
-            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
-            private void* _Resolve;
-            public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
+            if (_obj == null) return null;
 
-            public static readonly Vftbl AbiToProjectionVftable;
-            public static readonly IntPtr AbiToProjectionVftablePtr;
-
-#if !NET
-            public delegate int ResolveDelegate(IntPtr thisPtr, Guid* riid, IntPtr* objectReference);
-            private static readonly Delegate[] DelegateCache = new Delegate[1];
-#endif
-            static Vftbl()
-            {
-                AbiToProjectionVftable = new Vftbl
-                {
-                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
-#if !NET
-                    _Resolve = Marshal.GetFunctionPointerForDelegate(DelegateCache[0] = new ResolveDelegate(Do_Abi_Resolve)).ToPointer(),
-#else
-                    _Resolve = (delegate* unmanaged<IntPtr, Guid*, IntPtr*, int>)&Do_Abi_Resolve
-#endif
-                };
-                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
-                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
-            }
-
-#if NET
-            [UnmanagedCallersOnly]
-#endif
-            private static int Do_Abi_Resolve(IntPtr thisPtr, Guid* riid, IntPtr* objectReference)
-            {
-                IObjectReference _objectReference = default;
-
-                *objectReference = default;
-
-                try
-                {
-                    _objectReference = global::WinRT.ComWrappersSupport.FindObject<global::WinRT.Interop.IAgileReference>(thisPtr).Resolve(*riid);
-                    *objectReference = _objectReference?.GetRef() ?? IntPtr.Zero;
-                }
-                catch (Exception __exception__)
-                {
-                    return __exception__.HResult;
-                }
-                return 0;
-            }
-        }
-
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
-
-        IObjectReference global::WinRT.Interop.IAgileReference.Resolve(Guid riid)
-        {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IAgileReference).TypeHandle));
             var ThisPtr = _obj.ThisPtr;
-
-            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Resolve(ThisPtr, ref riid, out IntPtr ptr));
+            IntPtr ptr = IntPtr.Zero;
+            ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
+                ThisPtr, &riid, &ptr));
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(ptr);
@@ -111,33 +58,74 @@ namespace ABI.WinRT.Interop
                 MarshalInspectable<object>.DisposeAbi(ptr);
             }
         }
+
+        public static unsafe ObjectReference<T> Resolve<T>(IObjectReference _obj, Guid riid)
+        {
+            if (_obj == null) return null;
+
+            var ThisPtr = _obj.ThisPtr;
+            IntPtr ptr = IntPtr.Zero;
+            ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
+                ThisPtr, &riid, &ptr));
+            try
+            {
+                return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr);
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeAbi(ptr);
+            }
+        }
+    }
+
+    [DynamicInterfaceCastableImplementation]
+    [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
+    internal unsafe interface IAgileReference : global::WinRT.Interop.IAgileReference
+    {
+        public static IntPtr AbiToProjectionVftablePtr;
+        static unsafe IAgileReference()
+        {
+            AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(IAgileReference), sizeof(global::WinRT.Interop.IUnknownVftbl) + sizeof(IntPtr) * 1);
+            *(global::WinRT.Interop.IUnknownVftbl*)AbiToProjectionVftablePtr = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl;
+            ((delegate* unmanaged<IntPtr, Guid*, IntPtr*, int>*)AbiToProjectionVftablePtr)[3] = &Do_Abi_Resolve;
+        }
+
+        [UnmanagedCallersOnly]
+        private static int Do_Abi_Resolve(IntPtr thisPtr, Guid* riid, IntPtr* objectReference)
+        {
+            IObjectReference _objectReference = default;
+
+            *objectReference = default;
+
+            try
+            {
+                _objectReference = global::WinRT.ComWrappersSupport.FindObject<global::WinRT.Interop.IAgileReference>(thisPtr).Resolve(*riid);
+                *objectReference = _objectReference?.GetRef() ?? IntPtr.Zero;
+            }
+            catch (Exception __exception__)
+            {
+                return __exception__.HResult;
+            }
+            return 0;
+        }
+
+        IObjectReference global::WinRT.Interop.IAgileReference.Resolve(Guid riid)
+        {
+            var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IAgileReference).TypeHandle);
+            return IAgileReferenceMethods.Resolve(_obj, riid);
+        }
     }
 
     [DynamicInterfaceCastableImplementation]
     [Guid("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")]
     interface IAgileObject : global::WinRT.Interop.IAgileObject
     {
-        [Guid("94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90")]
-        public struct Vftbl
+        public static IntPtr AbiToProjectionVftablePtr;
+        static unsafe IAgileObject()
         {
-            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
-
-            public static readonly Vftbl AbiToProjectionVftable;
-            public static readonly IntPtr AbiToProjectionVftablePtr;
-
-            static Vftbl()
-            {
-                AbiToProjectionVftable = new Vftbl
-                {
-                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
-                };
-                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
-                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
-            }
+            AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(IAgileObject), sizeof(global::WinRT.Interop.IUnknownVftbl));
+            *(global::WinRT.Interop.IUnknownVftbl*)AbiToProjectionVftablePtr = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl;
         }
-
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
-
     }
 
     [Guid("00000146-0000-0000-C000-000000000046")]

--- a/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
@@ -38,6 +38,45 @@ namespace ABI.WinRT.Interop
 {
     using global::WinRT;
 
+    internal static class IAgileReferenceMethods
+    {
+        public static unsafe IObjectReference Resolve(IObjectReference _obj, Guid riid)
+        {
+            if (_obj == null) return null;
+
+            var ThisPtr = _obj.ThisPtr;
+            IntPtr ptr = IntPtr.Zero;
+            ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
+                ThisPtr, &riid, &ptr));
+            try
+            {
+                return ComWrappersSupport.GetObjectReferenceForInterface(ptr);
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeAbi(ptr);
+            }
+        }
+
+        public static unsafe ObjectReference<T> Resolve<T>(IObjectReference _obj, Guid riid)
+        {
+            if (_obj == null) return null;
+
+            var ThisPtr = _obj.ThisPtr;
+            IntPtr ptr = IntPtr.Zero;
+            ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
+                ThisPtr, &riid, &ptr));
+            try
+            {
+                return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr);
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeAbi(ptr);
+            }
+        }
+    }
+
     [Guid("C03F6A43-65A4-9818-987E-E0B810D2A6F2")]
     internal sealed unsafe class IAgileReference : global::WinRT.Interop.IAgileReference
     {
@@ -104,15 +143,7 @@ namespace ABI.WinRT.Interop
 
         public IObjectReference Resolve(Guid riid)
         {
-            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Resolve(ThisPtr, ref riid, out IntPtr ptr));
-            try
-            {
-                return ComWrappersSupport.GetObjectReferenceForInterface(ptr);
-            }
-            finally
-            {
-                MarshalInspectable<object>.DisposeAbi(ptr);
-            }
+            return IAgileReferenceMethods.Resolve(_obj, riid);
         }
     }
 

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -536,14 +536,21 @@ namespace WinRT
                     return null;
                 }
 
-                if (_iid == Guid.Empty)
+                try
                 {
-                    using var referenceInContext = agileReference.Get();
-                    return referenceInContext.TryAs<T>(out var objRef) >= 0 ? objRef : null;
+                    if (_iid == Guid.Empty)
+                    {
+                        return agileReference.Get<T>(GuidGenerator.GetIID(typeof(T)));
+                    }
+                    else
+                    {
+                        return agileReference.Get<T>(_iid);
+                    }
                 }
-                else
+                catch (Exception)
                 {
-                    return agileReference.Get<T>(_iid);
+                    // Fallback to using the current context in case of error.
+                    return null;
                 }
             }
         }

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -458,15 +458,15 @@ namespace WinRT
         }
 
         // Agile reference can be null, so whether it is set is tracked separately.
-        private volatile bool _agileReferenceSet;
+        private volatile bool _isAgileReferenceSet;
         private volatile AgileReference __agileReference;
-        private AgileReference AgileReference => _agileReferenceSet ? __agileReference : Make_AgileReference();
+        private AgileReference AgileReference => _isAgileReferenceSet ? __agileReference : Make_AgileReference();
         private AgileReference Make_AgileReference()
         { 
             Context.CallInContext(_contextCallbackPtr, _contextToken, InitAgileReference, null);
 
             // Set after CallInContext callback given callback can fail to occur.
-            _agileReferenceSet = true;
+            _isAgileReferenceSet = true;
             return __agileReference;
 
             void InitAgileReference()


### PR DESCRIPTION
This change brings in Joshua's change https://github.com/microsoft/CsWinRT/commit/3122ce19368d2d593de239f17fb56410ebfd0844 for removing uses of Lazy in ObjectReferenceWithContext and adds some benchmarks and a couple other improvements in agile references which are used in ObjectReferenceWithContext.

Master

|                          Method |     Mean |    Error |   StdDev | Allocated |
|-------------------------------- |---------:|---------:|---------:|----------:|
| ConstructAndQueryNonAgileObject | 15.74 ms | 0.287 ms | 0.341 ms |      8 KB |
|         ConstructNonAgileObject | 15.70 ms | 0.285 ms | 0.292 ms |      3 KB |


PR

|                          Method |     Mean |    Error |   StdDev | Allocated |
|-------------------------------- |---------:|---------:|---------:|----------:|
| ConstructAndQueryNonAgileObject | 15.74 ms | 0.309 ms | 0.289 ms |      5 KB |
|         ConstructNonAgileObject | 15.79 ms | 0.161 ms | 0.151 ms |      2 KB |

Overall the perf difference is within the error range, but we do reduce allocations which can be helpful with reducing GC time spent later.