### PR TITLE
Expose api's for Context on ObjectReference.

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -82,25 +82,23 @@ namespace WinRT
                 Marshal.Release(agilePtr);
                 return true;
             }
-            else
+
+            if (Marshal.QueryInterface(iUnknown, ref Unsafe.AsRef(InterfaceIIDs.IMarshal_IID), out var marshalPtr) >= 0)
             {
-                if (Marshal.QueryInterface(iUnknown, ref Unsafe.AsRef(InterfaceIIDs.IMarshal_IID), out var marshalPtr) >= 0)
+                try
                 {
-                    try
+                    Guid iid_IUnknown = InterfaceIIDs.IUnknown_IID;
+                    Guid iid_unmarshalClass;
+                    Marshal.ThrowExceptionForHR((**(ABI.WinRT.Interop.IMarshal.Vftbl**)marshalPtr).GetUnmarshalClass_0(
+                        marshalPtr, &iid_IUnknown, IntPtr.Zero, MSHCTX.InProc, IntPtr.Zero, MSHLFLAGS.Normal, &iid_unmarshalClass));
+                    if (iid_unmarshalClass == ABI.WinRT.Interop.IMarshal.IID_InProcFreeThreadedMarshaler.Value)
                     {
-                        Guid iid_IUnknown = InterfaceIIDs.IUnknown_IID;
-                        Guid iid_unmarshalClass;
-                        Marshal.ThrowExceptionForHR((**(ABI.WinRT.Interop.IMarshal.Vftbl**)marshalPtr).GetUnmarshalClass_0(
-                            marshalPtr, &iid_IUnknown, IntPtr.Zero, MSHCTX.InProc, IntPtr.Zero, MSHLFLAGS.Normal, &iid_unmarshalClass));
-                        if (iid_unmarshalClass == ABI.WinRT.Interop.IMarshal.IID_InProcFreeThreadedMarshaler.Value)
-                        {
-                            return true;
-                        }
+                        return true;
                     }
-                    finally
-                    {
-                        Marshal.Release(marshalPtr);
-                    }
+                }
+                finally
+                {
+                    Marshal.Release(marshalPtr);
                 }
             }
             return false;

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -77,16 +77,14 @@ namespace WinRT
         // This can either be if the object implements IAgileObject or the free threaded marshaler.
         internal unsafe static bool IsFreeThreaded(IntPtr iUnknown)
         {
-            Guid iid_IAgileObject = InterfaceIIDs.IAgileObject_IID;
-            if (Marshal.QueryInterface(iUnknown, ref iid_IAgileObject, out var agilePtr) >= 0)
+            if (Marshal.QueryInterface(iUnknown, ref Unsafe.AsRef(InterfaceIIDs.IAgileObject_IID), out var agilePtr) >= 0)
             {
                 Marshal.Release(agilePtr);
                 return true;
             }
             else
             {
-                Guid iid_IMarshal = InterfaceIIDs.IMarshal_IID;
-                if (Marshal.QueryInterface(iUnknown, ref iid_IMarshal, out var marshalPtr) >= 0)
+                if (Marshal.QueryInterface(iUnknown, ref Unsafe.AsRef(InterfaceIIDs.IMarshal_IID), out var marshalPtr) >= 0)
                 {
                     try
                     {

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -142,11 +142,11 @@ namespace WinRT
             if (requireQI)
             {
                 Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, ref iid, out IntPtr ptr));
-                return ObjectReference<T>.Attach(ref ptr);
+                return ObjectReference<T>.Attach(ref ptr, iid);
             }
             else
             {
-                return ObjectReference<T>.FromAbi(externalComObject);
+                return ObjectReference<T>.FromAbi(externalComObject, iid);
             }
         }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -175,7 +175,7 @@ namespace WinRT
         public static IObjectReference CreateCCWForObject(object obj)
         {
             IntPtr ccw = ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.TrackerSupport);
-            return ObjectReference<IUnknownVftbl>.Attach(ref ccw);
+            return ObjectReference<IUnknownVftbl>.Attach(ref ccw, InterfaceIIDs.IUnknown_IID);
         }
 
         internal static IntPtr CreateCCWForObjectForABI(object obj, Guid iid)

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -350,8 +350,7 @@ namespace WinRT
                 // otherwise the new instance will be used. Since the inner was composed
                 // it should answer immediately without going through the outer. Either way
                 // the reference count will go to the new instance.
