### PR TITLE
Fix non-generic ICollection interface calls not working

### DIFF
--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -104,6 +104,81 @@ namespace winrt::TestComponentCSharp::implementation
         }
     };
 
+    struct bindable_observable_vector : winrt::implements<bindable_observable_vector, IBindableObservableVector, IBindableIterable, IBindableVector>
+    {
+        IBindableObservableVector _wrapped;
+
+        bindable_observable_vector(IBindableObservableVector wrapped)
+        {
+            _wrapped = wrapped;
+        }
+
+        IBindableIterator First()
+        {
+            return _wrapped.First();
+        }
+
+        WF::IInspectable GetAt(uint32_t index)
+        {
+            return _wrapped.GetAt(index);
+        }
+
+        uint32_t Size()
+        {
+            return _wrapped.Size();
+        }
+
+        IBindableVectorView GetView()
+        {
+            return _wrapped.GetView();
+        }
+
+        bool IndexOf(WF::IInspectable const& value, uint32_t& index)
+        {
+            return _wrapped.IndexOf(value, index);
+        }
+
+        void SetAt(uint32_t index, WF::IInspectable const& value)
+        {
+            return _wrapped.SetAt(index, value);
+        }
+
+        void InsertAt(uint32_t index, WF::IInspectable const& value)
+        {
+            return _wrapped.InsertAt(index, value);
+        }
+
+        void RemoveAt(uint32_t index)
+        {
+            return _wrapped.RemoveAt(index);
+        }
+
+        void Append(WF::IInspectable const& value)
+        {
+            _wrapped.Append(value);
+        }
+
+        void RemoveAtEnd()
+        {
+            _wrapped.RemoveAtEnd();
+        }
+
+        void Clear()
+        {
+            _wrapped.Clear();
+        }
+
+        winrt::event_token VectorChanged(BindableVectorChangedEventHandler const& handler)
+        {
+            return _wrapped.VectorChanged(handler);
+        }
+
+        void VectorChanged(winrt::event_token const& token) noexcept
+        {
+            _wrapped.VectorChanged(token);
+        }
+    };
+
     struct data_errors_changed_event_args : implements<data_errors_changed_event_args, IDataErrorsChangedEventArgs>
     {
         data_errors_changed_event_args(winrt::hstring name) :
@@ -1395,6 +1470,11 @@ namespace winrt::TestComponentCSharp::implementation
                 }
                 e.as<IProperties2>().ReadWriteProperty(sum);
         });
+    }
+
+    IBindableObservableVector Class::GetBindableObservableVector(IBindableObservableVector vector)
+    {
+        return winrt::make<bindable_observable_vector>(vector);
     }
 
     void Class::CopyProperties(winrt::TestComponentCSharp::IProperties1 const& src)

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -295,6 +295,7 @@ namespace winrt::TestComponentCSharp::implementation
         void BindableVectorPropertyChanged(winrt::event_token const& token) noexcept;
         Microsoft::UI::Xaml::Interop::IBindableObservableVector BindableObservableVectorProperty();
         void BindableObservableVectorProperty(Microsoft::UI::Xaml::Interop::IBindableObservableVector const& value);
+        Microsoft::UI::Xaml::Interop::IBindableObservableVector GetBindableObservableVector(Microsoft::UI::Xaml::Interop::IBindableObservableVector vector);
 
         void CopyProperties(TestComponentCSharp::IProperties1 const& src);
         void CopyPropertiesViaWeakReference(TestComponentCSharp::IProperties1 const& src);

--- a/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.cpp
+++ b/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.cpp
@@ -3,6 +3,8 @@
 #include "CustomBindableIteratorTest.g.cpp"
 #include "CustomDisposableTest.g.cpp"
 #include "CustomBindableVectorTest.g.cpp"
