### PR TITLE
Resolve authoring issues with AnyCPU

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -105,8 +105,20 @@ Consuming a C#/WinRT component from a C++/WinRT desktop application is supported
 
 - **Package Reference**: In Visual Studio, right-click on the project in Solution Explorer and click **Manage NuGet packages** to search for and install the component package.
 
-- **Project Reference**: In Visual Studio, right-click on the project in Solution Explorer and click **Add** -> **Reference**. Select the C#/WinRT component project under the **Projects** node. 
+- **Project Reference**: In Visual Studio, right-click on the project in Solution Explorer and click **Add** -> **Reference**. Select the C#/WinRT component project under the **Projects** node. You will need to follow the steps below on distributing hosting binaries and creating a manifest.
   - Note: If your authored component is built with C#/WinRT version 1.3.3 or earlier, you also need a file reference to the `*.winmd` generated in the authored component's output directory. To add a file reference, right-click on the project in Solution Explorer and click **Add** -> **Reference**. Select the file from the **Browse** node. 
+
+#### Distribute Hosting Binaries
+
+Using a C#/WinRT component from native code requires the following files distributed in the C#/WinRT NuPkg: `WinRT.Host.dll`, `WinRT.Host.dll.mui` and 
+`WinRT.Host.Shim.dll`. These files are runtime dependencies of your component's assembly, and the C#/WinRT NuPkg provides build logic to distribute them. 
+To use this, set `CsWinRTHostPlatform` in your component's project file to the platform of the **C++** project. 
+Because the component builds for AnyCPU, you must set this value depending on how you want the **C++** app to build.
+
+`CsWinRTHostPlatform` must be set to one of `x64`, `x86` or `arm64`.
+
+**Note:** If you want to use your component in a C++ and C# project under the same solution, then this build logic will distribute the hosting assets 
+to the C# project output directory as well. They will not be used by the component when the C# app runs.
 
 #### Manifest Class Registration
 

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -15,11 +15,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <GetCopyToOutputDirectoryItemsDependsOn>$(GetCopyToOutputDirectoryItemsDependsOn);CsWinRTAuthoring_AddManagedDependencies</GetCopyToOutputDirectoryItemsDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <CsWinRTAuthoring_Platform Condition="'$(Platform)'=='AnyCPU'">x86</CsWinRTAuthoring_Platform>
-    <CsWinRTAuthoring_Platform Condition="'$(Platform)'!='AnyCPU'">$(Platform)</CsWinRTAuthoring_Platform>
-  </PropertyGroup>
-
   <ItemGroup>
     <CompilerVisibleProperty Include="AssemblyName" />
     <CompilerVisibleProperty Include="AssemblyVersion" />
@@ -55,22 +50,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     
   </Target>
 
-  <!-- For Project Reference consumers, copy the necessary WinRT DLLs to output directory --> 
-  <ItemGroup> 
+  <!-- For C++ projects referencing the component, copy the necessary hosting dlls to the output directory -->
+  <ItemGroup Condition="'$(CsWinRTHostPlatform)' == 'x64' or ('$(CsWinRTHostPlatform)' == 'x86' or '$(CsWinRTHostPlatform)' == 'arm64')"> 
 
-    <None Condition="Exists('$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll')" Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll">
+    <None Include="$(CsWinRTPath)lib\net5.0\WinRT.Host.Shim.dll">
       <TargetPath>WinRT.Host.Shim.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <None Condition="Exists('$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll')" 
-          Include="$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll">
+    <None Include="$(CsWinRTPath)hosting\win-$(CsWinRTHostPlatform)\native\WinRT.Host.dll">
       <TargetPath>WinRT.Host.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
 
-    <None Condition="Exists('$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui')"
-          Include="$(CsWinRTPath)runtimes\win-$(CsWinRTAuthoring_Platform)\native\en-us\WinRT.Host.dll.mui">
+    <None Include="$(CsWinRTPath)hosting\win-$(CsWinRTHostPlatform)\native\en-us\WinRT.Host.dll.mui">
       <TargetPath>WinRT.Host.dll.mui</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -294,38 +287,38 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </Content>
 
       <!-- We package a version of WinRT.Host.dll for each possible architecture -->
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-x64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x64\native</PackagePath>
+        <PackagePath>hosting\win-x64\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-x86\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-x86\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x86\native</PackagePath>
+        <PackagePath>hosting\win-x86\native</PackagePath>
       </Content> 
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-arm\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm\native</PackagePath>
+        <PackagePath>hosting\win-arm\native</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)runtimes\win-arm64\native\WinRT.Host.dll">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll')" Include="$(CsWinRTPath)hosting\win-arm64\native\WinRT.Host.dll">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm64\native</PackagePath>
+        <PackagePath>hosting\win-arm64\native</PackagePath>
       </Content>
       <!-- Package the MUI for WinRT.Host error strings -->
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-x64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x64\native\en-us</PackagePath>
+        <PackagePath>hosting\win-x64\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-x86\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-x86\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-x86\native\en-us</PackagePath>
+        <PackagePath>hosting\win-x86\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-arm\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm\native\en-us</PackagePath>
+        <PackagePath>hosting\win-arm\native\en-us</PackagePath>
       </Content>
-      <Content Condition="Exists('$(CsWinRTPath)runtimes\win-arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)runtimes\win-arm64\native\en-us\WinRT.Host.dll.mui">
+      <Content Condition="Exists('$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui')" Include="$(CsWinRTPath)hosting\win-arm64\native\en-us\WinRT.Host.dll.mui">
         <Pack>true</Pack>
-        <PackagePath>runtimes\win-arm64\native\en-us</PackagePath>
+        <PackagePath>hosting\win-arm64\native\en-us</PackagePath>
       </Content>
    </ItemGroup>
 


### PR DESCRIPTION
This PR changes how customers will work with authoring support when using cswinrt components with native apps (via project reference). 

Context: 
* For native apps to activate/use types authored in a CsWinRT component, must (at runtime) have a copy of WinRT.Host.dll (+ MUI) and WinRT.Host.Shim.dll 
* On project references, we assume the component will build for the same platform as the native app. Then, using that assumption, we copy the platform-specific hosting DLLs to the output directory. 

The issue today: 
* Components are advised to only target AnyCPU, and when they do this our build logic assumes they mean x86. 
This leads to an issue where a native app building for x64, referencing a component building for AnyCPU, will get the wrong version of the hosting DLL WinRT.Host.dll

Proposed solution:
* Make the automation triggered by a property instead of automatic. This PR introduces a new property "CsWinRTHostPlatform". Component authors will specify which platform the native app will build for, so the right WinRT.Host.dll is used. 
*  Arrived at this solution after not being able to use CsWinRT targets during the native app's build that read the native apps platform. 
* There is a drawback: if wanting to build for different platforms, the property must be changed in the component's .csproj 

Something else we considered:
* Providing a basic Directory.Build.targets that customers could include in their native app that copies the hosting DLLs. 
* Decided against it because locating the CsWinRT nuget package location (from some pre-written targets) isn't possible in the native app (since it doesn't have a reference to CsWinRT, just the component project) 