### PR TITLE
Make exported DllGetActivationFactory zero-alloc

### DIFF
--- a/src/Authoring/WinRT.Host.Shim/Module.cs
+++ b/src/Authoring/WinRT.Host.Shim/Module.cs
@@ -36,7 +36,7 @@ namespace WinRT.Host
                 {
                     return REGDB_E_READREGDB;
                 }
-                var GetActivationFactory = type.GetMethod("GetActivationFactory");
+                var GetActivationFactory = type.GetMethod("GetActivationFactory", new Type[] { typeof(string) });
                 if (GetActivationFactory == null)
                 {
                     return REGDB_E_READREGDB;

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -226,7 +226,7 @@ namespace Generator
 
                             try
                             {
-                                IntPtr obj = GetActivationFactory(MarshalString.FromAbi((IntPtr)activatableClassId));
+                                IntPtr obj = GetActivationFactory(MarshalString.FromAbiUnsafe((IntPtr)activatableClassId));
 
                                 if ((void*)obj is null)
                                 {

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -1282,6 +1282,22 @@ namespace UnitTest
         }
 
         [Fact]
+        public unsafe void TestFactoryCast_Unsafe()
+        {
+            IntPtr hstr;
+
+            // Access nonstatic class factory 
+            var instanceFactory = Class.As<IStringableInterop>();
+            instanceFactory.ToString(out hstr);
+            Assert.Equal("Class", MarshalString.FromAbiUnsafe(hstr).ToString());
+
+            // Access static class factory
+            var staticFactory = ComImports.As<IStringableInterop>();
+            staticFactory.ToString(out hstr);
+            Assert.Equal("ComImports", MarshalString.FromAbiUnsafe(hstr).ToString());
+        }
+
+        [Fact]
         public void TestFundamentalGeneric()
         {
             var ints = TestObject.GetIntVector();

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -171,6 +171,37 @@ namespace WinRT
             return new string(buffer, 0, (int)length);
         }
 
+        /// <summary>
+        /// Marshals an input <c>HSTRING</c> value to a <see cref="ReadOnlySpan{T}"/> value.
+        /// </summary>
+        /// <param name="value">The input <c>HSTRING</c> value to marshal.</param>
+        /// <returns>The resulting <see cref="ReadOnlySpan{T}"/> value.</returns>
+        /// <remarks>
+        /// <para>
+        /// This method is equivalent to <see cref="FromAbi"/>, but it does not create a new <see cref="string"/> instance.
+        /// Doing so makes it zero-allocation, but extra care should be taken by callers to ensure that the returned value
+        /// does not escape the scope where the source <c>HSTRING</c> is valid.
+        /// </para>
+        /// <para>
+        /// For instance, if this method is invoked in the scope of a method that receives the <c>HSTRING</c> value as one of
+        /// its parameters, the resulting <see cref="ReadOnlySpan{T}"/> is always valid for the scope of such method. But, if
+        /// the <c>HSTRING</c> was created by reference in a given scope, the resulting <see cref="ReadOnlySpan{T}"/> value
+        /// will also only be valid within such scope, and should not be used outside of it.
+        /// </para>
+        /// </remarks>
+        public static unsafe ReadOnlySpan<char> FromAbiUnsafe(IntPtr value)
+        {
+            if (value == IntPtr.Zero)
+            {
+                return "".AsSpan();
+            }
+
+            uint length;
+            char* buffer = Platform.WindowsGetStringRawBuffer(value, &length);
+
+            return new(buffer, (int)length);
+        }
+
         public static unsafe IntPtr FromManaged(string value)
         {
             if (value is null)
@@ -1194,7 +1225,7 @@ namespace WinRT
 
 #if EMBED
     internal
-#else 
+#else
     public
 #endif
     static class MarshalInspectable<

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -131,7 +131,7 @@ namespace WinRT
             { 
                 IntPtr hstring;
                 Debug.Assert(_header == IntPtr.Zero);
-                _header = Marshal.AllocHGlobal(Unsafe.SizeOf<HSTRING_HEADER>());
+                _header = Marshal.AllocHGlobal(sizeof(HSTRING_HEADER));
                 Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(
                     (ushort*)chars, value.Length, (IntPtr*)_header, &hstring));
                 return hstring;
@@ -249,7 +249,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                m._array = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                m._array = Marshal.AllocCoTaskMem(length * sizeof(IntPtr));
                 m._marshalers = new MarshalString[length];
                 var elements = (IntPtr*)m._array.ToPointer();
                 for (int i = 0; i < length; i++)
@@ -317,7 +317,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                data = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                data = Marshal.AllocCoTaskMem(length * sizeof(IntPtr));
                 var elements = (IntPtr*)data;
                 for (i = 0; i < length; i++)
                 {

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -120,4 +120,5 @@ TypesMustExist : Type 'WinRT.StructTypeDetails<T, TAbi>' does not exist in the r
 MembersMustExist : Member 'public void WinRT.WindowsRuntimeTypeAttribute..ctor(System.String, System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribute.GuidSignature.get()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 121
+MembersMustExist : Member 'public System.ReadOnlySpan<System.Char> WinRT.MarshalString.FromAbiUnsafe(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 122

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9450,14 +9450,16 @@ namespace WinRT
 {
 % static partial class Module
 {
-public static unsafe IntPtr GetActivationFactory(String runtimeClassId)
+public static unsafe IntPtr GetActivationFactory(% runtimeClassId)
 {%
 return IntPtr.Zero;
 }
+%
 }
 }
 )",
     internal_accessibility(),
+    settings.netstandard_compat ? "string" : "ReadOnlySpan<char>",
 bind_each([](writer& w, TypeDef const& type)
     {
         w.write(R"(
@@ -9473,7 +9475,13 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
 );
     },
     types
-        ));
+        ),
+    settings.netstandard_compat ? "// No ReadOnlySpan<char> overload available" : R"(
+public static IntPtr GetActivationFactory(string runtimeClassId)
+{
+    return GetActivationFactory(runtimeClassId.AsSpan());
+}"
+)");
     }
 
     void write_event_source_generic_args(writer& w, cswinrt::type_semantics eventTypeSemantics)


### PR DESCRIPTION
This PR makes the exported `DllGetActivationFactory` zero-alloc, skipping the useless `string runtimeClassId` parameter.
It does so by introducing the following new API to `MarshalString`:

```csharp
public static ReadOnlySpan<char> FromAbiUnsafe(IntPtr value);
```

This allows marshalling an `HSTRING` to a `ReadOnlySpan<char>` value, without allocating a temporary `string`. The "Unsafe" suffix matches the naming convention in the BCL for methods that are not safe when misused. In this case, callers have to make sure not to escape the returned `ReadOnlySpan<char>` value outside of the scope where the `HSTRING` is valid.

Then, it updates the generated `Module` type so that when not on .NET Standard, the `GetActivationFactory` method will actually take a `ReadOnlySpan<char>` parameter (with a second `string` overload just forwarding to it). The new native exports for NativeAOT can then just call this new `ReadOnlySpan<char>` overload using the new `FromAbiUnsafe` marshalling method.