### PR TITLE
Sign and package CsWinMD in pipeline

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -382,6 +382,7 @@ steps:
       CsWinMD.dll
       CsWinMD.exe
       CsWinMD.pdb
+      CsWinMD.deps.json
       CsWinMD.runtimeconfig.json
       Microsoft.CodeAnalysis.CSharp.dll
       Microsoft.CodeAnalysis.dll

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -372,6 +372,21 @@ steps:
       CsWinRTDiagnosticStrings.resx
     TargetFolder: $(Build.ArtifactStagingDirectory)\resx\WinRT.SourceGenerator
 
+# Stage CsWinMD
+- task: CopyFiles@2
+  displayName: Stage CsWinMD
+  condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+  inputs:
+    SourceFolder: $(Build.SourcesDirectory)\src\Authoring\cswinmd\bin\$(BuildConfiguration)\net6.0
+    Contents: |
+      CsWinMD.dll
+      CsWinMD.exe
+      CsWinMD.pdb
+      CsWinMD.runtimeconfig.json
+      Microsoft.CodeAnalysis.CSharp.dll
+      Microsoft.CodeAnalysis.dll
+    TargetFolder: $(Build.ArtifactStagingDirectory)\release_net6.0\CsWinMD
+
 # Publish ResX
 - task: PublishBuildArtifacts@1
   displayName: Publish ResX files

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
@@ -107,6 +107,8 @@ stages:
           release_arm64\WinRT.Host.dll.mui
           net6.0\IIDOptimizer\IIDOptimizer.exe
           net6.0\IIDOptimizer\IIDOptimizer.dll
+          net6.0\CsWinMD\CsWinMD.exe
+          net6.0\CsWinMD\CsWinMD.dll
         UseMinimatch: true
         signConfigType: inlineSignParams
         inlineOperation: |
@@ -221,6 +223,14 @@ stages:
         searchPatternPack: nuget/Microsoft.Windows.CsWinRT.nuspec
         configurationToPack: Release
         buildProperties: cswinrt_nuget_version=$(NugetVersion);cswinrt_exe=$(Build.SourcesDirectory)\cswinrt.exe;interop_winmd=$(Build.SourcesDirectory)\WinRT.Interop.winmd;netstandard2_runtime=$(Build.SourcesDirectory)\netstandard2.0\WinRT.Runtime.dll;net5_runtime=$(Build.SourcesDirectory)\net5.0\WinRT.Runtime.dll;net6_runtime=$(Build.SourcesDirectory)\net6.0\WinRT.Runtime.dll;source_generator=$(Build.SourcesDirectory)\netstandard2.0\WinRT.SourceGenerator.dll;winrt_shim=$(Build.SourcesDirectory)\net6.0\WinRT.Host.Shim.dll;winrt_host_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll;winrt_host_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll;winrt_host_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll;winrt_host_resource_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll.mui;winrt_host_resource_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll.mui;winrt_host_resource_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll.mui;guid_patch=$(Build.SourcesDirectory)\net6.0\IIDOptimizer\*.*
+
+    - task: NuGetCommand@2
+      displayName: NuGet pack
+      inputs:
+        command: pack
+        searchPatternPack: nuget/Microsoft.Windows.CsWinMD.nuspec
+        configurationToPack: Release
+        buildProperties: cswinmd_nuget_version=$(NugetVersion);cswinmd_outpath=$(Build.SourcesDirectory)\net6.0\CsWinMD;source_generator=$(Build.SourcesDirectory)\netstandard2.0\WinRT.SourceGenerator.dll
 
 # ESRP CodeSigning 
     - task: EsrpCodeSigning@1

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
@@ -226,6 +226,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: NuGet pack
+      condition: eq(variables['_PublishCsWinMD'], 'true')
       inputs:
         command: pack
         searchPatternPack: nuget/Microsoft.Windows.CsWinMD.nuspec

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -15,3 +15,4 @@ variables:
   _RunBenchmarks: $[coalesce(variables.RunBenchmarks, 'false')]
   _DotNetRuntimeVersion: $[coalesce(variables.DotNetRuntimeVersion, '5.0.17')]  
   _WindowsSdkVersionSuffix: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '25')]  
+  _PublishCsWinMD: $[coalesce(variables.PublishCsWinMD, 'false')]

--- a/nuget/Microsoft.Windows.CsWinMD.nuspec
+++ b/nuget/Microsoft.Windows.CsWinMD.nuspec
@@ -27,7 +27,7 @@
     <file src="$cswinmd_outpath$\CsWinMD.runtimeconfig.json" target="tools\native"/>
     <file src="$cswinmd_outpath$\Microsoft.CodeAnalysis.CSharp.dll" target="tools\native"/>
     <file src="$cswinmd_outpath$\Microsoft.CodeAnalysis.dll" target="tools\native"/>
-    <file src="$cswinmd_outpath$\WinRT.SourceGenerator.dll" target="tools\native"/>
+    <file src="$source_generator$" target="tools\native"/>
     <file src="Microsoft.Windows.CsWinMD.targets" target="build"/>
 
   </files>

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -264,9 +264,11 @@ set winrt_host_%cswinrt_platform%=%this_dir%_build\%cswinrt_platform%\%cswinrt_c
 set winrt_host_resource_%cswinrt_platform%=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Host\bin\WinRT.Host.dll.mui
 set winrt_shim=%this_dir%Authoring\WinRT.Host.Shim\bin\%cswinrt_configuration%\net6.0\WinRT.Host.Shim.dll
 set guid_patch=%this_dir%Perf\IIDOptimizer\bin\%cswinrt_configuration%\net6.0\*.*
+set cswinmd_outpath=%this_dir%Authoring\cswinmd\bin\%cswinrt_configuration%\net6.0
 rem Now call pack
 echo Creating nuget package
 call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinRT.nuspec -Properties cswinrt_exe=%cswinrt_exe%;interop_winmd=%interop_winmd%;netstandard2_runtime=%netstandard2_runtime%;net6_runtime=%net6_runtime%;source_generator=%source_generator%;cswinrt_nuget_version=%cswinrt_version_string%;winrt_host_x86=%winrt_host_x86%;winrt_host_x64=%winrt_host_x64%;winrt_host_arm=%winrt_host_arm%;winrt_host_arm64=%winrt_host_arm64%;winrt_host_resource_x86=%winrt_host_resource_x86%;winrt_host_resource_x64=%winrt_host_resource_x64%;winrt_host_resource_arm=%winrt_host_resource_arm%;winrt_host_resource_arm64=%winrt_host_resource_arm64%;winrt_shim=%winrt_shim%;guid_patch=%guid_patch% -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
+call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinMD.nuspec -Properties cswinmd_outpath=%cswinmd_outpath%;source_generator=%source_generator%cswinmd_nuget_version=%cswinrt_version_string%; -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
 goto :eof
 
 :exec


### PR DESCRIPTION
- Added signing of CsWinMD binaries
- Added packaging of the NuGet as part of build.cmd and the pipeline, but in the pipeline, it is conditional behind the variable _PublishCsWinMD_ as I expect we wouldn't want to update it every CsWinRT release if there are no changes.