### PR TITLE
Remove Resurrect logic as it shouldn't be needed for .NET 6 and newer.

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -115,12 +115,6 @@ namespace WinRT
             // We need to do the same thing for System.Type because there can be multiple WUX.Interop.TypeName's
             // for a single System.Type.
 
-            // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
-            if (rcw is IWinRTObject winrtObj)
-            {
-                winrtObj.Resurrect();
-            }
-
             return rcw switch
             {
                 ABI.System.Nullable nt => (T)nt.Value,
@@ -160,15 +154,7 @@ namespace WinRT
 
         public static object TryRegisterObjectForInterface(object obj, IntPtr thisPtr)
         {
-            var rcw = ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
-
-            // Resurrect IWinRTObject's disposed IObjectReferences, if necessary
-            var target = rcw is Delegate del ? del.Target : rcw;
-            if (target is IWinRTObject winrtObj)
-            {
-                winrtObj.Resurrect();
-            }
-            return rcw;
+            return ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
         }
 
         public static IObjectReference CreateCCWForObject(object obj)

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -184,23 +184,5 @@ namespace WinRT
         {
             return AdditionalTypeData.GetOrAdd(type, (type) => helperDataFactory());
         }
-
-        internal void Resurrect()
-        {
-            if (NativeObject.Resurrect())
-            {
-                foreach (var cached in QueryInterfaceCache)
-                {
-                    cached.Value.Resurrect();
-                }
-
-                // Delegates store their agile reference as an additional type data.
-                // These should be recreated when instances are resurrect.
-                if (AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj))
-                {
-                    AdditionalTypeData.TryUpdate(typeof(AgileReference).TypeHandle, new AgileReference(NativeObject), agileObj);
-                }
-            }
-        }
     }
 }

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -247,12 +247,9 @@ namespace WinRT
 
         protected void ThrowIfDisposed()
         {
-            if (disposed)
+            lock (_disposedLock)
             {
-                lock (_disposedLock)
-                {
-                    if (disposed) throw new ObjectDisposedException("ObjectReference");
-                }
+                if (disposed) throw new ObjectDisposedException("ObjectReference");
             }
         }
 

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -287,22 +287,6 @@ namespace WinRT
             }
         }
 
-        internal bool Resurrect()
-        {
-            lock (_disposedLock)
-            {
-                if (!disposed)
-                {
-                    return false;
-                }
-                disposed = false;
-                ResurrectTrackerSource();
-                AddRef();
-                GC.ReRegisterForFinalize(this);
-                return true;
-            }
-        }
-
         protected virtual unsafe void AddRef(bool refFromTrackerSource)
         {
             VftblIUnknown.AddRef(ThisPtr);
@@ -350,18 +334,6 @@ namespace WinRT
             if (ReferenceTrackerPtr != IntPtr.Zero)
             {
                 ReferenceTracker.ReleaseFromTrackerSource(ReferenceTrackerPtr);
-            }
-        }
-
-        private unsafe void ResurrectTrackerSource()
-        {
-            if (ReferenceTrackerPtr != IntPtr.Zero)
-            {
-                ReferenceTracker.IUnknownVftbl.AddRef(ReferenceTrackerPtr);
-                if (!PreventReleaseFromTrackerSourceOnDispose)
-                {
-                    ReferenceTracker.AddRefFromTrackerSource(ReferenceTrackerPtr);
-                }
             }
         }
 

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -247,9 +247,12 @@ namespace WinRT
 
         protected void ThrowIfDisposed()
         {
-            lock (_disposedLock)
+            if (disposed)
             {
-                if (disposed) throw new ObjectDisposedException("ObjectReference");
+                lock (_disposedLock)
+                {
+                    if (disposed) throw new ObjectDisposedException("ObjectReference");
+                }
             }
         }
 


### PR DESCRIPTION
After talking with @manodasanW we should no longer need Resurrect on .NET 6 and newer.