### PR TITLE
Remove IReference cache and add various tests for IPropertyValue and GetRuntimeClassName.

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -345,7 +345,7 @@ TEST(AuthoringTest, CustomTypes)
     }
 
     auto erasedProjectedArrays = testClass.GetTypeErasedProjectedArrays();
-    EXPECT_EQ(erasedProjectedArrays.Size(), 8);
+    EXPECT_EQ(erasedProjectedArrays.Size(), 7);
     for (auto obj : erasedProjectedArrays)
     {
         auto ra = obj.try_as<IPropertyValue>();

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -459,7 +459,6 @@ namespace AuthoringTest
                 new BasicDelegate[] { new BasicDelegate((uint value) => {}) },
                 new [] { new DisposableClass().GetType() , new NonProjectedDisposableClass().GetType() },
                 new Type[] { typeof(TestClass), typeof(DisposableClass) },
-                new PrivateEnum[] { PrivateEnum.PrivateFirst, PrivateEnum.PrivateSecond}
             };
         }
     }

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1528,6 +1528,11 @@ namespace winrt::TestComponentCSharp::implementation
         return obj.as<IReferenceArray<hstring>>().Value();
     }
 
+    PropertyType Class::GetPropertyType(WF::IInspectable const& obj)
+    {
+        return obj.as<IPropertyValue>().Type();
+    }
+
     TypeName Class::Int32Type()
     {
         return winrt::xaml_typename<int32_t>();

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1528,9 +1528,18 @@ namespace winrt::TestComponentCSharp::implementation
         return obj.as<IReferenceArray<hstring>>().Value();
     }
 
-    PropertyType Class::GetPropertyType(WF::IInspectable const& obj)
+    int32_t Class::GetPropertyType(IInspectable const& obj)
     {
-        return obj.as<IPropertyValue>().Type();
+        if (auto ipv = obj.try_as<IPropertyValue>())
+        {
+            return static_cast<int32_t>(ipv.Type());
+        }
+        return -1;
+    }
+
+    hstring Class::GetName(IInspectable const& obj)
+    {
+        return get_class_name(obj);
     }
 
     TypeName Class::Int32Type()

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -367,6 +367,8 @@ namespace winrt::TestComponentCSharp::implementation
         static com_array<bool> UnboxBooleanArray(IInspectable const& obj);
         static com_array<hstring> UnboxStringArray(IInspectable const& obj);
 
+        static Windows::Foundation::PropertyType GetPropertyType(IInspectable const& obj);
+
         static Windows::UI::Xaml::Interop::TypeName Int32Type();
         static Windows::UI::Xaml::Interop::TypeName ReferenceInt32Type();
         static Windows::UI::Xaml::Interop::TypeName ThisClassType();

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -367,7 +367,8 @@ namespace winrt::TestComponentCSharp::implementation
         static com_array<bool> UnboxBooleanArray(IInspectable const& obj);
         static com_array<hstring> UnboxStringArray(IInspectable const& obj);
 
-        static Windows::Foundation::PropertyType GetPropertyType(IInspectable const& obj);
+        static int GetPropertyType(Windows::Foundation::IInspectable const& obj);
+        static hstring GetName(Windows::Foundation::IInspectable const& obj);
 
         static Windows::UI::Xaml::Interop::TypeName Int32Type();
         static Windows::UI::Xaml::Interop::TypeName ReferenceInt32Type();

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -392,7 +392,8 @@ namespace TestComponentCSharp
         static Object BoxedDelegate{ get; };
         static Object BoxedEnum{ get; };
 
-        static Windows.Foundation.PropertyType GetPropertyType(Object obj);
+        static Int32 GetPropertyType(Object obj);
+        static String GetName(Object obj);
 
         // WUX.Interop.TypeName -> System.Type mapping
         static Windows.UI.Xaml.Interop.TypeName Int32Type { get; };

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -392,6 +392,8 @@ namespace TestComponentCSharp
         static Object BoxedDelegate{ get; };
         static Object BoxedEnum{ get; };
 
