### PR TITLE
Make CsWinRT build with VS 2022

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Below is our guidance for how to build the repo, report issues, propose new feat
 
 C#/WinRT currently requires the following packages, or newer, to build:
 
-- [Visual Studio 16.8](https://visualstudio.microsoft.com/downloads/) 
-- [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) 
-- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)
+- [Visual Studio 17.0](https://visualstudio.microsoft.com/downloads/) 
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) 
+- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 - [nuget.exe 5.8.0-preview.3](https://www.nuget.org/downloads)
 - Microsoft.WinUI 3.0.0-preview4.210210.4
 
-The [`build.cmd`](src/build.cmd) script takes care of all related configuration steps and is the simplest way to get started building C#/WinRT. It installs prerequisites such as `nuget.exe` and the .NET 5 SDK, configures the environment to use .NET 5 (creating a `global.json` if necessary), builds the compiler, and builds and executes the unit tests. To build C#/WinRT, follow these steps: 
+The [`build.cmd`](src/build.cmd) script takes care of all related configuration steps and is the simplest way to get started building C#/WinRT. It installs prerequisites such as `nuget.exe` and the .NET 6 SDK, configures the environment to use .NET 6 (creating a `global.json` if necessary), builds the compiler, and builds and executes the unit tests. To build C#/WinRT, follow these steps: 
 
 - Open a Visual Studio Developer command prompt pointing at the repo.
 - Run `src\build.cmd`. 

--- a/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
@@ -10,26 +10,13 @@ steps:
     script: get_testwinrt.cmd
     workingDirectory: $(Build.SourcesDirectory)\src
 
-# Use .NET Core SDK 2.1
+# Use .NET Core SDK 3.1
 - task: UseDotNet@2
-  displayName: Use .NET Core SDK 2.1
+  displayName: Use .NET Core SDK 3.1
   inputs:
-    version: 2.1.x
+    version: 3.1.x
     installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
     performMultiLevelLookup: true
-
-# Install .NET 5 SDK
-- task: PowerShell@2 
-  displayName: Install .NET 5 SDK
-  inputs:
-    targetType: inline
-    failOnStderr: true
-    script: |
-      Write-Host ##vso[task.setvariable variable=PATH;]${env:LocalAppData}\Microsoft\dotnet;${env:PATH};
-        
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-                
-      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET5_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
 
 # Install .NET 6 SDK 
 - task: PowerShell@2
@@ -63,7 +50,7 @@ steps:
     script: |
       if "%VSCMD_VER%"=="" (
         pushd c:
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
         popd
       )
 

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -24,11 +24,11 @@ steps:
 
       Write-Host ##vso[task.setvariable variable=PATH;]${env:Agent_TempDirectory}\procdump;${env:PATH};
 
-# Use .NET Core SDK 2.1
+# Use .NET Core SDK 3.1
 - task: UseDotNet@2
-  displayName: Use .NET Core SDK 2.1
+  displayName: Use .NET Core SDK 3.1
   inputs:
-    version: 2.1.x
+    version: 3.1.x
     installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
     performMultiLevelLookup: true
 

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -115,7 +115,7 @@ steps:
     script: |
       if "%VSCMD_VER%"=="" (
         pushd c:
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
         popd
       )
 
@@ -133,7 +133,7 @@ steps:
     script: |
       if "%VSCMD_VER%"=="" (
         pushd c:
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
         popd
       )
 

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -32,19 +32,6 @@ steps:
     installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
     performMultiLevelLookup: true
 
-# Install .NET 5 SDK
-- task: PowerShell@2 
-  displayName: Install .NET 5 SDK
-  inputs:
-    targetType: inline
-    failOnStderr: true
-    script: |
-      Write-Host ##vso[task.setvariable variable=PATH;]${env:LocalAppData}\Microsoft\dotnet;${env:PATH};
-    
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-            
-      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET5_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
-
 # Install .NET 6 SDK 
 - task: PowerShell@2
   displayName: Install .NET 6 SDK

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -115,7 +115,7 @@ steps:
     script: |
       if "%VSCMD_VER%"=="" (
         pushd c:
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
         popd
       )
 
@@ -133,7 +133,7 @@ steps:
     script: |
       if "%VSCMD_VER%"=="" (
         pushd c:
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
         popd
       )
 

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -36,6 +36,15 @@ stages:
 # Build Steps 
     - template: CsWinRT-Build-Steps.yml
 
+# Set Dotnet paths
+- task: PowerShell@2
+  displayName: Set DotNet paths
+  inputs:
+    targetType: inline
+    script: |
+      Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\"
+      Write-Host "##vso[task.setvariable variable=DOTNET_ROOT(x86);]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\x86\"
+
 # Run Unit Tests
     - task: DotNetCoreCLI@2
       displayName: Run Unit Tests

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -4,7 +4,7 @@ stages:
   jobs: 
   - job: BuildAndTest
     pool:
-      vmImage: windows-2019
+      vmImage: windows-latest
     timeoutInMinutes: 90
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#multi-job-configuration
     strategy:

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -118,7 +118,7 @@ stages:
     condition: or(eq(variables['_RunBenchmarks'],'true'), eq(variables['Build.Reason'],'Schedule'))
     dependsOn: []
     pool:
-      vmImage: windows-2019
+      vmImage: windows-latest
     timeoutInMinutes: 120
     steps:
     - template: CsWinRT-Benchmarks-Steps.yml

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -37,13 +37,13 @@ stages:
     - template: CsWinRT-Build-Steps.yml
 
 # Set Dotnet paths
-- task: PowerShell@2
-  displayName: Set DotNet paths
-  inputs:
-    targetType: inline
-    script: |
-      Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\"
-      Write-Host "##vso[task.setvariable variable=DOTNET_ROOT(x86);]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\x86\"
+    - task: PowerShell@2
+      displayName: Set DotNet paths
+      inputs:
+        targetType: inline
+        script: |
+          Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\"
+          Write-Host "##vso[task.setvariable variable=DOTNET_ROOT(x86);]C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\x86\"
 
 # Run Unit Tests
     - task: DotNetCoreCLI@2

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -5,7 +5,7 @@ variables:
   WinRT.Runtime.AssemblyVersion: '1.6.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
   Net5.SDK.Version: '5.0.408'
-  Net6.SDK.Version: '6.0.300'
+  Net6.SDK.Version: '6.0.301'
   NoSamples: 'false'
   
   # This 'coalesce' pattern allows the yml to define a default value for a variable but allows the value to be overridden at queue time.

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -4,8 +4,8 @@ variables:
   PatchVersion: 5
   WinRT.Runtime.AssemblyVersion: '1.6.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
-  Net5.SDK.Version: '5.0.404'
-  Net6.SDK.Version: '6.0.101'
+  Net5.SDK.Version: '5.0.408'
+  Net6.SDK.Version: '6.0.300'
   NoSamples: 'false'
   
   # This 'coalesce' pattern allows the yml to define a default value for a variable but allows the value to be overridden at queue time.
@@ -13,5 +13,5 @@ variables:
 
   _IsRelease: $[coalesce(variables.IsRelease, '')]
   _RunBenchmarks: $[coalesce(variables.RunBenchmarks, 'false')]
-  _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.13')]  
+  _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.17')]  
   _WindowsSdkVersionSuffix: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '25')]  

