### PR TITLE
Make QueryInterface function pointer blittable

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net5.0.txt
@@ -8,4 +8,6 @@ MembersMustExist : Member 'public void WinRT.MarshalString..ctor()' does not exi
 TypesMustExist : Type 'WinRT.MarshalString.HStringHeader' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.SingleInterfaceOptimizedObject.WinRT.IWinRTObject.get_AdditionalTypeData()' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'WinRT.SingleInterfaceOptimizedObject.WinRT.IWinRTObject.get_QueryInterfaceCache()' in the contract but not the implementation.
-Total Issues: 9
+MembersMustExist : Member 'public function System.Int32 (System.IntPtr, System.Guid, System.IntPtr) WinRT.Interop.IUnknownVftbl.QueryInterface.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void WinRT.Interop.IUnknownVftbl.QueryInterface.set(function System.Int32 (System.IntPtr, System.Guid, System.IntPtr))' does not exist in the implementation but it does exist in the contract.
+Total Issues: 11

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -446,7 +446,7 @@ namespace WinRT
             IUnknownVftblPtr = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IUnknownVftbl), sizeof(IUnknownVftbl));
             (*(IUnknownVftbl*)IUnknownVftblPtr) = new IUnknownVftbl
             {
-                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)qi,
+                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>)qi,
                 AddRef = (delegate* unmanaged[Stdcall]<IntPtr, uint>)addRef,
                 Release = (delegate* unmanaged[Stdcall]<IntPtr, uint>)release,
             };

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -208,12 +208,7 @@ namespace WinRT
         private unsafe static QueryInterface Abi_QueryInterface = Do_Abi_QueryInterface; 
         private unsafe static int Do_Abi_QueryInterface(IntPtr pThis, Guid* iid, IntPtr* ptr)
         {
-            int hr = UnmanagedObject.FindObject<ComCallableWrapper>(pThis).QueryInterface(*iid, out IntPtr thatPtr);
-            if (hr == 0)
-            {
-                *ptr = thatPtr;
-            }
-            return hr;
+            return UnmanagedObject.FindObject<ComCallableWrapper>(pThis).QueryInterface(*iid, out *ptr);
         }
 
         private delegate uint AddRefRelease(IntPtr pThis);

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -196,7 +196,7 @@ namespace WinRT
             IUnknownVftblPtr = Marshal.AllocHGlobal(sizeof(IUnknownVftbl));
             (*(IUnknownVftbl*)IUnknownVftblPtr) = new IUnknownVftbl
             {
-                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)Marshal.GetFunctionPointerForDelegate(Abi_QueryInterface),
+                QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>)Marshal.GetFunctionPointerForDelegate(Abi_QueryInterface),
                 AddRef = (delegate* unmanaged[Stdcall]<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_AddRef),
                 Release = (delegate* unmanaged[Stdcall]<IntPtr, uint>)Marshal.GetFunctionPointerForDelegate(Abi_Release),
             };
@@ -204,11 +204,16 @@ namespace WinRT
         
         public static IntPtr AllocateVtableMemory(Type vtableType, int size) => Marshal.AllocCoTaskMem(size);
 
-        private delegate int QueryInterface(IntPtr pThis, ref Guid iid, out IntPtr ptr);
-        private static QueryInterface Abi_QueryInterface = Do_Abi_QueryInterface; 
-        private static int Do_Abi_QueryInterface(IntPtr pThis, ref Guid iid, out IntPtr ptr)
+        private unsafe delegate int QueryInterface(IntPtr pThis, Guid* iid, IntPtr* ptr);
+        private unsafe static QueryInterface Abi_QueryInterface = Do_Abi_QueryInterface; 
+        private unsafe static int Do_Abi_QueryInterface(IntPtr pThis, Guid* iid, IntPtr* ptr)
         {
-            return UnmanagedObject.FindObject<ComCallableWrapper>(pThis).QueryInterface(iid, out ptr);
+            int hr = UnmanagedObject.FindObject<ComCallableWrapper>(pThis).QueryInterface(*iid, out IntPtr thatPtr);
+            if (hr == 0)
+            {
+                *ptr = thatPtr;
+            }
+            return hr;
         }
 
         private delegate uint AddRefRelease(IntPtr pThis);

