### PR TITLE
Remove unnecessary new.

### DIFF
--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -487,7 +487,7 @@ namespace WinRT
             _contextToken = contextToken;
         }
 
-        public static new unsafe FactoryObjectReference<T> FromAbi(IntPtr thisPtr)
+        public static unsafe FactoryObjectReference<T> FromAbi(IntPtr thisPtr)
         {
             if (thisPtr == IntPtr.Zero)
             {


### PR DESCRIPTION
Fixes warning CS0109: The member 'FactoryObjectReference<T>.FromAbi(nint)' does not hide an accessible member. The new keyword is not required. [D:\a\_work\1\s\src\WinRT.Runtime\WinRT.Runtime.csproj::TargetFramework=net7.0]