+        static Windows.Foundation.PropertyType GetPropertyType(Object obj);
+
         // WUX.Interop.TypeName -> System.Type mapping
         static Windows.UI.Xaml.Interop.TypeName Int32Type { get; };
         static Windows.UI.Xaml.Interop.TypeName ThisClassType { get; };

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2208,6 +2208,16 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestNonWinRTEnumType()
+        {
+            FileMode fileMode = FileMode.Open;
+            Assert.Equal(PropertyType.OtherType, Class.GetPropertyType(fileMode));
+
+            FileMode[] fileModeArray = new FileMode[] { FileMode.Open };
+            Assert.Equal(PropertyType.OtherTypeArray, Class.GetPropertyType(fileModeArray));
+        }
+
+        [Fact]
         public void PrimitiveTypeInfo()
         {
             Assert.Equal(typeof(int), Class.Int32Type);

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -53,6 +53,13 @@ namespace UnitTest
             TestObject = new Class();
         }
 
+        public enum E { A, B, C }
+
+        public struct Estruct
+        {
+            E value;
+        }
+
 
         // Test a fix for a bug in Mono.Cecil that was affecting the IIDOptimizer when it encountered long class names 
         [Fact]
@@ -2152,6 +2159,48 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestGetPropertyType()
+        {
+            Array arr = new[] { E.A, E.B, E.C };
+            Array arr2 = new[] { new Estruct(), new Estruct() };
+            Array arr3 = new int[] { 1, 2, 3 };
+            IList<E> arr4 = new List<E>() { E.A, E.B, E.C };
+            Array arr5 = new PropertyType[] { PropertyType.UInt8, PropertyType.Int16, PropertyType.UInt16 };
+
+            Assert.Equal(-1, Class.GetPropertyType(arr));
+            Assert.Equal(-1, Class.GetPropertyType(arr2));
+            Assert.Equal((int)PropertyType.Int32Array, Class.GetPropertyType(arr3));
+            Assert.Equal(-1, Class.GetPropertyType(arr4));
+            Assert.Equal((int)PropertyType.OtherTypeArray, Class.GetPropertyType(arr5));
+            Assert.Equal(-1, Class.GetPropertyType(arr.GetValue(0)));
+            Assert.Equal(-1, Class.GetPropertyType(arr2.GetValue(0)));
+            Assert.Equal((int)PropertyType.Int32, Class.GetPropertyType(arr3.GetValue(0)));
+            Assert.Equal(-1, Class.GetPropertyType(arr4[0]));
+            Assert.Equal((int)PropertyType.OtherType, Class.GetPropertyType(arr5.GetValue(0)));
+        }
+
+        [Fact]
+        public void TestGetRuntimeClassName()
+        {
+            Array arr = new[] { E.A, E.B, E.C };
+            Array arr2 = new[] { new Estruct(), new Estruct() };
+            Array arr3 = new int[] { 1, 2, 3 };
+            IList<E> arr4 = new List<E>() { E.A, E.B, E.C };
+            Array arr5 = new PropertyType[] { PropertyType.UInt8, PropertyType.Int16, PropertyType.UInt16 };
+
+            Assert.Equal(string.Empty, Class.GetName(arr));
+            Assert.Equal(string.Empty, Class.GetName(arr2));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Int32>", Class.GetName(arr3));
+            Assert.Equal("Microsoft.UI.Xaml.Interop.IBindableVector", Class.GetName(arr4));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Windows.Foundation.PropertyType>", Class.GetName(arr5));
+            Assert.Equal(string.Empty, Class.GetName(arr.GetValue(0)));
+            Assert.Equal(string.Empty, Class.GetName(arr2.GetValue(0)));
+            Assert.Equal("Windows.Foundation.IReference`1<Int32>", Class.GetName(arr3.GetValue(0)));
+            Assert.Equal(string.Empty, Class.GetName(arr4[0]));
+            Assert.Equal("Windows.Foundation.IReference`1<Windows.Foundation.PropertyType>", Class.GetName(arr5.GetValue(0)));
+        }
+
+        [Fact]
         public void TestGeneratedRuntimeClassName_Primitive()
         {
             IInspectable inspectable = new IInspectable(ComWrappersSupport.CreateCCWForObject(2));
@@ -2205,16 +2254,6 @@ namespace UnitTest
             var obj = PropertyValue.CreateInt32Array(i);
             Assert.IsType<int[]>(obj);
             Assert.Equal(i, (IEnumerable<int>)obj);
-        }
-
-        [Fact]
-        public void TestNonWinRTEnumType()
-        {
-            FileMode fileMode = FileMode.Open;
-            Assert.Equal(PropertyType.OtherType, Class.GetPropertyType(fileMode));
-
-            FileMode[] fileModeArray = new FileMode[] { FileMode.Open };
-            Assert.Equal(PropertyType.OtherTypeArray, Class.GetPropertyType(fileModeArray));
         }
 
         [Fact]

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -207,7 +207,7 @@ namespace WinRT
                     });
                 }
 
