### PR TITLE
Add public option to embedded support for enums

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -140,8 +140,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <CsWinRTInternalProjection Condition="'$(CsWinRTPrivateProjection)' == 'true'">-internal</CsWinRTInternalProjection>
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
-	    <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
-	    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
+      <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
+      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) > 5">net6.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -140,8 +140,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <CsWinRTInternalProjection Condition="'$(CsWinRTPrivateProjection)' == 'true'">-internal</CsWinRTInternalProjection>
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
-	  <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
-	  <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
+	    <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
+	    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) > 5">net6.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -140,7 +140,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <CsWinRTInternalProjection Condition="'$(CsWinRTPrivateProjection)' == 'true'">-internal</CsWinRTInternalProjection>
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
+	  <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
+	  <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) > 5">net6.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
 
@@ -153,6 +154,7 @@ $(CsWinRTWindowsMetadataInput)
 $(CsWinRTFilters)
 $(CsWinRTIncludeWinRTInterop)
 $(CsWinRTEmbeddedProjection)
+$(CsWinRTEmbeddedEnums)
       </CsWinRTParams>
 
       <CsWinRTPrivateParams Condition="'$(CsWinRTPrivateParams)' == ''">

--- a/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestEmbeddedLibrary.csproj
+++ b/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestEmbeddedLibrary.csproj
@@ -11,6 +11,7 @@
     <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
     <CsWinRTGenerateProjection>true</CsWinRTGenerateProjection>
+    <CsWinRTEmbeddedPublicEnums>true</CsWinRTEmbeddedPublicEnums>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestEmbeddedLibrary.csproj
+++ b/src/Samples/TestEmbedded/TestEmbeddedLibrary/TestEmbeddedLibrary.csproj
@@ -11,7 +11,8 @@
     <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
     <CsWinRTGenerateProjection>true</CsWinRTGenerateProjection>
-    <CsWinRTEmbeddedPublicEnums>true</CsWinRTEmbeddedPublicEnums>
+    <!-- Will expose enums as public in the projection
+      <CsWinRTEmbeddedPublicEnums>true</CsWinRTEmbeddedPublicEnums> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6956,7 +6956,7 @@ global::WinRT.ComWrappersSupport.FindObject<%>(%).Invoke(%)
 )", 
         bind<write_winrt_attribute>(type),
         bind<write_type_custom_attributes>(type, true),
-        internal_accessibility(),
+        (settings.internal || settings.embedded) ? (settings.public_enums ? "public" : "internal") : "public",
         bind<write_type_name>(type, typedef_name_type::Projected, false), enum_underlying_type);
         {
             for (auto&& field : type.FieldList())

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -37,6 +37,7 @@ namespace cswinrt
         { "verbose", 0, 0, {}, "Show detailed progress information" },
         { "internal", 0, 0, {}, "Generates a private projection."},
         { "embedded", 0, 0, {}, "Generates an embedded projection."},
+        { "public_enums", 0, 0, {}, "Used with embedded option to generate enums as public"},
         { "help", 0, option::no_max, {}, "Show detailed help" },
         { "?", 0, option::no_max, {}, {} },
     };
@@ -97,6 +98,7 @@ Where <spec> is one or more of:
         settings.component = args.exists("component");
         settings.internal = args.exists("internal");
         settings.embedded = args.exists("embedded");
+        settings.public_enums = args.exists("public_enums");
         settings.input = args.files("input", database::is_database);
 
         for (auto && include : args.values("include"))

--- a/src/cswinrt/settings.h
+++ b/src/cswinrt/settings.h
@@ -14,6 +14,7 @@ namespace cswinrt
         bool component{};
         bool internal{};
         bool embedded{};
+        bool public_enums{};
     };
 
     extern settings_type settings;


### PR DESCRIPTION
In trying to enable PowerShell's AppX module, we found that some of the commands shipped within the module have options. These command line options are based on projected enum values, and the existing embedded support made those enums private to the module. There's no harm in exposing enums since they're simple objects, so we support public enums now.