### PR TITLE
Move attributes used for authoring

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -189,7 +189,7 @@ namespace Generator
         public void Execute(GeneratorExecutionContext context)
         {
             var isTest = string.CompareOrdinal(Process.GetCurrentProcess().ProcessName, "testhost") == 0;
-            if (!isTest/* && !context.IsCsWinRTComponent()*/)
+            if (!isTest && !context.IsCsWinRTComponent())
             {
                 return;
             }

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -17,20 +17,6 @@ namespace Generator
 {
     public class ComponentGenerator
     {
-        private static readonly string ArrayAttributes = @"
-namespace System.Runtime.InteropServices.WindowsRuntime
-{
-    [global::System.AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    internal sealed class ReadOnlyArrayAttribute : global::System.Attribute
-    {
-    }
-
-    [global::System.AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    internal sealed class WriteOnlyArrayAttribute : global::System.Attribute
-    {
-    }
-}";
-
         private Logger Logger { get; }
         private readonly GeneratorExecutionContext context;
         private string tempFolder;
@@ -159,7 +145,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             try
             {
-                context.AddSource("System.Runtime.InteropServices.WindowsRuntime", SourceText.From(ArrayAttributes, Encoding.UTF8));
                 string assembly = context.GetAssemblyName();
                 string version = context.GetAssemblyVersion();
                 MetadataBuilder metadataBuilder = new MetadataBuilder();
@@ -204,7 +189,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public void Execute(GeneratorExecutionContext context)
         {
             var isTest = string.CompareOrdinal(Process.GetCurrentProcess().ProcessName, "testhost") == 0;
-            if (!isTest && !context.IsCsWinRTComponent())
+            if (!isTest/* && !context.IsCsWinRTComponent()*/)
             {
                 return;
             }

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -99,3 +99,26 @@ namespace WinRT
         public Type HelperType { get; }
     }
 }
+
+namespace System.Runtime.InteropServices.WindowsRuntime
+{
+    [AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+#if EMBED
+    internal
+#else
+    public
+#endif
+    sealed class ReadOnlyArrayAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+#if EMBED
+    internal
+#else
+    public
+#endif
+    sealed class WriteOnlyArrayAttribute : Attribute
+    {
+    }
+}

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -61,4 +61,6 @@ CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exis
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'WinRT.Interop.IAgileObject' in the implementation but not the reference.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-Total Issues: 62
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WriteOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
+Total Issues: 64


### PR DESCRIPTION
This resolves a small issue when using CsWinRT Authoring. 
The issue is that when the generator fails, it exits before generating these two attributes. This causes error messages about missing attributes, which misleads developers away from the real issue. 
Given that we are adding to the public api surface of WinRT.Runtime, this is a breaking change.