-                if (ShouldProvideIReference(type))
+                if (type.ShouldProvideIReference())
                 {
                     entries.Add(IPropertyValueEntry);
                     entries.Add(ProvideIReference(type));
@@ -250,7 +250,25 @@ namespace WinRT
                     }
                 }
 
-                if (objType.IsGenericType && objType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
+#if !NET
+                // We can't easily determine from just the type
+                // if the array is an "single dimension index from zero"-array in .NET Standard 2.0,
+                // so just approximate it.
+                // (Other array types will be blocked in other code-paths anyway where we have an object.)
+                if (type.IsArray && type.GetArrayRank() == 1)
+#else
+                if (type.IsSZArray)
+#endif
+                {
+                    // We treat arrays as if they implemented IIterable<T>, IVector<T>, and IVectorView<T> (WinRT only)
+                    var elementType = type.GetElementType();
+                    if (elementType.ShouldProvideIReference())
+                    {
+                        entries.Add(IPropertyValueEntry);
+                        entries.Add(ProvideIReferenceArray(type));
+                    }
+                }
+                else if (objType.IsGenericType && objType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
                 {
                     var ifaceAbiType = objType.FindHelperType();
                     entries.Add(new ComInterfaceEntry
@@ -259,15 +277,10 @@ namespace WinRT
                         Vtable = (IntPtr)ifaceAbiType.GetAbiToProjectionVftblPtr()
                     });
                 }
-                else if (ShouldProvideIReference(type))
+                else if (type.ShouldProvideIReference())
                 {
                     entries.Add(IPropertyValueEntry);
                     entries.Add(ProvideIReference(type));
-                }
-                else if (ShouldProvideIReferenceArray(type))
-                {
-                    entries.Add(IPropertyValueEntry);
-                    entries.Add(ProvideIReferenceArray(type));
                 }
             }
 
@@ -344,21 +357,6 @@ namespace WinRT
             return (
                 new InspectableInfo(type, iids),
                 interfaceTableEntries);
-        }
-
-        private static bool IsNullableT(Type implementationType)
-        {
-            return implementationType.IsGenericType && implementationType.GetGenericTypeDefinition() == typeof(System.Nullable<>);
-        }
-
-        private static bool IsAbiNullableDelegate(Type implementationType)
-        {
-            return implementationType.IsGenericType && implementationType.GetGenericTypeDefinition() == typeof(ABI.System.Nullable_Delegate<>);
-        }
-
-        private static bool IsIReferenceArray(Type implementationType)
-        {
-            return implementationType.IsGenericType && implementationType.GetGenericTypeDefinition() == typeof(Windows.Foundation.IReferenceArray<>);
         }
 
         private static Func<IInspectable, object> CreateKeyValuePairFactory(Type type)
@@ -481,7 +479,7 @@ namespace WinRT
 
             if (implementationType.IsValueType)
             {
-                if (IsNullableT(implementationType))
+                if (implementationType.IsNullableT())
                 {
                     return CreateReferenceCachingFactory(CreateNullableTFactory(implementationType));
                 }
@@ -490,11 +488,11 @@ namespace WinRT
                     return CreateReferenceCachingFactory(CreateNullableTFactory(typeof(System.Nullable<>).MakeGenericType(implementationType)));
                 }
             }
-            else if (IsAbiNullableDelegate(implementationType))
+            else if (implementationType.IsAbiNullableDelegate())
             {
                 return CreateReferenceCachingFactory(CreateAbiNullableTFactory(implementationType));
             }
-            else if (IsIReferenceArray(implementationType))
+            else if (implementationType.IsIReferenceArray())
             {
                 return CreateReferenceCachingFactory(CreateArrayFactory(implementationType));
             }
@@ -535,38 +533,6 @@ namespace WinRT
 
             return implementationType;
         }
