### PR TITLE
Improve startup performance

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -357,9 +357,11 @@ namespace WinRT
                 throw new MissingMethodException();
             }
 
-            var parms = new[] { Expression.Parameter(typeof(IInspectable), "obj") };
-            return Expression.Lambda<Func<IInspectable, object>>(
-                Expression.Call(fromAbiMethod, Expression.Property(parms[0], "ThisPtr")), parms).Compile();
+            var fromAbiMethodFunc = (Func<IntPtr, object>) fromAbiMethod.CreateDelegate(typeof(Func<IntPtr, object>));
+            return (IInspectable obj) => fromAbiMethodFunc(obj.ThisPtr);
+  //          var parms = new[] { Expression.Parameter(typeof(IInspectable), "obj") };
+    //        return Expression.Lambda<Func<IInspectable, object>>(
+      //          Expression.Call(fromAbiMethod, Expression.Property(parms[0], "ThisPtr")), parms).Compile();
         }
 
         internal static Func<IInspectable, object> CreateTypedRcwFactory(Type implementationType, string runtimeClassName = null)

--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -24,7 +24,7 @@ namespace WinRT.Interop
         public static IUnknownVftbl AbiToProjectionVftbl => ComWrappersSupport.IUnknownVftbl;
         public static IntPtr AbiToProjectionVftblPtr => ComWrappersSupport.IUnknownVftblPtr;
 