--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -15,7 +15,7 @@ namespace WinRT.Interop
     unsafe struct IUnknownVftbl
     {
         private void* _QueryInterface;
-        public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> QueryInterface { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_QueryInterface; set => _QueryInterface = (void*)value; }
+        public delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int> QueryInterface { get => (delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>)_QueryInterface; set => _QueryInterface = (void*)value; }
         private void* _AddRef;
         public delegate* unmanaged[Stdcall]<IntPtr, uint> AddRef { get => (delegate* unmanaged[Stdcall]<IntPtr, uint>)_AddRef; set => _AddRef = (void*)value; }
         private void* _Release;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net5.0.txt
@@ -22,6 +22,8 @@ MembersMustExist : Member 'public WinRT.ObjectReferenceValue ABI.System.Componen
 MembersMustExist : Member 'public System.ComponentModel.PropertyChangedEventHandler ABI.System.ComponentModel.PropertyChangedEventHandler.CreateRcw(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.WinRT.Interop.IWeakReferenceSourceMethods' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Numerics.VectorExtensions' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WriteOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'Windows.Foundation.Point' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'Windows.Foundation.Rect' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'Windows.Foundation.Size' in the implementation but not the reference.
@@ -59,8 +61,8 @@ TypesMustExist : Type 'WinRT.ObjectReferenceValue' does not exist in the referen
 TypesMustExist : Type 'WinRT.WindowsRuntimeHelperTypeAttribute' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'WinRT.Interop.IActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'WinRT.Interop.IAgileObject' in the implementation but not the reference.
+MembersMustExist : Member 'public function System.Int32 (System.IntPtr, System.Guid*, System.IntPtr*) WinRT.Interop.IUnknownVftbl.QueryInterface.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public void WinRT.Interop.IUnknownVftbl.QueryInterface.set(function System.Int32 (System.IntPtr, System.Guid*, System.IntPtr*))' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReference' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IWeakReferenceSource' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'System.Runtime.InteropServices.WindowsRuntime.WriteOnlyArrayAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 64
+Total Issues: 66

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -144,7 +144,8 @@ namespace WinRT
             if (typeof(TInterface).IsDefined(typeof(System.Runtime.InteropServices.ComImportAttribute)))
             {
                 Guid iid = typeof(TInterface).GUID;
-                Marshal.ThrowExceptionForHR(VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr comPtr));
+                IntPtr comPtr = IntPtr.Zero;
+                Marshal.ThrowExceptionForHR(VftblIUnknown.QueryInterface(ThisPtr, &iid, &comPtr));
                 try
                 {
                     return (TInterface)Marshal.GetObjectForIUnknown(comPtr);
@@ -178,7 +179,8 @@ namespace WinRT
         {
             objRef = null;
             ThrowIfDisposed();
-            int hr = VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr);
+            IntPtr thatPtr = IntPtr.Zero;
+            int hr = VftblIUnknown.QueryInterface(ThisPtr, &iid, &thatPtr);
             if (hr >= 0)
             {
                 if (IsAggregated)
@@ -214,7 +216,8 @@ namespace WinRT
         {
             ppv = IntPtr.Zero;
             ThrowIfDisposed();
-            int hr = VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr);
+            IntPtr thatPtr = IntPtr.Zero;
+            int hr = VftblIUnknown.QueryInterface(ThisPtr, &iid, &thatPtr);
             if (hr >= 0)
             {
                 ppv = thatPtr;
@@ -387,7 +390,8 @@ namespace WinRT
 
         public unsafe ObjectReferenceValue AsValue(Guid iid)
         {
-            Marshal.ThrowExceptionForHR(VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr));
+            IntPtr thatPtr = IntPtr.Zero;
+            Marshal.ThrowExceptionForHR(VftblIUnknown.QueryInterface(ThisPtr, &iid, &thatPtr));
             if (IsAggregated)
             {
                 Marshal.Release(thatPtr);
@@ -641,7 +645,8 @@ namespace WinRT
         {
             objRef = null;
 
-            int hr = VftblIUnknown.QueryInterface(ThisPtr, ref iid, out IntPtr thatPtr);
+            IntPtr thatPtr = IntPtr.Zero;
+            int hr = VftblIUnknown.QueryInterface(ThisPtr, &iid, &thatPtr);
             if (hr >= 0)
             {
                 if (IsAggregated)


### PR DESCRIPTION
Per https://github.com/microsoft/CsWinRT/discussions/1232#discussioncomment-3370693, the use of ref and out in the function pointers makes it not blittable and can have an impact on perf.  This change addresses that by making them pointers instead.

This change can be considered breaking given it is in the public API surface, but this change doesn't break any existing projections or users of those projections as the use of QueryInterface is limited to callers in WinRT.Runtime and none of our generated projection code directly references it.

There are other function pointers that maybe should be addressed too (i..e within the generated projections) but given they don't seem to be in the public API surface, deferring that to be addressed later.