### PR TITLE
Remove ARM hosting mui files

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -34,7 +34,6 @@
     <file src="$source_generator$" target="analyzers\dotnet\cs\"/>
     <file src="$winrt_host_x64$" target ="hosting\x64\native"/>
     <file src="$winrt_host_x86$" target ="hosting\x86\native"/>
-    <file src="$winrt_host_arm$" target ="hosting\arm\native"/>
     <file src="$winrt_host_arm64$" target ="hosting\arm64\native"/>
     <file src="$winrt_shim$" target ="lib\net5.0\"/>
 
@@ -44,11 +43,9 @@
          E.g. fr-FR/WinRT.Host.dll.mui -->
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\x64\native"/>
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\x86\native"/>
-    <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\arm\native"/>
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\arm64\native"/>
     <file src="$winrt_host_resource_x64$" target ="hosting\x64\native\en-US"/>
     <file src="$winrt_host_resource_x86$" target ="hosting\x86\native\en-US"/>
-    <file src="$winrt_host_resource_arm$" target ="hosting\arm\native\en-US"/>
     <file src="$winrt_host_resource_arm64$" target ="hosting\arm64\native\en-US"/>
 
     <file src="..\src\WinRT.Runtime\ResX\**" target ="lib\net5.0\"/>


### PR DESCRIPTION
We only ship ARM64, not the ARM version of the WinRT.Host.dll.  But the resources files were getting included for ARM with no DLL being there.  Removing them from nuspec to make it consistent.