--- a/src/Authoring/WinRT.Host/WinRT.Host.vcxproj
+++ b/src/Authoring/WinRT.Host/WinRT.Host.vcxproj
@@ -34,44 +34,32 @@
     <RootNamespace>WinRTHost</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>	
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/Authoring/WinRT.Host/WinRT.Host.vcxproj
+++ b/src/Authoring/WinRT.Host/WinRT.Host.vcxproj
@@ -290,11 +290,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\WinRT.Host.Shim\WinRT.Host.Shim.csproj">
-      <Project>{0bb8f82d-874e-45aa-bca3-20ce0562164a}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="WinRTHostErrorStrings.rc" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -13,6 +13,7 @@
     <BenchmarkTargetFramework Condition="$(IsTargetFrameworkNet5OrGreater)">$(TargetFramework)</BenchmarkTargetFramework>
     <IsDotnetBuild Condition="'$(IsDotnetBuild)' == ''">false</IsDotnetBuild>
     <LangVersion Condition="$(IsDotnetBuild) == true">9.0</LangVersion>
+    <DefineConstants Condition="$(UseWinmd) == true">USE_WINMD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -39,7 +39,7 @@ namespace Benchmarks
                 Config = Config.AddExporter(JsonExporter.Full);
 
                 // Test WinMD support
