### PR TITLE
Auto generate projections for all referenced winmd files

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -62,6 +62,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!--Remove winmd references from deps.json to prevent CLR failing unit test execution-->
       <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'"/>
     </ItemGroup>
+    <PropertyGroup>
+      <!--If CsWinRTIncludes is not specified, generate projections for all referenced winmd files-->
+      <CsWinRTIncludes Condition="'$(CsWinRTIncludes)' == ''">@(CsWinRTRemovedReferences->'%(FileName)')</CsWinRTIncludes>
+    </PropertyGroup>
   </Target>
 
   <Target Name="CsWinRTPrepareProjection" DependsOnTargets="$(CsWinRTPrepareProjectionDependsOn)" Outputs="$(CsWinRTGeneratedFilesDir)">


### PR DESCRIPTION
This is to solve #780.

This PR allows generating projections for all referenced WinRT projects, without any manual editing of the csproj file. Just add a reference to CsWinRT, add one or more references to C++/WinRT component projects, and you are ready to compile. All projections are generated and compiled. This should make dev's lives easier (and also simplify documentation for the most common case).

Tested with the sample project, and also with multiple WinRT references.