### PR TITLE
Make MarshalGeneric use ObjectReferenceValue and remove MarshalArray2

### DIFF
--- a/src/WinRT.Runtime/CastExtensions.cs
+++ b/src/WinRT.Runtime/CastExtensions.cs
@@ -75,6 +75,10 @@ namespace WinRT
                 {
                     return new AgileReference<T>(objref);
                 }
+                else if (marshal is ObjectReferenceValue objrefValue)
+                {
+                    return new AgileReference<T>(objrefValue);
+                }
             }
             finally
             {

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -29,7 +29,7 @@ namespace WinRT.Interop
     [Guid("00000146-0000-0000-C000-000000000046")]
     internal interface IGlobalInterfaceTable
     {
-        IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid);
+        IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid);
         void RevokeInterfaceFromGlobal(IntPtr cookie);
         IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid);
     }
@@ -161,9 +161,9 @@ namespace ABI.WinRT.Interop
             _obj = obj;
         }
 
-        public IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid)
+        public IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid)
         {
-            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, objRef.ThisPtr, ref riid, out IntPtr cookie));
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, ptr, ref riid, out IntPtr cookie));
             return cookie;
 
         }

--- a/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
@@ -28,7 +28,7 @@ namespace WinRT.Interop
     [Guid("00000146-0000-0000-C000-000000000046")]
     internal interface IGlobalInterfaceTable
     {
-        IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid);
+        IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid);
         void RevokeInterfaceFromGlobal(IntPtr cookie);
         IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid);
     }
@@ -225,9 +225,9 @@ namespace ABI.WinRT.Interop
             _obj = obj;
         }
 
-        public IntPtr RegisterInterfaceInGlobal(IObjectReference objRef, Guid riid)
+        public IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid)
         {
-            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, objRef.ThisPtr, ref riid, out IntPtr cookie));
+            ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, ptr, ref riid, out IntPtr cookie));
             return cookie;
 
         }

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -33,11 +33,9 @@ MembersMustExist : Member 'public T WinRT.MarshalDelegate.FromAbi<T>(System.IntP
 MembersMustExist : Member 'public WinRT.ObjectReferenceValue WinRT.MarshalInspectable<T>.CreateMarshaler2(T, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReferenceValue WinRT.MarshalInspectable<T>.CreateMarshaler2(T, System.Guid, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.IObjectReference WinRT.MarshalInspectable<T>.CreateMarshaler<V>(T, System.Guid, System.Boolean)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public WinRT.MarshalInterfaceHelper<T>.MarshalerArray WinRT.MarshalInspectable<T>.CreateMarshalerArray2(T[])' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalInspectable<T>.DisposeMarshaler(WinRT.ObjectReferenceValue)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalInspectable<T>.GetAbi(WinRT.ObjectReferenceValue)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReferenceValue WinRT.MarshalInterface<T>.CreateMarshaler2(T, System.Guid)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public WinRT.MarshalInterfaceHelper<T>.MarshalerArray WinRT.MarshalInterface<T>.CreateMarshalerArray2(T[])' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalInterface<T>.DisposeMarshaler(WinRT.ObjectReferenceValue)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.IntPtr WinRT.MarshalInterface<T>.GetAbi(WinRT.ObjectReferenceValue)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalInterfaceHelper<T>.MarshalerArray WinRT.MarshalInterfaceHelper<T>.CreateMarshalerArray2(T[], System.Func<T, WinRT.ObjectReferenceValue>)' does not exist in the reference but it does exist in the implementation.
@@ -51,4 +49,4 @@ TypesMustExist : Type 'WinRT.MarshalString.Pinnable' does not exist in the refer
 TypesMustExist : Type 'WinRT.ObjectReferenceValue' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-Total Issues: 52
+Total Issues: 50

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -68,9 +68,6 @@ namespace ABI.System.Collections.Generic
         }
 
         internal static MarshalInterfaceHelper<global::System.Collections.Generic.KeyValuePair<K, V>>.MarshalerArray CreateMarshalerArray(global::System.Collections.Generic.KeyValuePair<K, V>[] array) =>
-            MarshalInterfaceHelper<global::System.Collections.Generic.KeyValuePair<K, V>>.CreateMarshalerArray(array, (o) => CreateMarshaler(o));
-
-        internal static MarshalInterfaceHelper<global::System.Collections.Generic.KeyValuePair<K, V>>.MarshalerArray CreateMarshalerArray2(global::System.Collections.Generic.KeyValuePair<K, V>[] array) => 
             MarshalInterfaceHelper<global::System.Collections.Generic.KeyValuePair<K, V>>.CreateMarshalerArray2(array, (o) => CreateMarshaler2(o));
 
         internal static (int length, IntPtr data) GetAbiArray(object box) => MarshalInterfaceHelper<global::System.Collections.Generic.KeyValuePair<K, V>>.GetAbiArray(box);

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -81,7 +81,10 @@ namespace WinRT
 
         public static Type GetMarshalerType(this Type type)
         {
-            return type.GetHelperType().GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).ReturnType;
+            var helperType = type.GetHelperType();
+            var createMarshaler = helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static) ??
+                helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            return createMarshaler.ReturnType;
         }
 
         internal static Type GetMarshalerArrayType(this Type type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -3354,7 +3354,7 @@ event % %;)",
             {
                 w.write("% = %.GetAbi%(%);\n",
                     get_param_local(w),
-                    is_marshal_by_object_reference_value() && !is_array() ? "MarshalInspectable<object>" : marshaler_type,
+                    is_marshal_by_object_reference_value() ? "MarshalInspectable<object>" : marshaler_type,
                     is_array() ? "Array" : "",
                     get_marshaler_local(w));
             }
