### PR TITLE
Return the actual type as it makes more sense and avoids an interface dispatch.

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1848,7 +1848,7 @@ internal sealed class _% : ABI.%.%
 {
 public _%() : base(%()) { }
 %
-internal static % Instance => _instance;
+internal static _% Instance => _instance;
 }
 )",
                 cache_type_name,


### PR DESCRIPTION
Should result in a small perf improvement.