### PR TITLE
Fix invalid assembly reference in type lookup

### DIFF
--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -453,7 +453,7 @@ namespace GuidPatch
             il.Emit(OpCodes.Pop);
 
             // Fix endianness, bytes
-            var memoryExtensions = CecilExtensions.FindTypeReference(module, "System", "MemoryExtensions", "System.Memory", false);
+            var memoryExtensions = CecilExtensions.FindTypeReference(module, "System", "MemoryExtensions", "System.Private.CoreLib", false);
 
             var reverseMethod_Generic = new MethodReference("Reverse", module.TypeSystem.Void, memoryExtensions) { };
 


### PR DESCRIPTION
```csharp
CecilExtensions.FindTypeReference(module, "System", "MemoryExtensions", "System.Memory", false);
```
will return a `null` and causes the subsequent emit process failed.
But the exception was caught and ignored.

Instead it should look up the type in `System.Private.CoreLib`.