### PR TITLE
Add MarshalString.FromAbiUnsafe API

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -171,6 +171,37 @@ namespace WinRT
             return new string(buffer, 0, (int)length);
         }
 
+        /// <summary>
+        /// Marshals an input <c>HSTRING</c> value to a <see cref="ReadOnlySpan{T}"/> value.
+        /// </summary>
+        /// <param name="value">The input <c>HSTRING</c> value to marshal.</param>
+        /// <returns>The resulting <see cref="ReadOnlySpan{T}"/> value.</returns>
+        /// <remarks>
+        /// <para>
+        /// This method is equivalent to <see cref="FromAbi"/>, but it does not create a new <see cref="string"/> instance.
+        /// Doing so makes it zero-allocation, but extra care should be taken by callers to ensure that the returned value
+        /// does not escape the scope where the source <c>HSTRING</c> is valid.
+        /// </para>
+        /// <para>
+        /// For instance, if this method is invoked in the scope of a method that receives the <c>HSTRING</c> value as one of
+        /// its parameters, the resulting <see cref="ReadOnlySpan{T}"/> is always valid for the scope of such method. But, if
+        /// the <c>HSTRING</c> was created by reference in a given scope, the resulting <see cref="ReadOnlySpan{T}"/> value
+        /// will also only be valid within such scope, and should not be used outside of it.
+        /// </para>
+        /// </remarks>
+        public static unsafe ReadOnlySpan<char> FromAbiUnsafe(IntPtr value)
+        {
+            if (value == IntPtr.Zero)
+            {
+                return "".AsSpan();
+            }
+
+            uint length;
+            char* buffer = Platform.WindowsGetStringRawBuffer(value, &length);
+
+            return new(buffer, (int)length);
+        }
+
         public static unsafe IntPtr FromManaged(string value)
         {
             if (value is null)
@@ -1194,7 +1225,7 @@ namespace WinRT
 
 #if EMBED
     internal
-#else 
+#else
     public
 #endif
     static class MarshalInspectable<

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -131,7 +131,7 @@ namespace WinRT
             { 
                 IntPtr hstring;
                 Debug.Assert(_header == IntPtr.Zero);
-                _header = Marshal.AllocHGlobal(Unsafe.SizeOf<HSTRING_HEADER>());
+                _header = Marshal.AllocHGlobal(sizeof(HSTRING_HEADER));
                 Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(
                     (ushort*)chars, value.Length, (IntPtr*)_header, &hstring));
                 return hstring;
@@ -249,7 +249,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                m._array = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                m._array = Marshal.AllocCoTaskMem(length * sizeof(IntPtr));
                 m._marshalers = new MarshalString[length];
                 var elements = (IntPtr*)m._array.ToPointer();
                 for (int i = 0; i < length; i++)
@@ -317,7 +317,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                data = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                data = Marshal.AllocCoTaskMem(length * sizeof(IntPtr));
                 var elements = (IntPtr*)data;
                 for (i = 0; i < length; i++)
                 {

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -120,4 +120,5 @@ TypesMustExist : Type 'WinRT.StructTypeDetails<T, TAbi>' does not exist in the r
 MembersMustExist : Member 'public void WinRT.WindowsRuntimeTypeAttribute..ctor(System.String, System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribute.GuidSignature.get()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 121
+MembersMustExist : Member 'public System.ReadOnlySpan<System.Char> WinRT.MarshalString.FromAbiUnsafe(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 122


### PR DESCRIPTION
### Extracted from #1399

### Description

This PR adds a new `MarshalString` API:

```csharp
public static ReadOnlySpan<char> FromAbiUnsafe(IntPtr value);
```

This allows marshalling an `HSTRING` to a `ReadOnlySpan<char>` value, without allocating a temporary `string`. The "Unsafe" suffix matches the naming convention in the BCL for methods that are not safe when misused. In this case, callers have to make sure not to escape the returned `ReadOnlySpan<char>` value outside of the scope where the `HSTRING` is valid.

Developers can use this where appropriate, and we can also use this in eg. marshalling stubs in the future. Once we update the projections to require C# 11, we can also restore #1399 and leverage this API there as well.