+#include "CustomBindableObservableVectorTest.g.cpp"
+#include "CustomIteratorTest.g.cpp"
 
 namespace winrt::TestComponentCSharp::implementation
 {
@@ -74,5 +76,68 @@ namespace winrt::TestComponentCSharp::implementation
     winrt::Microsoft::UI::Xaml::Interop::IBindableIterator CustomBindableVectorTest::First()
     {
         return winrt::Microsoft::UI::Xaml::Interop::IBindableIterator();
+    }
+
+    winrt::Microsoft::UI::Xaml::Interop::IBindableIterator CustomBindableObservableVectorTest::First()
+    {
+        return winrt::Microsoft::UI::Xaml::Interop::IBindableIterator();
+    }
+    winrt::Windows::Foundation::IInspectable CustomBindableObservableVectorTest::GetAt(uint32_t index)
+    {
+        return Windows::Foundation::PropertyValue::CreateInt32(1);
+    }
+    uint32_t CustomBindableObservableVectorTest::Size()
+    {
+        return 1;
+    }
+    winrt::Microsoft::UI::Xaml::Interop::IBindableVectorView CustomBindableObservableVectorTest::GetView()
+    {
+        return winrt::Microsoft::UI::Xaml::Interop::IBindableVectorView();
+    }
+    bool CustomBindableObservableVectorTest::IndexOf(winrt::Windows::Foundation::IInspectable const& value, uint32_t& index)
+    {
+        return false;
+    }
+    void CustomBindableObservableVectorTest::SetAt(uint32_t index, winrt::Windows::Foundation::IInspectable const& value)
+    {
+    }
+    void CustomBindableObservableVectorTest::InsertAt(uint32_t index, winrt::Windows::Foundation::IInspectable const& value)
+    {
+    }
+    void CustomBindableObservableVectorTest::RemoveAt(uint32_t index)
+    {
+    }
+    void CustomBindableObservableVectorTest::Append(winrt::Windows::Foundation::IInspectable const& value)
+    {
+    }
+    void CustomBindableObservableVectorTest::RemoveAtEnd()
+    {
+    }
+    void CustomBindableObservableVectorTest::Clear()
+    {
+    }
+    winrt::event_token CustomBindableObservableVectorTest::VectorChanged(winrt::Microsoft::UI::Xaml::Interop::BindableVectorChangedEventHandler const& handler)
+    {
+        throw hresult_not_implemented();
+    }
+    void CustomBindableObservableVectorTest::VectorChanged(winrt::event_token const& token) noexcept
+    {
+    }
+
+    int32_t CustomIteratorTest::Current()
+    {
+        return 2;
+    }
+    bool CustomIteratorTest::HasCurrent()
+    {
+        return true;
+    }
+    bool CustomIteratorTest::MoveNext()
+    {
+        return true;
+    }
+    uint32_t CustomIteratorTest::GetMany(array_view<int32_t> items)
+    {
+        throw hresult_not_implemented();
     }
 }

--- a/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.h
+++ b/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.h
@@ -2,6 +2,8 @@
 #include "CustomBindableIteratorTest.g.h"
 #include "CustomDisposableTest.g.h"
 #include "CustomBindableVectorTest.g.h"
+#include "CustomBindableObservableVectorTest.g.h"
+#include "CustomIteratorTest.g.h"
 
 namespace winrt::TestComponentCSharp::implementation
 {
@@ -34,6 +36,35 @@ namespace winrt::TestComponentCSharp::implementation
 		int32_t Size();
 		winrt::Microsoft::UI::Xaml::Interop::IBindableIterator First();
 	};
+
+	struct CustomBindableObservableVectorTest : CustomBindableObservableVectorTestT<CustomBindableObservableVectorTest>
+	{
+		CustomBindableObservableVectorTest() = default;
+
+		winrt::Microsoft::UI::Xaml::Interop::IBindableIterator First();
+		winrt::Windows::Foundation::IInspectable GetAt(uint32_t index);
+		uint32_t Size();
+		winrt::Microsoft::UI::Xaml::Interop::IBindableVectorView GetView();
+		bool IndexOf(winrt::Windows::Foundation::IInspectable const& value, uint32_t& index);
+		void SetAt(uint32_t index, winrt::Windows::Foundation::IInspectable const& value);
+		void InsertAt(uint32_t index, winrt::Windows::Foundation::IInspectable const& value);
+		void RemoveAt(uint32_t index);
+		void Append(winrt::Windows::Foundation::IInspectable const& value);
+		void RemoveAtEnd();
+		void Clear();
+		winrt::event_token VectorChanged(winrt::Microsoft::UI::Xaml::Interop::BindableVectorChangedEventHandler const& handler);
+		void VectorChanged(winrt::event_token const& token) noexcept;
+	};
+
+	struct CustomIteratorTest : CustomIteratorTestT<CustomIteratorTest>
+	{
+		CustomIteratorTest() = default;
+
+		int32_t Current();
+		bool HasCurrent();
+		bool MoveNext();
+		uint32_t GetMany(array_view<int32_t> items);
+	};
 }
 
 namespace winrt::TestComponentCSharp::factory_implementation