-        internal static readonly Guid IID = new(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+        internal static readonly Guid IID = InterfaceIIDs.IUnknown_IID;
 
         // Avoids boxing when using default Equals.
         internal bool Equals(IUnknownVftbl other)

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -92,7 +92,7 @@ namespace ABI.WinRT.Interop
     [Guid("00000038-0000-0000-C000-000000000046")]
     internal unsafe interface IWeakReferenceSource : global::WinRT.Interop.IWeakReferenceSource
     {
-        internal static readonly Guid IID = new(0x00000038, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+        internal static readonly Guid IID = InterfaceIIDs.IWeakReferenceSource_IID;
 
         public static IntPtr AbiToProjectionVftablePtr;
         static unsafe IWeakReferenceSource()

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -434,9 +434,7 @@ namespace ABI.System.Collections
                 if(enumGenericType != null)
                 {
                     var getEnumerator = enumGenericType.GetMethod("GetEnumerator");
-                    var obj = Expression.Variable(typeof(IWinRTObject));
-                    _enumerator = Expression.Lambda<Func<IWinRTObject, global::System.Collections.IEnumerator>>(
-                        Expression.Call(Expression.Convert(obj, runtimeType), getEnumerator), obj).Compile();
+                    _enumerator = (IWinRTObject obj) => (global::System.Collections.IEnumerator)getEnumerator.Invoke(obj, null);
                 }
             }
 

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -46,6 +46,8 @@ namespace System.Collections.Generic
             this._lookupCache = new Dictionary<K, (IntPtr, V)>();
         }
 
+        public static IDictionaryImpl<K, V> CreateRcw(IInspectable obj) => new(obj.ObjRef);
+
         private volatile IObjectReference __iDictionaryObjRef;
         private IObjectReference Make_IDictionaryObjRef()
         {

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -74,6 +74,8 @@ namespace System.Collections.Generic
             this._inner = _inner;
         }
 
+        public static IEnumerableImpl<T> CreateRcw(IInspectable obj) => new(obj.ObjRef);
+
         private volatile IObjectReference __iEnumerableObjRef;
         private IObjectReference Make_IEnumerableObjRef()
         {

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -64,6 +64,8 @@ namespace System.Collections.Generic
             this._inner = _inner;
         }
 
+        public static IListImpl<T> CreateRcw(IInspectable obj) => new(obj.ObjRef);
+
         public T this[int index] 
         {
             get => ABI.System.Collections.Generic.IListMethods<T>.Indexer_Get(iListObjRef, index);

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -39,6 +39,8 @@ namespace System.Collections.Generic
             this._inner = _inner;
         }
 
+        public static IReadOnlyDictionaryImpl<K, V> CreateRcw(IInspectable obj) => new(obj.ObjRef);
+
         private volatile IObjectReference __iReadOnlyDictionaryObjRef;
         private IObjectReference Make_IDictionaryObjRef()
         {

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -334,7 +334,6 @@ namespace ABI.System.Collections.Generic
             public static Guid PIID = GuidGenerator.CreateIID(typeof(IReadOnlyList<T>));
             private static readonly Type GetAt_0_Type = Expression.GetDelegateType(new Type[] { typeof(void*), typeof(uint), Marshaler<T>.AbiType.MakeByRefType(), typeof(int) });
             private static readonly Type IndexOf_2_Type = Expression.GetDelegateType(new Type[] { typeof(void*), Marshaler<T>.AbiType, typeof(uint).MakeByRefType(), typeof(byte).MakeByRefType(), typeof(int) });
-//            private static readonly Type GetAt_0_Type2 = typeof(IReadOnlyList_Delegates<>).MakeGenericType(Marshaler<T>.AbiType).GetMethod("GetAt_0");
 
             internal unsafe Vftbl(IntPtr thisPtr) : this()
             {
@@ -507,11 +506,5 @@ namespace ABI.System.Collections.Generic
     static class IReadOnlyList_Delegates
     {
         public unsafe delegate int GetMany_3(IntPtr thisPtr, uint startIndex, int __itemsSize, IntPtr items, out uint __return_value__);
-    }
-
-    internal static class IReadOnlyList_Delegates<TAbi>
-    {
-        public unsafe delegate int GetAt_0(IntPtr thisPtr, uint index, out TAbi __return_value__);
-        public unsafe delegate int IndexOf_2(IntPtr thisPtr, TAbi value, out uint index, out byte __return_value__);
     }
 }

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -52,6 +52,8 @@ namespace System.Collections.Generic
             this._inner = _inner;
         }
 
+        public static IReadOnlyListImpl<T> CreateRcw(IInspectable obj) => new(obj.ObjRef);
+
         IObjectReference IWinRTObject.NativeObject => _inner;
 
         bool IWinRTObject.HasUnwrappableNativeObject => true;
@@ -332,6 +334,7 @@ namespace ABI.System.Collections.Generic
             public static Guid PIID = GuidGenerator.CreateIID(typeof(IReadOnlyList<T>));
             private static readonly Type GetAt_0_Type = Expression.GetDelegateType(new Type[] { typeof(void*), typeof(uint), Marshaler<T>.AbiType.MakeByRefType(), typeof(int) });
             private static readonly Type IndexOf_2_Type = Expression.GetDelegateType(new Type[] { typeof(void*), Marshaler<T>.AbiType, typeof(uint).MakeByRefType(), typeof(byte).MakeByRefType(), typeof(int) });
+//            private static readonly Type GetAt_0_Type2 = typeof(IReadOnlyList_Delegates<>).MakeGenericType(Marshaler<T>.AbiType).GetMethod("GetAt_0");
 
             internal unsafe Vftbl(IntPtr thisPtr) : this()
             {
@@ -504,5 +507,11 @@ namespace ABI.System.Collections.Generic
     static class IReadOnlyList_Delegates
     {
         public unsafe delegate int GetMany_3(IntPtr thisPtr, uint startIndex, int __itemsSize, IntPtr items, out uint __return_value__);
+    }
+
+    internal static class IReadOnlyList_Delegates<TAbi>
+    {
+        public unsafe delegate int GetAt_0(IntPtr thisPtr, uint index, out TAbi __return_value__);
+        public unsafe delegate int IndexOf_2(IntPtr thisPtr, TAbi value, out uint index, out byte __return_value__);
     }
 }

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -83,6 +83,24 @@ namespace ABI.Windows.Foundation
             return wrapper.Value;
         }
 
