### PR TITLE
Run benchmarks against .NET 6 dll.

### DIFF
--- a/src/benchmark.cmd
+++ b/src/benchmark.cmd
@@ -1,7 +1,7 @@
 nuget restore TestWinRT\Test.sln
 nuget restore cswinrt.sln
 msbuild Benchmarks\Benchmarks.csproj -t:restore -t:build /p:platform=x64 /p:configuration=release /p:solutiondir=%~dp0 /p:IsDotnetBuild=false
-dotnet %~dp0Benchmarks\bin\x64\Release\netcoreapp3.1\Benchmarks.dll -filter * --runtimes net6.0
+dotnet %~dp0Benchmarks\bin\x64\Release\net6.0\Benchmarks.dll -filter * --runtimes net6.0
 nuget restore Perf\ResultsComparer\ResultsComparer.sln
 msbuild Perf\ResultsComparer\ResultsComparer.sln -t:restore -t:build /p:platform="Any CPU" /p:configuration=release
 set baselinedir=%1


### PR DESCRIPTION
Run benchmarks against .NET 6 dll so there is no need for older SDKs.