### PR TITLE
Add support for components defining their own Equals and GetHashCode

### DIFF
--- a/src/Tests/TestComponentCSharp/CustomEquals.cpp
+++ b/src/Tests/TestComponentCSharp/CustomEquals.cpp
@@ -1,0 +1,109 @@
+#include "pch.h"
+#include "CustomEquals.h"
+#include "CustomEquals.g.cpp"
+#include "CustomEquals2.g.cpp"
+#include "UnSealedCustomEquals.g.cpp"
+#include "DerivedCustomEquals.g.cpp"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    int32_t CustomEquals::Value()
+    {
+        return value;
+    }
+
+    void CustomEquals::Value(int32_t value)
+    {
+        this->value = value;
+    }
+
+    // Returns true as long as it is the same type (CustomEquals).
+    bool CustomEquals::Equals(winrt::Windows::Foundation::IInspectable const& obj)
+    {
+        if (obj == nullptr)
+        {
+            return false;
+        }
+
+        auto customEqualsObj = obj.try_as<CustomEquals>();
+        if (customEqualsObj)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    int32_t CustomEquals::GetHashCode()
+    {
+        return 5;
+    }
+
+    // Returns true if Value is the same in both.
+    bool CustomEquals::Equals(winrt::TestComponentCSharp::CustomEquals const& other)
+    {
+        return other != nullptr && Value() == other.Value();
+    }
+
+    int32_t CustomEquals2::Value()
+    {
+        return value;
+    }
+
+    void CustomEquals2::Value(int32_t value)
+    {
+        this->value = value;
+    }
+
+    int32_t CustomEquals2::Equals(winrt::Windows::Foundation::IInspectable const& obj)
+    {
+        return value;
+    }
+
+    int32_t CustomEquals2::Equals(winrt::TestComponentCSharp::CustomEquals2 const& other)
+    {
+        return value;
+    }
+
+    int32_t UnSealedCustomEquals::Value()
+    {
+        return value;
+    }
+
+    void UnSealedCustomEquals::Value(int32_t value)
+    {
+        this->value = value;
+    }
+
+    int32_t UnSealedCustomEquals::GetHashCode()
+    {
+        return 8;
+    }
+
+    bool DerivedCustomEquals::Equals(winrt::Windows::Foundation::IInspectable const& obj)
+    {
+        if (obj == nullptr)
+        {
+            return false;
+        }
+
+        auto customEqualsObj = obj.try_as<DerivedCustomEquals>();
+        if (customEqualsObj)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    int32_t DerivedCustomEquals::GetHashCode()
+    {
+        return 10;
+    }
+
+    bool DerivedCustomEquals::Equals(winrt::TestComponentCSharp::UnSealedCustomEquals const& other)
+    {
+        return other != nullptr && Value() == other.Value();
+    }
+
+}

--- a/src/Tests/TestComponentCSharp/CustomEquals.h
+++ b/src/Tests/TestComponentCSharp/CustomEquals.h
@@ -1,0 +1,74 @@
+#pragma once
+#include "CustomEquals.g.h"
+#include "CustomEquals2.g.h"
+#include "UnSealedCustomEquals.g.h"
+#include "DerivedCustomEquals.g.h"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    struct CustomEquals : CustomEqualsT<CustomEquals>
+    {
+        CustomEquals() = default;
+
+        int32_t Value();
+        void Value(int32_t value);
+        bool Equals(winrt::Windows::Foundation::IInspectable const& obj);
+        int32_t GetHashCode();
+        bool Equals(winrt::TestComponentCSharp::CustomEquals const& other);
+
+    private:
+        int32_t value;
+    };
+
+    struct CustomEquals2 : CustomEquals2T<CustomEquals2>
+    {
+        CustomEquals2() = default;
+
+        int32_t Value();
+        void Value(int32_t value);
+        int32_t Equals(winrt::Windows::Foundation::IInspectable const& obj);
+        int32_t Equals(winrt::TestComponentCSharp::CustomEquals2 const& other);
+
+    private:
+        int32_t value;
+    };
+
+    struct UnSealedCustomEquals : UnSealedCustomEqualsT<UnSealedCustomEquals>
+    {
+        UnSealedCustomEquals() = default;
+
+        int32_t Value();
+        void Value(int32_t value);
+        int32_t GetHashCode();
+
+    private:
+        int32_t value;
+    };
+
+    struct DerivedCustomEquals : DerivedCustomEqualsT<DerivedCustomEquals, TestComponentCSharp::implementation::UnSealedCustomEquals>
+    {
+        DerivedCustomEquals() = default;
+
+        bool Equals(winrt::Windows::Foundation::IInspectable const& obj);
+        int32_t GetHashCode();
+        bool Equals(winrt::TestComponentCSharp::UnSealedCustomEquals const& other);
+    };
+}
+namespace winrt::TestComponentCSharp::factory_implementation
+{
+    struct CustomEquals : CustomEqualsT<CustomEquals, implementation::CustomEquals>
+    {
+    };
+
+    struct CustomEquals2 : CustomEquals2T<CustomEquals2, implementation::CustomEquals2>
+    {
+    };
+
+    struct UnSealedCustomEquals : UnSealedCustomEqualsT<UnSealedCustomEquals, implementation::UnSealedCustomEquals>
+    {
+    };
+
+    struct DerivedCustomEquals : DerivedCustomEqualsT<DerivedCustomEquals, implementation::DerivedCustomEquals>
+    {
+    };
+}

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -548,6 +548,48 @@ And this is another one"
         void f();
     }
 
