### PR TITLE
Change benchmark task in build

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -106,7 +106,7 @@ stages:
 
   - job: Benchmarks
     displayName: Run Benchmarks
-    condition: eq(variables['_RunBenchmarks'],'true')
+    condition: and(eq(variables['_RunBenchmarks'],'true'), eq(variables['Build.Reason'],'Schedule'))
     dependsOn: []
     pool:
       vmImage: windows-2019

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -106,7 +106,7 @@ stages:
 
   - job: Benchmarks
     displayName: Run Benchmarks
-    condition: and(eq(variables['_RunBenchmarks'],'true'), eq(variables['Build.Reason'],'Schedule'))
+    condition: or(eq(variables['_RunBenchmarks'],'true'), eq(variables['Build.Reason'],'Schedule'))
     dependsOn: []
     pool:
       vmImage: windows-2019

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -12,6 +12,6 @@ variables:
   # E.g. '_IsRelease' defaults to empty string, but if 'IsRelease' is set at queue time that value will be used.
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
-  _RunBenchmarks: $[coalesce(variables.RunBenchmarks, 'true')]
+  _RunBenchmarks: $[coalesce(variables.RunBenchmarks, 'false')]
   _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
   _WindowsSdkVersionSuffix: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '25')]  


### PR DESCRIPTION
This change makes it so that the benchmarks do not run on typical pipeline runs; they can be run by setting the variable at queue-time. Also, the benchmarks will automatically run on scheduled runs (right now, this means on our nightly CI builds). 

Fixes #1169 