### PR TITLE
Add details about CsWinRTPrivateProjection nuget property

### DIFF
--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -42,6 +42,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTEnableLogging | true \| *false | Generates a log.txt file to help with diagnosing issues with generating the metadata file and sources for a C#/WinRT authoring component |
 | CsWinRTWindowsMetadata | \<path\> \| "local" \| "sdk" \| *$(WindowsSDKVersion) | Specifies the source for Windows metadata |
 | CsWinRTGenerateProjection | *true \| false | Indicates whether to generate and compile projection sources (true), or only to compile them (false) |
+| CsWinRTPrivateProjection | true \| *false | Indicates if a projection based on `CsWinRTIncludesPrivate` and related 'private' properties should be generated as `internal` |
 | CsWinRTGeneratedFilesDir | *"$(IntermediateOutputPath)\Generated Files" | Specifies the location for generated project source files |
 | CsWinRTIIDOptimizerOptOut | true \| *false | Determines whether to run the IIDOptimizer on the projection assembly |
 \*Default value


### PR DESCRIPTION
The private properties are described, but only take effect if CsWinRTPrivateProjection is set to true. Added documentation to this effect.