-#if NETCOREAPP3_1
+#if USE_WINMD
                 // BenchmarkDotNet will rebuild the project with a project reference to this project when this project's output exe is ran.  It
                 // will be ran from the same folder as where we have the application manifest binplaced which we want to embed in the new exe.
                 string manifestFile = Path.Combine(

--- a/src/Samples/TestEmbedded/UnitTestEmbedded/UnitTestEmbedded.csproj
+++ b/src/Samples/TestEmbedded/UnitTestEmbedded/UnitTestEmbedded.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <IsPackable>false</IsPackable>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
@@ -33,7 +33,8 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AuthoringConsumptionTest</RootNamespace>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <_WinMDPlatform>$(Platform)</_WinMDPlatform>
     <_WinMDPlatform Condition="'$(Platform)' == 'Win32'">x86</_WinMDPlatform>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
@@ -68,21 +68,26 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Projections\Windows\Windows.csproj">
       <Project>{ffa9a78b-f53f-43ee-af87-24a80f4c330a}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Projections\WinUI\WinUI.csproj">
       <Project>{0a991d5f-bfee-4d2f-9aad-6ad06470a5df}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Authoring\WinRT.Host.Shim\WinRT.Host.Shim.csproj">
       <Project>{0bb8f82d-874e-45aa-bca3-20ce0562164a}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Authoring\WinRT.Host\WinRT.Host.vcxproj">
       <Project>{7e33bcb7-19c5-4061-981d-ba695322708a}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\WinRT.Runtime\WinRT.Runtime.csproj">
       <Project>{25244ced-966e-45f2-9711-1f51e951ff89}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\AuthoringTest\AuthoringTest.csproj">
       <Project>{41e2a272-150f-42f5-ad40-047aad9088a0}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/AuthoringWinUITest/AuthoringWinUITest (Package)/AuthoringWinUITest (Package).wapproj
+++ b/src/Tests/AuthoringWinUITest/AuthoringWinUITest (Package)/AuthoringWinUITest (Package).wapproj
@@ -37,7 +37,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>75b1621f-ec51-4d77-bd7e-bee576b3adc9</ProjectGuid>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>

--- a/src/Tests/AuthoringWinUITest/AuthoringWinUITest (Package)/AuthoringWinUITest (Package).wapproj
+++ b/src/Tests/AuthoringWinUITest/AuthoringWinUITest (Package)/AuthoringWinUITest (Package).wapproj
@@ -37,7 +37,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>75b1621f-ec51-4d77-bd7e-bee576b3adc9</ProjectGuid>
-    <TargetPlatformVersion>10.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>

--- a/src/Tests/HostTest/HostTest.vcxproj
+++ b/src/Tests/HostTest/HostTest.vcxproj
@@ -32,7 +32,8 @@
     <ProjectGuid>{b511b7c9-c8e2-47ed-a0d1-538c00747d30}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>	  
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Tests/HostTest/HostTest.vcxproj
+++ b/src/Tests/HostTest/HostTest.vcxproj
@@ -58,21 +58,26 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Projections\TestHost.ProbeByClass\TestHost.ProbeByClass.csproj">
       <Project>{ef3326b5-716f-41d2-ab30-4efab30955e2}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Projections\Test\Test.csproj">
       <Project>{c6d580c5-7037-4733-b933-916ff400afe2}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Projections\Windows\Windows.csproj">
       <Project>{ffa9a78b-f53f-43ee-af87-24a80f4c330a}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Authoring\WinRT.Host.Shim\WinRT.Host.Shim.csproj">
       <Project>{0bb8f82d-874e-45aa-bca3-20ce0562164a}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\Authoring\WinRT.Host\WinRT.Host.vcxproj">
       <Project>{7e33bcb7-19c5-4061-981d-ba695322708a}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\WinRT.Runtime\WinRT.Runtime.csproj">
       <Project>{25244ced-966e-45f2-9711-1f51e951ff89}</Project>
+      <SetTargetFramework>TargetFramework=net5.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--Target .NET Core 2.0 to test .NET Standard 2.0 projection -->
-    <TargetFrameworks>netcoreapp2.0;net5.0;net6.0</TargetFrameworks>
+    <!--Target .NET Core 3.1 to test .NET Standard 2.0 projection -->
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <ProjectName>UnitTest</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>

--- a/src/benchmark.cmd
+++ b/src/benchmark.cmd
@@ -1,7 +1,7 @@
 nuget restore TestWinRT\Test.sln
 nuget restore cswinrt.sln
 msbuild Benchmarks\Benchmarks.csproj -t:restore -t:build /p:platform=x64 /p:configuration=release /p:solutiondir=%~dp0 /p:IsDotnetBuild=false
-dotnet %~dp0Benchmarks\bin\x64\Release\netcoreapp2.0\Benchmarks.dll -filter * --runtimes netcoreapp5.0
+dotnet %~dp0Benchmarks\bin\x64\Release\netcoreapp3.1\Benchmarks.dll -filter * --runtimes netcoreapp5.0
 nuget restore Perf\ResultsComparer\ResultsComparer.sln
 msbuild Perf\ResultsComparer\ResultsComparer.sln -t:restore -t:build /p:platform="Any CPU" /p:configuration=release
 set baselinedir=%1

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 if /i "%cswinrt_echo%" == "on" @echo on
 
-set CsWinRTBuildNetSDKVersion=6.0.300
+set CsWinRTBuildNetSDKVersion=6.0.301
 set CsWinRTNet5SdkVersion=5.0.408
 set this_dir=%~dp0
 

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -1,8 +1,8 @@
 @echo off
 if /i "%cswinrt_echo%" == "on" @echo on
 
-set CsWinRTBuildNetSDKVersion=6.0.101
-set CsWinRTNet5SdkVersion=5.0.404
+set CsWinRTBuildNetSDKVersion=6.0.300
+set CsWinRTNet5SdkVersion=5.0.408
 set this_dir=%~dp0
 
 :dotnet
@@ -12,17 +12,6 @@ set DOTNET_ROOT(86)=%LocalAppData%\Microsoft\dotnet\x86
 set path=%DOTNET_ROOT%;%path%
 set DownloadTimeout=1200
 
-rem Install .net5 to run our projects  targeting it
-powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
-&([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
--Version '%CsWinRTNet5SdkVersion%' -InstallDir '%DOTNET_ROOT%' -Architecture 'x64' -DownloadTimeout %DownloadTimeout% ^
--AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
-powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
-&([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
--Version '%CsWinRTNet5SdkVersion%' -InstallDir '%DOTNET_ROOT(86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
--AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
 rem Install .NET Version used to build projection
 powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -8,8 +8,8 @@ set this_dir=%~dp0
 :dotnet
 rem Install required .NET SDK version and add to environment
 set DOTNET_ROOT=%LocalAppData%\Microsoft\dotnet
-set DOTNET_ROOT(86)=%LocalAppData%\Microsoft\dotnet\x86
-set path=%DOTNET_ROOT%;%path%
+set DOTNET_ROOT(x86)=%LocalAppData%\Microsoft\dotnet\x86
+set path=%DOTNET_ROOT%;%DOTNET_ROOT(x86)%;%path%
 set DownloadTimeout=1200
 
 rem Install .NET Version used to build projection
@@ -21,7 +21,7 @@ powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
--Version '%CsWinRTBuildNetSDKVersion%' -InstallDir '%DOTNET_ROOT(86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
+-Version '%CsWinRTBuildNetSDKVersion%' -InstallDir '%DOTNET_ROOT(x86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
 -AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
 
 :globaljson
@@ -157,7 +157,7 @@ if %cswinrt_platform%==arm64 goto :package
 :test
 rem Build/Run xUnit tests, generating xml output report for Azure Devops reporting, via XunitXml.TestLogger NuGet
 if %cswinrt_platform%==x86 (
-  set dotnet_exe="%DOTNET_ROOT(86)%\dotnet.exe"
+  set dotnet_exe="%DOTNET_ROOT(x86)%\dotnet.exe"
 ) else (
   set dotnet_exe="%DOTNET_ROOT%\dotnet.exe"
 )


### PR DESCRIPTION
- As part of bringing up IL trimming support, there is a csproj property needed to be set which is available in the .NET 6 SDK.  So this PR as a first step enables us to build with VS 2022 and the .NET 6 SDK.  Note that this PR does not change anything about what we target (i.e. we still currently target .NET 5 using the .NET 6 SDK).
- Fixed some issues that arose from moving to .NET 6 SDK and VS 2022.
- Moved off of .NET core app 2.0 for our .NET standard testing as .NET Core 2.0 is EOL and using .NET core 3.1 instead.