### PR TITLE
Fix issue with properties implemented across multiple static interfaces

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -505,11 +505,13 @@ namespace TestComponentCSharp
         static void Method();
         static Int32 Property;
         static event Windows.Foundation.EventHandler<Int32> Event;
+        static Int32 ReadWriteProperty{ get; };
         [contract(Windows.Foundation.UniversalApiContract, 10)]
         {
             static void WarningMethod();
             static Int32 WarningProperty;
             static event Windows.Foundation.EventHandler<Int32> WarningEvent;
+            static Int32 ReadWriteProperty{ set; };
         }
     }
     

--- a/src/Tests/TestComponentCSharp/WarningStatic.cpp
+++ b/src/Tests/TestComponentCSharp/WarningStatic.cpp
@@ -38,4 +38,11 @@ namespace winrt::TestComponentCSharp::implementation
     void WarningStatic::WarningEvent(winrt::event_token const& token) noexcept
     {
     }
+    int32_t WarningStatic::ReadWriteProperty()
+    {
+        return 0;
+    }
+    void WarningStatic::ReadWriteProperty(int32_t value)
+    {
+    }
 }

--- a/src/Tests/TestComponentCSharp/WarningStatic.h
+++ b/src/Tests/TestComponentCSharp/WarningStatic.h
@@ -17,6 +17,8 @@ namespace winrt::TestComponentCSharp::implementation
         static void WarningProperty(int32_t value);
         static winrt::event_token WarningEvent(Windows::Foundation::EventHandler<int32_t> const& handler);
         static void WarningEvent(winrt::event_token const& token) noexcept;
+        static int32_t ReadWriteProperty();
+        static void ReadWriteProperty(int32_t value);
     };
 }
 namespace winrt::TestComponentCSharp::factory_implementation

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2660,6 +2660,14 @@ namespace UnitTest
             Assert.Equal(4, property.ReadWriteProperty);
         }
 
+        [Fact]
+        public void TestStaticPropertyImplementedAcrossInterfaces()
+        {
+            // Testing call doesn't fail.
+            WarningStatic.ReadWriteProperty = 4; // expected warning CA1416
+            _ = WarningStatic.ReadWriteProperty;
+        }
+
         // Test scenario where type reported by runtimeclass name is not a valid type (i.e. internal type).
         [Fact]
         public void TestNonProjectedRuntimeClass()


### PR DESCRIPTION
Today if you had a static class which had a property implemented across multiple interfaces (i.e. get in one, set in the other), you would get "Could not find property getter interface".  This is because we didn't merge properties across interfaces for static classes like we did for regular classes.  This brings that logic that we had in classes to do merging of properties to static classes.

Fix #1414