+    [default_interface]
+    runtimeclass CustomEquals
+    {
+        Int32 Value{ get; set; };
+
+        CustomEquals();
+        [default_overload]
+        Boolean Equals(Object obj);
+        Int32 GetHashCode();
+        Boolean Equals(CustomEquals other);
+    }
+
+    [default_interface]
+    runtimeclass CustomEquals2
+    {
+        Int32 Value{ get; set; };
+
+        CustomEquals2();
+        [default_overload]
+        Int32 Equals(Object obj);
+        Int32 Equals(CustomEquals2 other);
+    }
+
+    [default_interface]
+    unsealed runtimeclass UnSealedCustomEquals
+    {
+        Int32 Value{ get; set; };
+
+        UnSealedCustomEquals();
+        Int32 GetHashCode();
+    }
+
+    [default_interface]
+    runtimeclass DerivedCustomEquals : UnSealedCustomEquals
+    {
+        DerivedCustomEquals();
+        [default_overload]
+        Boolean Equals(Object obj);
+        Int32 GetHashCode();
+        Boolean Equals(UnSealedCustomEquals other);
+    }
+
     // Compile time test for sub windows namespace
     namespace Windows
     {

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <ClInclude Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.h" />
     <ClInclude Include="AnotherAssembly.SetPropertyClass.h" />
+    <ClInclude Include="CustomEquals.h" />
     <ClInclude Include="ManualProjectionTestClasses.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Class.h">
@@ -93,6 +94,7 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.cpp" />
     <ClCompile Include="AnotherAssembly.SetPropertyClass.cpp" />
+    <ClCompile Include="CustomEquals.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -19,6 +19,7 @@
     <ClCompile Include="Windows.Class.cpp" />
     <ClCompile Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.cpp" />
     <ClCompile Include="AnotherAssembly.SetPropertyClass.cpp" />
+    <ClCompile Include="CustomEquals.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -31,6 +32,7 @@
     <ClInclude Include="Windows.Class.h" />
     <ClInclude Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.h" />
     <ClInclude Include="AnotherAssembly.SetPropertyClass.h" />
+    <ClInclude Include="CustomEquals.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2848,5 +2848,62 @@ namespace UnitTest
             WarningStatic.WarningEvent += (object s, Int32 v) => { }; // warning CA1416
         }
 #endif