@@ -51,5 +82,13 @@ namespace winrt::TestComponentCSharp::factory_implementation
 	struct CustomBindableVectorTest : CustomBindableVectorTestT<CustomBindableVectorTest, implementation::CustomBindableVectorTest>
 	{
 
+	};
+
+	struct CustomBindableObservableVectorTest : CustomBindableObservableVectorTestT<CustomBindableObservableVectorTest, implementation::CustomBindableObservableVectorTest>
+	{
+	};
+
+	struct CustomIteratorTest : CustomIteratorTestT<CustomIteratorTest, implementation::CustomIteratorTest>
+	{
 	};
 }

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -334,6 +334,7 @@ namespace TestComponentCSharp
         event Windows.Foundation.EventHandler<Microsoft.UI.Xaml.Interop.IBindableVector> BindableVectorPropertyChanged;
         
         Microsoft.UI.Xaml.Interop.IBindableObservableVector BindableObservableVectorProperty;
+        Microsoft.UI.Xaml.Interop.IBindableObservableVector GetBindableObservableVector(Microsoft.UI.Xaml.Interop.IBindableObservableVector vector);
 
         void CopyProperties(IProperties1 src);
         void CopyPropertiesViaWeakReference(IProperties1 src);
@@ -454,6 +455,18 @@ namespace TestComponentCSharp
     runtimeclass CustomBindableVectorTest : Microsoft.UI.Xaml.Interop.IBindableVector
     {
         CustomBindableVectorTest();
+    }
+
+    [default_interface]
+    runtimeclass CustomBindableObservableVectorTest : Microsoft.UI.Xaml.Interop.IBindableObservableVector
+    {
+        CustomBindableObservableVectorTest();
+    }
+
+    [default_interface]
+    runtimeclass CustomIteratorTest : Windows.Foundation.Collections.IIterator<Int32>
+    {
+        CustomIteratorTest();
     }
 
     // SupportedOSPlatform warning tests

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -1361,7 +1361,7 @@ namespace UnitTest
 
             private void OnChanged()
             {
-                VectorChanged.Invoke(this, _observation = new TObservation());
+                VectorChanged?.Invoke(this, _observation = new TObservation());
             }
 
             public event BindableVectorChangedEventHandler VectorChanged;
@@ -2575,6 +2575,39 @@ namespace UnitTest
 
             var enumerator = ((IEnumerable)vector).GetEnumerator();
             Assert.NotNull(enumerator);
+        }
+
+        [Fact]
+        public void TestBindableObservableVector()
+        {
+            CustomBindableObservableVectorTest vector = new CustomBindableObservableVectorTest();
+            Assert.Equal(1, vector.Count);
+            Assert.False(vector.IsSynchronized);
+            Assert.NotNull(vector.SyncRoot);
+            Assert.Equal(1, vector[0]);
+            vector.Clear();
+        }
+
+        [Fact]
+        public void TestNonProjectedBindableObservableVector()
+        {
+            var expected = new int[] { 0, 1, 2 };
+            var observable = new ManagedBindableObservable(expected);
+            var nativeObservable = TestObject.GetBindableObservableVector(observable);
+            Assert.Equal(3, nativeObservable.Count);
+            Assert.NotNull(nativeObservable.SyncRoot);
+            Assert.Equal(0, nativeObservable[0]);
+            nativeObservable.Clear();
+            Assert.Equal(0, nativeObservable.Count);
+        }
+
+        [Fact(Skip = "InvalidOperationException due to missing non-generic IEnumerator #1302")]
+        public void TestIterator()
+        {
+            CustomIteratorTest iterator = new CustomIteratorTest();
+            iterator.MoveNext();
+            Assert.Equal(2, iterator.Current);
+            Assert.Equal(2, ((IEnumerator)iterator).Current);
         }
 
         [Fact]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2568,6 +2568,13 @@ namespace UnitTest
         {
             CustomBindableVectorTest vector = new CustomBindableVectorTest();
             Assert.NotNull(vector);
+            Assert.Equal(1, vector.Count);
+            Assert.False(vector.IsSynchronized);
+            Assert.NotNull(vector.SyncRoot);
+            Assert.Equal(1, vector[0]);
+
+            var enumerator = ((IEnumerable)vector).GetEnumerator();
+            Assert.NotNull(enumerator);
         }
 
         [Fact]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2547,7 +2547,7 @@ namespace UnitTest
             Assert.NotNull(cryptoKey);
         }
 
