### PR TITLE
Fix vftbl nested types finding

### DIFF
--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -134,7 +134,7 @@ namespace WinRT
 
         internal static IntPtr GetAbiToProjectionVftblPtr(
 #if NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicNestedTypes)]
 #endif
             this Type helperType)
         {


### PR DESCRIPTION
In some cases (such as NativeAOT compilation), `TypeExtensions.GetAbiToProjectionVftblPtr` will not be able to get the nested `Vftbl` type in the specified helper type, resulting in the method being unable to get the field `AbiToProjectionVftblPtr`, causing the method to fail.

This error is caused due to the `DynamicallyAccessedMemberTypes` specified in the `DynamicallyAccessedMembersAttribute` of `GetAbiToProjectionVftblPtr` being inconsistent with that of `FindVftblType`, causing the `FindVftblType` method to be unable to get the nested `Vftbl` type.

This PR fixes that by adding in `DynamicallyAccessedMemberTypes.PublicNestedTypes` to `GetAbiToProjectionVftblPtr`, allowing `FindVftblType` to find nested types.