### PR TITLE
Cache StringBuilder per thread and remove Lazy from GetRuntimeClassName.

### DIFF
--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -311,16 +311,13 @@ namespace WinRT
             }
 
             // Get instance for this thread
-            StringBuilder? nameBuilder = nameForTypeBuilderInstance ?? new StringBuilder();
+            StringBuilder? nameBuilder = nameForTypeBuilderInstance ??= new StringBuilder();
             nameBuilder.Clear();
             if (TryAppendTypeName(type, nameBuilder, flags))
             {
-                var name = nameBuilder.ToString();
-                nameForTypeBuilderInstance = nameBuilder;
-                return name;
+                return nameBuilder.ToString();
             }
 
-            nameForTypeBuilderInstance = nameBuilder;
             return string.Empty;
         }
 

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -300,17 +300,27 @@ namespace WinRT
         /// </summary>
         private static readonly ThreadLocal<Stack<VisitedType>> VisitedTypes = new ThreadLocal<Stack<VisitedType>>(() => new Stack<VisitedType>());
 
+        [ThreadStatic]
+        private static StringBuilder? nameForTypeBuilderInstance;
+
         public static string GetNameForType(Type type, TypeNameGenerationFlags flags)
         {
             if (type is null)
             {
                 return string.Empty;
             }
-            StringBuilder nameBuilder = new StringBuilder();
+
+            // Get instance for this thread
+            StringBuilder? nameBuilder = nameForTypeBuilderInstance ?? new StringBuilder();
+            nameBuilder.Clear();
             if (TryAppendTypeName(type, nameBuilder, flags))
             {
-                return nameBuilder.ToString();
+                var name = nameBuilder.ToString();
+                nameForTypeBuilderInstance = nameBuilder;
+                return name;
             }
+
+            nameForTypeBuilderInstance = nameBuilder;
             return string.Empty;
         }
 


### PR DESCRIPTION
Remove uses of Lazy in InspectableInfo and uses a StringBuilder cache per thread to reduce memory waste for GetRuntimeClassName.