-        [Fact(Skip="Operation not supported")]
+        [Fact]
         public void TestIBindableIterator()
         {
             CustomBindableIteratorTest bindableIterator = new CustomBindableIteratorTest();

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2594,6 +2594,7 @@ namespace UnitTest
             var expected = new int[] { 0, 1, 2 };
             var observable = new ManagedBindableObservable(expected);
             var nativeObservable = TestObject.GetBindableObservableVector(observable);
+            Assert.Equal(3, ((ICollection)(object)nativeObservable).Count);
             Assert.Equal(3, nativeObservable.Count);
             Assert.NotNull(nativeObservable.SyncRoot);
             Assert.Equal(0, nativeObservable[0]);

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -95,6 +95,18 @@ namespace WinRT
                     return true;
                 }
             }
+            else if (type == typeof(System.Collections.ICollection))
+            {
+                Type iList = typeof(global::System.Collections.IList);
+                if (IsInterfaceImplemented(iList.TypeHandle, false))
+                {
+                    if (QueryInterfaceCache.TryGetValue(iList.TypeHandle, out var typedObjRef) && !QueryInterfaceCache.TryAdd(interfaceType, typedObjRef))
+                    {
+                        typedObjRef.Dispose();
+                    }
+                    return true;
+                }
+            }
 
             Type helperType = type.FindHelperType();
             if (helperType is null || !helperType.IsInterface)

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -104,7 +104,7 @@ namespace WinRT
 #if NET
             CustomTypeToHelperTypeMappings.Add(typeof(ICollection<>), typeof(ABI.System.Collections.Generic.ICollection<>));
             CustomTypeToHelperTypeMappings.Add(typeof(IReadOnlyCollection<>), typeof(ABI.System.Collections.Generic.IReadOnlyCollection<>));
-            CustomTypeToHelperTypeMappings.Add(typeof(ICollection), typeof(ABI.System.Collections.Generic.ICollection));
+            CustomTypeToHelperTypeMappings.Add(typeof(ICollection), typeof(ABI.System.Collections.ICollection));
 #endif
             RegisterCustomAbiTypeMappingNoLock(typeof(EventHandler), typeof(ABI.System.EventHandler));
 

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -104,6 +104,7 @@ namespace WinRT
 #if NET
             CustomTypeToHelperTypeMappings.Add(typeof(ICollection<>), typeof(ABI.System.Collections.Generic.ICollection<>));
             CustomTypeToHelperTypeMappings.Add(typeof(IReadOnlyCollection<>), typeof(ABI.System.Collections.Generic.IReadOnlyCollection<>));
+            CustomTypeToHelperTypeMappings.Add(typeof(ICollection), typeof(ABI.System.Collections.Generic.ICollection));
 #endif
             RegisterCustomAbiTypeMappingNoLock(typeof(EventHandler), typeof(ABI.System.EventHandler));
 

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -1275,7 +1275,7 @@ namespace ABI.System.Collections
             return ObjectReference<Vftbl>.FromAbi(thisPtr);
         }
 
-        private static FromAbiHelper _VectorToList(IWinRTObject _this)
+        internal static FromAbiHelper _VectorToList(IWinRTObject _this)
         {
             return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.IList).TypeHandle,
                 () => new FromAbiHelper((global::Microsoft.UI.Xaml.Interop.IBindableVector)_this));

--- a/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
@@ -691,7 +691,7 @@ namespace ABI.System.Collections
 
             public void Clear()
             {
-                _vector.Clear();
+                _vector._Clear();
             }
 
             public bool IsFixedSize { get => false; }

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -29,7 +29,7 @@ namespace ABI.System.Collections.Generic
                         .Invoke(new object[] { _this.NativeObject });
                 }
             }
-             
+
             var iReadOnlyList = typeof(global::System.Collections.Generic.IReadOnlyList<T>);
             if (_this.IsInterfaceImplemented(iReadOnlyList.TypeHandle, false))
             {
@@ -41,7 +41,7 @@ namespace ABI.System.Collections.Generic
 
         private static global::System.Collections.Generic.IReadOnlyCollection<T> GetHelper(IWinRTObject _this)
         {
-            return (global::System.Collections.Generic.IReadOnlyCollection<T>) _this.GetOrCreateTypeHelperData(
+            return (global::System.Collections.Generic.IReadOnlyCollection<T>)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.Generic.IReadOnlyCollection<T>).TypeHandle,
                 () => CreateHelper(_this));
         }
