### PR TITLE
Move factory caching into BaseActivationFactory and invalidate instance when context is different to avoid CO_E_OBJNOTCONNECTED.

### DIFF
--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -7,7 +7,7 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    static class Context
+    public static class Context
     {
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern unsafe int CoGetContextToken(IntPtr* contextToken);

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -7,7 +7,7 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    public static class Context
+    static class Context
     {
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern unsafe int CoGetContextToken(IntPtr* contextToken);

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -7,10 +7,8 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    static class Context
+    internal static partial class Context
     {
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        private static extern unsafe int CoGetContextToken(IntPtr* contextToken);
 
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
@@ -23,14 +21,6 @@ namespace WinRT
             Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
             return contextCallbackPtr;
         }
-
-        public unsafe static IntPtr GetContextToken()
-        {
-            IntPtr contextToken;
-            Marshal.ThrowExceptionForHR(CoGetContextToken(&contextToken));
-            return contextToken;
-        }
-
         // Calls the given callback in the right context.
         // On any exception, calls onFail callback if any set.
         // If not set, exception is handled due to today we don't

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2106,24 +2106,14 @@ private IObjectReference % => __% ?? Make__%();
             {
                 auto objrefname = bind<write_objref_type_name>(factory.type);
                 w.write(R"(
-private static volatile IObjectReference __%;
-private static IObjectReference Make__%()
-{
-    global::System.Threading.Interlocked.CompareExchange(ref __%, %As(GuidGenerator.GetIID(typeof(%).GetHelperType())), null);
-    return __%;
-}
-private static IObjectReference % => __% ?? Make__%();
+private static IObjectReference % => %As(GuidGenerator.GetIID(typeof(%).GetHelperType()));
 
 )",
                     objrefname,
                     objrefname,
                     objrefname,
                     target,
-                    bind<write_type_name>(factory.type, typedef_name_type::Projected, false),
-                    objrefname,
-                    objrefname,
-                    objrefname,
-                    objrefname);
+                    bind<write_type_name>(factory.type, typedef_name_type::Projected, false));
             }
         }
     }

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -390,50 +390,50 @@ namespace WinRT
         }
     }
 
