### PR TITLE
Add Context checks to factory caching and simplify factory caching between factories and statics.

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -199,6 +199,7 @@ $(CsWinRTInternalProjection)
 
     <ItemGroup Condition="'$(CsWinRTComponent)' != 'true' and Exists('$(CsWinRTResponseFile)')">
       <UpToDateCheckInput Include="@(CsWinRTInputs)" Set="WinMDs" />
+      <UpToDateCheckInput Include="$(CsWinRTExe)" Set="WinMDs" />
       <UpToDateCheckBuilt Include="$(CsWinRTResponseFile)" Set="WinMDs" />
     </ItemGroup>
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2438,8 +2438,6 @@ namespace UnitTest
                 // Object gets proxied to the apartment.
                 Assert.Equal(2, proxyObject.Commands.Count);
                 agileReference.Dispose();
-
-                proxyObject2 = agileReference2.Get();
             }
 
             public void CheckValue()
@@ -2448,9 +2446,6 @@ namespace UnitTest
                 Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
                 proxyObject = agileReference.Get();
                 Assert.Equal(2, proxyObject.Commands.Count);
-                
-                nonAgileObject2 = new Windows.UI.Popups.PopupMenu();
-                agileReference2 = nonAgileObject2.AsAgile();
 
                 valueAcquired.Set();
             }
@@ -2462,8 +2457,8 @@ namespace UnitTest
                 Assert.ThrowsAny<System.Exception>(() => proxyObject.Commands);
             }
 
-            private Windows.UI.Popups.PopupMenu nonAgileObject, nonAgileObject2;
-            private Windows.UI.Popups.PopupMenu proxyObject, proxyObject2;
+            private Windows.UI.Popups.PopupMenu nonAgileObject;
+            private Windows.UI.Popups.PopupMenu proxyObject;
             private AgileReference<Windows.UI.Popups.PopupMenu> agileReference, agileReference2;
             private readonly AutoResetEvent objectAcquired = new AutoResetEvent(false);
             private readonly AutoResetEvent valueAcquired = new AutoResetEvent(false);

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -7,11 +7,8 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    static class Context
+    static partial class Context
     {
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        private static extern unsafe int CoGetContextToken(IntPtr* contextToken);
-
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
 
@@ -22,13 +19,6 @@ namespace WinRT
             Guid riid = ABI.WinRT.Interop.IContextCallback.IID;
             Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
             return contextCallbackPtr;
-        }
-
-        public unsafe static IntPtr GetContextToken()
-        {
-            IntPtr contextToken;
-            Marshal.ThrowExceptionForHR(CoGetContextToken(&contextToken));
-            return contextToken;
         }
 
         // Calls the given callback in the right context.

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -98,7 +98,7 @@ namespace ABI.System.ComponentModel
             }
 
             internal static ABI.Microsoft.UI.Xaml.Data.WinRTDataErrorsChangedEventArgsRuntimeClassFactory Instance =
-                new ActivationFactory()._As<ABI.Microsoft.UI.Xaml.Data.WinRTDataErrorsChangedEventArgsRuntimeClassFactory.Vftbl>();
+                new ActivationFactory().As<ABI.Microsoft.UI.Xaml.Data.WinRTDataErrorsChangedEventArgsRuntimeClassFactory.Vftbl>();
         }
 
         public static IObjectReference CreateMarshaler(global::System.ComponentModel.DataErrorsChangedEventArgs value)

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -202,7 +202,7 @@ namespace ABI.System.Collections.Specialized
             }
 
             internal static WinRTNotifyCollectionChangedEventArgsRuntimeClassFactory Instance = 
-                new ActivationFactory()._As<WinRTNotifyCollectionChangedEventArgsRuntimeClassFactory.Vftbl>();
+                new ActivationFactory().As<WinRTNotifyCollectionChangedEventArgsRuntimeClassFactory.Vftbl>();
         }
 
         public static IObjectReference CreateMarshaler(global::System.Collections.Specialized.NotifyCollectionChangedEventArgs value)

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -109,7 +109,7 @@ namespace ABI.System.ComponentModel
             }
 
             internal static ABI.Microsoft.UI.Xaml.Data.WinRTPropertyChangedEventArgsRuntimeClassFactory Instance = 