-
-        private readonly static ConcurrentDictionary<Type, bool> IsIReferenceTypeCache = new ConcurrentDictionary<Type, bool>();
-        private static bool IsIReferenceType(Type type)
-        {
-            static bool IsIReferenceTypeHelper(Type type)
-            {
-                if (type.IsDefined(typeof(WindowsRuntimeTypeAttribute)) ||
-                    WinRT.Projections.IsTypeWindowsRuntimeType(type))
-                    return true;
-                type = type.GetAuthoringMetadataType();
-                if (type is object)
-                {
-                    if (type.IsDefined(typeof(WindowsRuntimeTypeAttribute)) ||
-                        WinRT.Projections.IsTypeWindowsRuntimeType(type))
-                        return true;
-                }
-                return false;
-            }
-
-            return IsIReferenceTypeCache.GetOrAdd(type, (type) =>
-            {
-                if (type == typeof(string) || type.IsTypeOfType())
-                    return true;
-                if (type.IsDelegate())
-                    return IsIReferenceTypeHelper(type);
-                if (!type.IsValueType)
-                    return false;
-                return type.IsPrimitive || type.IsEnum || IsIReferenceTypeHelper(type);
-            });
-        }
-
-        private static bool ShouldProvideIReference(Type type) => IsIReferenceType(type);
 
         private static ComInterfaceEntry IPropertyValueEntry =>
             new ComInterfaceEntry
@@ -738,12 +704,6 @@ namespace WinRT
             };
         }
 
-        private static bool ShouldProvideIReferenceArray(Type type)
-        {
-            // Check if one dimensional array with lower bound of 0
-            return type.IsArray && type == type.GetElementType().MakeArrayType() && !type.GetElementType().IsArray;
-        }
-
         private static ComInterfaceEntry ProvideIReferenceArray(Type arrayType)
         {
             Type type = arrayType.GetElementType();
@@ -899,7 +859,7 @@ namespace WinRT
 
             internal InspectableInfo(Type type, Guid[] iids)
             {
-                runtimeClassName = new Lazy<string>(() => TypeNameSupport.GetNameForType(type, TypeNameGenerationFlags.GenerateBoxedName | TypeNameGenerationFlags.NoCustomTypeName));
+                runtimeClassName = new Lazy<string>(() => TypeNameSupport.GetNameForType(type, TypeNameGenerationFlags.GenerateBoxedName | TypeNameGenerationFlags.ForGetRuntimeClassName));
                 IIDs = iids;
             }
         }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -562,7 +562,7 @@ namespace WinRT
                     return IsIReferenceTypeHelper(type);
                 if (!type.IsValueType)
                     return false;
-                return type.IsPrimitive || IsIReferenceTypeHelper(type);
+                return type.IsPrimitive || type.IsEnum || IsIReferenceTypeHelper(type);
             });
         }
 

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -169,6 +169,32 @@ namespace WinRT
             return typeof(Delegate).IsAssignableFrom(type);
         }
 
+        internal static bool IsNullableT(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Nullable<>);
+        }
+
+        internal static bool IsAbiNullableDelegate(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ABI.System.Nullable_Delegate<>);
+        }
+
+        internal static bool IsIReferenceArray(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Windows.Foundation.IReferenceArray<>);
+        }
+
+        internal static bool ShouldProvideIReference(this Type type)
+        {
+            return type.IsPrimitive ||
+                type == typeof(string) ||
+                type == typeof(Guid) ||
+                type == typeof(DateTimeOffset) ||
+                type == typeof(TimeSpan) ||
+                type.IsTypeOfType() ||
+                ((type.IsValueType || type.IsDelegate()) && Projections.IsTypeWindowsRuntimeType(type));
+        }
+
         internal static bool IsTypeOfType(this Type type)
         {
             return typeof(Type).IsAssignableFrom(type);

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -25,7 +25,7 @@ namespace WinRT
         /// <summary>
         /// Don't output a type name of a custom .NET type. Generate a compatible WinRT type name if needed.
         /// </summary>
-        ForGetRuntimeClassName = 0x1,
+        ForGetRuntimeClassName = 0x2,
     }
 
     internal static class TypeNameSupport

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
@@ -24,7 +25,7 @@ namespace WinRT
         /// <summary>
         /// Don't output a type name of a custom .NET type. Generate a compatible WinRT type name if needed.
         /// </summary>
-        NoCustomTypeName = 0x2
+        ForGetRuntimeClassName = 0x1,
     }
 
     internal static class TypeNameSupport
@@ -295,7 +296,7 @@ namespace WinRT
 
         /// <summary>
         /// Tracker for visited types when determining a WinRT interface to use as the type name.
-        /// Only used when GetNameForType is called with <see cref="TypeNameGenerationFlags.NoCustomTypeName"/>.
+        /// Only used when GetNameForType is called with <see cref="TypeNameGenerationFlags.ForGetRuntimeClassName"/>.
         /// </summary>
         private static readonly ThreadLocal<Stack<VisitedType>> VisitedTypes = new ThreadLocal<Stack<VisitedType>>(() => new Stack<VisitedType>());
 
