### PR TITLE
Add NativeAOT size and experimentation options

### DIFF
--- a/src/Tests/AuthoringTest/AuthoringTest.csproj
+++ b/src/Tests/AuthoringTest/AuthoringTest.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;x86</Platforms>
     <CsWinRTComponent>true</CsWinRTComponent>
-    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <!-- CsWinRTEnableLogging helps to diagnose generation issues -->
     <!-- <CsWinRTEnableLogging>true</CsWinRTEnableLogging> -->
     <!--<CsWinRTKeepGeneratedSources>true</CsWinRTKeepGeneratedSources>--> 

--- a/src/Tests/AuthoringTest/Directory.Build.props
+++ b/src/Tests/AuthoringTest/Directory.Build.props
@@ -13,10 +13,22 @@
     it we can also further validate that the self-contained authoring scenario works correctly
   -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release' and '$(Platform)' == 'x64'">
-    <IsAotCompatible>true</IsAotCompatible>
     <PublishAot>true</PublishAot>
     <NativeLib>Shared</NativeLib>
-    <SelfContained>true</SelfContained>
+
+    <!-- General .NET and NativeAOT size saving options -->
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+    <StackTraceSupport>false</StackTraceSupport>
+
+    <!-- Unsupported size saving options, can be experimented with to investigate binary size -->
+    <IlcFoldIdenticalMethodBodies>false</IlcFoldIdenticalMethodBodies>
+    <IlcDisableReflection>false</IlcDisableReflection>
+
+    <!-- Enable generating files to inspect the binary size with sizoscope (https://github.com/MichalStrehovsky/sizoscope) -->
+    <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
+    <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds some size saving and experimentation options to the authoring sample using NativeAOT. Most importantly, it also sets the options to generate the necessary files to use [sizoscope](https://github.com/MichalStrehovsky/sizoscope), to investigate and improve the published binary size.

**TODO:** upload the .mstat and .xml files to the CI.