### PR TITLE
Fix interface name returned for GetRuntimeClassName and fix build

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -36,7 +36,7 @@ steps:
   displayName: Use .NET Core SDK 3.1
   inputs:
     version: 3.1.x
-    installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
+    installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\x86
     performMultiLevelLookup: true
   env:
     PROCESSOR_ARCHITECTURE: x86

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -32,6 +32,15 @@ steps:
     installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
     performMultiLevelLookup: true
 
+- task: UseDotNet@2
+  displayName: Use .NET Core SDK 3.1
+  inputs:
+    version: 3.1.x
+    installationPath: C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet\
+    performMultiLevelLookup: true
+  env:
+    PROCESSOR_ARCHITECTURE: x86
+
 # Install .NET 6 SDK 
 - task: PowerShell@2
   displayName: Install .NET 6 SDK

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -1,7 +1,7 @@
 variables:
   MajorVersion: 2
   MinorVersion: 0
-  PatchVersion: 1
+  PatchVersion: 2
   WinRT.Runtime.AssemblyVersion: '2.0.0.0'
   Net5.SDK.Feed: 'https://dotnetcli.blob.core.windows.net/dotnet'
   Net5.SDK.Version: '5.0.408'

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -394,7 +394,7 @@ namespace WinRT
                 {
                     if (Projections.IsTypeWindowsRuntimeType(iface))
                     {
-                        if (interfaceTypeToUse is null || iface.IsAssignableFrom(interfaceTypeToUse))
+                        if (interfaceTypeToUse is null || interfaceTypeToUse.IsAssignableFrom(iface))
                         {
                             interfaceTypeToUse = iface;
                         }


### PR DESCRIPTION
When we have a non-WinRT C# class which we need to return the runtime class name for, we go through all the WinRT interfaces and decide on one of them to use as we can only return one.  As part of this, we try to see if an interface implements the others and if so, we try to choose the one which implements the other interfaces.  The logic to check this was previously incorrect and chose the child interface rather than the parent.