### PR TITLE
Replace . with _ when generating authored component's targets.

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -233,10 +233,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Transform the fetched xml nodes -->
     <PropertyGroup>      
-      <Transformed1>$([System.String]::Copy('$(Flat_Peeked_Depends1)').Replace('CsWinRT','$(AssemblyName)'))</Transformed1>
-      <Transformed2>$([System.String]::Copy('$(Flat_Peeked_Depends2)').Replace('CsWinRT','$(AssemblyName)'))</Transformed2>
-      <Transformed3>$([System.String]::Copy('$(Flat_Peeked_Target1)').Replace('CsWinRT','$(AssemblyName)'))</Transformed3>
-      <Transformed4>$([System.String]::Copy('$(Flat_Peeked_Target2)').Replace('CsWinRT','$(AssemblyName)'))</Transformed4>
+      <Transformed1>$([System.String]::Copy('$(Flat_Peeked_Depends1)').Replace('CsWinRT','$(AssemblyName)').Replace(".","_"))</Transformed1>
+      <Transformed2>$([System.String]::Copy('$(Flat_Peeked_Depends2)').Replace('CsWinRT','$(AssemblyName)').Replace(".","_"))</Transformed2>
+      <Transformed3>$([System.String]::Copy('$(Flat_Peeked_Target1)').Replace('CsWinRT','$(AssemblyName)').Replace(".","_"))</Transformed3>
+      <Transformed4>$([System.String]::Copy('$(Flat_Peeked_Target2)').Replace('CsWinRT','$(AssemblyName)').Replace(".","_"))</Transformed4>
     </PropertyGroup>
 
     <!-- Change the target names -->


### PR DESCRIPTION
Users of CsWinRT Authoring may choose to create a NuPkg for their component. We have some automation tools for this scenario which generate a targets file for the project/nupkg to help with the custom build logic necessary for authored components. 

Today the generated targets file uses the authoring project's AssemblyName, but fails to consider if that includes `.`. 
E.g. AssemblyName = Microsoft.Coords vs. AssemblyName = Coords. 

This oversight caused build failures because MSBuild targets cannot have `.` in their name. 
The fix is to make sure the generated file replaces `.` with `_` when generating target names. 

Fixes #1229 

I tested this with a sample authoring component and confirmed the targets' names change to valid format for MSBuild.