+        internal static unsafe object GetValue(IInspectable inspectable)
+        {
+            IntPtr referenceArrayPtr = IntPtr.Zero;
+            int __retval_length = default;
+            IntPtr __retval_data = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref PIID, out referenceArrayPtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, IntPtr*, int>**)referenceArrayPtr)[6](referenceArrayPtr, &__retval_length, &__retval_data));
+                return Marshaler<T>.FromAbiArray((__retval_length, __retval_data));
+            }
+            finally
+            {
+                Marshaler<T>.DisposeAbiArray((__retval_length, __retval_data));
+                Marshal.Release(referenceArrayPtr);
+            }
+        }
+
         public static unsafe void CopyManaged(object o, IntPtr dest)
         {
             using var objRef = CreateMarshaler(o);

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -85,6 +85,12 @@ namespace ABI.Windows.Foundation
             return wrapper.Value;
         }
 
+        internal static object GetValue(IInspectable inspectable)
+        {
+            var array = new IReferenceArray<T>(inspectable.ObjRef);
+            return array.Value;
+        }
+
         public static unsafe void CopyManaged(object o, IntPtr dest)
         {
             using var objRef = CreateMarshaler(o);

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -132,10 +132,22 @@ namespace ABI.System
             _obj = obj;
         }
 
-        internal static T GetValue(IInspectable inspectable)
+        internal static unsafe T GetValue(IInspectable inspectable)
         {
-            var nullable = new Nullable<T>(inspectable.ObjRef);
-            return nullable.Value;
+            IntPtr nullablePtr = IntPtr.Zero;
+            var __params = new object[] { IntPtr.Zero, null };
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref PIID, out nullablePtr));
+                __params[0] = nullablePtr;
+                Marshal.GetDelegateForFunctionPointer((*(IntPtr**)nullablePtr)[6], Vftbl.get_Value_0_Type).DynamicInvokeAbi(__params);
+                return Marshaler<T>.FromAbi(__params[1]);
+            }
+            finally
+            {
+                Marshaler<T>.DisposeAbi(__params[1]);
+                Marshal.Release(nullablePtr);
+            }
         }
 
         public unsafe T Value

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2012,44 +2012,47 @@ ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
                     }
     
                     auto objrefname = bind<write_objref_type_name>(semantics);
+                    bool useInner = replaceDefaultByInner && has_attribute(ii, "Windows.Foundation.Metadata", "DefaultAttribute") && distance(ifaceType.GenericParam()) == 0;
 
-                    w.write(R"(
+                    if (!useInner)
+                    {
+                        w.write(R"(
 private volatile IObjectReference __%;
 private IObjectReference Make__%()
 {
 )",
                         objrefname,
                         objrefname);
-                   
-                    if (replaceDefaultByInner && has_attribute(ii, "Windows.Foundation.Metadata", "DefaultAttribute") && distance(ifaceType.GenericParam()) == 0)
-                    {
-                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, _inner, null);)", objrefname);
-                    }
-                    else if (distance(ifaceType.GenericParam()) == 0)
-                    {
 
-                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(GuidGenerator.GetIID(typeof(%).GetHelperType())), null);)", 
-                            objrefname,
-                            bind<write_type_name>(semantics, typedef_name_type::Projected, false)
-                            ); 
-                    }
-                    else
-                    {
-                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, (IObjectReference)typeof(IObjectReference).GetMethod("As", Type.EmptyTypes).MakeGenericMethod(typeof(%).GetHelperType().FindVftblType()).Invoke(((IWinRTObject)this).NativeObject, null), null);)",
-                            objrefname,
-                            bind<write_type_name>(semantics, typedef_name_type::Projected, false));
-                    }
+                        if (distance(ifaceType.GenericParam()) == 0)
+                        {
 
-                     w.write(R"(
-    return __%;
+                            w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(GuidGenerator.GetIID(typeof(%).GetHelperType())), null);)",
+                                objrefname,
+                                bind<write_type_name>(semantics, typedef_name_type::Projected, false)
+                            );
+                        }
+                        else
+                        {
+                            w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, (IObjectReference)typeof(IObjectReference).GetMethod("As", Type.EmptyTypes).MakeGenericMethod(typeof(%).GetHelperType().FindVftblType()).Invoke(((IWinRTObject)this).NativeObject, null), null);)",
+                                objrefname,
+                                bind<write_type_name>(semantics, typedef_name_type::Projected, false));
+                        }
+
+                        w.write(R"(
+return __%;
 }
 private IObjectReference % => __% ?? Make__%();
