### PR TITLE
Skip interfaces not publicly accessible in authoring scenarios

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -87,10 +87,12 @@ namespace Generator
             foreach (var declaration in syntaxReceiver.Declarations)
             {
                 var model = _context.Compilation.GetSemanticModel(declaration.SyntaxTree);
+                var symbol = model.GetDeclaredSymbol(declaration);
 
                 // Check symbol information for whether it is public to properly detect partial types
-                // which can leave out modifier.
-                if (model.GetDeclaredSymbol(declaration).DeclaredAccessibility != Accessibility.Public)
+                // which can leave out modifier. Also ignore nested types not effectively public
+                if (symbol.DeclaredAccessibility != Accessibility.Public ||
+                    (symbol is ITypeSymbol typeSymbol && !typeSymbol.IsPubliclyAccessible()))
                 {
                     continue;
                 }

--- a/src/Authoring/WinRT.SourceGenerator/Extensions/SymbolExtensions.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Extensions/SymbolExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+
+#nullable enable
+
+namespace Generator;
+
+/// <summary>
+/// Extensions for symbol types.
+/// </summary>
+internal static class SymbolExtensions
+{
+    /// <summary>
+    /// Checks whether a given type symbol is publicly accessible (ie. it's public and not nested in any non public type).
+    /// </summary>
+    /// <param name="type">The type symbol to check for public accessibility.</param>
+    /// <returns>Whether <paramref name="type"/> is publicly accessible.</returns>
+    public static bool IsPubliclyAccessible(this ITypeSymbol type)
+    {
+        for (ITypeSymbol? currentType = type; currentType is not null; currentType = currentType.ContainingType)
+        {
+            // If any type in the type hierarchy is not public, the type is not public.
+            // This makes sure to detect public types nested into eg. a private type.
+            if (currentType.DeclaredAccessibility is not Accessibility.Public)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1211,7 +1211,7 @@ namespace Generator
             // Ignoring them here makes sure that they're not processed to be part of the .winmd file.
             foreach (var @interface in symbol.AllInterfaces)
             {
-                if (IsPubliclyAccessible(@interface))
+                if (@interface.IsPubliclyAccessible())
                 {
                     _ = interfaces.Add(@interface);
                 }
@@ -2696,28 +2696,6 @@ namespace Generator
                 type is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
                 type is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty;
         }
-
-#nullable enable
-        /// <summary>
-        /// Checks whether a given type symbol is publicly accessible (ie. it's public and not nested in any non public type).
-        /// </summary>
-        /// <param name="type">The type symbol to check for public accessibility.</param>
-        /// <returns>Whether <paramref name="type"/> is publicly accessible.</returns>
-        public bool IsPubliclyAccessible(ITypeSymbol type)
-        {
-            for (ITypeSymbol? currentType = type; currentType is not null; currentType = currentType.ContainingType)
-            {
-                // If any type in the type hierarchy is not public, the type is not public.
-                // This makes sure to detect public types nested into eg. a private type.
-                if (currentType.DeclaredAccessibility is not Accessibility.Public)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-#nullable restore
 
         public void GetNamespaceAndTypename(string qualifiedName, out string @namespace, out string typename)
         {

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2696,12 +2696,19 @@ namespace Generator
             }
         }
 
-        public bool IsPublic(ISymbol type)
+        public bool IsPublic(ISymbol symbol)
         {
-            return type.DeclaredAccessibility == Accessibility.Public ||
-                type is IMethodSymbol method && !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
-                type is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
-                type is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty;
+            // Check that the type has either public accessibility, or is an explicit interface implementation
+            if (symbol.DeclaredAccessibility == Accessibility.Public ||
+                symbol is IMethodSymbol method && !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
+                symbol is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
+                symbol is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+            {
+                // If we have a containing type, we also check that it's publicly accessible
+                return symbol.ContainingType is not { } containingType || containingType.IsPubliclyAccessible();
+            }
+
+            return false;
         }
 
         public void GetNamespaceAndTypename(string qualifiedName, out string @namespace, out string typename)

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1917,6 +1917,13 @@ namespace Generator
                 }
                 else
                 {
+                    // Special case: skip members that are explicitly implementing internal interfaces.
+                    // This allows implementing classic COM internal interfaces with non-WinRT signatures.
+                    if (member.IsExplicitInterfaceImplementationOfInternalInterfaces())
+                    {
+                        continue;
+                    }
+
                     if (member is IMethodSymbol method &&
                         (method.MethodKind == MethodKind.Ordinary ||
                          method.MethodKind == MethodKind.ExplicitInterfaceImplementation ||

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1204,11 +1204,17 @@ namespace Generator
 
         private IEnumerable<INamedTypeSymbol> GetInterfaces(INamedTypeSymbol symbol, bool includeInterfacesWithoutMappings = false)
         {
-            HashSet<INamedTypeSymbol> interfaces = new HashSet<INamedTypeSymbol>();
-            foreach (var @interface in symbol.Interfaces)
+            HashSet<INamedTypeSymbol> interfaces = new();
+
+            // Gather all interfaces that are publicly accessible. We specifically need to exclude interfaces
+            // that are not public, as eg. those might be used for additional cloaked WinRT/COM interfaces.
+            // Ignoring them here makes sure that they're not processed to be part of the .winmd file.
+            foreach (var @interface in symbol.AllInterfaces)
             {
-                interfaces.Add(@interface);
-                interfaces.UnionWith(@interface.AllInterfaces);
+                if (IsPubliclyAccessible(@interface))
+                {
+                    _ = interfaces.Add(@interface);
+                }
             }
 
             var baseType = symbol.BaseType;
@@ -2690,6 +2696,28 @@ namespace Generator
                 type is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
                 type is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsDefaultOrEmpty;
         }
+
+#nullable enable
+        /// <summary>
+        /// Checks whether a given type symbol is publicly accessible (ie. it's public and not nested in any non public type).
+        /// </summary>
+        /// <param name="type">The type symbol to check for public accessibility.</param>
+        /// <returns>Whether <paramref name="type"/> is publicly accessible.</returns>
+        public bool IsPubliclyAccessible(ITypeSymbol type)
+        {
+            for (ITypeSymbol? currentType = type; currentType is not null; currentType = currentType.ContainingType)
+            {
+                // If any type in the type hierarchy is not public, the type is not public.
+                // This makes sure to detect public types nested into eg. a private type.
+                if (currentType.DeclaredAccessibility is not Accessibility.Public)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+#nullable restore
 
         public void GetNamespaceAndTypename(string qualifiedName, out string @namespace, out string typename)
         {

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -74,5 +74,9 @@
         name="AuthoringTest.TestClass"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.TestMixedWinRTCOMWrapper"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/pch.h
+++ b/src/Tests/AuthoringConsumptionTest/pch.h
@@ -4,6 +4,7 @@
 // conflict with Storyboard::GetCurrentTime
 #undef GetCurrentTime
 
+#include <Windows.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -662,15 +662,15 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     winrt::com_ptr<::IUnknown> internalInterface2;
     EXPECT_EQ(unknown2->QueryInterface(internalInterface2Iid, internalInterface2.put_void()), S_OK);
 
-    typedef int (*GetNumber)(void*, int*);
+    typedef int (__stdcall* GetNumber)(void*, int*);
 
     int number;
 
     // Validate the first call on IInternalInterface1
-    EXPECT_EQ(reinterpret_cast<GetNumber>(reinterpret_cast<void**>(internalInterface1.get())[3])(internalInterface1.get(), &number), S_OK);
+    EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface1.get()))[3])(internalInterface1.get(), &number), S_OK);
     EXPECT_EQ(number, 42);
 
     // Validate the second call on IInternalInterface2
-    EXPECT_EQ(reinterpret_cast<GetNumber>(reinterpret_cast<void**>(internalInterface2.get())[3])(internalInterface2.get(), &number), S_OK);
+    EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface2.get()))[3])(internalInterface2.get(), &number), S_OK);
     EXPECT_EQ(number, 123);
 }

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -649,18 +649,18 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     EXPECT_EQ(wrapper.HelloWorld(), L"Hello from mixed WinRT/COM");
 
     // Verify we can grab the internal interface
-    std::string internalInterface1IidText = "C7850559-8FF2-4E54-A237-6ED813F20CDC";
-    winrt::guid internalInterface1IidValue(internalInterface1IidText);
-    winrt::com_ptr<IUnknown> unknown = wrapper.as<IUnknown>();
-    winrt::com_ptr<IUnknown> internalInterface1;
-    EXPECT_EQ(unknown->QueryInterface(internalInterface1IidValue, internalInterface1.put_void()), S_OK);
+    IID internalInterface1Iid;
+    check_hresult(IIDFromString(L"{C7850559-8FF2-4E54-A237-6ED813F20CDC}", &internalInterface1Iid));
+    winrt::com_ptr<::IUnknown> unknown1 = wrapper.as<::IUnknown>();
+    winrt::com_ptr<::IUnknown> internalInterface1;
+    EXPECT_EQ(unknown1->QueryInterface(internalInterface1Iid, internalInterface1.put_void()), S_OK);
 
     // Verify we can grab the nested public interface (in an internal type)
-    std::string internalInterface2IidText = "8A08E18A-8D20-4E7C-9242-857BFE1E3159";
-    winrt::guid internalInterface2IidValue(internalInterface2IidText);
-    winrt::com_ptr<IUnknown> unknown = wrapper.as<IUnknown>();
-    winrt::com_ptr<IUnknown> internalInterface2;
-    EXPECT_EQ(unknown->QueryInterface(internalInterface2IidValue, internalInterface2.put_void()), S_OK);
+    IID internalInterface2Iid;
+    check_hresult(IIDFromString(L"{8A08E18A-8D20-4E7C-9242-857BFE1E3159}", &internalInterface2Iid));
+    winrt::com_ptr<::IUnknown> unknown2 = wrapper.as<::IUnknown>();
+    winrt::com_ptr<::IUnknown> internalInterface2;
+    EXPECT_EQ(unknown2->QueryInterface(internalInterface2Iid, internalInterface2.put_void()), S_OK);
 
     typedef int (*GetNumber)(void*, int*);
 

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -9,12 +9,16 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
+using WinRT;
+using WinRT.Interop;
 
 #pragma warning disable CA1416
 
@@ -1568,5 +1572,121 @@ namespace AuthoringTest
     public partial struct PartialStruct
     {
         public double Z;
+    }
+
+    public sealed class TestMixedWinRTCOMWrapper : IPublicInterface, IInternalInterface1, SomeInternalType.IInternalInterface2
+    {
+        public string HelloWorld()
+        {
+            return "Hello from mixed WinRT/COM";
+        }
+
+        unsafe int IInternalInterface1.GetNumber(int* value)
+        {
+            *value = 42;
+
+            return 0;
+        }
+
+        unsafe int SomeInternalType.IInternalInterface2.GetNumber(int* value)
+        {
+            *value = 123;
+
+            return 0;
+        }
+    }
+
+    public interface IPublicInterface
+    {
+        string HelloWorld();
+    }
+
+    // Internal, classic COM interface
+    [Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
+    [WindowsRuntimeType]
+    [WindowsRuntimeHelperType(typeof(IInternalInterface1))]
+    internal unsafe interface IInternalInterface1
+    {
+        int GetNumber(int* value);
+
+        [Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
+        public struct Vftbl
+        {
+            public static readonly IntPtr AbiToProjectionVftablePtr = InitVtbl();
+
+            private static IntPtr InitVtbl()
+            {
+                Vftbl* lpVtbl = (Vftbl*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(Vftbl));
+
+                lpVtbl->IUnknownVftbl = IUnknownVftbl.AbiToProjectionVftbl;
+                lpVtbl->GetNumber = &GetDeviceFromAbi;
+
+                return (IntPtr)lpVtbl;
+            }
+
+            private IUnknownVftbl IUnknownVftbl;
+            private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
+
+            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+            private static int GetDeviceFromAbi(void* thisPtr, int* value)
+            {
+                try
+                {
+                    return ComWrappersSupport.FindObject<IInternalInterface1>((IntPtr)thisPtr).GetNumber(value);
+                }
+                catch (Exception e)
+                {
+                    ExceptionHelpers.SetErrorInfo(e);
+
+                    return Marshal.GetHRForException(e);
+                }
+            }
+        }
+    }
+
+    internal struct SomeInternalType
+    {
+        // Nested, classic COM interface
+        [Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
+        [WindowsRuntimeType]
+        [WindowsRuntimeHelperType(typeof(IInternalInterface2))]
+        public unsafe interface IInternalInterface2
+        {
+            int GetNumber(int* value);
+
+            [Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
+            public struct Vftbl
+            {
+                public static readonly IntPtr AbiToProjectionVftablePtr = InitVtbl();
+
+                private static IntPtr InitVtbl()
+                {
+                    Vftbl* lpVtbl = (Vftbl*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(Vftbl));
+
+                    lpVtbl->IUnknownVftbl = IUnknownVftbl.AbiToProjectionVftbl;
+                    lpVtbl->GetNumber = &GetDeviceFromAbi;
+
+                    return (IntPtr)lpVtbl;
+                }
+
+                private IUnknownVftbl IUnknownVftbl;
+                private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
+
+                [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+                private static int GetDeviceFromAbi(void* thisPtr, int* value)
+                {
+                    try
+                    {
+                        return ComWrappersSupport.FindObject<IInternalInterface2>((IntPtr)thisPtr).GetNumber(value);
+                    }
+                    catch (Exception e)
+                    {
+                        ExceptionHelpers.SetErrorInfo(e);
+
+                        return Marshal.GetHRForException(e);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -10,6 +10,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -1626,7 +1627,7 @@ namespace AuthoringTest
             private IUnknownVftbl IUnknownVftbl;
             private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
 
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
             private static int GetDeviceFromAbi(void* thisPtr, int* value)
             {
                 try
@@ -1671,7 +1672,7 @@ namespace AuthoringTest
                 private IUnknownVftbl IUnknownVftbl;
                 private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
 
-                [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+                [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
                 private static int GetDeviceFromAbi(void* thisPtr, int* value)
                 {
                     try

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -10,7 +10,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -1602,14 +1601,14 @@ namespace AuthoringTest
     }
 
     // Internal, classic COM interface
-    [Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
+    [global::System.Runtime.InteropServices.Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
     [WindowsRuntimeType]
     [WindowsRuntimeHelperType(typeof(IInternalInterface1))]
     internal unsafe interface IInternalInterface1
     {
         int GetNumber(int* value);
 
-        [Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
+        [global::System.Runtime.InteropServices.Guid("C7850559-8FF2-4E54-A237-6ED813F20CDC")]
         public struct Vftbl
         {
             public static readonly IntPtr AbiToProjectionVftablePtr = InitVtbl();
@@ -1647,14 +1646,14 @@ namespace AuthoringTest
     internal struct SomeInternalType
     {
         // Nested, classic COM interface
-        [Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
+        [global::System.Runtime.InteropServices.Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
         [WindowsRuntimeType]
         [WindowsRuntimeHelperType(typeof(IInternalInterface2))]
         public unsafe interface IInternalInterface2
         {
             int GetNumber(int* value);
 
-            [Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
+            [global::System.Runtime.InteropServices.Guid("8A08E18A-8D20-4E7C-9242-857BFE1E3159")]
             public struct Vftbl
             {
                 public static readonly IntPtr AbiToProjectionVftablePtr = InitVtbl();

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -17,6 +17,7 @@ using System.Windows.Input;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
+using Windows.Graphics.Effects;
 using WinRT;
 using WinRT.Interop;
 
@@ -1574,7 +1575,7 @@ namespace AuthoringTest
         public double Z;
     }
 
-    public sealed class TestMixedWinRTCOMWrapper : IPublicInterface, IInternalInterface1, SomeInternalType.IInternalInterface2
+    public sealed class TestMixedWinRTCOMWrapper : IGraphicsEffectSource, IPublicInterface, IInternalInterface1, SomeInternalType.IInternalInterface2
     {
         public string HelloWorld()
         {
@@ -1687,6 +1688,26 @@ namespace AuthoringTest
                     }
                 }
             }
+        }
+    }
+}
+
+namespace ABI.AuthoringTest
+{
+    internal static class IInternalInterface1Methods
+    {
+        public static Guid IID => typeof(global::AuthoringTest.IInternalInterface1).GUID;
+
+        public static IntPtr AbiToProjectionVftablePtr => global::AuthoringTest.IInternalInterface1.Vftbl.AbiToProjectionVftablePtr;
+    }
+
+    internal struct SomeInternalType
+    {
+        internal static class IInternalInterface2Methods
+        {
+            public static Guid IID => typeof(global::AuthoringTest.SomeInternalType.IInternalInterface2).GUID;
+
+            public static IntPtr AbiToProjectionVftablePtr => global::AuthoringTest.SomeInternalType.IInternalInterface2.Vftbl.AbiToProjectionVftablePtr;
         }
     }
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1620,7 +1620,7 @@ namespace AuthoringTest
                 Vftbl* lpVtbl = (Vftbl*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(Vftbl));
 
                 lpVtbl->IUnknownVftbl = IUnknownVftbl.AbiToProjectionVftbl;
-                lpVtbl->GetNumber = &GetDeviceFromAbi;
+                lpVtbl->GetNumber = &GetNumberFromAbi;
 
                 return (IntPtr)lpVtbl;
             }
@@ -1629,7 +1629,7 @@ namespace AuthoringTest
             private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
 
             [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-            private static int GetDeviceFromAbi(void* thisPtr, int* value)
+            private static int GetNumberFromAbi(void* thisPtr, int* value)
             {
                 try
                 {
@@ -1665,7 +1665,7 @@ namespace AuthoringTest
                     Vftbl* lpVtbl = (Vftbl*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(Vftbl));
 
                     lpVtbl->IUnknownVftbl = IUnknownVftbl.AbiToProjectionVftbl;
-                    lpVtbl->GetNumber = &GetDeviceFromAbi;
+                    lpVtbl->GetNumber = &GetNumberFromAbi;
 
                     return (IntPtr)lpVtbl;
                 }
@@ -1674,7 +1674,7 @@ namespace AuthoringTest
                 private delegate* unmanaged[Stdcall]<void*, int*, int> GetNumber;
 
                 [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-                private static int GetDeviceFromAbi(void* thisPtr, int* value)
+                private static int GetNumberFromAbi(void* thisPtr, int* value)
                 {
                     try
                     {


### PR DESCRIPTION
### Closes #1369

### Overview

This PR updates the WinRT authoring generator to skip interfaces that are not publicly accessible.
