### PR TITLE
Make exported DllGetActivationFactory zero-alloc (take 2)

### DIFF
--- a/src/Authoring/WinRT.Host.Shim/Module.cs
+++ b/src/Authoring/WinRT.Host.Shim/Module.cs
@@ -36,7 +36,7 @@ namespace WinRT.Host
                 {
                     return REGDB_E_READREGDB;
                 }
-                var GetActivationFactory = type.GetMethod("GetActivationFactory");
+                var GetActivationFactory = type.GetMethod("GetActivationFactory", new Type[] { typeof(string) });
                 if (GetActivationFactory == null)
                 {
                     return REGDB_E_READREGDB;

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -226,7 +226,7 @@ namespace Generator
 
                             try
                             {
-                                IntPtr obj = GetActivationFactory(MarshalString.FromAbi((IntPtr)activatableClassId));
+                                IntPtr obj = GetActivationFactory(MarshalString.FromAbiUnsafe((IntPtr)activatableClassId));
 
                                 if ((void*)obj is null)
                                 {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9684,23 +9684,25 @@ namespace WinRT
 % static partial class Module
 {
 public static unsafe IntPtr GetActivationFactory(% runtimeClassId)
-{%
-return IntPtr.Zero;
+{
+switch (runtimeClassId)
+{
+%
+default:
+    return IntPtr.Zero;
+}
 }
 %
 }
 }
 )",
     internal_accessibility(),
-    settings.netstandard_compat ? "string" : "ReadOnlySpan<char>",
+    settings.net7_0_or_greater ? "ReadOnlySpan<char>" : "string",
 bind_each([](writer& w, TypeDef const& type)
     {
         w.write(R"(
-
-if (runtimeClassId == "%.%")
-{
-return %ServerActivationFactory.Make();
-}
+case "%.%":
+    return %ServerActivationFactory.Make();
 )",
 type.TypeNamespace(),
 type.TypeName(),
@@ -9709,12 +9711,12 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
     },
     types
         ),
-    settings.netstandard_compat ? "// No ReadOnlySpan<char> overload available" : R"(
+    settings.net7_0_or_greater ? R"(
 public static IntPtr GetActivationFactory(string runtimeClassId)
 {
     return GetActivationFactory(runtimeClassId.AsSpan());
 }"
-)");
+)" : "// No ReadOnlySpan<char> overload available");
     }
 
     void write_event_source_generic_args(writer& w, cswinrt::type_semantics eventTypeSemantics)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9683,14 +9683,16 @@ namespace WinRT
 {
 % static partial class Module
 {
-public static unsafe IntPtr GetActivationFactory(String runtimeClassId)
+public static unsafe IntPtr GetActivationFactory(% runtimeClassId)
 {%
 return IntPtr.Zero;
 }
+%
 }
 }
 )",
     internal_accessibility(),
+    settings.netstandard_compat ? "string" : "ReadOnlySpan<char>",
 bind_each([](writer& w, TypeDef const& type)
     {
         w.write(R"(
@@ -9706,7 +9708,13 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
 );
     },
     types
-        ));
+        ),
+    settings.netstandard_compat ? "// No ReadOnlySpan<char> overload available" : R"(
+public static IntPtr GetActivationFactory(string runtimeClassId)
+{
+    return GetActivationFactory(runtimeClassId.AsSpan());
+}"
+)");
     }
 
     void write_event_source_generic_args(writer& w, cswinrt::type_semantics eventTypeSemantics)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9697,6 +9697,13 @@ default:
 }
 )",
     internal_accessibility(),
+    // We want to leverage C# support for switching on a ReadOnlySpan<char>, which allows the exported
+    // 'DllGetActivationFactory' method to avoid the temporary allocation of the string instance for the
+    // input runtime class name. Because that's a C# 11 feature, we only enable this on .NET 7 and above.
+    // If that's the TFM in use, we generate this method using ReadOnlySpan<char>, and then a string overload
+    // just calling it. Otherwise, we switch on the string parameter, and generate a dummy ReadOnlySpan<char>
+    // overload just allocating and calling that. We always need both exports to make sure that hosting
+    // scenarios also work, since those will be looking up the string overload via reflection.
     settings.net7_0_or_greater ? "ReadOnlySpan<char>" : "string",
 bind_each([](writer& w, TypeDef const& type)
     {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9716,7 +9716,12 @@ public static IntPtr GetActivationFactory(string runtimeClassId)
 {
     return GetActivationFactory(runtimeClassId.AsSpan());
 }"
-)" : "// No ReadOnlySpan<char> overload available");
+)" : R"(
+public static IntPtr GetActivationFactory(ReadOnlySpan<char> runtimeClassId)
+{
+    return GetActivationFactory(runtimeClassId.ToString());
+}"
+)");
     }
 
     void write_event_source_generic_args(writer& w, cswinrt::type_semantics eventTypeSemantics)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9715,12 +9715,12 @@ bind<write_type_name>(type, typedef_name_type::CCW, true)
 public static IntPtr GetActivationFactory(string runtimeClassId)
 {
     return GetActivationFactory(runtimeClassId.AsSpan());
-}"
+}
 )" : R"(
 public static IntPtr GetActivationFactory(ReadOnlySpan<char> runtimeClassId)
 {
     return GetActivationFactory(runtimeClassId.ToString());
-}"
+}
 )");
     }
 

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -96,6 +96,7 @@ Where <spec> is one or more of:
             throw usage_exception();
         }
         settings.netstandard_compat = target == "netstandard2.0";
+        settings.net7_0_or_greater = target == "net7.0" || target == "net8.0";
         settings.component = args.exists("component");
         settings.internal = args.exists("internal");
         settings.embedded = args.exists("embedded");

--- a/src/cswinrt/settings.h
+++ b/src/cswinrt/settings.h
@@ -11,6 +11,7 @@ namespace cswinrt
         std::set<std::string> exclude;
         winmd::reader::filter filter;
         bool netstandard_compat{};
+        bool net7_0_or_greater{};
         bool component{};
         bool internal{};
         bool embedded{};


### PR DESCRIPTION
Second attempt from #1399 😄

This PR makes the exported `DllGetActivationFactory` zero-alloc, skipping the useless `string runtimeClassId` parameter.
It does so by leveraging the new `MarshalString.FromAbiUnsafe` API added in #1400, and it updates the generated `Module` type so that when not on .NET Standard, the `GetActivationFactory` method will actually take a `ReadOnlySpan<char>` parameter (with a second `string` overload just forwarding to it). The new native exports for NativeAOT can then just call this new `ReadOnlySpan<char>` overload using the new `FromAbiUnsafe` marshalling method.