### PR TITLE
Handle async calls correctly in AotOptimizer

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -562,7 +562,7 @@ namespace Generator
                     if (GeneratorHelper.IsWinRTType(methodSymbol.ReturnType))
                     {
                         var completedProperty = methodSymbol.ReturnType.GetMembers("Completed").FirstOrDefault() as IPropertySymbol;
-                        if (completedProperty?.Type.MetadataName.Contains("`") ?? false)
+                        if (completedProperty != null && completedProperty.Type.MetadataName.Contains("Async") && completedProperty.Type.MetadataName.Contains("`"))
                         {
                             vtableAttributes.Add(GetVtableAttributeToAdd(completedProperty.Type, GeneratorHelper.IsWinRTType, context.SemanticModel.Compilation.Assembly, false));
                         }


### PR DESCRIPTION
Instead of handling async calls from the await expression, we need to handle it from the invocation expression.

Because an async call is not necessarily to be awaited directly. 