### PR TITLE
Rename "runtimes" directory in NuPkg for hosting assemblies

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -72,12 +72,12 @@ To make your component available as a NuGet package, it is important to include 
             target="lib\$(TargetFramework)\WinRT.Runtime.dll" />
       
       <!-- Include the native DLLs -->
-      <file src="C:\Path\To\CsWinRT\NugetDir\runtimes\win-x64\native\WinRT.Host.dll"                                  
-            target="runtimes\win-x64\native\WinRT.Host.dll" />
-      <file src="C:\Path\To\CsWinRT\NugetDir\runtimes\win-x86\native\WinRT.Host.dll"                                  
-            target="runtimes\win-x86\native\WinRT.Host.dll" />
-      <file src="C:\Path\To\CsWinRT\NugetDir\runtimes\win-arm64\native\WinRT.Host.dll"                                  
-            target="runtimes\win-arm64\native\WinRT.Host.dll" />
+      <file src="C:\Path\To\CsWinRT\NugetDir\hosting\x64\native\WinRT.Host.dll"                                  
+            target="hosting\x64\native\WinRT.Host.dll" />
+      <file src="C:\Path\To\CsWinRT\NugetDir\hosting\x86\native\WinRT.Host.dll"                                  
+            target="hosting\x86\native\WinRT.Host.dll" />
+      <file src="C:\Path\To\CsWinRT\NugetDir\hosting\arm64\native\WinRT.Host.dll"                                  
+            target="hosting\arm64\native\WinRT.Host.dll" />
       
       </files>
       ```

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.Transitive.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.Transitive.targets
@@ -21,8 +21,8 @@
     <!-- Add the runtimeconfig.json -->
     <HostingAssets Include="$(MSBuildThisFileDirectory)..\build\native\WinRT.Host.runtimeconfig.json"/>
     <!-- Get the proper WinRT.Host.dll -->
-    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\win-$(_NormalizedPlatform)\native\WinRT.Host.dll" />
-    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\win-$(_NormalizedPlatform)\native\en-us\WinRT.Host.dll.mui" />
+    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\$(_NormalizedPlatform)\native\WinRT.Host.dll" />
+    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\$(_NormalizedPlatform)\native\en-us\WinRT.Host.dll.mui" />
   </ItemGroup>
     
   <!-- Add the WinMD file as a reference of the native app so a projection gets made --> 

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.Transitive.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.Transitive.targets
@@ -21,8 +21,8 @@
     <!-- Add the runtimeconfig.json -->
     <HostingAssets Include="$(MSBuildThisFileDirectory)..\build\native\WinRT.Host.runtimeconfig.json"/>
     <!-- Get the proper WinRT.Host.dll -->
-    <HostingAssets Include="$(MSBuildThisFileDirectory)..\runtimes\win-$(_NormalizedPlatform)\native\WinRT.Host.dll" />
-    <HostingAssets Include="$(MSBuildThisFileDirectory)..\runtimes\win-$(_NormalizedPlatform)\native\en-us\WinRT.Host.dll.mui" />
+    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\win-$(_NormalizedPlatform)\native\WinRT.Host.dll" />
+    <HostingAssets Include="$(MSBuildThisFileDirectory)..\hosting\win-$(_NormalizedPlatform)\native\en-us\WinRT.Host.dll.mui" />
   </ItemGroup>
     
   <!-- Add the WinMD file as a reference of the native app so a projection gets made --> 

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -63,14 +63,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <None Condition="Exists('$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll')" 
-          Include="$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll">
+    <None Condition="Exists('$(CsWinRTPath)hosting\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll')" 
+          Include="$(CsWinRTPath)hosting\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll">
       <TargetPath>WinRT.Host.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <None Condition="Exists('$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui')"
-          Include="$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui">
+    <None Condition="Exists('$(CsWinRTPath)hosting\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui')"
+          Include="$(CsWinRTPath)hosting\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui">
       <TargetPath>WinRT.Host.dll.mui</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -294,38 +294,38 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </Content>
 
       <!-- We package a version of WinRT.Host.dll for each possible architecture -->
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x64\native</PackagePath>
+        <PackagePath>hosting\win-x64\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x86\native</PackagePath>
+        <PackagePath>hosting\win-x86\native</PackagePath>
       </Content> 
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm\native</PackagePath>
+        <PackagePath>hosting\win-arm\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm64\native</PackagePath>
+        <PackagePath>hosting\win-arm64\native</PackagePath>
       </Content>
       <!-- Package the MUI for WinRT.Host error strings -->
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-x64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x64\native\en-us</PackagePath>
+        <PackagePath>hosting\win-x64\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-x86\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x86\native\en-us</PackagePath>
+        <PackagePath>hosting\win-x86\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-arm\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm\native\en-us</PackagePath>
+        <PackagePath>hosting\win-arm\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-arm64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm64\native\en-us</PackagePath>
+        <PackagePath>hosting\win-arm64\native\en-us</PackagePath>
       </Content>
    </ItemGroup>
 

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -294,38 +294,38 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </Content>
 
       <!-- We package a version of WinRT.Host.dll for each possible architecture -->
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\x64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-x64\native</PackagePath>
+        <PackagePath>hosting\x64\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\x86\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-x86\native</PackagePath>
+        <PackagePath>hosting\x86\native</PackagePath>
       </Content> 
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\arm\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-arm\native</PackagePath>
+        <PackagePath>hosting\arm\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\arm64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-arm64\native</PackagePath>
+        <PackagePath>hosting\arm64\native</PackagePath>
       </Content>
       <!-- Package the MUI for WinRT.Host error strings -->
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\x64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-x64\native\en-us</PackagePath>
+        <PackagePath>hosting\x64\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)hosting\x86\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-x86\native\en-us</PackagePath>
+        <PackagePath>hosting\x86\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\arm\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-arm\native\en-us</PackagePath>
+        <PackagePath>hosting\arm\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\arm64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>hosting\win-arm64\native\en-us</PackagePath>
+        <PackagePath>hosting\arm64\native\en-us</PackagePath>
       </Content>
    </ItemGroup>
 

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -32,14 +32,14 @@
     <file src="readme.txt"/>
     <file src="$net5_runtime$" target="lib\net5.0\"/>
     <file src="$source_generator$" target="analyzers\dotnet\cs\"/>
-    <file src="$winrt_host_x64$" target ="hosting\win-x64\native"/>
-    <file src="$winrt_host_x86$" target ="hosting\win-x86\native"/>
-    <file src="$winrt_host_arm$" target ="hosting\win-arm\native"/>
-    <file src="$winrt_host_arm64$" target ="hosting\win-arm64\native"/>
-    <file src="$winrt_host_resource_x64$" target ="hosting\win-x64\native\en-us"/>
-    <file src="$winrt_host_resource_x86$" target ="hosting\win-x86\native\en-us"/>
-    <file src="$winrt_host_resource_arm$" target ="hosting\win-arm\native\en-us"/>
-    <file src="$winrt_host_resource_arm64$" target ="hosting\win-arm64\native\en-us"/>
+    <file src="$winrt_host_x64$" target ="hosting\x64\native"/>
+    <file src="$winrt_host_x86$" target ="hosting\x86\native"/>
+    <file src="$winrt_host_arm$" target ="hosting\arm\native"/>
+    <file src="$winrt_host_arm64$" target ="hosting\arm64\native"/>
+    <file src="$winrt_host_resource_x64$" target ="hosting\x64\native\en-us"/>
+    <file src="$winrt_host_resource_x86$" target ="hosting\x86\native\en-us"/>
+    <file src="$winrt_host_resource_arm$" target ="hosting\arm\native\en-us"/>
+    <file src="$winrt_host_resource_arm64$" target ="hosting\arm64\native\en-us"/>
     <file src="$winrt_shim$" target ="lib\net5.0\"/>
     
     <!-- Add the WinRT.Runtime sources to the pkg for embedded scenarios -->

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -32,14 +32,14 @@
     <file src="readme.txt"/>
     <file src="$net5_runtime$" target="lib\net5.0\"/>
     <file src="$source_generator$" target="analyzers\dotnet\cs\"/>
-    <file src="$winrt_host_x64$" target ="runtimes\win-x64\native"/>
-    <file src="$winrt_host_x86$" target ="runtimes\win-x86\native"/>
-    <file src="$winrt_host_arm$" target ="runtimes\win-arm\native"/>
-    <file src="$winrt_host_arm64$" target ="runtimes\win-arm64\native"/>
-    <file src="$winrt_host_resource_x64$" target ="runtimes\win-x64\native\en-us"/>
-    <file src="$winrt_host_resource_x86$" target ="runtimes\win-x86\native\en-us"/>
-    <file src="$winrt_host_resource_arm$" target ="runtimes\win-arm\native\en-us"/>
-    <file src="$winrt_host_resource_arm64$" target ="runtimes\win-arm64\native\en-us"/>
+    <file src="$winrt_host_x64$" target ="hosting\win-x64\native"/>
+    <file src="$winrt_host_x86$" target ="hosting\win-x86\native"/>
+    <file src="$winrt_host_arm$" target ="hosting\win-arm\native"/>
+    <file src="$winrt_host_arm64$" target ="hosting\win-arm64\native"/>
+    <file src="$winrt_host_resource_x64$" target ="hosting\win-x64\native\en-us"/>
+    <file src="$winrt_host_resource_x86$" target ="hosting\win-x86\native\en-us"/>
+    <file src="$winrt_host_resource_arm$" target ="hosting\win-arm\native\en-us"/>
+    <file src="$winrt_host_resource_arm64$" target ="hosting\win-arm64\native\en-us"/>
     <file src="$winrt_shim$" target ="lib\net5.0\"/>
     
     <!-- Add the WinRT.Runtime sources to the pkg for embedded scenarios -->


### PR DESCRIPTION
We saw an issue in the WinUI test pass where the hosting binaries were not being packaged correctly. Root causing showed that they seemed to be pulled in involuntarily because of their path in the nupkg. Nuget has convention based logic for distributing binaries from the "runtimes" directory of a nupkg. So we opt for a unique folder to contain our hosting binaries, given they are only needed in select scenarios. 

Validated with authoring samples and the WinUI test pass