### PR TITLE
Add vtbls for IWeakReferenceSource and IWeakReference.

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2912,5 +2912,34 @@ namespace UnitTest
             CustomExperimentClass custom = new CustomExperimentClass();
             custom.f();
         }
+
+        void OnDeviceAdded(DeviceWatcher sender, DeviceInformation args)
+        {
+        }
+
+        [Fact]
+        public void TestWeakReferenceEventsFromMultipleContexts()
+        {
+            var watcher = DeviceInformation.CreateWatcher();
+            Exception exception = null;
+
+            Thread staThread = new Thread(() =>
+            {
+                exception = Record.Exception(() => { watcher.DeviceAdded += OnDeviceAdded; });
+            });
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+            staThread.Join();
+            Assert.Null(exception);
+
+            Thread mtaThread = new Thread(() =>
+            {
+                exception = Record.Exception(() => { watcher.DeviceAdded += OnDeviceAdded; });
+            });
+            mtaThread.SetApartmentState(ApartmentState.MTA);
+            mtaThread.Start();
+            mtaThread.Join();
+            Assert.Null(exception);
+        }
     }
 }

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -539,7 +539,7 @@ namespace WinRT
                 {
                     // IWeakReference is IUnknown-based, so implementations of it may not (and likely won't) implement
                     // IInspectable. As a result, we need to check for them explicitly.
-                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(ptr);
+                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterface<ABI.WinRT.Interop.IWeakReference.Vftbl>(ptr);
                     ComWrappersHelper.Init(iunknownObjRef);
 
                     return new SingleInterfaceOptimizedObject(typeof(IWeakReference), iunknownObjRef, false);

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -94,6 +94,45 @@ namespace ABI.WinRT.Interop
     [Guid("00000038-0000-0000-C000-000000000046")]
     internal unsafe interface IWeakReferenceSource : global::WinRT.Interop.IWeakReferenceSource
     {
+        [Guid("00000038-0000-0000-C000-000000000046")]
+        internal struct Vftbl
+        {
+            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+            private void* _GetWeakReference;
+            public delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int> GetWeakReference { get => (delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int>)_GetWeakReference; set => _GetWeakReference = value; }
+
+            public static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+            internal delegate int GetWeakReferenceDelegate(IntPtr thisPtr, IntPtr* weakReference);
+            private static readonly Delegate[] DelegateCache = new Delegate[1];
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
+                    _GetWeakReference = Marshal.GetFunctionPointerForDelegate(DelegateCache[0] = new GetWeakReferenceDelegate(Do_Abi_GetWeakReference)).ToPointer(),
+                };
+                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
+                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
+            }
+
+            private static int Do_Abi_GetWeakReference(IntPtr thisPtr, IntPtr* weakReference)
+            {
+                *weakReference = default;
+
+                try
+                {
+                    *weakReference = ComWrappersSupport.CreateCCWForObject(new global::WinRT.Interop.ManagedWeakReference(ComWrappersSupport.FindObject<object>(thisPtr))).As<ABI.WinRT.Interop.IWeakReference.Vftbl>().GetRef();
+                }
+                catch (Exception __exception__)
+                {
+                    return __exception__.HResult;
+                }
+                return 0;
+            }
+        }
+
         internal static readonly Guid IID = InterfaceIIDs.IWeakReferenceSource_IID;
 
         public static IntPtr AbiToProjectionVftablePtr;
@@ -131,6 +170,48 @@ namespace ABI.WinRT.Interop
     [Guid("00000037-0000-0000-C000-000000000046")]
     internal unsafe interface IWeakReference : global::WinRT.Interop.IWeakReference
     {
+        [Guid("00000037-0000-0000-C000-000000000046")]
+        public struct Vftbl
+        {
+            public global::WinRT.Interop.IUnknownVftbl IUnknownVftbl;
+            private void* _Resolve;
+            public delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int> Resolve { get => (delegate* unmanaged[Stdcall]<IntPtr, ref Guid, out IntPtr, int>)_Resolve; set => _Resolve = value; }
+
+            public static readonly Vftbl AbiToProjectionVftable;
+            public static readonly IntPtr AbiToProjectionVftablePtr;
+
+            public delegate int ResolveDelegate(IntPtr thisPtr, Guid* riid, IntPtr* objectReference);
+            private static readonly Delegate[] DelegateCache = new Delegate[1];
+            static Vftbl()
+            {
+                AbiToProjectionVftable = new Vftbl
+                {
+                    IUnknownVftbl = global::WinRT.Interop.IUnknownVftbl.AbiToProjectionVftbl,
+                    _Resolve = Marshal.GetFunctionPointerForDelegate(DelegateCache[0] = new ResolveDelegate(Do_Abi_Resolve)).ToPointer(),
+                };
+                AbiToProjectionVftablePtr = Marshal.AllocHGlobal(Marshal.SizeOf<Vftbl>());
+                Marshal.StructureToPtr(AbiToProjectionVftable, AbiToProjectionVftablePtr, false);
+            }
+
+            private static int Do_Abi_Resolve(IntPtr thisPtr, Guid* riid, IntPtr* objectReference)
+            {
+                IObjectReference _objectReference = default;
+
+                *objectReference = default;
+
+                try
+                {
+                    _objectReference = global::WinRT.ComWrappersSupport.FindObject<global::WinRT.Interop.IWeakReference>(thisPtr).Resolve(*riid);
+                    *objectReference = _objectReference?.GetRef() ?? IntPtr.Zero;
+                }
+                catch (Exception __exception__)
+                {
+                    return __exception__.HResult;
+                }
+                return 0;
+            }
+        }
+
         internal static readonly Guid IID = new(0x00000037, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
 
         public static IntPtr AbiToProjectionVftablePtr;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -540,7 +540,7 @@ namespace WinRT
                     return;
                 }
 #else
-            int hr = obj.TryAs<ABI.WinRT.Interop.IWeakReferenceSource.Vftbl>(InterfaceIIDs.IWeakReferenceSource_IID, out var weakRefSource);
+            int hr = obj.TryAs<IUnknownVftbl>(InterfaceIIDs.IWeakReferenceSource_IID, out var weakRefSource);
             if (hr != 0)
             {
                 return;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -540,7 +540,7 @@ namespace WinRT
                     return;
                 }
 #else
-            int hr = obj.TryAs<IUnknownVftbl>(InterfaceIIDs.IWeakReferenceSource_IID, out var weakRefSource);
+            int hr = obj.TryAs<ABI.WinRT.Interop.IWeakReferenceSource.Vftbl>(InterfaceIIDs.IWeakReferenceSource_IID, out var weakRefSource);
             if (hr != 0)
             {
                 return;
@@ -860,6 +860,7 @@ namespace WinRT
         internal static readonly Guid IInspectable_IID = new(0xAF86E2E0, 0xB12D, 0x4c6a, 0x9C, 0x5A, 0xD7, 0xAA, 0x65, 0x10, 0x1E, 0x90);
         internal static readonly Guid IUnknown_IID = new(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
         internal static readonly Guid IWeakReferenceSource_IID = new(0x00000038, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+        internal static readonly Guid IWeakReference_IID = new(0x00000037, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
     }
 }
 


### PR DESCRIPTION
Fixes ADO#41937903

When resolving an IWeakReference from a different context, we resolve as IUnknown and then assume that Resolve is the next method in the vtbl, see https://github.com/microsoft/CsWinRT/blob/418229436353d05edccd4f94fd3f6539735d810a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs#L256. This turns out to not be true and we end up calling an unrelated COM interface with incorrect parameters that than tries to allocate a very large array on the stack resulting in stack overflow.