### PR TITLE
Custom IWindowNative for ILTrimming

### DIFF
--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
@@ -113,7 +113,8 @@ namespace ObjectLifetimeTests
                 .CallFromUIThread(() =>
                 {
                     Microsoft.UI.Xaml.Window testWindow = new();
-                    var x = WindowNative.GetWindowHandle(testWindow);
+                    var hwnd = WindowNative.GetWindowHandle(testWindow);
+                    Verify(hwnd != IntPtr.Zero, "Window Handle was null");
                 });
         }
 

--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
@@ -15,6 +15,7 @@ using Microsoft.UI.Xaml.Shapes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+using WinRT.Interop;
 
 namespace ObjectLifetimeTests
 {
@@ -104,6 +105,18 @@ namespace ObjectLifetimeTests
 
             o = null;
         }
+
+        [TestMethod]
+        public void TestWindowNative()
+        {
+            _asyncQueue
+                .CallFromUIThread(() =>
+                {
+                    Microsoft.UI.Xaml.Window testWindow = new();
+                    var x = WindowNative.GetWindowHandle(testWindow);
+                });
+        }
+
         [TestMethod]
         public void BasicTest1()
         {

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -60,12 +60,18 @@ namespace WinRT.Interop
         public static unsafe global::System.IntPtr get_WindowHandle(object _obj)
         {
             var asObjRef = global::WinRT.MarshalInspectable<object>.CreateMarshaler2(_obj, IWindowNativeIID);
-
             var ThisPtr = asObjRef.GetAbi();
-
             global::System.IntPtr __retval = default;
-            global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, out global::System.IntPtr, int>**)ThisPtr)[3](ThisPtr, out __retval));
-            return __retval;
+
+            try
+            {
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, out global::System.IntPtr, int>**)ThisPtr)[3](ThisPtr, out __retval));
+                return __retval;
+            }
+            finally
+            {
+                asObjRef.Dispose();
+            }
         }
     }
 

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -53,10 +53,10 @@ using WinRT.Interop;
 
 namespace WinRT.Interop
 {
-    internal static readonly Guid IWindowNativeIID = new(0xEECDBF0E, 0xBAE9, 0x4CB6, 0xA6, 0x8E, 0x95, 0x98, 0xE1, 0xCB, 0x57, 0xBB);
-
     internal static class IWindowNativeMethods
     {
+        internal static readonly Guid IWindowNativeIID = new(0xEECDBF0E, 0xBAE9, 0x4CB6, 0xA6, 0x8E, 0x95, 0x98, 0xE1, 0xCB, 0x57, 0xBB);
+
         public static unsafe global::System.IntPtr get_WindowHandle(object _obj)
         {
             var asObjRef = global::WinRT.MarshalInspectable<object>.CreateMarshaler2(_obj, IWindowNativeIID);

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -53,7 +53,7 @@ using WinRT.Interop;
 
 namespace WinRT.Interop
 {
-    internal static readonly Guid IWindowNativeIID = new("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB");
+    internal static readonly Guid IWindowNativeIID = new(0xEECDBF0E, 0xBAE9, 0x4CB6, 0xA6, 0x8E, 0x95, 0x98, 0xE1, 0xCB, 0x57, 0xBB);
 
     internal static class IWindowNativeMethods
     {

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -53,24 +53,37 @@ using WinRT.Interop;
 
 namespace WinRT.Interop
 {
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
-    internal interface IWindowNative
+ 
+#if EMBED
+    internal 
+#else
+    public
+#endif
+    static class IWindowNativeMethods
     {
-        IntPtr WindowHandle { get; }
+        public static unsafe global::System.IntPtr get_WindowHandle(object _obj)
+        {
+            var asObjRef = global::WinRT.MarshalInspectable<object>.CreateMarshaler2(_obj, System.Guid.Parse("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"));
+
+            var ThisPtr = asObjRef.GetAbi();
+
+            global::System.IntPtr __retval = default;
+            global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, out global::System.IntPtr, int>**)ThisPtr)[3](ThisPtr, out __retval));
+            return __retval;
+        }
     }
 
-#if EMBED 
+
+#if EMBED
     internal 
-#else 
-    public 
+#else
+    public
 #endif
     static class WindowNative
     {
-        public static IntPtr GetWindowHandle(object target) => target.As<IWindowNative>().WindowHandle;
+        public static IntPtr GetWindowHandle(object target) => IWindowNativeMethods.get_WindowHandle(target);   // target.As<IWindowNative>().WindowHandle;
     }
-
+   
     [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -65,6 +65,7 @@ namespace WinRT.Interop
 
             try
             {
+                // We use 3 here because IWindowNative only implements IUnknown, whose only functions are AddRef, Release and QI
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, out global::System.IntPtr, int>**)ThisPtr)[3](ThisPtr, out __retval));
                 return __retval;
             }

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -53,17 +53,13 @@ using WinRT.Interop;
 
 namespace WinRT.Interop
 {
- 
-#if EMBED
-    internal 
-#else
-    public
-#endif
-    static class IWindowNativeMethods
+    internal static readonly Guid IWindowNativeIID = new("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB");
+
+    internal static class IWindowNativeMethods
     {
         public static unsafe global::System.IntPtr get_WindowHandle(object _obj)
         {
-            var asObjRef = global::WinRT.MarshalInspectable<object>.CreateMarshaler2(_obj, System.Guid.Parse("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"));
+            var asObjRef = global::WinRT.MarshalInspectable<object>.CreateMarshaler2(_obj, IWindowNativeIID);
 
             var ThisPtr = asObjRef.GetAbi();
 

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -75,15 +75,15 @@ namespace WinRT.Interop
 
 
 #if EMBED
-    internal 
+    internal
 #else
     public
 #endif
     static class WindowNative
     {
-        public static IntPtr GetWindowHandle(object target) => IWindowNativeMethods.get_WindowHandle(target);   // target.As<IWindowNative>().WindowHandle;
+        public static IntPtr GetWindowHandle(object target) => IWindowNativeMethods.get_WindowHandle(target);
     }
-   
+
     [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]


### PR DESCRIPTION
To support ILTrimming, we need to remove our dependency on ComImport for IWindowNative and IInitializeWithWindow. By replacing them with custom projections, we become trimmable. We should see some perf gains from this change because we do not require IDIC anymore (`.As<IWindowNative>()`), and the ComImport itself probably had some overhead. 