+
+        [Fact]
+        public void TestObjectFunctions()
+        {
+            CustomEquals first = new()
+            {
+                Value = 2
+            };
+            CustomEquals second = new()
+            {
+                Value = 4
+            };
+            CustomEquals third = new()
+            {
+                Value = 2
+            };
+
+            Assert.False(first.Equals(second));
+            Assert.True(first.Equals(third));
+            Assert.True(first.Equals(first));
+            Assert.True(Object.Equals(first, second));
+            Assert.True(Object.Equals(second, third));
+            Assert.Equal(5, first.GetHashCode());
+            Assert.Equal(5, second.GetHashCode());
+
+            Class fourth = new();
+            Class fifth = new();
+            Assert.True(fourth.Equals(fourth));
+            Assert.False(fourth.Equals(fifth));
+            Assert.False(Object.Equals(fourth, fifth));
+            Assert.True(Object.Equals(fifth, fifth));
+            fourth.GetHashCode();
+
+            CustomEquals2 sixth = new()
+            {
+                Value = 4
+            };
+            Assert.Equal(4, sixth.Equals(sixth));
+            Assert.Equal(4, sixth.Equals(fifth));
+            Assert.False(object.Equals(sixth, fifth));
+            Assert.True(object.Equals(sixth, sixth));
+            Assert.False(((IEquatable<CustomEquals2>)sixth).Equals(new CustomEquals2()));
+            Assert.True(((IEquatable<CustomEquals2>)sixth).Equals(sixth));
+
+            UnSealedCustomEquals seventh = new()
+            {
+                Value = 2
+            };
+            DerivedCustomEquals eighth = new()
+            {
+                Value = 2
+            };
+            Assert.Equal(10, eighth.GetHashCode());
+            // Uses Equals defined on derived.
+            Assert.True(eighth.Equals(seventh));
+            Assert.False(seventh.Equals(eighth));
+        }
     }
 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1099,6 +1099,20 @@ namespace cswinrt
             }
         }
 
+        bool method_return_matches;
+        if (is_object_equals_method(method, &method_return_matches) ||
+            is_object_hashcode_method(method, &method_return_matches))
+        {
+            if (method_return_matches)
+            {
+                method_spec = "override ";
+            }
+            else
+            {
+                method_spec += "new ";
+            }
+        }
+
         bool is_private = is_implemented_as_private_method(w, class_type, method);
         auto static_method_params = call_static_method.has_value() ? std::optional(std::pair(call_static_method.value(), method)) : std::nullopt;
         if (!is_private)
@@ -6229,9 +6243,7 @@ _defaultLazy = new Lazy<%>(() => ifc);
 
 public static bool operator ==(% x, % y) => (x?.ThisPtr ?? IntPtr.Zero) == (y?.ThisPtr ?? IntPtr.Zero);
 public static bool operator !=(% x, % y) => !(x == y);
-public bool Equals(% other) => this == other;
-public override bool Equals(object obj) => obj is % that && this == that;
-public override int GetHashCode() => ThisPtr.GetHashCode();
+%
 %
 
 private struct InterfaceTag<I>{};
@@ -6281,8 +6293,23 @@ GC.RemoveMemoryPressure(%);
             type_name,
             type_name,
             type_name,