-                Guid iid = IReferenceTrackerVftbl.IID;
-                int hr = Marshal.QueryInterface(objRef.ThisPtr, ref iid, out referenceTracker);
+                int hr = Marshal.QueryInterface(objRef.ThisPtr, ref Unsafe.AsRef(IReferenceTrackerVftbl.IID), out referenceTracker);
                 if (hr != 0)
                 {
                     referenceTracker = default;
@@ -451,8 +450,7 @@ namespace WinRT
         {
             if (objRef.ReferenceTrackerPtr == IntPtr.Zero)
             {
-                Guid iid = IReferenceTrackerVftbl.IID;
-                int hr = Marshal.QueryInterface(objRef.ThisPtr, ref iid, out var referenceTracker);
+                int hr = Marshal.QueryInterface(objRef.ThisPtr, ref Unsafe.AsRef(IReferenceTrackerVftbl.IID), out var referenceTracker);
                 if (hr == 0)
                 {
                     // WinUI scenario

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -364,6 +364,7 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                 if (restrictedErrorInfoRef != null)
                 {
                     roReportUnhandledError(restrictedErrorInfoRef.ThisPtr);
+                    GC.KeepAlive(restrictedErrorInfoRef);
                 }
             }
         }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1581,8 +1581,7 @@ namespace WinRT
             IntPtr iunknownPtr = IntPtr.Zero;
             try
             {
-                Guid iid_iunknown = IUnknownVftbl.IID;
-                Marshal.QueryInterface(ptr, ref iid_iunknown, out iunknownPtr);
+                Marshal.QueryInterface(ptr, ref Unsafe.AsRef(IUnknownVftbl.IID), out iunknownPtr);
                 if (IUnknownVftbl.IsReferenceToManagedObject(iunknownPtr))
                 {
                     return (T)ComWrappersSupport.FindObject<object>(iunknownPtr);

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -131,4 +131,6 @@ MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribut
 TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public T ABI.System.Nullable<T>.GetValue(WinRT.IInspectable)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.EventRegistrationTokenTable<T>' does not exist in the reference but it does exist in the implementation.
-Total Issues: 132
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsFreeThreaded.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsInCurrentContext.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 134

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -133,4 +133,7 @@ MembersMustExist : Member 'public T ABI.System.Nullable<T>.GetValue(WinRT.IInspe
 TypesMustExist : Type 'WinRT.EventRegistrationTokenTable<T>' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsFreeThreaded.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsInCurrentContext.get()' does not exist in the reference but it does exist in the implementation.
-Total Issues: 134
+MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.Attach(System.IntPtr, System.Guid)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, System.Guid)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, T, System.Guid)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 137

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -547,7 +547,6 @@ namespace WinRT
         T> : ObjectReference<T>
     {
         private readonly IntPtr _contextCallbackPtr;
-        private readonly IntPtr _contextToken;
 
         private volatile ConcurrentDictionary<IntPtr, ObjectReference<T>> __cachedContext;
         private ConcurrentDictionary<IntPtr, ObjectReference<T>> CachedContext => __cachedContext ?? Make_CachedContext();

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -106,6 +106,17 @@ namespace WinRT
             }
         }
 
+        [Obsolete]
+        protected IObjectReference(IntPtr thisPtr)
+        {
+            if (thisPtr == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(thisPtr));
+            }
+            _thisPtr = thisPtr;
+            _contextPtr = ComWrappersSupport.IsFreeThreaded(thisPtr) ? IntPtr.Zero : Context.GetContextToken();
+        }
+
         protected IObjectReference(IntPtr thisPtr, IntPtr contextPtr)
         {
             if (thisPtr == IntPtr.Zero)

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -26,7 +26,7 @@ namespace WinRT
         private readonly IntPtr _thisPtr;
         private object _disposedLock = new object();
         private IntPtr _referenceTrackerPtr;
-        private IntPtr _contextPtr;
+        protected IntPtr _contextToken;
 
         public IntPtr ThisPtr
         {
@@ -37,9 +37,9 @@ namespace WinRT
             }
         }
 
