### PR TITLE
Pack project PRI next to WinMD

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -281,6 +281,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PackagePath>lib\$(TargetFramework)</PackagePath>
       </Content>
 
+      <!-- Pack any XAML resource PRI files next to the .winmd -->
+      <Content Include="$(ProjectPriFullPath)">
+        <Pack>true</Pack>
+        <PackagePath>lib\$(TargetFramework)\winmd</PackagePath>
+      </Content>    
+
       <!-- Pack the WinMD we generated in its own folder, under the managed TFM folder -->
       <Content Include="$(TargetDir)$(AssemblyName).winmd">
         <Pack>true</Pack> 


### PR DESCRIPTION
Today, C++ apps that try to use XAML/WinUI types authored with C#/WinRT fail at runtime because they can't find the xaml resources. 

E.g.
`WinRT originate error - 0x80004005 : 'Cannot locate resource from 'ms-appx:///WinUIComponentCs/NameReporter.xaml'.'.`

Evelyn and I found that the component's PRI file needs to live in same folder as the WinMD. 
This PR updates our build logic to reflect this requirement. 

Fixes #1118 

We're taking advantage of msbuild here actually. Since the pri file has the same name as the winmd and the winmd is a reference assembly, msbuild will grab the pri. It's not just for PRI, PRI is one of the allowed extensions for this behavior. 