-            type_name,
-            type_name,
+            bind([&](writer& w)
+            {
+                if (!has_class_equals_method(type))
+                {
+                    w.write("public bool Equals(% other) => this == other;", type_name);
+                }
+
+                if (!has_object_equals_method(type))
+                {
+                    w.write("public override bool Equals(object obj) => obj is % that && this == that;", type_name);
+                }
+
+                if (!has_object_hashcode_method(type))
+                {
+                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();");
+                }
+            }),
             bind([&](writer& w)
             {
                 bool has_base_type = !std::holds_alternative<object_type>(get_type_semantics(type.Extends()));
@@ -6378,9 +6405,7 @@ _inner = objRef.As(GuidGenerator.GetIID(typeof(%).GetHelperType()));
 
 public static bool operator ==(% x, % y) => (x?.ThisPtr ?? IntPtr.Zero) == (y?.ThisPtr ?? IntPtr.Zero);
 public static bool operator !=(% x, % y) => !(x == y);
-public bool Equals(% other) => this == other;
-public override bool Equals(object obj) => obj is % that && this == that;
-public override int GetHashCode() => ThisPtr.GetHashCode();
+%
 %
 
 private struct InterfaceTag<I>{};
@@ -6430,8 +6455,23 @@ private struct InterfaceTag<I>{};
             type_name,
             type_name,
             type_name,
-            type_name,
-            type_name,
+            bind([&](writer& w)
+            {
+                if (!has_class_equals_method(type))
+                {
+                    w.write("public bool Equals(% other) => this == other;", type_name);
+                }
+
+                if (!has_object_equals_method(type))
+                {
+                    w.write("public override bool Equals(object obj) => obj is % that && this == that;", type_name);
+                }
+
+                if (!has_object_hashcode_method(type))
+                {
+                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();");
+                }
+            }),
             bind([&](writer& w)
             {
                 if (is_fast_abi_class(type))

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6295,19 +6295,26 @@ GC.RemoveMemoryPressure(%);
             type_name,
             bind([&](writer& w)
             {
-                if (!has_class_equals_method(type))
+                bool return_type_matches = false;
+                if (!has_class_equals_method(type, &return_type_matches))
                 {
-                    w.write("public bool Equals(% other) => this == other;", type_name);
+                    w.write("public bool Equals(% other) => this == other;\n", type_name);
+                }
+                // Even though there is an equals method defined, it doesn't match the signature for IEquatable
+                // so we define an explicitly implemented one.
+                else if (!return_type_matches)
+                {
+                    w.write("bool IEquatable<%>.Equals(% other) => this == other;\n", type_name, type_name);
                 }
 
                 if (!has_object_equals_method(type))
                 {
-                    w.write("public override bool Equals(object obj) => obj is % that && this == that;", type_name);
+                    w.write("public override bool Equals(object obj) => obj is % that && this == that;\n", type_name);
                 }
 
                 if (!has_object_hashcode_method(type))
                 {
-                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();");
+                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();\n");
                 }
             }),
             bind([&](writer& w)
@@ -6457,19 +6464,26 @@ private struct InterfaceTag<I>{};
             type_name,
             bind([&](writer& w)
             {
-                if (!has_class_equals_method(type))
+                bool return_type_matches = false;
+                if (!has_class_equals_method(type, &return_type_matches))
                 {
-                    w.write("public bool Equals(% other) => this == other;", type_name);
+                    w.write("public bool Equals(% other) => this == other;\n", type_name);
+                }
+                // Even though there is an equals method defined, it doesn't match the signature for IEquatable
+                // so we define an explicitly implemented one.
+                else if (!return_type_matches)
+                {
+                    w.write("bool IEquatable<%>.Equals(% other) => this == other;\n", type_name, type_name);
                 }
 
                 if (!has_object_equals_method(type))
                 {
-                    w.write("public override bool Equals(object obj) => obj is % that && this == that;", type_name);
+                    w.write("public override bool Equals(object obj) => obj is % that && this == that;\n", type_name);
                 }
 
                 if (!has_object_hashcode_method(type))
                 {
-                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();");
+                    w.write("public override int GetHashCode() => ThisPtr.GetHashCode();\n");
                 }
             }),
             bind([&](writer& w)

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -463,9 +463,9 @@ namespace cswinrt
     bool is_param_expected_type(TypeSig const& param, T const& expected_type)
     {
         auto semantics = get_type_semantics(param);
-        if (auto ft = std::get_if<T>(&semantics))
+        if (auto variant_type = std::get_if<T>(&semantics))
         {
-            return *ft == expected_type;
+            return *variant_type == expected_type;
         }
 
         return false;

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -459,6 +459,180 @@ namespace cswinrt
         return {};
     }
 
+    template<typename T>
+    bool is_param_expected_type(TypeSig const& param, T const& expected_type)
+    {
+        auto semantics = get_type_semantics(param);
+        if (auto ft = std::get_if<T>(&semantics))
+        {
+            return *ft == expected_type;
+        }
+
+        return false;
+    }
+
+    // Checks for expected method name and parameters and returns true if those
+    // match (ignoring the return type). The parameter return_type_matches indicates whether
+    // the return type also matches.
+    template <typename ParamMatches, typename ReturnMatches>
+    bool is_expected_method(
+        MethodDef const& method,
+        std::string_view expected_method,
+        ParamMatches&& check_expected_params,
+        ReturnMatches&& check_expected_return,
+        bool* return_type_matches = nullptr)
+    {
+        if (method.Name() != expected_method)
+        {
+            return false;
+        }
+
+        method_signature signature(method);
+        if (!check_expected_params(signature))
+        {
+            return false;
+        }
+
+        if (return_type_matches)
+        {
+            *return_type_matches = false;
+            if (check_expected_return(signature))
+            {
+                *return_type_matches = true;
+            }
+        }
+
+        return true;
+    }
+
+    // Checks for Equals(object obj).
+    bool is_object_equals_method(MethodDef const& method, bool* return_type_matches = nullptr)
+    {
+        auto checkParams = [](method_signature signature)
+        {
+            return signature.has_params() && 
+                signature.params().size() == 1 && 
+                std::holds_alternative<object_type>(get_type_semantics(signature.params()[0].second->Type()));
+        };
+
+        auto checkReturn = [](method_signature signature)
+        {
+            if (auto return_sig = signature.return_signature())
+            {
+                if (is_param_expected_type(return_sig.Type(), fundamental_type::Boolean))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        return is_expected_method(method, "Equals"sv, checkParams, checkReturn, return_type_matches);
+    }
+
+    // Checks for Equals(Class obj).
+    bool is_class_equals_method(MethodDef const& method, std::string_view expected_namespace, std::string_view expected_type_name, bool* return_type_matches = nullptr)
+    {
+        auto checkParams = [&expected_namespace, &expected_type_name](method_signature signature)
+        {
+            if (signature.has_params() && signature.params().size() == 1)
+            {
+                auto semantics = get_type_semantics(signature.params()[0].second->Type());
+                if (auto td = std::get_if<type_definition>(&semantics))
+                {
+                    return td->TypeNamespace() == expected_namespace && td->TypeName() == expected_type_name;
+                }
+            }
+
+            return false;
+        };
+
+        auto checkReturn = [](method_signature signature)
+        {
+            if (auto return_sig = signature.return_signature())
+            {
+                if (is_param_expected_type(return_sig.Type(), fundamental_type::Boolean))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        return is_expected_method(method, "Equals"sv, checkParams, checkReturn, return_type_matches);
+    }
+
+    // Checks for GetHashCode().
+    bool is_object_hashcode_method(MethodDef const& method, bool* return_type_matches = nullptr)
+    {
+        auto checkParams = [](method_signature signature)
+        {
+            return !signature.has_params();
+        };
+
+        auto checkReturn = [](method_signature signature)
+        {
+            if (auto return_sig = signature.return_signature())
+            {
+                if (is_param_expected_type(return_sig.Type(), fundamental_type::Int32))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        return is_expected_method(method, "GetHashCode"sv, checkParams, checkReturn, return_type_matches);
+    }
+
+    bool has_object_equals_method(TypeDef const& type, bool* return_type_matches = nullptr)
+    {
+        XLANG_ASSERT(get_category(type) == category::class_type);
+
+        for (auto&& method : type.MethodList())
+        {
+            if (is_object_equals_method(method, return_type_matches))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool has_class_equals_method(TypeDef const& type, bool* return_type_matches = nullptr)
+    {
+        XLANG_ASSERT(get_category(type) == category::class_type);
+
+        for (auto&& method : type.MethodList())
+        {
+            if (is_class_equals_method(method, type.TypeNamespace(), type.TypeName(), return_type_matches))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool has_object_hashcode_method(TypeDef const& type, bool* return_type_matches = nullptr)
+    {
+        XLANG_ASSERT(get_category(type) == category::class_type);
+
+        for (auto&& method : type.MethodList())
+        {
+            if (is_object_hashcode_method(method, return_type_matches))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     struct mapped_type
     {
         std::string_view abi_name;


### PR DESCRIPTION
- If a component doesn't provide one, CsWinRT provides one as it did before.
- If a component does provide one, then CsWinRT calls the provided one instead.
- For Equal(Class..), if the return type doesn't match with IEquatable, then CsWinRT generates its own explicitly implemented version for the IEquatable interface and also defines one to call the component provided one.

Fixes #864 