### PR TITLE
Fix generic marshaler in CsWinRT 1.6 compatibility with CsWinRT projections generated using <=1.3.0

### DIFF
--- a/src/WinRT.Runtime/CastExtensions.cs
+++ b/src/WinRT.Runtime/CastExtensions.cs
@@ -68,7 +68,7 @@ namespace WinRT
                 return new AgileReference<T>(null);
             }
 
-            var marshal = Marshaler<T>.CreateMarshaler(value);
+            var marshal = Marshaler<T>.CreateMarshaler2(value);
             try
             {
                 if (marshal is IObjectReference objref)

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1372,7 +1372,7 @@ namespace WinRT
             (object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
         internal static unsafe Action<object, IntPtr> CopyUIntEnumFunc =
             (object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
-        internal static Action<object, Lazy<Action<object>>> DisposeMarshaler = (object arg, Lazy<Action<object>> disposeMarshalerFallback) =>
+        internal static Action<object, Lazy<Action<object>>> DisposeMarshaler = (object arg, Lazy<Action<object>> genericDisposeMarshaler) =>
         {
             if (arg is ObjectReferenceValue objectReferenceValue)
             {
@@ -1380,10 +1380,10 @@ namespace WinRT
             }
             else
             {
-                disposeMarshalerFallback.Value(arg);
+                genericDisposeMarshaler.Value(arg);
             }
         };
-        internal static Func<object, Lazy<Func<object, object>>, object> GetAbi = (object arg, Lazy<Func<object, object>> getAbiFallback) => arg is ObjectReferenceValue objectReferenceValue ? objectReferenceValue.GetAbi() : getAbiFallback.Value(arg);
+        internal static Func<object, Lazy<Func<object, object>>, object> GetAbi = (object arg, Lazy<Func<object, object>> genericGetAbi) => arg is ObjectReferenceValue objectReferenceValue ? objectReferenceValue.GetAbi() : genericGetAbi.Value(arg);
     }
 
 #if EMBED

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -441,38 +441,32 @@ namespace WinRT
         protected static readonly Type HelperType = typeof(T).GetHelperType();
         protected static readonly Type AbiType = typeof(T).GetAbiType();
         protected static readonly Type MarshalerType = typeof(T).GetMarshalerType();
-        private static readonly bool MarshalByObjectReferenceValue = MarshalerType == typeof(ObjectReferenceValue);
+        private static readonly bool MarshalByObjectReferenceValueSupported = typeof(T).GetMarshaler2Type() == typeof(ObjectReferenceValue);
 
         public static readonly Func<T, object> CreateMarshaler = (T value) => CreateMarshalerLazy.Value(value);
         private static readonly Lazy<Func<T, object>> CreateMarshalerLazy = new(BindCreateMarshaler);
         private static Func<T, object> BindCreateMarshaler()
         {
-            if (MarshalByObjectReferenceValue)
-            {
-                var createMarshaler = (Func<T, ObjectReferenceValue>)HelperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).
-                    CreateDelegate(typeof(Func<T, ObjectReferenceValue>));
-                return (T arg) => createMarshaler(arg);
-            }
-            else
-            {
-                var createMarshaler = HelperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-                return (T arg) => createMarshaler.Invoke(null, new object[] { arg });
-            }
+            var createMarshaler = HelperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            return (T arg) => createMarshaler.Invoke(null, new object[] { arg });
         }
 
-        public static readonly Func<object, object> GetAbi = (object objRef) => GetAbiLazy.Value(objRef);
+        internal static Func<T, object> CreateMarshaler2 => MarshalByObjectReferenceValueSupported ? CreateMarshaler2Lazy.Value : CreateMarshaler;
+        private static readonly Lazy<Func<T, object>> CreateMarshaler2Lazy = new(BindCreateMarshaler2);
+        private static Func<T, object> BindCreateMarshaler2()
+        {
+            var createMarshaler = (Func<T, ObjectReferenceValue>)HelperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).
+                CreateDelegate(typeof(Func<T, ObjectReferenceValue>));
+            return (T arg) => createMarshaler(arg);
+        }
+
+        public static readonly Func<object, object> GetAbi = MarshalByObjectReferenceValueSupported ? (object objRef) => Marshaler.GetAbi(objRef, GetAbiLazy) :
+            (object objRef) => GetAbiLazy.Value(objRef);
         private static readonly Lazy<Func<object, object>> GetAbiLazy = new(BindGetAbi);
         private static Func<object, object> BindGetAbi()
         {
-            if (MarshalByObjectReferenceValue)
-            {
-                return Marshaler.GetAbiObjectReferenceValueFunc;
-            }
-            else
-            {
-                var getAbi = HelperType.GetMethod("GetAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-                return (object arg) => getAbi.Invoke(null, new[] { arg });
-            }
+            var getAbi = HelperType.GetMethod("GetAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            return (object arg) => getAbi.Invoke(null, new[] { arg });
         }
 
         public static readonly Action<object, IntPtr> CopyAbi = (object box, IntPtr dest) => CopyAbiLazy.Value(box, dest);
@@ -509,19 +503,12 @@ namespace WinRT
             return (T arg, IntPtr dest) => copyManaged.Invoke(null, new object[] { arg, dest });
         }
 
-        public static readonly Action<object> DisposeMarshaler = (object objRef) => DisposeMarshalerLazy.Value(objRef);
+        public static readonly Action<object> DisposeMarshaler = MarshalByObjectReferenceValueSupported ? (object objRef) => Marshaler.DisposeMarshaler(objRef, DisposeMarshalerLazy) : (object objRef) => DisposeMarshalerLazy.Value(objRef);
         private static readonly Lazy<Action<object>> DisposeMarshalerLazy = new(BindDisposeMarshaler);
         private static Action<object> BindDisposeMarshaler()
         {
-            if (MarshalByObjectReferenceValue)
-            {
-                return Marshaler.DisposeObjectReferenceValueFunc;
-            }
-            else
-            {
-                var disposeMarshaler = HelperType.GetMethod("DisposeMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-                return (object arg) => disposeMarshaler.Invoke(null, new[] { arg });
-            }
+            var disposeMarshaler = HelperType.GetMethod("DisposeMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            return (object arg) => disposeMarshaler.Invoke(null, new[] { arg });
         }
 
         internal static readonly Action<object> DisposeAbi = (object box) => DisposeAbiLazy.Value(box);
@@ -589,10 +576,10 @@ namespace WinRT
 
         private static unsafe void CopyManagedFallback(T value, IntPtr dest)
         {
-            if (MarshalByObjectReferenceValue)
+            if (MarshalByObjectReferenceValueSupported)
             {
                 *(IntPtr*)dest.ToPointer() =
-                    (value is null) ? IntPtr.Zero : ((ObjectReferenceValue)CreateMarshaler(value)).Detach();
+                    (value is null) ? IntPtr.Zero : ((ObjectReferenceValue)CreateMarshaler2(value)).Detach();
             }
             else
             {
@@ -1385,8 +1372,18 @@ namespace WinRT
             (object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
         internal static unsafe Action<object, IntPtr> CopyUIntEnumFunc =
             (object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
-        internal static Action<object> DisposeObjectReferenceValueFunc = (object arg) => ((ObjectReferenceValue)arg).Dispose();
-        internal static Func<object, object> GetAbiObjectReferenceValueFunc = (object arg) => ((ObjectReferenceValue)arg).GetAbi();
+        internal static Action<object, Lazy<Action<object>>> DisposeMarshaler = (object arg, Lazy<Action<object>> disposeMarshalerFallback) =>
+        {
+            if (arg is ObjectReferenceValue objectReferenceValue)
+            {
+                objectReferenceValue.Dispose();
+            }
+            else
+            {
+                disposeMarshalerFallback.Value(arg);
+            }
+        };
+        internal static Func<object, Lazy<Func<object, object>>, object> GetAbi = (object arg, Lazy<Func<object, object>> getAbiFallback) => arg is ObjectReferenceValue objectReferenceValue ? objectReferenceValue.GetAbi() : getAbiFallback.Value(arg);
     }
 
 #if EMBED
@@ -1410,6 +1407,7 @@ namespace WinRT
             {
                 AbiType = typeof(IntPtr);
                 CreateMarshaler = (T value) => MarshalString.CreateMarshaler((string)(object)value);
+                CreateMarshaler2 = CreateMarshaler;
                 GetAbi = (object box) => MarshalString.GetAbi(box);
                 FromAbi = (object value) => (T)(object)MarshalString.FromAbi((IntPtr)value);
                 FromManaged = (T value) => MarshalString.FromManaged((string)(object)value);
@@ -1426,7 +1424,8 @@ namespace WinRT
             else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
             {
                 AbiType = typeof(IntPtr);
-                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler;
+                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler2;
+                CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
                 GetAbi = MarshalGeneric<T>.GetAbi;
                 CopyAbi = MarshalGeneric<T>.CopyAbi;
                 FromAbi = MarshalGeneric<T>.FromAbi;
@@ -1446,6 +1445,7 @@ namespace WinRT
             {
                 AbiType = typeof(ABI.System.Type);
                 CreateMarshaler = (T value) => ABI.System.Type.CreateMarshaler((Type)(object)value);
+                CreateMarshaler2 = CreateMarshaler;
                 GetAbi = (object box) => ABI.System.Type.GetAbi((ABI.System.Type.Marshaler)box);
                 FromAbi = (object value) => (T)(object)ABI.System.Type.FromAbi((ABI.System.Type)value);
                 CopyAbi = (object box, IntPtr dest) => ABI.System.Type.CopyAbi((ABI.System.Type.Marshaler)box, dest);
@@ -1478,6 +1478,7 @@ namespace WinRT
                     Func<T, object> ReturnTypedParameterFunc = (T value) => value;
                     AbiType = type;
                     CreateMarshaler = ReturnTypedParameterFunc;
+                    CreateMarshaler2 = CreateMarshaler;
                     GetAbi = Marshaler.ReturnParameterFunc;
                     FromAbi = (object value) => (T)value;
                     FromManaged = ReturnTypedParameterFunc;
@@ -1508,6 +1509,7 @@ namespace WinRT
                 else
                 {
                     CreateMarshaler = MarshalNonBlittable<T>.CreateMarshaler;
+                    CreateMarshaler2 = CreateMarshaler;
                     GetAbi = MarshalNonBlittable<T>.GetAbi;
                     CopyAbi = MarshalNonBlittable<T>.CopyAbi;
                     FromAbi = MarshalNonBlittable<T>.FromAbi;
@@ -1528,6 +1530,7 @@ namespace WinRT
             {
                 AbiType = typeof(IntPtr);
                 CreateMarshaler = (T value) => MarshalInterface<T>.CreateMarshaler2(value);
+                CreateMarshaler2 = CreateMarshaler;
                 GetAbi = (object objRef) => objRef is ObjectReferenceValue objRefValue ? 
                     MarshalInspectable<object>.GetAbi(objRefValue) : MarshalInterface<T>.GetAbi((IObjectReference)objRef);
                 FromAbi = (object value) => MarshalInterface<T>.FromAbi((IntPtr)value);
@@ -1546,6 +1549,7 @@ namespace WinRT
             {
                 AbiType = typeof(IntPtr);
                 CreateMarshaler = (T value) => MarshalInspectable<T>.CreateMarshaler2(value);
+                CreateMarshaler2 = CreateMarshaler;
                 GetAbi = (object objRef) => objRef is ObjectReferenceValue objRefValue ? 
                     MarshalInspectable<T>.GetAbi(objRefValue) : MarshalInspectable<T>.GetAbi((IObjectReference)objRef);
                 FromAbi = (object box) => MarshalInspectable<T>.FromAbi((IntPtr)box);
@@ -1564,7 +1568,11 @@ namespace WinRT
             else // delegate, class 
             {
                 AbiType = typeof(IntPtr);
-                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler;
+                // Prior to CsWinRT 1.3.1, generic marshalers were used for delegates and they assumed the marshaler type was IObjectReference.
+                // Due to that, not updating the CreateMarshaler to the new version in that instance, and only updating it for new code using
+                // CreateMarshaler2.
+                CreateMarshaler = typeof(T).IsDelegate() ? MarshalGeneric<T>.CreateMarshaler : MarshalGeneric<T>.CreateMarshaler2;
+                CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
                 GetAbi = MarshalGeneric<T>.GetAbi;
                 FromAbi = MarshalGeneric<T>.FromAbi;
                 FromManaged = MarshalGeneric<T>.FromManaged;
@@ -1585,6 +1593,7 @@ namespace WinRT
         public static readonly Type AbiType;
         public static readonly Type RefAbiType;
         public static readonly Func<T, object> CreateMarshaler;
+        internal static readonly Func<T, object> CreateMarshaler2;
         public static readonly Func<object, object> GetAbi;
         public static readonly Action<object, IntPtr> CopyAbi;
         public static readonly Func<object, T> FromAbi;

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -107,7 +107,7 @@ namespace ABI.System
                 {
                     __sender = MarshalInspectable<object>.CreateMarshaler2(sender);
                     __params[1] = MarshalInspectable<object>.GetAbi(__sender);
-                    __args = Marshaler<T>.CreateMarshaler(args);
+                    __args = Marshaler<T>.CreateMarshaler2(args);
                     __params[2] = Marshaler<T>.GetAbi(__args);
                     abiInvoke.DynamicInvokeAbi(__params);
                 }

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -170,7 +170,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null }; 
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
 
@@ -203,7 +203,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
                 return (byte)__params[2] != 0;
@@ -239,9 +239,9 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
-                __value = Marshaler<V>.CreateMarshaler(value);
+                __value = Marshaler<V>.CreateMarshaler2(value);
                 __params[2] = Marshaler<V>.GetAbi(__value);
                 _obj.Vftbl.Insert_4.DynamicInvokeAbi(__params);
                 return (byte)__params[3] != 0;
@@ -261,7 +261,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Remove_5.DynamicInvokeAbi(__params);
             }

--- a/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -733,7 +733,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
                 return Marshaler<V>.FromAbi(__params[2]);
@@ -751,7 +751,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
                 return (byte)__params[2] != 0;
@@ -783,9 +783,9 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
-                __value = Marshaler<V>.CreateMarshaler(value);
+                __value = Marshaler<V>.CreateMarshaler2(value);
                 __params[2] = Marshaler<V>.GetAbi(__value);
                 _obj.Vftbl.Insert_4.DynamicInvokeAbi(__params);
                 return (byte)__params[3] != 0;
@@ -803,7 +803,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Remove_5.DynamicInvokeAbi(__params);
             }

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -388,7 +388,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_3.DynamicInvokeAbi(__params);
                 index = (uint)__params[2];
@@ -408,7 +408,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.SetAt_4.DynamicInvokeAbi(__params);
             }
@@ -426,7 +426,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.InsertAt_5.DynamicInvokeAbi(__params);
             }
@@ -451,7 +451,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.Append_7.DynamicInvokeAbi(__params);
             }
@@ -1064,7 +1064,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_3.DynamicInvokeAbi(__params);
                 index = (uint)__params[2];
@@ -1084,7 +1084,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.SetAt_4.DynamicInvokeAbi(__params);
             }
@@ -1102,7 +1102,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.InsertAt_5.DynamicInvokeAbi(__params);
             }
@@ -1127,7 +1127,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.Append_7.DynamicInvokeAbi(__params);
             }

--- a/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -798,7 +798,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_3.DynamicInvokeAbi(__params);
                 index = (uint)__params[2];
@@ -816,7 +816,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.SetAt_4.DynamicInvokeAbi(__params);
             }
@@ -832,7 +832,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, index, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.InsertAt_5.DynamicInvokeAbi(__params);
             }
@@ -853,7 +853,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.Append_7.DynamicInvokeAbi(__params);
             }

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -113,7 +113,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
                 return Marshaler<V>.FromAbi(__params[2]);
@@ -134,7 +134,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
                 return (byte)__params[2] != 0;

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -670,7 +670,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
                 return Marshaler<V>.FromAbi(__params[2]);
@@ -688,7 +688,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null };
             try
             {
-                __key = Marshaler<K>.CreateMarshaler(key);
+                __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
                 return (byte)__params[2] != 0;

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -116,7 +116,7 @@ namespace ABI.Windows.Foundation.Collections
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_2.DynamicInvokeAbi(__params);
                 index = (uint)__params[2];

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -394,7 +394,7 @@ namespace ABI.System.Collections.Generic
             var __params = new object[] { ThisPtr, null, null, null };
             try
             {
-                __value = Marshaler<T>.CreateMarshaler(value);
+                __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_2.DynamicInvokeAbi(__params);
                 index = (uint)__params[2];

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -81,6 +81,11 @@ namespace WinRT
 
         public static Type GetMarshalerType(this Type type)
         {
+            return type.GetHelperType().GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).ReturnType;
+        }
+
+        internal static Type GetMarshaler2Type(this Type type)
+        {
             var helperType = type.GetHelperType();
             var createMarshaler = helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static) ??
                 helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);


### PR DESCRIPTION
In CsWinRT 1.6.1, we have improvements to our generic marshalers, but it turns out they weren't compatible with CsWinRT projections generated using CsWinRT 1.3.0 or earlier specifically when they had events.  This is because before we use to generate code in the projections for events which assumed the marshaler for events would be IObjectReference and did a cast to it from the returned object which was of type object.  But now with recent changes that isn't no longer true as they are ObjectReferenceValue and that caused an InvalidCastException.

Addressing the issue, by creating a new CreateMarshaler2 separate from CreateMarshaler.  In most cases they are the same, but in the case of delegates, CreateMarshaler is unmodified and uses IObjectReference as the marshaler type and CreateMarshaler2 uses the new ObjectReferenceValue.  Given other types like for Classes weren't affected, I didn't do the same for the others and left CreateMarshaler2 and CreateMarshaler to be the same improved ObjectReferenceValue.