-
 )",
                         objrefname,
                         objrefname,
                         objrefname,
                         objrefname);
+                    }
+                    else
+                    {
+                        w.write(R"(private IObjectReference % => _inner;)", objrefname);
+                    }
                 });
         }
     }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2028,14 +2028,14 @@ private IObjectReference Make__%()
                     else if (distance(ifaceType.GenericParam()) == 0)
                     {
 
-                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(GuidGenerator.GetIID(typeof(%).FindHelperType())), null);)", 
+                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(GuidGenerator.GetIID(typeof(%).GetHelperType())), null);)", 
                             objrefname,
                             bind<write_type_name>(semantics, typedef_name_type::Projected, false)
                             ); 
                     }
                     else
                     {
-                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, (IObjectReference)typeof(IObjectReference).GetMethod("As", Type.EmptyTypes).MakeGenericMethod(typeof(%).FindHelperType().FindVftblType()).Invoke(((IWinRTObject)this).NativeObject, null), null);)",
+                        w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, (IObjectReference)typeof(IObjectReference).GetMethod("As", Type.EmptyTypes).MakeGenericMethod(typeof(%).GetHelperType().FindVftblType()).Invoke(((IWinRTObject)this).NativeObject, null), null);)",
                             objrefname,
                             bind<write_type_name>(semantics, typedef_name_type::Projected, false));
                     }

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -466,7 +466,7 @@ namespace WinRT
             // If target no longer exists, destroy cache
             lock (this)
             {
-                using var resolved = this.target.Resolve(typeof(IUnknownVftbl).GUID);
+                using var resolved = this.target.Resolve(InterfaceIIDs.IUnknown_IID);
                 if (resolved == null)
                 {
                     this.target = target;
@@ -482,7 +482,7 @@ namespace WinRT
             // If target no longer exists, destroy cache
             lock (this)
             {
-                using var resolved = this.target.Resolve(typeof(IUnknownVftbl).GUID);
+                using var resolved = this.target.Resolve(InterfaceIIDs.IUnknown_IID);
                 if (resolved == null)
                 {
                     return null;
@@ -522,7 +522,7 @@ namespace WinRT
                     return;
                 }
 #else
-            int hr = obj.TryAs<IUnknownVftbl>(typeof(IWeakReferenceSource).GUID, out var weakRefSource);
+            int hr = obj.TryAs<IUnknownVftbl>(InterfaceIIDs.IWeakReferenceSource_IID, out var weakRefSource);
             if (hr != 0)
             {
                 return;
@@ -850,6 +850,8 @@ namespace WinRT
     internal static class InterfaceIIDs
     {
         internal static readonly Guid IInspectable_IID = new(0xAF86E2E0, 0xB12D, 0x4c6a, 0x9C, 0x5A, 0xD7, 0xAA, 0x65, 0x10, 0x1E, 0x90);
+        internal static readonly Guid IUnknown_IID = new(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+        internal static readonly Guid IWeakReferenceSource_IID = new(0x00000038, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
     }
 }
 


### PR DESCRIPTION
- Reduce use of linq expressions and replace them with reflection as our uses of linq expressions were found to have a significant initial cost possibly due to its internal initialization which the replacements don't seem to have.  In addition, comparing the over time performance after the initial call with some scenarios don't seem to show a regression in performance.
- Reorder the logic in GUID generation in order of expense to avoid unnecessary cost.
- For IsIReferenceArray, do a type check instead of full name check as the full name cost was showing up in traces and type checks should be faster.
- Improve the generic nullable scenario to reduce allocating objects and reduce the time spent jitting different generic versions of nullable.
- As part of our lazy replacement, we generated Make functions along with properties to retrieve them.  These were also done for the ones which reuse inner as is when they were not needed.  Removing those and making those properties directly refer to inner instead.
- Replace a couple more .Guid calls which were showing up on traces as GetCustomAttribute calls with equivalent hard coded values.