### PR TITLE
Address couple trim warnings

### DIFF
--- a/src/WinRT.Runtime/Projections/IDisposable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDisposable.net5.cs
@@ -21,7 +21,6 @@ namespace ABI.System
         [Guid("30D5A829-7FA4-4026-83BB-D75BAE4EA99E")]
         public struct Vftbl
         {
-            private delegate int CloseDelegate(IntPtr thisPtr);
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _Close_0;
             public delegate* unmanaged[Stdcall]<IntPtr, int> Close_0 { get => (delegate* unmanaged[Stdcall]<IntPtr, int>)_Close_0; set => _Close_0 = value; }
@@ -35,9 +34,7 @@ namespace ABI.System
                 AbiToProjectionVftable = new Vftbl
                 {
                     IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
-
                     _Close_0 = (delegate* unmanaged<IntPtr, int>)&Do_Abi_Close_0
-
                 };
                 var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
                 Marshal.StructureToPtr(AbiToProjectionVftable, (IntPtr)nativeVftbl, false);
@@ -46,11 +43,8 @@ namespace ABI.System
 
 
             [UnmanagedCallersOnly]
-
             private static unsafe int Do_Abi_Close_0(IntPtr thisPtr)
             {
-
-
                 try
                 {
                     global::WinRT.ComWrappersSupport.FindObject<global::System.IDisposable>(thisPtr).Dispose();

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -180,6 +180,8 @@ namespace WinRT
         }
 
         private readonly static ConcurrentDictionary<Type, Type> AuthoringMetadataTypeCache = new ConcurrentDictionary<Type, Type>();
+
+        [RequiresUnreferencedCodeAttribute("If authoring a WinRT component in C# using C#/WinRT authoring support, it might require ABI helper types that might get trimmed. Avoid marking such components trimmable or ensure types don't get trimmed from it.")]
         internal static Type GetAuthoringMetadataType(this Type type)
         {
             return AuthoringMetadataTypeCache.GetOrAdd(type, (type) =>

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -181,7 +181,9 @@ namespace WinRT
 
         private readonly static ConcurrentDictionary<Type, Type> AuthoringMetadataTypeCache = new ConcurrentDictionary<Type, Type>();
 
+#if NET
         [RequiresUnreferencedCodeAttribute("If authoring a WinRT component in C# using C#/WinRT authoring support, it might require ABI helper types that might get trimmed. Avoid marking such components trimmable or ensure types don't get trimmed from it.")]
+#endif
         internal static Type GetAuthoringMetadataType(this Type type)
         {
             return AuthoringMetadataTypeCache.GetOrAdd(type, (type) =>

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -181,16 +181,17 @@ namespace WinRT
 
         private readonly static ConcurrentDictionary<Type, Type> AuthoringMetadataTypeCache = new ConcurrentDictionary<Type, Type>();
 
-#if NET
-        [RequiresUnreferencedCodeAttribute("If authoring a WinRT component in C# using C#/WinRT authoring support, it might require ABI helper types that might get trimmed. Avoid marking such components trimmable or ensure types don't get trimmed from it.")]
-#endif
         internal static Type GetAuthoringMetadataType(this Type type)
         {
-            return AuthoringMetadataTypeCache.GetOrAdd(type, (type) =>
-            {
-                var ccwTypeName = $"ABI.Impl.{type.FullName}";
-                return type.Assembly.GetType(ccwTypeName, false);
-            });
+            return AuthoringMetadataTypeCache.GetOrAdd(type,
+#if NET
+                [RequiresUnreferencedCodeAttribute("If authoring a WinRT component in C# using C#/WinRT authoring support, it might require ABI helper types that might get trimmed. Avoid marking such components trimmable or ensure types don't get trimmed from it.")]
+#endif
+                (type) =>
+                {
+                    var ccwTypeName = $"ABI.Impl.{type.FullName}";
+                    return type.Assembly.GetType(ccwTypeName, false);
+                });
         }
     }
 }


### PR DESCRIPTION
- The delegate in IDisposable seems to cause trim warnings when used in RegisterCustomAbiTypeMappingNoLock.  It doesn't seem to be used, so removed it and confirmed the warnings went away.
- Improved trim warning for C#/WinRT authoring support.

Fix #1269 