@@ -3440,7 +3440,7 @@ event % %;)",
             }
 
             w.write("%.GetAbi%(%%)",
-                is_marshal_by_object_reference_value() && !is_array() ? "MarshalInspectable<object>" : marshaler_type,
+                is_marshal_by_object_reference_value() ? "MarshalInspectable<object>" : marshaler_type,
                 is_array() ? "Array" : "",
                 is_pinnable ? "ref " : "",
                 get_marshaler_local(w));
@@ -3557,7 +3557,7 @@ event % %;)",
             else
             {
                 w.write("%.DisposeMarshaler%(%);\n",
-                    is_marshal_by_object_reference_value() && !is_array() ? "MarshalInspectable<object>" : marshaler_type,
+                    is_marshal_by_object_reference_value() ? "MarshalInspectable<object>" : marshaler_type,
                     is_array() ? "Array" : "",
                     get_marshaler_local(w));
             }
@@ -3613,37 +3613,37 @@ event % %;)",
                 break;
             case category::interface_type:
                 m.marshaler_type = "MarshalInterface<" + m.param_type + ">";
-                m.marshal_by_object_reference_value = true;
                 if (m.is_array())
                 {
                     m.local_type = w.write_temp("MarshalInterfaceHelper<%>.MarshalerArray", m.param_type);
                 }
                 else
                 {
+                    m.marshal_by_object_reference_value = true;
                     m.local_type = m.is_out() ? "IntPtr" : "ObjectReferenceValue";
                 }
                 break;
             case category::class_type:
                 m.marshaler_type = w.write_temp("%", bind<write_type_name>(semantics, typedef_name_type::ABI, true));
-                m.marshal_by_object_reference_value = true;
                 if (m.is_array())
                 {
                     m.local_type = w.write_temp("MarshalInterfaceHelper<%>.MarshalerArray", m.param_type);
                 }
                 else
                 {
+                    m.marshal_by_object_reference_value = true;
                     m.local_type = m.is_out() ? "IntPtr" : "ObjectReferenceValue";
                 }
                 break;
             case category::delegate_type:
                 m.marshaler_type = get_abi_type();
-                m.marshal_by_object_reference_value = true;
                 if (m.is_array())
                 {
                     m.local_type = w.write_temp("MarshalInterfaceHelper<%>.MarshalerArray", m.param_type);
                 }
                 else
                 {
+                    m.marshal_by_object_reference_value = true;
                     m.local_type = m.is_out() ? "IntPtr" : "ObjectReferenceValue";
                 }
                 break;
@@ -3654,13 +3654,13 @@ event % %;)",
             [&](object_type)
             {
                 m.marshaler_type = "MarshalInspectable<object>";
-                m.marshal_by_object_reference_value = true;
                 if (m.is_array())
                 {
                     m.local_type = "MarshalInterfaceHelper<object>.MarshalerArray";
                 }
                 else
                 {
+                    m.marshal_by_object_reference_value = true;
                     m.local_type = m.is_out() ? "IntPtr" : "ObjectReferenceValue";
                 }
             },
@@ -6538,8 +6538,7 @@ global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, ob
 public static IntPtr GetAbi(IObjectReference value) => value is null ? IntPtr.Zero : MarshalInterfaceHelper<object>.GetAbi(value);
 public static % FromAbi(IntPtr thisPtr) => %.FromAbi(thisPtr);
 public static IntPtr FromManaged(% obj) => obj is null ? IntPtr.Zero : CreateMarshaler2(obj).Detach();
-public static unsafe MarshalInterfaceHelper<%>.MarshalerArray CreateMarshalerArray(%[] array) => MarshalInterfaceHelper<%>.CreateMarshalerArray(array, (o) => CreateMarshaler(o));
-public static unsafe MarshalInterfaceHelper<%>.MarshalerArray CreateMarshalerArray2(%[] array) => MarshalInterfaceHelper<%>.CreateMarshalerArray2(array, (o) => CreateMarshaler2(o));
+public static unsafe MarshalInterfaceHelper<%>.MarshalerArray CreateMarshalerArray(%[] array) => MarshalInterfaceHelper<%>.CreateMarshalerArray2(array, (o) => CreateMarshaler2(o));
 public static (int length, IntPtr data) GetAbiArray(object box) => MarshalInterfaceHelper<%>.GetAbiArray(box);
 public static unsafe %[] FromAbiArray(object box) => MarshalInterfaceHelper<%>.FromAbiArray(box, FromAbi);
 public static (int length, IntPtr data) FromManagedArray(%[] array) => MarshalInterfaceHelper<%>.FromManagedArray(array, (o) => FromManaged(o));
@@ -6590,9 +6589,6 @@ public static ObjectReferenceValue CreateMarshaler2(% obj) => MarshalInterface<%
             }),
             projected_type_name,
             ccw_type_name,
-            projected_type_name,
-            projected_type_name,
-            projected_type_name,
             projected_type_name,
             projected_type_name,
             projected_type_name,


### PR DESCRIPTION
- MarshalArray2 is actually not needed as we can just update the implementation.  To avoid that API addition, removing it before our release.
- Updated generic marshalers to use ObjectReferenceValue but boxing makes it such that it doesn't get as much perf improvements as the non generic marshaler scenario.
- Remove potential race in setting and reading guid value as it is not atomic set.
- Reduce the # of funcs created by moving common ones outside of the generic class which was previously causing them to JIT each time.
- Update agile reference to also accept ObjectReferenceValue since we are updating the generic marshalers.