### PR TITLE
Some QoL improvements for diag tests

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -29,9 +29,9 @@ namespace Generator
         /// Perform code analysis to find scenarios that are erroneous in Windows Runtime</summary>
         public void FindDiagnostics()
         {
-            WinRTSyntaxReciever syntaxReciever = (WinRTSyntaxReciever)_context.SyntaxReceiver;
+            WinRTSyntaxReceiver syntaxReceiver = (WinRTSyntaxReceiver)_context.SyntaxReceiver;
 
-            if (!syntaxReciever.Declarations.Any())
+            if (!syntaxReceiver.Declarations.Any())
             {
                 Report(WinRTRules.NoPublicTypesRule, null);
                 return;
@@ -43,12 +43,12 @@ namespace Generator
 
         private void CheckNamespaces()
         {
-            WinRTSyntaxReciever syntaxReciever = (WinRTSyntaxReciever)_context.SyntaxReceiver;
+            WinRTSyntaxReceiver syntaxReceiver = (WinRTSyntaxReceiver)_context.SyntaxReceiver;
 
             // Used to check for conflicitng namespace names
             HashSet<string> namespaceNames = new();
 
-            foreach (var @namespace in syntaxReciever.Namespaces)
+            foreach (var @namespace in syntaxReceiver.Namespaces)
             {
                 var model = _context.Compilation.GetSemanticModel(@namespace.SyntaxTree);
                 var namespaceSymbol = model.GetDeclaredSymbol(@namespace);
@@ -82,7 +82,7 @@ namespace Generator
 
         private void CheckDeclarations()
         {
-            WinRTSyntaxReciever syntaxReceiver = (WinRTSyntaxReciever)_context.SyntaxReceiver;
+            WinRTSyntaxReceiver syntaxReceiver = (WinRTSyntaxReceiver)_context.SyntaxReceiver;
 
             foreach (var declaration in syntaxReceiver.Declarations)
             {

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -140,9 +140,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         private bool CatchWinRTDiagnostics()
         {
-            // "DiagnosticTests" is a workaround, GetAssemblyName returns null when used by unit tests 
-            // shouldn't need workaround once we can pass AnalyzerConfigOptionsProvider in DiagnosticTests.Helpers.cs
-            string assemblyName = context.GetAssemblyName() ?? "DiagnosticTests";
+            string assemblyName = context.GetAssemblyName();
             WinRTComponentScanner winrtScanner = new(context, assemblyName);
             winrtScanner.FindDiagnostics();
             return winrtScanner.Found();
@@ -154,6 +152,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             {
                 Logger.Log("Exiting early -- found errors in authored runtime component.");
                 Logger.Close();
+                Environment.ExitCode = -1;
                 return;
             }
 
@@ -170,9 +169,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                     metadataBuilder,
                     Logger);
 
-                WinRTSyntaxReciever syntaxReciever = (WinRTSyntaxReciever)context.SyntaxReceiver;
-                Logger.Log("Found " + syntaxReciever.Declarations.Count + " types");
-                foreach (var declaration in syntaxReciever.Declarations)
+                WinRTSyntaxReceiver syntaxReceiver = (WinRTSyntaxReceiver)context.SyntaxReceiver;
+                Logger.Log("Found " + syntaxReceiver.Declarations.Count + " types");
+                foreach (var declaration in syntaxReceiver.Declarations)
                 {
                     writer.Model = context.Compilation.GetSemanticModel(declaration.SyntaxTree);
                     writer.Visit(declaration);
@@ -190,6 +189,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                     Logger.Log(e.InnerException.ToString());
                 }
                 Logger.Close();
+                Environment.ExitCode = -2;
                 throw;
             }
 
@@ -203,8 +203,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     {
         public void Execute(GeneratorExecutionContext context)
         {
-            var isTest = string.CompareOrdinal(Process.GetCurrentProcess().ProcessName, "testhost") == 0;
-            if (!isTest && !context.IsCsWinRTComponent())
+            if (!context.IsCsWinRTComponent())
             {
                 return;
             }
@@ -215,11 +214,11 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         public void Initialize(GeneratorInitializationContext context)
         {
-            context.RegisterForSyntaxNotifications(() => new WinRTSyntaxReciever());
+            context.RegisterForSyntaxNotifications(() => new WinRTSyntaxReceiver());
         }
     }
 
-    class WinRTSyntaxReciever : ISyntaxReceiver
+    class WinRTSyntaxReceiver : ISyntaxReceiver
     {
         public List<MemberDeclarationSyntax> Declarations = new();
         public List<NamespaceDeclarationSyntax> Namespaces = new();
@@ -245,7 +244,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 return;
             }
 
-            if (syntaxNode is not MemberDeclarationSyntax decaralation || !IsPublic(decaralation))
+            if (syntaxNode is not MemberDeclarationSyntax declaration || !IsPublic(declaration))
             {
                 return;
             }
@@ -256,7 +255,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 syntaxNode is DelegateDeclarationSyntax ||
                 syntaxNode is StructDeclarationSyntax)
             {
-                Declarations.Add(decaralation);
+                Declarations.Add(declaration);
             }
         }
 

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -59,7 +59,7 @@ namespace Benchmarks
                     )
                     .WithId("WinMD NetCoreApp31");
 
-                // Optimizer needs to be diabled as it errors on WinMDs
+                // Optimizer needs to be disabled as it errors on WinMDs
                 Config = Config.WithOption(ConfigOptions.DisableOptimizationsValidator, true)
                         .AddJob(winmdJob);
 #else

--- a/src/Tests/DiagnosticTests/Helpers.cs
+++ b/src/Tests/DiagnosticTests/Helpers.cs
@@ -34,7 +34,6 @@ namespace DiagnosticTests
                 additionalTexts: ImmutableArray<AdditionalText>.Empty,
                 parseOptions: (CSharpParseOptions)compilation.SyntaxTrees.First().Options,
                 optionsProvider: options); 
-        // todo: pass the CsWinRTComponent config option here so we don't have to comment out the check in the source generator 
 
         /// <summary>
         /// RunGenerators makes a driver and applies the given generators to the compilation, storing diagnostics in an out param

--- a/src/Tests/DiagnosticTests/Helpers.cs
+++ b/src/Tests/DiagnosticTests/Helpers.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace DiagnosticTests
 {
@@ -15,7 +16,7 @@ namespace DiagnosticTests
         /// <param name="source">string of source code</param>
         /// <returns></returns>
         private static Compilation CreateCompilation(string source)
-            => CSharpCompilation.Create(
+        => CSharpCompilation.Create(
                 assemblyName: "compilation",
                 syntaxTrees: new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)) },
                 references: new[] { MetadataReference.CreateFromFile(typeof(Binder).GetTypeInfo().Assembly.Location) },
@@ -27,12 +28,12 @@ namespace DiagnosticTests
         /// <param name="compilation"></param>
         /// <param name="generators"></param>
         /// <returns></returns>
-        private static GeneratorDriver CreateDriver(Compilation compilation, params ISourceGenerator[] generators)
+        private static GeneratorDriver CreateDriver(Compilation compilation, AnalyzerConfigOptionsProvider? options, params ISourceGenerator[] generators)
             => CSharpGeneratorDriver.Create(
                 generators: ImmutableArray.Create(generators),
                 additionalTexts: ImmutableArray<AdditionalText>.Empty,
                 parseOptions: (CSharpParseOptions)compilation.SyntaxTrees.First().Options,
-                optionsProvider: null); 
+                optionsProvider: options); 
         // todo: pass the CsWinRTComponent config option here so we don't have to comment out the check in the source generator 
 
         /// <summary>
@@ -42,9 +43,10 @@ namespace DiagnosticTests
         /// <param name="diagnostics"></param>
         /// <param name="generators"></param>
         /// <returns></returns>
-        private static Compilation RunGenerators(Compilation compilation, out ImmutableArray<Diagnostic> diagnostics, params ISourceGenerator[] generators)
+        private static Compilation RunGenerators(Compilation compilation, out ImmutableArray<Diagnostic> diagnostics, out GeneratorDriverRunResult result, AnalyzerConfigOptionsProvider? options, params ISourceGenerator[] generators)
         {
-            CreateDriver(compilation, generators).RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out diagnostics);
+            var driver = CreateDriver(compilation, options, generators).RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out diagnostics);
+            result = driver.GetRunResult();
             return updatedCompilation;
         }
 


### PR DESCRIPTION
- Fixes DiagnosticTests! There were a few non-passing tests so I debugged into it and saw that we're failing because in some codepaths we didn't have an assembly name or version. Passing these requires a context options object.
- DiagnosticTests can now pass a context with options, so we can remove special casing we had for cswinrt generator when running inside a test host
- When tests failed, the inner exception was not being captured, so the error just said "...But  found:" and no additional information about the exception in the generator was provided
- Setting ExitCode upon error, which should cause builds to fail when the generator fails to produce. Fixes #1202 
- Fixes some typos


<img width="296" alt="image" src="https://user-images.githubusercontent.com/22989529/173958745-b4d441bc-6698-4ab2-ba41-d7070cad18c7.png">
