### PR TITLE
Fix the tooling incompatible issue with NativeAOT

### DIFF
--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -227,14 +227,14 @@ namespace GuidPatch
                     case StringStep(string str):
                         {
                             byte[] segmentBytes = Encoding.UTF8.GetBytes(str);
-                            var staticDataField = new FieldDefinition($"<SignatureDataPart={i}>", FieldAttributes.Private | FieldAttributes.InitOnly | FieldAttributes.Static | FieldAttributes.HasFieldRVA, CecilExtensions.GetOrCreateDataBlockType(implementationDetailsType, segmentBytes.Length))
+                            var staticDataField = new FieldDefinition($"<IIDDataField>{describedType.FullName}<SignatureDataPart={i}>", FieldAttributes.Private | FieldAttributes.InitOnly | FieldAttributes.Static | FieldAttributes.HasFieldRVA, CecilExtensions.GetOrCreateDataBlockType(implementationDetailsType, segmentBytes.Length))
                             {
                                 InitialValue = segmentBytes
                             };
-                            cacheType.Fields.Add(staticDataField);
+                            implementationDetailsType.Fields.Add(staticDataField);
 
                             // Load a ReadOnlySpan<byte> of the signature segment into the local for this step.
-                            il.Emit(OpCodes.Ldsflda, new FieldReference(staticDataField.Name, staticDataField.FieldType, selfInstantiatedCacheType));
+                            il.Emit(OpCodes.Ldsflda, new FieldReference(staticDataField.Name, staticDataField.FieldType, implementationDetailsType));
                             il.Emit(OpCodes.Ldc_I4, segmentBytes.Length);
                             il.Emit(OpCodes.Newobj, readOnlySpanOfBytePtrCtor);
                             il.Emit(OpCodes.Stloc, signatureParts[i]);


### PR DESCRIPTION
An RVA field within a generic type is not expressible with C#, and the NativeAOT compiler doesn't support such IL at all.
To resolve this issue, we can simply move IIDDataField out of the generic types instead of nesting the data inside of a generic type.

Unblocks the tooling issue to make sure ilc can compile CsWinRT projection assemblies. 

After this PR is merged, we can finally start investigating what is missing for NativeAOT-compatible. 

Fixes https://github.com/dotnet/runtime/issues/68278

/cc: @manodasanW @jkotas @MichalStrehovsky 