-                new ActivationFactory()._As<ABI.Microsoft.UI.Xaml.Data.WinRTPropertyChangedEventArgsRuntimeClassFactory.Vftbl>();
+                new ActivationFactory().As<ABI.Microsoft.UI.Xaml.Data.WinRTPropertyChangedEventArgsRuntimeClassFactory.Vftbl>();
         }
 
         public static IObjectReference CreateMarshaler(global::System.ComponentModel.PropertyChangedEventArgs value)

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -103,7 +103,7 @@ namespace ABI.System
             }
 
             internal static WinRTUriRuntimeClassFactory Instance = 
-                new ActivationFactory()._As<WinRTUriRuntimeClassFactory.Vftbl>();
+                new ActivationFactory().As<WinRTUriRuntimeClassFactory.Vftbl>();
         }
 
         public static IObjectReference CreateMarshaler(global::System.Uri value)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -4051,7 +4051,7 @@ internal sealed class _% : ABI.%.%
 {
 public _%() : base(%()) { }
 private static _% _instance = new _%();
-internal static _% Instance => _instance;
+internal static % Instance => _instance;
 %
 }
 )",

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5961,12 +5961,11 @@ static global::System.Guid IHasGuid.IID { get; } = new Guid(new global::System.R
     template<auto method_writer>
     std::string write_static_factory_class_with_raw_return_type(writer& w, std::string_view cache_type_name, TypeDef const& iface)
     {
-        w.write(R"(% static class _%
+        w.write(R"(internal static class _%
 {
 %
 }
-)", 
-            (is_exclusive_to(iface) || is_projection_internal(iface)) ? "internal" : internal_accessibility(),
+)",
             bind<write_type_name>(iface, typedef_name_type::StaticAbiClass, false),
             bind_each<method_writer>(iface.MethodList()));
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6298,7 +6298,7 @@ private readonly % _comp;
 {
 public %IntPtr ThisPtr => _default.ThisPtr;
 
-private IObjectReference _inner = null;
+private readonly IObjectReference _inner = null;
 private readonly Lazy<%> _defaultLazy;
 %
 
@@ -6467,7 +6467,7 @@ _defaultLazy = new Lazy<%>(() => GetDefaultReference<%.Vftbl>());
 {
 private IntPtr ThisPtr => _inner == null ? (((IWinRTObject)this).NativeObject).ThisPtr : _inner.ThisPtr;
 
-private IObjectReference _inner = null;
+private readonly IObjectReference _inner = null;
 %
 %
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1823,7 +1823,7 @@ remove => %;
     {
         return settings.netstandard_compat ?
             w.write_temp("Factory<%, %.Vftbl>.Instance.Value", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true)) :
-            w.write_temp("Factory<%, %>.Instance.Value", class_type.TypeName(), static_type.TypeName());
+            w.write_temp("Factory<%, %>.Instance.Value", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true));
     }
 
     static std::string get_default_interface_name(writer& w, TypeDef const& type, bool abiNamespace = true, bool forceCCW = false)
@@ -6008,7 +6008,7 @@ internal static global::System.Guid IID { get; } = new Guid(new global::System.R
 
         return settings.netstandard_compat ?
             w.write_temp("Factory<%, %.Vftbl>.Instance.Value", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true)) :
-            w.write_temp("Factory<%, %>.Instance.Value", cache_type_name, iface.TypeName());
+            w.write_temp("Factory<%, %>.Instance.Value", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true));
     }
 
     bool write_abi_interface(writer& w, TypeDef const& type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5904,7 +5904,7 @@ public static Guid PIID = Vftbl.PIID;
 
         if (settings.netstandard_compat)
         {
-            w.write(R"(% class %
+            w.write(R"(% sealed class %
 {
 internal static global::System.Guid IID { get; } = new Guid(new byte[] { % });
 
@@ -5931,7 +5931,7 @@ internal static global::System.Guid IID { get; } = new Guid(new byte[] { % });
         }
         else
         {
-            w.write(R"(% class % : global::WinRT.IHasGuid
+            w.write(R"(% sealed class % : global::WinRT.IHasGuid
 {
 static global::System.Guid IHasGuid.IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { % }));
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1846,7 +1846,7 @@ internal sealed class _% : ABI.%.%
 {
 public _%() : base(%()) { }
 %
-internal static _% Instance => _instance;
+internal static % Instance => _instance;
 }
 )",
                 cache_type_name,
@@ -4051,7 +4051,7 @@ internal sealed class _% : ABI.%.%
 {
 public _%() : base(%()) { }
 private static _% _instance = new _%();
-internal static % Instance => _instance;
+internal static _% Instance => _instance;
 %
 }
 )",

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1822,8 +1822,8 @@ remove => %;
     std::string write_static_cache_object(writer& w, TypeDef const& static_type, TypeDef const& class_type)
     {
         return settings.netstandard_compat ?
-            w.write_temp("Factory<%, %.Vftbl>.Instance.Value", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true)) :
-            w.write_temp("Factory<%, %>.Instance.Value", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true));
+            w.write_temp("Factory<%, %.Vftbl>.Get(GuidGenerator.GetIID(typeof(%).GetHelperType()))", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true), bind<write_type_name>(static_type, typedef_name_type::Projected, true)) :
+            w.write_temp("Factory<%, %>.Get(GuidGenerator.GetIID(typeof(%).GetHelperType()))", class_type.TypeName(), bind<write_type_name>(static_type, typedef_name_type::ABI, true), bind<write_type_name>(static_type, typedef_name_type::Projected, true));
     }
 
     static std::string get_default_interface_name(writer& w, TypeDef const& type, bool abiNamespace = true, bool forceCCW = false)
@@ -1920,7 +1920,7 @@ ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
         else
         {
             w.write(R"(
-public %() : this(%(ActivationFactory<%>.Instance.ActivateInstance<IUnknownVftbl>()))
+public %() : this(%(ActivationFactory<%>.Get().ActivateInstance<IUnknownVftbl>()))
 {
 ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
 %
@@ -2228,7 +2228,7 @@ Marshal.Release(inner);
                     }
 
                     w.write(R"(
-public static %I As<I>() => ActivationFactory<%>.Instance.AsInterface<I>();
+public static %I As<I>() => ActivationFactory<%>.Get().AsInterface<I>();
 )",
                         has_base_factory ? "new " : "",
                         type.TypeName());
@@ -3932,7 +3932,7 @@ public static unsafe % %(% _obj%%)
             auto cache_vftbl_type = w.write_temp("ABI.%.%.Vftbl", class_type.TypeNamespace(), cache_type_name);
             auto cache_interface =
                 w.write_temp(
-                    R"(ActivationFactory<%>.Instance.As<%>)",
+                    R"(ActivationFactory<%>.Get().As<%>)",
                     class_type.TypeName(),
                     cache_vftbl_type);
 
@@ -6007,8 +6007,8 @@ internal static global::System.Guid IID { get; } = new Guid(new global::System.R
             bind_each<method_writer>(iface.MethodList()));
 
         return settings.netstandard_compat ?
-            w.write_temp("Factory<%, %.Vftbl>.Instance.Value", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true)) :
-            w.write_temp("Factory<%, %>.Instance.Value", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true));
+            w.write_temp("Factory<%, %.Vftbl>.Get(GuidGenerator.GetIID(typeof(%).GetHelperType()))", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true), bind<write_type_name>(iface, typedef_name_type::Projected, true)) :
+            w.write_temp("Factory<%, %>.Get(GuidGenerator.GetIID(typeof(%).GetHelperType()))", cache_type_name, bind<write_type_name>(iface, typedef_name_type::ABI, true), bind<write_type_name>(iface, typedef_name_type::Projected, true));
     }
 
     bool write_abi_interface(writer& w, TypeDef const& type)

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -286,10 +286,11 @@ Where <spec> is one or more of:
                                     case category::interface_type:
                                         if (settings.netstandard_compat)
                                         {
+                                            write_static_abi_classes(w, type);
                                             write_abi_interface_netstandard(w, type);
                                         }
                                         else