-    internal static class Context
-    {
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        private static extern unsafe int CoGetContextToken(IntPtr* contextToken);
-
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
-
-        private static readonly Guid IID_ICallbackWithNoReentrancyToApplicationSTA = new(0x0A299774, 0x3E4E, 0xFC42, 0x1D, 0x9D, 0x72, 0xCE, 0xE1, 0x05, 0xCA, 0x57);
-
-        internal static IntPtr GetContextCallback()
-        {
-            Guid riid = ABI.WinRT.Interop.IContextCallback.IID;
-            Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
-            return contextCallbackPtr;
-        }
-
-        internal unsafe static IntPtr GetContextToken()
-        {
-            IntPtr contextToken;
-            Marshal.ThrowExceptionForHR(CoGetContextToken(&contextToken));
-            return contextToken;
-        }
-
-        // If we are free threaded, we do not need to keep track of context.
-        // This can either be if the object implements IAgileObject or the free threaded marshaler.
-        internal unsafe static bool IsFreeThreaded(IObjectReference objRef)
-        {
-            if (objRef.TryAs(ABI.WinRT.Interop.IAgileObject.IID, out var agilePtr) >= 0)
-            {
-                Marshal.Release(agilePtr);
-                return true;
-            }
-            return false;
-        }
-
-        public static void DisposeContextCallback(IntPtr contextCallbackPtr)
-        {
-            MarshalInspectable<object>.DisposeAbi(contextCallbackPtr);
-        }
-    }
-
     internal class BaseActivationFactory
     {
+        internal static class Context
+        {
+            [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+            private static extern unsafe int CoGetContextToken(IntPtr* contextToken);
+
+            [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+            private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
+
+            private static readonly Guid IID_ICallbackWithNoReentrancyToApplicationSTA = new(0x0A299774, 0x3E4E, 0xFC42, 0x1D, 0x9D, 0x72, 0xCE, 0xE1, 0x05, 0xCA, 0x57);
+
+            internal static IntPtr GetContextCallback()
+            {
+                Guid riid = new(0x000001da, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+                Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
+                return contextCallbackPtr;
+            }
+
+            internal unsafe static IntPtr GetContextToken()
+            {
+                IntPtr contextToken;
+                Marshal.ThrowExceptionForHR(CoGetContextToken(&contextToken));
+                return contextToken;
+            }
+
+            // If we are free threaded, we do not need to keep track of context.
+            // This can either be if the object implements IAgileObject or the free threaded marshaler.
+            internal unsafe static bool IsFreeThreaded(IObjectReference objRef)
+            {
+                if (objRef.TryAs(new(0x94ea2b94, 0xe9cc, 0x49e0, 0xc0, 0xff, 0xee, 0x64, 0xca, 0x8f, 0x5b, 0x90), out var agilePtr) >= 0)
+                {
+                    Marshal.Release(agilePtr);
+                    return true;
+                }
+                return false;
+            }
+
+            internal static void DisposeContextCallback(IntPtr contextCallbackPtr)
+            {
+                MarshalInspectable<object>.DisposeAbi(contextCallbackPtr);
+            }
+        }
+
         internal sealed class BaseActivationFactoryEntry : IDisposable
         {
             public IntPtr _contextToken;
@@ -571,7 +571,7 @@ namespace WinRT
         public IObjectReference _As(Guid iid)
         {
             var entry = Entry;
-            return entry._IActivationFactoryIIDCache.GetOrAdd(iid, _ => entry._IActivationFactory.As<WinRT.Interop.IUnknownVftbl>(iid));
+            return entry._IActivationFactoryIIDCache.GetOrAdd(iid, g => entry._IActivationFactory.As(g));
         }
     }
 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -577,12 +577,11 @@ namespace WinRT
 
     internal sealed class ActivationFactory<T> : BaseActivationFactory
     {
+        private static ActivationFactory<T> _instance;
+
         public ActivationFactory() : base(typeof(T).Namespace, typeof(T).FullName) { }
 
-        static readonly ActivationFactory<T> _factory = new ActivationFactory<T>();
-        public static new I AsInterface<I>() => _factory.Value.AsInterface<I>();
-        public static ObjectReference<I> As<I>() => _factory._As<I>();
-        public static IObjectReference As(Guid iid) => _factory._As(iid);
+        public static ActivationFactory<T> Instance => LazyInitializer.EnsureInitialized(ref _instance, () => new ActivationFactory<T>());
 
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:RequiresUnreferencedCode", 
@@ -591,8 +590,8 @@ namespace WinRT
         public static ObjectReference<I> ActivateInstance<
 #if NET
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.None)]
-#endif
-            I>() => _factory._ActivateInstance<I>();
+#endif 
+            I>() => Instance._ActivateInstance<I>();
     }
 
     internal class ComponentActivationFactory : global::WinRT.Interop.IActivationFactory

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -533,8 +533,8 @@ namespace WinRT
         {
             bool isFreeThreaded = Context.IsFreeThreaded(objRef);
             var entry = new BaseActivationFactoryEntry();
-            entry._contextToken = isFreeThreaded ? Context.GetContextToken() : IntPtr.Zero;
-            entry._contextCallbackPtr = isFreeThreaded ? Context.GetContextCallback() : IntPtr.Zero;
+            entry._contextToken = isFreeThreaded ? IntPtr.Zero : Context.GetContextToken();
+            entry._contextCallbackPtr = isFreeThreaded ? IntPtr.Zero : Context.GetContextCallback();
             entry._IActivationFactory = objRef;
             entry._IActivationFactoryIIDCache = new ConcurrentDictionary<Guid, IObjectReference>();
             return entry;


### PR DESCRIPTION
Move factory caching into BaseActivationFactory and cache factories per context, similar to coreclr/.NET Native behavior.

Fixes #1112