### PR TITLE
Fix resolving IWeakReference from different context

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -9,7 +9,6 @@ using WinRT;
 
 using Windows.Foundation;
 using Windows.UI;
-using Windows.Security.Credentials.UI;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using Microsoft.UI.Xaml;
@@ -30,6 +29,7 @@ using Windows.Security.Cryptography.Core;
 using System.Reflection;
 using Windows.Devices.Enumeration.Pnp;
 using System.Diagnostics;
+using Windows.Devices.Enumeration;
 
 #if NET
 using WeakRefNS = System;
@@ -2935,6 +2935,48 @@ namespace UnitTest
         {
             CustomExperimentClass custom = new CustomExperimentClass();
             custom.f();
+        }
+
+        void OnDeviceAdded(DeviceWatcher sender, DeviceInformation args)
+        {
+        }
+
+        void OnDeviceUpdated(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+        }
+
+        [Fact]
+        public void TestWeakReferenceEventsFromMultipleContexts()
+        {
+            SemaphoreSlim semaphore = new SemaphoreSlim(0);
+            DeviceWatcher watcher = null;
+
+            Thread staThread = new Thread(() =>
+            {
+                Assert.True(Thread.CurrentThread.GetApartmentState() == ApartmentState.STA);
+
+                watcher = DeviceInformation.CreateWatcher();
+                var exception = Record.Exception(() => { 
+                    watcher.Added += OnDeviceAdded; 
+                });
+                Assert.Null(exception);
+
+                Thread mtaThread = new Thread(() =>
+                {
+                    Assert.True(Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA);
+
+                    exception = Record.Exception(() => { 
+                        watcher.Updated += OnDeviceUpdated; 
+                    });
+                    Assert.Null(exception);
+                });
+                mtaThread.SetApartmentState(ApartmentState.MTA);
+                mtaThread.Start();
+                mtaThread.Join();
+            });
+            staThread.SetApartmentState(ApartmentState.STA);
+            staThread.Start();
+            staThread.Join();
         }
     }
 }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -150,6 +150,31 @@ namespace WinRT
             }
         }
 
+        internal static ObjectReference<T> GetObjectReferenceForInterfaceWithKnownIID<T>(IntPtr externalComObject, Guid iid)
+        {
+            if (externalComObject == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            ObjectReference<T> objRef = ObjectReference<T>.FromAbi(externalComObject);
+            if (IsFreeThreaded(objRef))
+            {
+                return objRef;
+            }
+            else
+            {
+                using (objRef)
+                {
+                    return new ObjectReferenceWithContext<T>(
+                        objRef.GetRef(),
+                        Context.GetContextCallback(),
+                        Context.GetContextToken(),
+                        iid);
+                }
+            }
+        }
+
         public static void RegisterProjectionAssembly(Assembly assembly) => TypeNameSupport.RegisterProjectionAssembly(assembly);
 
         public static void RegisterProjectionTypeBaseTypeMapping(IDictionary<string, string> typeNameToBaseTypeNameMapping) => TypeNameSupport.RegisterProjectionTypeBaseTypeMapping(typeNameToBaseTypeNameMapping);

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -126,38 +126,27 @@ namespace WinRT
 
         public static ObjectReference<T> GetObjectReferenceForInterface<T>(IntPtr externalComObject, Guid iid)
         {
-            if (externalComObject == IntPtr.Zero)
-            {
-                return null;
-            }
-
-            Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, ref iid, out IntPtr ptr));
-            ObjectReference<T> objRef = ObjectReference<T>.Attach(ref ptr);
-            if (IsFreeThreaded(objRef))
-            {
-                return objRef;
-            }
-            else
-            {
-                using (objRef)
-                {
-                    return new ObjectReferenceWithContext<T>(
-                        objRef.GetRef(),
-                        Context.GetContextCallback(),
-                        Context.GetContextToken(),
-                        iid);
-                }
-            }
+            return GetObjectReferenceForInterface<T>(externalComObject, iid, true);
         }
 
-        internal static ObjectReference<T> GetObjectReferenceForInterfaceWithKnownIID<T>(IntPtr externalComObject, Guid iid)
+        internal static ObjectReference<T> GetObjectReferenceForInterface<T>(IntPtr externalComObject, Guid iid, bool requireQI)
         {
             if (externalComObject == IntPtr.Zero)
             {
                 return null;
             }
 
-            ObjectReference<T> objRef = ObjectReference<T>.FromAbi(externalComObject);
+            ObjectReference<T> objRef;
+            if (requireQI)
+            {
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, ref iid, out IntPtr ptr));
+                objRef = ObjectReference<T>.Attach(ref ptr);
+            }
+            else
+            {
+                objRef = ObjectReference<T>.FromAbi(externalComObject);
+            }
+
             if (IsFreeThreaded(objRef))
             {
                 return objRef;

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -539,7 +539,7 @@ namespace WinRT
                 {
                     // IWeakReference is IUnknown-based, so implementations of it may not (and likely won't) implement
                     // IInspectable. As a result, we need to check for them explicitly.
-                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterfaceWithKnownIID<IUnknownVftbl>(ptr, weakReferenceIID);
+                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(ptr, weakReferenceIID, false);
                     ComWrappersHelper.Init(iunknownObjRef);
 
                     return new SingleInterfaceOptimizedObject(typeof(IWeakReference), iunknownObjRef, false);

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -539,7 +539,7 @@ namespace WinRT
                 {
                     // IWeakReference is IUnknown-based, so implementations of it may not (and likely won't) implement
                     // IInspectable. As a result, we need to check for them explicitly.
-                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(ptr);
+                    var iunknownObjRef = ComWrappersSupport.GetObjectReferenceForInterfaceWithKnownIID<IUnknownVftbl>(ptr, weakReferenceIID);
                     ComWrappersHelper.Init(iunknownObjRef);
 
                     return new SingleInterfaceOptimizedObject(typeof(IWeakReference), iunknownObjRef, false);


### PR DESCRIPTION
Taking the findings from #1300 and putting in a slightly different fix.  Reusing the test case from it.

For weak references, when they are accessed from a different context, we use the agile reference to resolve a pointer in the current context.  This ptr doesn't necessarily point to the same interface / vtbl from when we initially created it.  Instead, it can point to IUnknown and can cause unexpected issues when we call it with the assumption it is the IWeakReference vftbl.  This fix ensures we retrieve the pointer on the right context by making sure IObjectReference is aware of the IID it was initially created for which means it can use it when resolving the agile reference.