### PR TITLE
ABI static classes for ProjectionInternal types were public

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5973,7 +5973,7 @@ public static Guid PIID = Vftbl.PIID;
 %
 }
 )", 
-        is_exclusive_to(iface) ? "internal" : internal_accessibility(), 
+        (is_exclusive_to(iface) || is_projection_internal(iface)) ? "internal" : internal_accessibility(),
         bind<write_type_name>(iface, typedef_name_type::StaticAbiClass, false), 
         [&](writer& w) {
             if (!fast_abi_class_val.has_value() || (!fast_abi_class_val.value().contains_other_interface(iface) && !interfaces_equal(fast_abi_class_val.value().default_interface, iface))) {


### PR DESCRIPTION
Fixing issue where the ABI static classes for `ProjectionInternal` types were public.  They weren't intended to be part of the public API surface given the only consumer of it is from ComInteropHelpers.cs and the ABI interface which are both in the same projection (Windows SDK projection).  Given no one should be referencing these types, it should be fine to make internal and allows us to avoid changing the assembly version for previous versions of the Windows SDK projection due to the newly added API.