### PR TITLE
Change WindowsSdk variable used to publish to maestro

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -44,4 +44,4 @@ stages:
     - template: ..\..\eng\common\AzurePipelineTemplates\Maestro-PublishBuildToMaestro-Steps.yml 
       parameters:
         AssetNames: Microsoft.Windows.CsWinRT;CsWinRT.Dependency.DotNetCoreSdk;CsWinRT.Dependency.DotNetCoreRuntime;CsWinRT.Dependency.WindowsSdkPackage
-        AssetVersions: $(NugetVersion);$(Net5.Sdk.Version);$(_DotNetRuntimeVersion);$(_WindowsSdkPackageVersion)
+        AssetVersions: $(NugetVersion);$(Net5.Sdk.Version);$(_DotNetRuntimeVersion);$(_WindowsSdkVersionSuffix)

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -43,5 +43,5 @@ stages:
 
     - template: ..\..\eng\common\AzurePipelineTemplates\Maestro-PublishBuildToMaestro-Steps.yml 
       parameters:
-        AssetNames: Microsoft.Windows.CsWinRT;CsWinRT.Dependency.DotNetCoreSdk;CsWinRT.Dependency.DotNetCoreRuntime;CsWinRT.Dependency.WindowsSdkPackage
+        AssetNames: Microsoft.Windows.CsWinRT;CsWinRT.Dependency.DotNetCoreSdk;CsWinRT.Dependency.DotNetCoreRuntime;CsWinRT.Dependency.WindowsSdkVersionSuffix
         AssetVersions: $(NugetVersion);$(Net5.Sdk.Version);$(_DotNetRuntimeVersion);$(_WindowsSdkVersionSuffix)

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -13,4 +13,4 @@ variables:
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
   _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
-  _WindowsSdkPackageVersion: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '23')]  
+  _WindowsSdkVersionSuffix: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '23')]  


### PR DESCRIPTION
In [this PR](https://github.com/microsoft/WindowsAppSDK/pull/2015#discussion_r792928818) we agreed to rename this variable to something more clear and descriptive. [Here](https://github.com/microsoft/WindowsAppSDK/pull/2294) is the corresponding update to WinAppSDK.

Fixes #1091 

Note that we don't need to change the CsWinRT CI's queue-time variable; only CsWinRT folks will see it and the name there is fine IMO.