@@ -90,7 +90,7 @@ namespace ABI.System.Collections.Generic
                 () => CreateHelper(_this));
         }
 
-        int global::System.Collections.Generic.ICollection<T>.Count 
+        int global::System.Collections.Generic.ICollection<T>.Count
             => GetHelper((IWinRTObject)this).Count;
 
         bool global::System.Collections.Generic.ICollection<T>.IsReadOnly
@@ -117,7 +117,10 @@ namespace ABI.System.Collections.Generic
         global::System.Collections.Generic.IEnumerator<T> global::System.Collections.Generic.IEnumerable<T>.GetEnumerator()
             => GetHelper((IWinRTObject)this).GetEnumerator();
     }
+}
 
+namespace ABI.System.Collections
+{
     [DynamicInterfaceCastableImplementation]
     interface ICollection : global::System.Collections.ICollection
     {

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -36,7 +36,7 @@ namespace ABI.System.Collections.Generic
                 return new global::System.Collections.Generic.IReadOnlyListImpl<T>(_this.NativeObject);
             }
 
-            throw new InvalidOperationException("IReadOnlyCollection helper can not determine derived type.");
+            throw new InvalidOperationException("IReadOnlyCollection<> helper can not determine derived type.");
         }
 
         private static global::System.Collections.Generic.IReadOnlyCollection<T> GetHelper(IWinRTObject _this)
@@ -80,7 +80,7 @@ namespace ABI.System.Collections.Generic
                 return new global::System.Collections.Generic.IListImpl<T>(_this.NativeObject);
             }
 
-            throw new InvalidOperationException("ICollection helper can not determine derived type.");
+            throw new InvalidOperationException("ICollection<> helper can not determine derived type.");
         }
 
         private static global::System.Collections.Generic.ICollection<T> GetHelper(IWinRTObject _this)
@@ -115,6 +115,43 @@ namespace ABI.System.Collections.Generic
             => GetHelper((IWinRTObject)this).GetEnumerator();
 
         global::System.Collections.Generic.IEnumerator<T> global::System.Collections.Generic.IEnumerable<T>.GetEnumerator()
+            => GetHelper((IWinRTObject)this).GetEnumerator();
+    }
+
+    [DynamicInterfaceCastableImplementation]
+    interface ICollection : global::System.Collections.ICollection
+    {
+        private static global::System.Collections.ICollection CreateHelper(IWinRTObject _this)
+        {
+            var iList = typeof(global::System.Collections.IList);
+            if (_this.IsInterfaceImplemented(iList.TypeHandle, false))
+            {
+                return IList._VectorToList(_this);
+            }
+
+            throw new InvalidOperationException("ICollection helper can not determine derived type.");
+        }
+
+        private static global::System.Collections.ICollection GetHelper(IWinRTObject _this)
+        {
+            return (global::System.Collections.ICollection)_this.GetOrCreateTypeHelperData(
+                typeof(global::System.Collections.ICollection).TypeHandle,
+                () => CreateHelper(_this));
+        }
+
+        int global::System.Collections.ICollection.Count
+            => GetHelper((IWinRTObject)this).Count;
+
+        bool global::System.Collections.ICollection.IsSynchronized
+            => GetHelper((IWinRTObject)this).IsSynchronized;
+
+        object global::System.Collections.ICollection.SyncRoot
+            => GetHelper((IWinRTObject)this).SyncRoot;
+
+        void global::System.Collections.ICollection.CopyTo(Array array, int arrayIndex)
+            => GetHelper((IWinRTObject)this).CopyTo(array, arrayIndex);
+
+        IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
             => GetHelper((IWinRTObject)this).GetEnumerator();
     }
 }


### PR DESCRIPTION
We previously had support for handling the ICollection<> interface.  But we were missing the non-generic ICollection interface.  This causes IDIC casts to that interface to fail which is used by IList.  Resolving it by handling it similarly to ICollection<> via our IDIC hybrid collection support.

Note, I did a review of the other interfaces and found out that the non-generic IEnumerator might also be affected in some scenarios.  Tracking that separately with #1302 given it has the possibility of requiring a change to our API surface.