### PR TITLE
Fix escaping of embedded quotes.

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -542,7 +542,7 @@ And this is another one"
       void f();
     }
 
-    [attr_string("a string with embedded quotes, like the string \"quotes\"")]
+    [attr_string("a string with embedded escape characters, like the string \"quotes\" and string \\\"quotes\\\" and string \'char\'")]
     runtimeclass EmbeddedQuotesTest
     {
         void f();

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1488,10 +1488,24 @@ remove => %;
                 },
                 [&](std::string_view type_name)
                 {
+                    bool previous_char_escape = false;
                     std::string sanitized_type_name;
                     sanitized_type_name.reserve(type_name.length() * 2);
                     for (const auto& c : type_name)
                     {
+                        if (c == '\\' && !previous_char_escape)
+                        {
+                            previous_char_escape = true;
+                            continue;
+                        }
+
+                        // We only handle the following escape characters for now.
+                        if (previous_char_escape && c != '\\' && c != '\'' && c != '"')
+                        {
+                            sanitized_type_name += '\\';
+                        }
+                        previous_char_escape = false;
+
                         sanitized_type_name += c;
                         if (c == '"')
                         {


### PR DESCRIPTION
Followed the conventions for @ in C#, where quotes (\") are embedded as double quotes ("") and ' and \ are embedded as is without the escape character.

Fixes #1040 