### PR TITLE
Remove the need for GuidGenerator/IIDOptimizer for all ABI interfaces.

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2050,7 +2050,7 @@ private IObjectReference Make__%()
                         else if (distance(ifaceType.GenericParam()) == 0)
                         {
 
-                            w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(global::System.Runtime.InteropServices.MemoryMarshal.Read<Guid>(%.IID)), null);)",
+                            w.write(R"(global::System.Threading.Interlocked.CompareExchange(ref __%, ((IWinRTObject)this).NativeObject.As<IUnknownVftbl>(%.IID), null);)",
                                 objrefname,
                                 bind<write_type_name>(semantics, typedef_name_type::StaticAbiClass, true)
                             );
@@ -5995,7 +5995,7 @@ public static Guid PIID = Vftbl.PIID;
 
         w.write(R"(% static class %
 {
-public static global::System.ReadOnlySpan<byte> IID => new byte[] { % };
+public static global::System.Guid IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { % }));
 
 %
 }
@@ -6198,7 +6198,7 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
                     settings.netstandard_compat ?
                         w.write("GuidGenerator.GetIID(typeof(%)) == iid",
                             bind<write_type_name>(get_type_semantics(iface.Interface()), typedef_name_type::ABI, false)) :
-                        w.write("global::System.Runtime.InteropServices.MemoryMarshal.Read<Guid>(%.IID) == iid",
+                        w.write("%.IID == iid",
                             bind<write_type_name>(get_type_semantics(iface.Interface()), typedef_name_type::StaticAbiClass, true));
                 }
             }, type.InterfaceImpl()),

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6195,8 +6195,11 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
                 if (has_attribute(iface, "Windows.Foundation.Metadata", "OverridableAttribute"))
                 {
                     s();
-                    w.write("%.IID == iid",
-                        bind<write_type_name>(get_type_semantics(iface.Interface()), typedef_name_type::StaticAbiClass, true));
+                    settings.netstandard_compat ?
+                        w.write("GuidGenerator.GetIID(typeof(%)) == iid",
+                            bind<write_type_name>(get_type_semantics(iface.Interface()), typedef_name_type::ABI, false)) :
+                        w.write("global::System.Runtime.InteropServices.MemoryMarshal.Read<Guid>(%.IID) == iid",
+                            bind<write_type_name>(get_type_semantics(iface.Interface()), typedef_name_type::StaticAbiClass, true));
                 }
             }, type.InterfaceImpl()),
             bind([&](writer& w)

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -508,7 +508,6 @@ namespace WinRT
 #endif
         public ObjectReference<I> _As<I>() => _IActivationFactory.As<I>();
         public IObjectReference _As(Guid iid) => _IActivationFactory.As<WinRT.Interop.IUnknownVftbl>(iid);
-        public IObjectReference _As(ReadOnlySpan<byte> iid) => _IActivationFactory.As<WinRT.Interop.IUnknownVftbl>(global::System.Runtime.InteropServices.MemoryMarshal.Read<Guid>(iid));
     }
 
     internal sealed class ActivationFactory<T> : BaseActivationFactory
@@ -519,7 +518,6 @@ namespace WinRT
         public static new I AsInterface<I>() => _factory.Value.AsInterface<I>();
         public static ObjectReference<I> As<I>() => _factory._As<I>();
         public static IObjectReference As(Guid iid) => _factory._As(iid);
-        public static IObjectReference As(ReadOnlySpan<byte> iid) => _factory._As(iid);
 
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:RequiresUnreferencedCode", 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -508,6 +508,7 @@ namespace WinRT
 #endif
         public ObjectReference<I> _As<I>() => _IActivationFactory.As<I>();
         public IObjectReference _As(Guid iid) => _IActivationFactory.As<WinRT.Interop.IUnknownVftbl>(iid);
+        public IObjectReference _As(ReadOnlySpan<byte> iid) => _IActivationFactory.As<WinRT.Interop.IUnknownVftbl>(global::System.Runtime.InteropServices.MemoryMarshal.Read<Guid>(iid));
     }
 
     internal sealed class ActivationFactory<T> : BaseActivationFactory
@@ -518,6 +519,7 @@ namespace WinRT
         public static new I AsInterface<I>() => _factory.Value.AsInterface<I>();
         public static ObjectReference<I> As<I>() => _factory._As<I>();
         public static IObjectReference As(Guid iid) => _factory._As(iid);
+        public static IObjectReference As(ReadOnlySpan<byte> iid) => _factory._As(iid);
 
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:RequiresUnreferencedCode", 


### PR DESCRIPTION
This PR generates ReadOnlySpan<byte> for guids for all ABI types which can then be efficiently passed to QI methods by doing `MemoryMarshal.Read<Guid>(span)`.

The C# compiler since .NET7 optimizes the byte array to a readonly data section as it sees that there are no ways the byte array can be changed, resulting in less byte arrays created.

There are a few places left with this PR where generics can show up and we need to decide how we generate IIDs for those, for example IList<string>.