### PR TITLE
Remove generated VftblPtr type

### DIFF
--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -4,14 +4,6 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace WinRT
-{
-    internal struct VftblPtr
-    {
-        public IntPtr Vftbl;
-    }
-}
-
 namespace WinRT.Interop
 {
     [Guid("00000000-0000-0000-C000-000000000046")]

--- a/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
+++ b/src/WinRT.Runtime/Interop/IUnknownVftbl.cs
@@ -4,6 +4,14 @@
 using System;
 using System.Runtime.InteropServices;
 
+namespace WinRT
+{
+    internal struct VftblPtr
+    {
+        public IntPtr Vftbl;
+    }
+}
+
 namespace WinRT.Interop
 {
     [Guid("00000000-0000-0000-C000-000000000046")]

--- a/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -529,9 +529,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 Lookup_0 = Marshal.GetDelegateForFunctionPointer(vftbl[6], Lookup_0_Type);
                 get_Size_1 = Marshal.GetDelegateForFunctionPointer<_get_PropertyAsUInt32>(vftbl[7]);
                 HasKey_2 = Marshal.GetDelegateForFunctionPointer(vftbl[8], HasKey_2_Type);

--- a/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -114,9 +114,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 First_0 = Marshal.GetDelegateForFunctionPointer<IEnumerable_Delegates.First_0>(vftbl[6]);
             }
 
@@ -458,9 +458,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 get_Current_0 = Marshal.GetDelegateForFunctionPointer(vftbl[6], get_Current_0_Type);
                 get_HasCurrent_1 = Marshal.GetDelegateForFunctionPointer<_get_PropertyAsBoolean>(vftbl[7]);
                 MoveNext_2 = Marshal.GetDelegateForFunctionPointer<IEnumerator_Delegates.MoveNext_2>(vftbl[8]);

--- a/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -484,9 +484,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 GetAt_0 = Marshal.GetDelegateForFunctionPointer(vftbl[6], GetAt_0_Type);
                 get_Size_1 = Marshal.GetDelegateForFunctionPointer<_get_PropertyAsUInt32>(vftbl[7]);
                 GetView_2 = Marshal.GetDelegateForFunctionPointer<IList_Delegates.GetView_2>(vftbl[8]);

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -521,9 +521,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 Lookup_0 = Marshal.GetDelegateForFunctionPointer(vftbl[6], Lookup_0_Type);
                 get_Size_1 = Marshal.GetDelegateForFunctionPointer<_get_PropertyAsUInt32>(vftbl[7]);
                 HasKey_2 = Marshal.GetDelegateForFunctionPointer(vftbl[8], HasKey_2_Type);

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -227,9 +227,9 @@ namespace ABI.System.Collections.Generic
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 GetAt_0 = Marshal.GetDelegateForFunctionPointer(vftbl[6], GetAt_0_Type);
                 get_Size_1 = Marshal.GetDelegateForFunctionPointer<_get_PropertyAsUInt32>(vftbl[7]);
                 IndexOf_2 = Marshal.GetDelegateForFunctionPointer(vftbl[8], IndexOf_2_Type);

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -152,9 +152,9 @@ namespace ABI.Windows.Foundation
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 get_Value_0 = Marshal.GetDelegateForFunctionPointer<IReferenceArray_Delegates.get_Value_0>(vftbl[6]);
             }
         }

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -309,9 +309,9 @@ namespace ABI.System
 
             internal unsafe Vftbl(IntPtr thisPtr)
             {
-                var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-                var vftbl = (IntPtr*)vftblPtr.Vftbl;
-                IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+                var vftblPtr = *(void***)thisPtr;
+                var vftbl = (IntPtr*)vftblPtr;
+                IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
                 get_Value_0 = GetValueDelegateForFunctionPointer(vftbl[6]);
             }
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6915,9 +6915,9 @@ internal IInspectable.Vftbl IInspectableVftbl;
                 w.write(R"(%
 internal unsafe Vftbl(IntPtr thisPtr) : this()
 {
-var vftblPtr = Marshal.PtrToStructure<VftblPtr>(thisPtr);
-var vftbl = (IntPtr*)vftblPtr.Vftbl;
-IInspectableVftbl = Marshal.PtrToStructure<IInspectable.Vftbl>(vftblPtr.Vftbl);
+var vftblPtr = *(void***)thisPtr;
+var vftbl = (IntPtr*)vftblPtr;
+IInspectableVftbl = *(IInspectable.Vftbl*)vftblPtr;
 %}
 )",
                     bind_each([&](writer& w, MethodDef const& method)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6955,7 +6955,7 @@ AbiToProjectionVftable = new Vftbl
 IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable, 
 %
 };
-var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * %);
+var nativeVftbl = (IntPtr*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(global::WinRT.IInspectable.Vftbl) + sizeof(IntPtr) * %);
 %
 AbiToProjectionVftablePtr = (IntPtr)nativeVftbl;
 }
@@ -6983,7 +6983,7 @@ public static readonly IntPtr AbiToProjectionVftablePtr;
 %
 static unsafe Vftbl()
 {
-AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * %);
+AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(global::WinRT.IInspectable.Vftbl) + sizeof(IntPtr) * %);
 (*(Vftbl*)AbiToProjectionVftablePtr) = new Vftbl
 {
 IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable, 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -341,11 +341,6 @@ namespace WinRT
         }
     }
 
-    internal struct VftblPtr
-    {
-        public IntPtr Vftbl;
-    }
-
     internal static class IActivationFactoryMethods
     {
         public static unsafe ObjectReference<I> ActivateInstance<I>(IObjectReference obj)


### PR DESCRIPTION
This PR removes the generated VftblType, which wasn't even used most of the time. The only code path referencing it has been rewritten to manually reinterpret a pointer instead of using `Marshal`, which also makes it a bit faster while at it.