-                                        {   
+                                        {
                                             write_static_abi_classes(w, type);
                                             write_abi_interface(w, type);
                                         }

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -478,7 +478,7 @@ namespace WinRT
     internal interface IHasGuid
     {
 #pragma warning disable CA2252 // This API requires opting into preview features
-        static abstract ReadOnlySpan<byte> IID { get; }
+        static abstract global::System.Guid IID { get; }
 #pragma warning restore CA2252 // This API requires opting into preview features
     }
 #endif
@@ -594,7 +594,7 @@ namespace WinRT
         public BaseFactory(string typeNamespace, string typeFullName)
         {
 #if NET
-            Guid interfaceGuid = MemoryMarshal.Read<Guid>(I.IID);
+            Guid interfaceGuid = I.IID;
 #else
             Guid interfaceGuid = typeof(I).GUID;
 #endif

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -540,47 +540,6 @@ namespace WinRT
         }
     }
 
-    internal class Factory
-    {
-        private readonly IObjectReference _factory;
-        public IObjectReference Value { get => _factory; }
-
-        public Factory(string typeNamespace, string typeFullName, Guid iid)
-        {
-            // Prefer the RoGetActivationFactory HRESULT failure over the LoadLibrary/etc. failure
-            int hr;
-            ObjectReference<IActivationFactoryVftbl> factory;
-            (factory, hr) = WinrtModule.GetActivationFactory(typeFullName);
-            if (factory != null) 
-            {
-                _factory = factory.As(iid);
-                return; 
-            }
-
-            var moduleName = typeNamespace;
-            while (true)
-            {
-                DllModule module = null;
-                if (DllModule.TryLoad(moduleName + ".dll", out module))
-                {
-                    (factory, _) = module.GetActivationFactory(typeFullName);
-                    if (factory != null)
-                    {
-                        _factory = factory.As(iid);
-                        return;
-                    }
-                }
-
-                var lastSegment = moduleName.LastIndexOf(".", StringComparison.Ordinal);
-                if (lastSegment <= 0)
-                {
-                    Marshal.ThrowExceptionForHR(hr);
-                }
-                moduleName = moduleName.Remove(lastSegment);
-            }
-        }
-    }
-
     internal class BaseFactory<I>
     {
 #if NET

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -346,10 +346,10 @@ namespace WinRT
                 module = null;
                 return false;
             }
