### PR TITLE
Make CI faster/lighter

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToMaestro-Stage.yml
@@ -5,7 +5,7 @@ stages:
   - job: TriggerMaestroPublish
     condition: eq(variables['_IsRelease'],'true')
     pool: 
-      vmImage: windows-2019
+      vmImage: windows-latest
     steps:
   
   # Parse Versions needed for offical CsWinRT version of build

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
@@ -4,7 +4,7 @@ stages:
   jobs:
   - job: PublishTo_CsWinRT_InternalFeed
     pool:
-      vmImage: windows-2019
+      vmImage: windows-latest
     steps:
     - checkout: self
       clean: True

--- a/build/AzurePipelineTemplates/CsWinRT-UpdateWinUIRepo-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-UpdateWinUIRepo-Stage.yml
@@ -3,9 +3,10 @@ stages:
   displayName: CI with WinUI
   jobs:
   - job: TriggerWinUIPipelines
+    condition: or(eq(variables['_IsRelease'],'true'), eq(variables['Build.Reason'],'Schedule'))
     pool: 
       name: Azure Pipelines
-      vmImage: windows-2019
+      vmImage: windows-latest
     steps:
     - script: |
         rem Parse the build-generated Build.BuildNumber into components that 


### PR DESCRIPTION
Avoid taking up two agents by adding a condition to the UpdateWinUI stage. Also have the agents use `windows-latest` as it seems `windows-2019` is lower on resources. 