-        public bool IsFreeThreaded => _contextPtr == IntPtr.Zero;
+        public bool IsFreeThreaded => _contextToken == IntPtr.Zero;
 
-        public bool IsInCurrentContext => IsFreeThreaded || _contextPtr == Context.GetContextToken();
+        public bool IsInCurrentContext => IsFreeThreaded || _contextToken == Context.GetContextToken();
 
         private protected IntPtr ThisPtrFromOriginalContext
         {
@@ -122,17 +122,17 @@ namespace WinRT
                 throw new ArgumentNullException(nameof(thisPtr));
             }
             _thisPtr = thisPtr;
-            _contextPtr = ComWrappersSupport.IsFreeThreaded(thisPtr) ? IntPtr.Zero : Context.GetContextToken();
+            _contextToken = ComWrappersSupport.IsFreeThreaded(thisPtr) ? IntPtr.Zero : Context.GetContextToken();
         }
 
-        protected IObjectReference(IntPtr thisPtr, IntPtr contextPtr)
+        protected IObjectReference(IntPtr thisPtr, IntPtr contextToken)
         {
             if (thisPtr == IntPtr.Zero)
             {
                 throw new ArgumentNullException(nameof(thisPtr));
             }
             _thisPtr = thisPtr;
-            _contextPtr = contextPtr;
+            _contextToken = contextToken;
         }
 
         ~IObjectReference()
@@ -440,14 +440,14 @@ namespace WinRT
             }
         }
 
-        ObjectReference(IntPtr thisPtr, IntPtr contextPtr, T vftblT) :
-            base(thisPtr, contextPtr)
+        ObjectReference(IntPtr thisPtr, IntPtr contextToken, T vftblT) :
+            base(thisPtr, contextToken)
         {
             _vftbl = vftblT;
         }
 
-        private protected ObjectReference(IntPtr thisPtr, IntPtr contextPtr) :
-            this(thisPtr, contextPtr, GetVtable(thisPtr))
+        private protected ObjectReference(IntPtr thisPtr, IntPtr contextToken) :
+            this(thisPtr, contextToken, GetVtable(thisPtr))
         {
         }
 
