### PR TITLE
Add localization pipeline

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -370,6 +370,34 @@ stages:
           zh-Hant/System.CommandLine.resources.dll 
         TargetFolder: $(Build.ArtifactStagingDirectory)\release_net5.0\IIDOptimizer
 
+# Stage WinRT.Runtime ResX
+    - task: CopyFiles@2
+      displayName: Stage WinRT.Runtime ResX
+      condition: succeeded()
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Runtime
+        Contents: |
+          WinRTRuntimeErrorStrings.resx
+        TargetFolder: $(Build.ArtifactStagingDirectory)\resx\WinRT.Runtime
+
+# Stage Authoring Diagnostics ResX
+    - task: CopyFiles@2
+      displayName: Stage Authoring Diagnostics ResX
+      condition: succeeded()
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\src\Authoring\WinRT.SourceGenerator
+        Contents: |
+          CsWinRTDiagnosticStrings.resx
+        TargetFolder: $(Build.ArtifactStagingDirectory)\resx\WinRT.SourceGenerator
+
+# Publish ResX
+    - task: PublishBuildArtifacts@1
+      displayName: Publish ResX files
+      condition: succeeded()
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)\resx
+        ArtifactName: ResX
+
 # Publish Net5.0
     - task: PublishBuildArtifacts@1
       displayName: Publish Net5.0

--- a/build/AzurePipelineTemplates/CsWinRT-LocalizationPipeline.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-LocalizationPipeline.yml
@@ -1,0 +1,10 @@
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion)$(PrereleaseVersion).$(date:yyMMdd)$(rev:.r)
+
+variables:
+- template: CsWinRT-Variables.yml
+- group: CsWinRT-TouchdownBuild-Secrets
+
+stages:
+- template: CsWinRT-BuildAndTest-Stage.yml
+
+- template: CsWinRT-LocalizeResources-Stage.yml

--- a/build/AzurePipelineTemplates/CsWinRT-LocalizeResources-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-LocalizeResources-Stage.yml
@@ -1,0 +1,52 @@
+stages:
+- stage: LocalizeStrings
+  displayName: Call TDBuild to Localize Resources
+  jobs:
+  - job: Localize
+    pool: 
+      vmImage: windows-2019
+    timeoutInMinutes: 90
+    steps:
+    - checkout: self
+      clean: true
+      persistCredentials: true
+
+    # This is needed to avoid credentials errors for later in the TDBuild Task
+    - script: |
+        git config --global user.email "DoNotEmailThis@dev.null.microsoft.com"
+        git config --global user.name "TDBuild"
+
+    # Download x64
+    - task: DownloadBuildArtifacts@0
+      displayName: Download x64
+      inputs:
+        artifactName: release_x64
+        itemPattern: ''
+        downloadPath: $(Build.SourcesDirectory)
+        extractTars: false
+
+    # Download RESX
+    - task: DownloadBuildArtifacts@0
+      displayName: Download ResX
+      inputs:
+        artifactName: ResX
+        itemPattern: ''
+        downloadPath: $(Build.SourcesDirectory)
+        extractTars: false
+
+    - task: TouchdownBuildTask@1
+      inputs:
+        environment: 'PRODEXT'
+        teamId: $(CsWinRTTDBuildTeamID)
+        authType: 'OAuth'
+        authId: $(CsWinRTTDBuildAuthID)
+        authKey: $(CsWinRTTDBuildAuthKey)
+        localizationTarget: true
+        isPreview: false
+        resourceFilePath: |
+          $(Build.SourcesDirectory)\release_x64\WinRT.Host.dll.mui
+          $(Build.SourcesDirectory)\ResX\WinRT.SourceGenerator\CsWinRTDiagnosticStrings.resx
+          $(Build.SourcesDirectory)\ResX\WinRT.Runtime\WinRTRuntimeErrorStrings.resx
+        appendRelativeDir: true
+        cultureMappingType: 'None'
+        gitAction: NONE


### PR DESCRIPTION
To localize our error strings, we use a service called TDBuild via an ADO pipeline introduced in this PR. This required modifications to the BuildAndTest stage to publish the resource files to the build output. Then The localization pipeline can run the build step, download the resources files, and give them to TDBuild. 

I have confirmed that TDBuild received the correct files from a run of this new pipeline.