@@ -310,23 +311,13 @@ namespace WinRT
             {
                 return nameBuilder.ToString();
             }
-            return null;
+            return string.Empty;
         }
 
         private static bool TryAppendSimpleTypeName(Type type, StringBuilder builder, TypeNameGenerationFlags flags)
         {
             if (type.IsPrimitive || type == typeof(string) || type == typeof(Guid) || type == typeof(TimeSpan))
             {
-                if ((flags & TypeNameGenerationFlags.GenerateBoxedName) != 0)
-                {
-                    builder.Append("Windows.Foundation.IReference`1<");
-                    if (!TryAppendSimpleTypeName(type, builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
-                    {
-                        return false;
-                    }
-                    builder.Append('>');
-                    return true;
-                }
                 if (type == typeof(byte))
                 {
                     builder.Append("UInt8");
@@ -355,13 +346,16 @@ namespace WinRT
                 {
                     builder.Append(type.FullName);
                 }
-                else if ((flags & TypeNameGenerationFlags.NoCustomTypeName) != 0)
-                {
-                    return TryAppendWinRTInterfaceNameForType(type, builder, flags);
-                }
                 else
                 {
-                    builder.Append(type.FullName);
+                    if ((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0)
+                    {
+                        return TryAppendWinRTInterfaceNameForType(type, builder, flags);
+                    }
+                    else
+                    {
+                        builder.Append(type.FullName);
+                    }
                 }
             }
             return true;
@@ -369,7 +363,7 @@ namespace WinRT
 
         private static bool TryAppendWinRTInterfaceNameForType(Type type, StringBuilder builder, TypeNameGenerationFlags flags)
         {
-            Debug.Assert((flags & TypeNameGenerationFlags.NoCustomTypeName) != 0);
+            Debug.Assert((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0);
             Debug.Assert(!type.IsGenericTypeDefinition);
 
             var visitedTypes = VisitedTypes.Value;
@@ -426,13 +420,32 @@ namespace WinRT
             if (type.IsSZArray)
 #endif
             {
-                builder.Append("Windows.Foundation.IReferenceArray`1<");
-                if (TryAppendTypeName(type.GetElementType(), builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
+                var elementType = type.GetElementType();
+                if (elementType.ShouldProvideIReference())
                 {
-                    builder.Append('>');
-                    return true;
+                    builder.Append("Windows.Foundation.IReferenceArray`1<");
+                    if (TryAppendTypeName(elementType, builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
+                    {
+                        builder.Append('>');
+                        return true;
+                    }
+                    return false;
                 }
-                return false;
+                else
+                {
+                    return false;
+                }
+            }
+
+            if ((flags & TypeNameGenerationFlags.GenerateBoxedName) != 0 && type.ShouldProvideIReference())
+            {
+                builder.Append("Windows.Foundation.IReference`1<");
+                if (!TryAppendSimpleTypeName(type, builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
+                {
+                    return false;
+                }
+                builder.Append('>');
+                return true;
             }
 
             if (!type.IsGenericType || type.IsGenericTypeDefinition)
@@ -440,7 +453,7 @@ namespace WinRT
                 return TryAppendSimpleTypeName(type, builder, flags);
             }
 
-            if ((flags & TypeNameGenerationFlags.NoCustomTypeName) != 0 && !Projections.IsTypeWindowsRuntimeType(type))
+            if ((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0 && !Projections.IsTypeWindowsRuntimeType(type))
             {
                 return TryAppendWinRTInterfaceNameForType(type, builder, flags);
             }
@@ -473,7 +486,7 @@ namespace WinRT
                 }
                 first = false;
 
-                if ((flags & TypeNameGenerationFlags.NoCustomTypeName) != 0)
+                if ((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0)
                 {
                     VisitedTypes.Value.Push(new VisitedType
                     {
@@ -484,7 +497,7 @@ namespace WinRT
 
                 bool success = TryAppendTypeName(argument, builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName);
 
-                if ((flags & TypeNameGenerationFlags.NoCustomTypeName) != 0)
+                if ((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0)
                 {
                     VisitedTypes.Value.Pop();
                 }


### PR DESCRIPTION
Generation of boxed types is now consistent between Vtable generation and GetRuntimeClassName.