### PR TITLE
Wrapped enums should implement IPropertyValue and IReference of the underlying type.

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -562,7 +562,7 @@ namespace WinRT
                     return IsIReferenceTypeHelper(type);
                 if (!type.IsValueType)
                     return false;
-                return type.IsPrimitive || IsIReferenceTypeHelper(type);
+                return type.IsPrimitive || type.IsEnum || IsIReferenceTypeHelper(type);
             });
         }
 
@@ -577,6 +577,11 @@ namespace WinRT
 
         private static ComInterfaceEntry ProvideIReference(Type type)
         {
+            if (type.IsEnum)
+            {
+                type = type.GetEnumUnderlyingType();
+            }
+
             if (type == typeof(int))
             {
                 return new ComInterfaceEntry

--- a/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
@@ -1180,9 +1180,14 @@ namespace ABI.Windows.Foundation
             global::Windows.Foundation.PropertyType value;
             global::System.Type managedType = obj.GetType();
             bool isArray = managedType.IsArray;
+            bool isEnum = managedType.IsEnum;
             if (isArray)
             {
                 managedType = managedType.GetElementType();
+            }
+            else if (isEnum)
+            {
+                managedType = managedType.GetEnumUnderlyingType();
             }
             if (!NumericScalarTypes.TryGetValue(managedType, out value))
             {

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -11,10 +11,10 @@
     <Company>Microsoft Corporation</Company>
     <Product>C#/WinRT</Product>
     <PackageId>WinRT.Runtime</PackageId>
-    <FileVersion>$(VersionNumber)</FileVersion>
-    <Version>$(VersionNumber)</Version>
-    <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
-    <InformationalVersion>$(VersionNumber)</InformationalVersion>
+    <FileVersion>2.0.0</FileVersion>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <InformationalVersion>2.0.0</InformationalVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>C#/WinRT Runtime v$(VersionString)</Description>
     <AssemblyTitle>C#/WinRT Runtime v$(VersionString)</AssemblyTitle>


### PR DESCRIPTION
Fixes ADO#43881817