-            
+
             module = new DllModule(
-                fileName, 
-                moduleHandle, 
+                fileName,
+                moduleHandle,
                 getActivationFactory);
             return true;
         }
@@ -495,7 +495,7 @@ namespace WinRT
             if (_IActivationFactory != null)
             {
                 _contextToken = Context.IsFreeThreaded(_IActivationFactory) ? IntPtr.Zero : Context.GetContextToken();
-                return; 
+                return;
             }
 
             var moduleName = typeNamespace;
@@ -581,7 +581,7 @@ namespace WinRT
         public IntPtr ContextToken { get => _contextToken; }
 
         public BaseFactory(string typeNamespace, string typeFullName)
-            : this(typeNamespace, typeFullName, GuidGenerator.GetIID(typeof(I)))
+            : this(typeNamespace, typeFullName, typeof(I).GUID)
         {
         }
 
@@ -599,7 +599,7 @@ namespace WinRT
                 _factory = factory.As<I>(interfaceGuid);
 #endif
                 _contextToken = Context.IsFreeThreaded(_factory) ? IntPtr.Zero : Context.GetContextToken();
-                return; 
+                return;
             }
 
             var moduleName = typeNamespace;
@@ -616,8 +616,8 @@ namespace WinRT
 #else
                         _factory = factory.As<I>(interfaceGuid);
 #endif
-                        _contextToken = Context.IsFreeThreaded(_factory) ? IntPtr.Zero : Context.GetContextToken(); 
-                        return; 
+                        _contextToken = Context.IsFreeThreaded(_factory) ? IntPtr.Zero : Context.GetContextToken();
+                        return;
                     }
                 }
 
@@ -636,9 +636,9 @@ namespace WinRT
         private static Factory<T, I> _instance;
 
 #if NET
-        internal static IObjectReference Get(Guid iid)
+        internal static IObjectReference Get()
 #else
-        internal static ObjectReference<I> Get(Guid iid)
+        internal static ObjectReference<I> Get()
 #endif
         {
             var existingInstance = _instance;
@@ -647,13 +647,13 @@ namespace WinRT
                 return existingInstance.Value;
             }
 
-            var newInstance = new Factory<T, I>(iid);
+            var newInstance = new Factory<T, I>();
             Interlocked.CompareExchange(ref _instance, newInstance, existingInstance);
             return newInstance.Value;
         }
 
-        private Factory(Guid iid)
-            : base (typeof(T).Namespace, typeof(T).FullName, iid)
+        private Factory()
+            : base(typeof(T).Namespace, typeof(T).FullName)
         {
         }
     }


### PR DESCRIPTION
Cache factories and statics per context, similar to coreclr/.NET Native behavior.

Fixes https://github.com/microsoft/CsWinRT/issues/1112