### PR TITLE
Return false if TryAppendTypeName fails for an array type.

### DIFF
--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -432,7 +432,7 @@ namespace WinRT
                     builder.Append('>');
                     return true;
                 }
-                return true;
+                return false;
             }
 
             if (!type.IsGenericType || type.IsGenericTypeDefinition)


### PR DESCRIPTION
This avoids returning a broken type name of "Windows.Foundation.IReferenceArray`1<"