### PR TITLE
Avoid generating duplicated symbols when patch method

### DIFF
--- a/src/Perf/IIDOptimizer/GuidPatcher.cs
+++ b/src/Perf/IIDOptimizer/GuidPatcher.cs
@@ -175,14 +175,10 @@ namespace GuidPatch
         {
             SignaturePart rootSignaturePart = signatureGenerator.GetSignatureParts(type);
             var methodName = $"<IIDData>{type.FullName}";
-            MethodReference guidDataMethodReference;
-            if (methodCache.ContainsKey(methodName))
+
+            if (!methodCache.TryGetValue(methodName, out var guidDataMethodReference))
             {
-                guidDataMethodReference = methodCache[methodName];
-            }
-            else
-            {
-                var guidDataMethod = new MethodDefinition($"<IIDData>{type.FullName}", MethodAttributes.Assembly | MethodAttributes.Static, readOnlySpanOfByte);
+                var guidDataMethod = new MethodDefinition(methodName, MethodAttributes.Assembly | MethodAttributes.Static, readOnlySpanOfByte);
 
                 guidImplementationDetailsType.Methods.Add(guidDataMethod);
 


### PR DESCRIPTION
Introduced a symbol cache to avoid symbols being re-generated.

Before:

![image](https://user-images.githubusercontent.com/14960345/164441180-f08497dd-5106-4993-ac09-6e91ae76cb63.png)

![image](https://user-images.githubusercontent.com/14960345/164443442-37f68f4d-52c9-4153-a912-423ea9824663.png)

![image](https://user-images.githubusercontent.com/14960345/164443651-f5c86987-6bf6-4738-bcbb-d3661071ffd0.png)


After:

![image](https://user-images.githubusercontent.com/14960345/164441439-56283077-31d2-4eaa-aa34-24c8ddc62c1d.png)

![image](https://user-images.githubusercontent.com/14960345/164443632-abc47b38-9ac9-4e5c-9aea-d4a80e55cb4c.png)

![image](https://user-images.githubusercontent.com/14960345/164443745-9a575cea-c8c9-4721-bf05-72eb741e7952.png)

Fixes #1173