### PR TITLE
Minor improvements to error info

### DIFF
--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -309,15 +309,15 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
             IDictionary dict = ex.Data;
             if (dict != null)
             {
-                dict.Add("Description", description);
-                dict.Add("RestrictedDescription", restrictedError);
-                dict.Add("RestrictedErrorReference", restrictedErrorReference);
-                dict.Add("RestrictedCapabilitySid", restrictedCapabilitySid);
+                dict["Description"] = description;
+                dict["RestrictedDescription"] = restrictedError;
+                dict["RestrictedErrorReference"] = restrictedErrorReference;
+                dict["RestrictedCapabilitySid"] = restrictedCapabilitySid;
 
                 // Keep the error object alive so that user could retrieve error information
                 // using Data["RestrictedErrorReference"]
-                dict.Add("__RestrictedErrorObjectReference", restrictedErrorObject == null ? null : new __RestrictedErrorObject(restrictedErrorObject));
-                dict.Add("__HasRestrictedLanguageErrorObject", hasRestrictedLanguageErrorObject);
+                dict["__RestrictedErrorObjectReference"] = restrictedErrorObject == null ? null : new __RestrictedErrorObject(restrictedErrorObject);
+                dict["__HasRestrictedLanguageErrorObject"] = hasRestrictedLanguageErrorObject;
             }
         }
 

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -34,7 +34,7 @@ namespace WinRT
         [DllImport("oleaut32.dll")]
         private static extern int SetErrorInfo(uint dwReserved, IntPtr perrinfo);
 
-        private static delegate* unmanaged[Stdcall]<out IntPtr, int> getRestrictedErrorInfo;
+        private static delegate* unmanaged[Stdcall]<IntPtr*, int> getRestrictedErrorInfo;
         private static delegate* unmanaged[Stdcall]<IntPtr, int> setRestrictedErrorInfo;
         private static delegate* unmanaged[Stdcall]<int, IntPtr, IntPtr, int> roOriginateLanguageException;
         private static delegate* unmanaged[Stdcall]<IntPtr, int> roReportUnhandledError;
@@ -56,7 +56,7 @@ namespace WinRT
 
             if (winRTErrorModule != IntPtr.Zero)
             {
-                getRestrictedErrorInfo = (delegate* unmanaged[Stdcall]<out IntPtr, int>)Platform.GetProcAddress(winRTErrorModule, "GetRestrictedErrorInfo");
+                getRestrictedErrorInfo = (delegate* unmanaged[Stdcall]<IntPtr*, int>)Platform.GetProcAddress(winRTErrorModule, "GetRestrictedErrorInfo");
                 setRestrictedErrorInfo = (delegate* unmanaged[Stdcall]<IntPtr, int>)Platform.GetProcAddress(winRTErrorModule, "SetRestrictedErrorInfo");
             }
 
@@ -90,7 +90,8 @@ namespace WinRT
             if (getRestrictedErrorInfo == null)
                 return null;
 
-            Marshal.ThrowExceptionForHR(getRestrictedErrorInfo(out IntPtr restrictedErrorInfoPtr));
+            IntPtr restrictedErrorInfoPtr = IntPtr.Zero;
+            Marshal.ThrowExceptionForHR(getRestrictedErrorInfo(&restrictedErrorInfoPtr));
             if (restrictedErrorInfoPtr == IntPtr.Zero)
                 return null;
 
@@ -144,16 +145,15 @@ namespace WinRT
                             }
                             else
                             {
+                                // This could also be a proxy to a managed exception.
                                 hasOtherLanguageException = true;
                             }
                         }
                     }
-                    else
+
+                    if (hr == hrLocal)
                     {
-                        if (hr == hrLocal)
-                        {
-                            restrictedErrorInfoRef.TryAs<ABI.WinRT.Interop.IErrorInfo.Vftbl>(out iErrorInfo);
-                        }
+                        restrictedErrorInfoRef.TryAs<ABI.WinRT.Interop.IErrorInfo.Vftbl>(out iErrorInfo);
                     }
                 }
             }
@@ -353,7 +353,8 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                     // HRESULT ABI return values.   However, in many cases async APIs will set the thread's restricted
                     // error info as a convention in order to provide extended debugging information for the ErrorCode
                     // property.
-                    Marshal.ThrowExceptionForHR(getRestrictedErrorInfo(out IntPtr restrictedErrorInfoPtr));
+                    IntPtr restrictedErrorInfoPtr = IntPtr.Zero;
+                    Marshal.ThrowExceptionForHR(getRestrictedErrorInfo(&restrictedErrorInfoPtr));
 
                     if (restrictedErrorInfoPtr != IntPtr.Zero)
                     {

--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -160,6 +160,11 @@ namespace WinRT
             }
 #if !NET
             var data = wrt_pinterface_namespace.ToByteArray().Concat(UTF8Encoding.UTF8.GetBytes(sig)).ToArray();
+
+            using (SHA1 sha = new SHA1CryptoServiceProvider())
+            {
+                return encode_guid(sha.ComputeHash(data));
+            }
 #else
             var maxBytes = UTF8Encoding.UTF8.GetMaxByteCount(sig.Length);
 
@@ -168,11 +173,9 @@ namespace WinRT
             wrt_pinterface_namespace.TryWriteBytes(dataSpan);
             var numBytes = UTF8Encoding.UTF8.GetBytes(sig, dataSpan[16..]);
             data = data[..(16 + numBytes)];
+
+            return encode_guid(SHA1.HashData(data));
 #endif
-            using (SHA1 sha = new SHA1CryptoServiceProvider())
-            {
-                return encode_guid(sha.ComputeHash(data));
-            }
         }
     }
 }

--- a/src/WinRT.Runtime/Interop/ExceptionErrorInfo.cs
+++ b/src/WinRT.Runtime/Interop/ExceptionErrorInfo.cs
@@ -438,9 +438,6 @@ namespace ABI.WinRT.Interop
         [Guid("82BA7092-4C88-427D-A7BC-16DD93FEB67E")]
         public struct Vftbl
         {
-            public delegate int _GetErrorDetails(IntPtr thisPtr, out IntPtr description, out int error, out IntPtr restrictedDescription, out IntPtr capabilitySid);
-            public delegate int _GetReference(IntPtr thisPtr, out IntPtr reference);
-
             internal global::WinRT.Interop.IUnknownVftbl unknownVftbl;
             private void* _GetErrorDetails_0;
             public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int> GetErrorDetails_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int*, IntPtr*, IntPtr*, int>)_GetErrorDetails_0;


### PR DESCRIPTION
- Making `GetRestrictedError` delegate blittable
- Updating to use the static API `SHA1.HashData` rather than via `SHA1CryptoServiceProvider` which is obsolete.
- As part of another investigation related to exceptions happening in different process and propagated back, I found that we were never passing the `IErrorInfo` to the `Marshal.GetExceptionForHR` call.  This doesn't really have an impact on .NET 5+ given it seems to be unused and we do the same as it would have done before as part of `AddExceptionDataForRestrictedErrorInfo`.  But for before .NET 5, it does seem to be used, so passing it in for both cases and handling the case where the old support does something similar to what `AddExceptionDataForRestrictedErrorInfo` does.  This in theory also had issues before when it wasn't an `IRestrictedErrorInfo` and we went down that code path, but having just an IErrorInfo which isn't an IRestrictedErrorInfo is probably an uncommon scenario with our use cases, so we never seen issues reported for that.

Fixes #1316