@@ -581,7 +581,6 @@ namespace WinRT
             : base(thisPtr, contextToken)
         {
             _contextCallbackPtr = contextCallbackPtr;
-            _contextToken = contextToken;
         }
 
         internal ObjectReferenceWithContext(IntPtr thisPtr, IntPtr contextCallbackPtr, IntPtr contextToken, Guid iid)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1941,7 +1941,7 @@ private static ObjectReference<IActivationFactoryVftbl> %
     get
     { 
         var factory = __%;
-        if (factory != null && factory.IsObjectInContext())
+        if (factory != null && factory.IsInCurrentContext)
         {
             return factory;
         }
@@ -1999,7 +1999,7 @@ private static ObjectReference<%> %
     get
     { 
         var factory = __%;
-        if (factory != null && factory.IsObjectInContext())
+        if (factory != null && factory.IsInCurrentContext)
         {
             return factory;
         }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -1935,8 +1935,8 @@ private static % _% = new %("%.%", %.IID);
     {
         auto objrefname = w.write_temp("%", bind<write_objref_type_name>(classType));
         w.write(R"(
-private static volatile FactoryObjectReference<IActivationFactoryVftbl> __%;
-private static FactoryObjectReference<IActivationFactoryVftbl> %
+private static volatile ObjectReference<IActivationFactoryVftbl> __%;
+private static ObjectReference<IActivationFactoryVftbl> %
 {
     get
     { 
@@ -1993,8 +1993,8 @@ private static ObjectReference<%> % => __% ?? Make__%();
         {
             auto objrefname = w.write_temp("%", bind<write_objref_type_name>(staticsType));
             w.write(R"(
-private static volatile FactoryObjectReference<%> __%;
-private static FactoryObjectReference<%> %
+private static volatile ObjectReference<%> __%;
+private static ObjectReference<%> %
 {
     get
     { 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -435,7 +435,7 @@ namespace WinRT
             }
         }
 
-        public unsafe (FactoryObjectReference<IActivationFactoryVftbl> obj, int hr) GetActivationFactory(string runtimeClassId)
+        public unsafe (ObjectReference<IActivationFactoryVftbl> obj, int hr) GetActivationFactory(string runtimeClassId)
         {
             IntPtr instancePtr = IntPtr.Zero;
             try
@@ -446,7 +446,7 @@ namespace WinRT
                     int hr = _GetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId), &instancePtr);
                     if (hr == 0)
                     {
-                        var objRef = FactoryObjectReference<IActivationFactoryVftbl>.Attach(ref instancePtr);
+                        var objRef = ObjectReference<IActivationFactoryVftbl>.Attach(ref instancePtr);
                         return (objRef, hr);
                     }
                     else
@@ -493,7 +493,7 @@ namespace WinRT
             _mtaCookie = mtaCookie;
         }
 
-        public static unsafe (FactoryObjectReference<I> obj, int hr) GetActivationFactory<I>(string runtimeClassId, Guid iid)
+        public static unsafe (ObjectReference<I> obj, int hr) GetActivationFactory<I>(string runtimeClassId, Guid iid)
         {
             var module = Instance; // Ensure COM is initialized
             IntPtr instancePtr = IntPtr.Zero;
@@ -505,7 +505,7 @@ namespace WinRT
                     int hr = Platform.RoGetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId), &iid, &instancePtr);
                     if (hr == 0)
                     {
-                        var objRef = FactoryObjectReference<I>.Attach(ref instancePtr);
+                        var objRef = ObjectReference<I>.Attach(ref instancePtr);
                         return (objRef, hr);
                     }
                     else
@@ -523,71 +523,6 @@ namespace WinRT
         ~WinrtModule()
         {
             Marshal.ThrowExceptionForHR(Platform.CoDecrementMTAUsage(_mtaCookie));
-        }
-    }
-
-    internal sealed class FactoryObjectReference<
-#if NET
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
-        T> : IObjectReference
-    {
-        private readonly IntPtr _contextToken;
-
-        public static FactoryObjectReference<T> Attach(ref IntPtr thisPtr)
-        {
-            if (thisPtr == IntPtr.Zero)
-            {
-                return null;
-            }
-            var obj = new FactoryObjectReference<T>(thisPtr);
-            thisPtr = IntPtr.Zero;
-            return obj;
-        }
-
-        internal FactoryObjectReference(IntPtr thisPtr) :
-            base(thisPtr)
-        {
-            if (!IsFreeThreaded(this))
-            {
-                _contextToken = Context.GetContextToken();
-            }
-        }
-
-        internal FactoryObjectReference(IntPtr thisPtr, IntPtr contextToken)
-            : base(thisPtr)
-        {
-            _contextToken = contextToken;
-        }
-
-        public static new unsafe FactoryObjectReference<T> FromAbi(IntPtr thisPtr)
-        {
-            if (thisPtr == IntPtr.Zero)
-            {
-                return null;
-            }
-            var obj = new FactoryObjectReference<T>(thisPtr);
-            obj.VftblIUnknown.AddRef(obj.ThisPtr);
-            return obj;
-        }
-
-        public bool IsObjectInContext()
-        {
-            return _contextToken == IntPtr.Zero || _contextToken == Context.GetContextToken();
-        }
-
-        // If we are free threaded, we do not need to keep track of context.
-        // This can either be if the object implements IAgileObject or the free threaded marshaler.
-        // We only check IAgileObject for now as the necessary code to check the
-        // free threaded marshaler is not exposed from WinRT.Runtime.
-        private unsafe static bool IsFreeThreaded(IObjectReference objRef)
-        {
-            if (objRef.TryAs(InterfaceIIDs.IAgileObject_IID, out var agilePtr) >= 0)
-            {
-                Marshal.Release(agilePtr);
-                return true;
-            }
-            return false;
         }
     }
 
@@ -610,11 +545,11 @@ namespace WinRT
 
     internal static class ActivationFactory
     {
-        public static FactoryObjectReference<IActivationFactoryVftbl> Get(string typeName)
+        public static ObjectReference<IActivationFactoryVftbl> Get(string typeName)
         {
             // Prefer the RoGetActivationFactory HRESULT failure over the LoadLibrary/etc. failure
             int hr;
-            FactoryObjectReference<IActivationFactoryVftbl> factory;
+            ObjectReference<IActivationFactoryVftbl> factory;
             (factory, hr) = WinrtModule.GetActivationFactory<IActivationFactoryVftbl>(typeName, InterfaceIIDs.IActivationFactory_IID);
             if (factory != null)
             {
@@ -644,7 +579,7 @@ namespace WinRT
         }
 
 #if NET
-        public static FactoryObjectReference<I> Get<
+        public static ObjectReference<I> Get<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)]
 #else
         public static ObjectReference<I> Get<
@@ -653,7 +588,7 @@ namespace WinRT
         {
             // Prefer the RoGetActivationFactory HRESULT failure over the LoadLibrary/etc. failure
             int hr;
-            FactoryObjectReference<I> factory;
+            ObjectReference<I> factory;
             (factory, hr) = WinrtModule.GetActivationFactory<I>(typeName, iid);
             if (factory != null)
             {
@@ -680,20 +615,13 @@ namespace WinRT
                 DllModule module = null;
                 if (DllModule.TryLoad(moduleName + ".dll", out module))
                 {
-                    FactoryObjectReference<IActivationFactoryVftbl> activationFactory;
+                    ObjectReference<IActivationFactoryVftbl> activationFactory;
                     (activationFactory, hr) = module.GetActivationFactory(typeName);
                     if (activationFactory != null)
                     {
                         using (activationFactory)
                         {
-#if NET
-                            if (activationFactory.TryAs(iid, out IntPtr iidPtr) >= 0)
-                            {
-                                return FactoryObjectReference<I>.Attach(ref iidPtr);
-                            }
-#else
                             return activationFactory.As<I>(iid);
-#endif
                         }
                     }
                 }

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -709,8 +709,7 @@ namespace WinRT
         public void InitalizeReferenceTracking(IntPtr ptr)
         {
             eventInvokePtr = ptr;
-            Guid iid = IReferenceTrackerTargetVftbl.IID;
-            int hr = Marshal.QueryInterface(ptr, ref iid, out referenceTrackerTargetPtr);
+            int hr = Marshal.QueryInterface(ptr, ref Unsafe.AsRef(IReferenceTrackerTargetVftbl.IID), out referenceTrackerTargetPtr);
             if (hr != 0)
             {
                 referenceTrackerTargetPtr = default;


### PR DESCRIPTION
This enables extra optimizations for factories as part of #1390 and should also allow us to add a Detach method.

This requires #1380 to go in first.