### PR TITLE
Fix diagnostics for namespaces with internal partial types

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
+++ b/src/Authoring/WinRT.SourceGenerator/DiagnosticUtils.cs
@@ -45,7 +45,7 @@ namespace Generator
         {
             WinRTSyntaxReceiver syntaxReceiver = (WinRTSyntaxReceiver)_context.SyntaxReceiver;
 
-            // Used to check for conflicitng namespace names
+            // Used to check for conflicting namespace names
             HashSet<string> namespaceNames = new();
 
             foreach (var @namespace in syntaxReceiver.Namespaces)

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -224,6 +224,10 @@ namespace Generator
             //   once from the namespace declaration and once from the member's declaration
             if (syntaxNode is NamespaceDeclarationSyntax @namespace)
             {
+                // We only include the namespace if it has a public type as otherwise it won't.
+                // be projected.  For partial types, there would be one instance that we encounter
+                // which declares the accessibility and we will use that to determine the accessibility
+                // of the type for the purpose of determining whether to include the namespace.
                 if (HasSomePublicTypes(syntaxNode))
                 {
                     Namespaces.Add(@namespace);
@@ -233,7 +237,7 @@ namespace Generator
                 return;
             }
 
-            if (syntaxNode is not MemberDeclarationSyntax declaration || !IsPublic(declaration))
+            if (syntaxNode is not MemberDeclarationSyntax declaration || !IsPublicOrPartial(declaration))
             {
                 return;
             }
@@ -249,6 +253,11 @@ namespace Generator
         }
 
         private bool IsPublic(MemberDeclarationSyntax member)
+        {
+            return member.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword));
+        }
+
+        private bool IsPublicOrPartial(MemberDeclarationSyntax member)
         {
             // We detect whether partial types are public using symbol information later.
             return member.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword) || m.IsKind(SyntaxKind.PartialKeyword));

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -224,7 +224,7 @@ namespace Generator
             //   once from the namespace declaration and once from the member's declaration
             if (syntaxNode is NamespaceDeclarationSyntax @namespace)
             {
-                // We only include the namespace if it has a public type as otherwise it won't.
+                // We only include the namespace if it has a public type as otherwise it won't
                 // be projected.  For partial types, there would be one instance that we encounter
                 // which declares the accessibility and we will use that to determine the accessibility
                 // of the type for the purpose of determining whether to include the namespace.

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1570,3 +1570,27 @@ namespace AuthoringTest
         public double Z;
     }
 }
+
+namespace AnotherNamespace
+{
+    internal partial class PartialClass3
+    {
+        public void InternalFunction()
+        {
+        }
+    }
+
+    partial class PartialClass3
+    {
+        public void InternalFunction2()
+        {
+        }
+    }
+
+    internal class InternalClass
+    {
+        public void InternalFunction()
+        {
+        }
+    }
+}

--- a/src/Tests/DiagnosticTests/NegativeData.cs
+++ b/src/Tests/DiagnosticTests/NegativeData.cs
@@ -43,6 +43,31 @@ namespace A
     public sealed class Blank { public Blank() {} }
 }";
 
+        private const string UnrelatedNamespaceWithPublicPartialTypes = @"
+namespace DiagnosticTests
+{
+    namespace Foo
+    {
+        public sealed class Dog
+        {
+            public int Woof { get; set; }
+        }
+    }
+}
+namespace Utilities
+{
+    public sealed partial class Sandwich
+    {
+        private int BreadCount { get; set; }
+    }
+
+    partial class Sandwich
+    {
+        private int BreadCount2 { get; set; }
+    }
+}
+";
+
         // note the below test should only fail if the AssemblyName is "DiagnosticTests.A", this is valid under the default "DiagnosticTests" 
         private const string NamespaceDifferByDot = @"
 namespace DiagnosticTests.A

--- a/src/Tests/DiagnosticTests/PositiveData.cs
+++ b/src/Tests/DiagnosticTests/PositiveData.cs
@@ -24,6 +24,30 @@ namespace Utilities
     }
 }";
 
+        private const string Valid_UnrelatedNamespaceWithNoPublicTypes2 = @"
+namespace DiagnosticTests
+{
+    namespace Foo
+    {
+        public sealed class Dog
+        {
+            public int Woof { get; set; }
+        }
+    }
+}
+namespace Utilities
+{
+    internal partial class Sandwich
+    {
+        private int BreadCount { get; set; }
+    }
+
+    partial class Sandwich
+    {
+        private int BreadCount2 { get; set; }
+    }
+}";
+
         private const string Valid_SubNamespacesWithOverlappingNames = @"
 namespace DiagnosticTests
 {

--- a/src/Tests/DiagnosticTests/UnitTesting.cs
+++ b/src/Tests/DiagnosticTests/UnitTesting.cs
@@ -120,6 +120,7 @@ namespace DiagnosticTests
                 yield return new TestCaseData(PropertyNoGetter, WinRTRules.PrivateGetterRule).SetName("Property. No Get, public Setter");
                 // namespace tests
                 yield return new TestCaseData(SameNameNamespacesDisjoint, WinRTRules.DisjointNamespaceRule).SetName("Namespace. isn't accessible without Test prefix, doesn't use type");
+                yield return new TestCaseData(UnrelatedNamespaceWithPublicPartialTypes, WinRTRules.DisjointNamespaceRule).SetName("Namespace. Component has public types in different namespaces");
                 yield return new TestCaseData(NamespacesDifferByCase, WinRTRules.NamespacesDifferByCase).SetName("Namespace. names only differ by case");
                 yield return new TestCaseData(DisjointNamespaces, WinRTRules.DisjointNamespaceRule).SetName("Namespace. isn't accessible without Test prefix, doesn't use type");
                 yield return new TestCaseData(DisjointNamespaces2, WinRTRules.DisjointNamespaceRule).SetName("Namespace. using type from inaccessible namespace");
@@ -415,6 +416,7 @@ namespace DiagnosticTests
             get
             {
                 yield return new TestCaseData(Valid_UnrelatedNamespaceWithNoPublicTypes).SetName("Valid. Namespace. Helper namespace with no public types");
+                yield return new TestCaseData(Valid_UnrelatedNamespaceWithNoPublicTypes2).SetName("Valid. Namespace. Helper namespace with partial types but aren't public");
                 yield return new TestCaseData(Valid_SubNamespacesWithOverlappingNames).SetName("Valid. Namespace. Overlapping namesepaces names is OK if in different namespaces");
                 yield return new TestCaseData(Valid_PrivateSetter).SetName("Valid. Property. Private Setter");
                 yield return new TestCaseData(Valid_RollYourOwnAsyncAction).SetName("Valid. AsyncInterfaces. Implementing your own IAsyncAction");


### PR DESCRIPTION
The diagnostics analyzer for namespaces found all the namespaces which had public types and then made sure they are a subset of the one which the authored component is.  As part of determining public types, the check also considered partial types to be public with the assumption that it would later to be checked to figure out whether it is really public or not.  But for the namespace diagnostics this wasn't done as it is done in other scenarios.  In addition, partial types don't matter for namespace diagnostics as the diagnostics analyzer will see at least one of the partial types with its declared accessibility.  Due to that, this PR addresses this issue by making the namespace check only look for public types and not partial ones.

Fixes #1425 