### PR TITLE
Minor trimming optimizations for authoring

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1237,11 +1237,6 @@ namespace WinRT
         T>
     {
         public static IObjectReference CreateMarshaler<V>(
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#elif NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
             T o,
             Guid iid,
             bool unwrapObject = true)
@@ -1267,11 +1262,6 @@ namespace WinRT
         }
 
         public static IObjectReference CreateMarshaler(
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#elif NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
             T o,
             bool unwrapObject = true)
         {
@@ -1279,11 +1269,6 @@ namespace WinRT
         }
 
         public static ObjectReferenceValue CreateMarshaler2(
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#elif NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
             T o,
             Guid iid,
             bool unwrapObject = true)
@@ -1309,11 +1294,6 @@ namespace WinRT
         }
 
         public static ObjectReferenceValue CreateMarshaler2(
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#elif NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
             T o, bool unwrapObject = true) => CreateMarshaler2(o, InterfaceIIDs.IInspectable_IID, unwrapObject);
 
         public static IntPtr GetAbi(IObjectReference objRef) =>

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -131,7 +131,7 @@ namespace WinRT
 
         public unsafe ObjectReference<T> As<
 #if NET
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 #endif
         T>(Guid iid)
         {
@@ -173,7 +173,7 @@ namespace WinRT
 
         public virtual unsafe int TryAs<
 #if NET
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 #endif
         T>(Guid iid, out ObjectReference<T> objRef)
         {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9647,7 +9647,7 @@ RuntimeHelpers.RunClassConstructor(typeof(%).TypeHandle);
 
 public static IntPtr Make()
 {
-using var marshaler = MarshalInspectable<%>.CreateMarshaler(_factory).As<ABI.WinRT.Interop.IActivationFactory.Vftbl>();
+using var marshaler = MarshalInspectable<%>.CreateMarshaler(_factory).As<ABI.WinRT.Interop.IActivationFactory.Vftbl>(InterfaceIIDs.IActivationFactory_IID);
 return marshaler.GetRef();
 }
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9647,8 +9647,7 @@ RuntimeHelpers.RunClassConstructor(typeof(%).TypeHandle);
 
 public static IntPtr Make()
 {
-using var marshaler = MarshalInspectable<%>.CreateMarshaler(_factory).As<ABI.WinRT.Interop.IActivationFactory.Vftbl>(InterfaceIIDs.IActivationFactory_IID);
-return marshaler.GetRef();
+    return MarshalInspectable<%>.CreateMarshaler2(_factory, InterfaceIIDs.IActivationFactory_IID).Detach();
 }
 
 static readonly % _factory = new %();


### PR DESCRIPTION
This PR includes two small tweaks for trimming in authoring scenarios:
- Remove an unnecessary `DynamicallyAccessedMemberTypes.PublicFields` flag in `TryAs<T>`
- Use `IActivationFactoryMethods.IID` to resolve the activation factory from `Make()`