### PR TITLE
Fix recurisve issue with covariant interfaces and fix IID being wrong for built-in interfaces used as generics

### DIFF
--- a/src/Tests/UnitTest/GuidTests.cs
+++ b/src/Tests/UnitTest/GuidTests.cs
@@ -110,6 +110,12 @@ namespace UnitTest
             AssertGuid<IList<Uri>>("0d82bd8d-fe62-5d67-a7b9-7886dd75bc4e");
             AssertGuid<IList<AsyncActionCompletedHandler>>("5dafe591-86dc-59aa-bfda-07f5d59fc708");
             AssertGuid<IList<ComposedNonBlittableStruct>>("c8477314-b257-511b-a3a1-9e4eb6385152");
+            AssertGuid<IList<IDisposable>>("1bfca4f6-2c4e-5174-9869-b39d35848fcc");
+            AssertGuid<IList<IWwwFormUrlDecoderEntry>>("2f5fb6d3-231f-57a1-9f2a-daa7e43bf075");
+            AssertGuid<IList<WwwFormUrlDecoderEntry>>("1d9ba3f5-b997-5a7d-82c4-7857ecbf3a42");
+            AssertGuid<IList<Deferral>>("a3c9b753-57ad-537f-9626-4ae5785473d4");
+            AssertGuid<IList<DateTimeOffset>>("94390dc5-e442-5870-88b6-007e232f902c");
+            AssertGuid<IList<Point>>("c0d513a9-ec4a-5a5d-b6d5-b707defdb9f7");
         }
     }
 }

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2279,6 +2279,30 @@ namespace UnitTest
             using var qiResult = ccw.As(GuidGenerator.GetIID(typeof(global::System.Collections.Generic.IEnumerable<object>).GetHelperType()));
         }
 
+        internal class ManagedType2 : List<ManagedType2> { }
+
+        internal class ManagedType3 : List<ManagedType3>, IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+
+        [Fact]
+        public void CCWOfListOfManagedType2()
+        {
+            using var ccw = ComWrappersSupport.CreateCCWForObject(new ManagedType2());
+            var qiResult = ccw.As(GuidGenerator.GetIID(typeof(global::System.Collections.Generic.IEnumerable<object>).GetHelperType()));
+        }
+
+        [Fact]
+        public void CCWOfListOfManagedType3()
+        {
+            using var ccw = ComWrappersSupport.CreateCCWForObject(new ManagedType3());
+            var qiResult = ccw.As(GuidGenerator.GetIID(typeof(global::System.Collections.Generic.IEnumerable<object>).GetHelperType()));
+            var qiResult2 = ccw.As(GuidGenerator.GetIID(typeof(global::System.Collections.Generic.IEnumerable<IDisposable>).GetHelperType()));
+        }
+
         [Fact]
         public void WeakReferenceOfManagedObject()
         {

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -222,7 +222,7 @@ namespace WinRT
                     }
 
                     if (iface.IsConstructedGenericType
-                        && Projections.TryGetCompatibleWindowsRuntimeTypesForVariantType(iface, out var compatibleIfaces))
+                        && Projections.TryGetCompatibleWindowsRuntimeTypesForVariantType(iface, null, out var compatibleIfaces))
                     {
                         foreach (var compatibleIface in compatibleIfaces)
                         {

--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -96,7 +96,10 @@ namespace WinRT
                 }
             }
 
-            type = type.IsInterface ? (type.GetAuthoringMetadataType() ?? type) : type;
+            // For authoring interfaces, we use the metadata type to get the guid.
+            // For built-in system interfaces that are custom type mapped, we use the helper type to get the guid.
+            // For others, either the type itself or the helper type has the same guid and can be used.
+            type = type.IsInterface ? (type.GetAuthoringMetadataType() ?? helperType ?? type) : type;
 
             if (type.IsGenericType)
             {


### PR DESCRIPTION
When an CCW is created for an object, we also add the vtables for covariant interfaces.  If one of the generics of a covariant interface was to the type that the CCW is being created for, this can end up in a recursive loop.  This can also happen with base types too.  Looking at the behavior of .NET Core and .NET native, both of them seem to differ with respect to which covariant interfaces got created, but both don't create them for the recursive instances.  Based on that, putting in a stack to keep track of the types we are recursively trying to get all the covariant interfaces for to avoid getting into a recursive loop.

As part of this, also found out that when we have a generic of a custom mapped interface like System.IDisposable, we are generating the wrong IID.  Resolving that by using the helper type when available.

Fixes #1291 