### PR TITLE
Add support for feature switches, add option to disable dynamic objects support

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -234,4 +234,14 @@ $(CsWinRTInternalProjection)
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>
 
+  <!-- Automatically set the configuration switches -->
+  <ItemGroup>
+
+    <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
+    <RuntimeHostConfigurationOption Condition="'$(CsWinRTEnableDynamicObjectsSupport)' != ''"
+                                    Include="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT"
+                                    Value="$(CsWinRTEnableDynamicObjectsSupport)"
+                                    Trim="true" />
+  </ItemGroup>
+
 </Project>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -234,12 +234,14 @@ $(CsWinRTInternalProjection)
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>
 
-  <!-- Automatically set the configuration switches -->
+  <!-- Configuration for all custom CsWinRT runtime feature switches -->
   <ItemGroup>
 
+    <!-- Default values -->
+    <CsWinRTEnableDynamicObjectsSupport Condition="'$(CsWinRTEnableDynamicObjectsSupport)' == ''">true</CsWinRTEnableDynamicObjectsSupport>
+
     <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
-    <RuntimeHostConfigurationOption Condition="'$(CsWinRTEnableDynamicObjectsSupport)' != ''"
-                                    Include="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT"
+    <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT"
                                     Value="$(CsWinRTEnableDynamicObjectsSupport)"
                                     Trim="true" />
   </ItemGroup>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -234,11 +234,16 @@ $(CsWinRTInternalProjection)
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>
 
-  <!-- Configuration for all custom CsWinRT runtime feature switches -->
-  <ItemGroup>
-
-    <!-- Default values -->
+  <!-- Default values for all custom CsWinRT runtimem feature switches -->
+  <PropertyGroup>
     <CsWinRTEnableDynamicObjectsSupport Condition="'$(CsWinRTEnableDynamicObjectsSupport)' == ''">true</CsWinRTEnableDynamicObjectsSupport>
+  </PropertyGroup>
+
+  <!--
+    Configuration for the feature switches (to support IL trimming).
+    See the 'ILLink.Substitutions.xml' file for more details on that.
+  -->
+  <ItemGroup>
 
     <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT"

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace WinRT;
+
+/// <summary>
+/// A container for all shared <see cref="AppContext"/> configuration switches for CsWinRT.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type uses a very specific setup for configuration switches to ensure ILLink can work the best.
+/// This mirrors the architecture of feature switches in the runtime as well, and it's needed so that
+/// no static constructor is generated for the type.
+/// </para>
+/// <para>
+/// For more info, see <see href="https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md#adding-new-feature-switch"/>.
+/// </para>
+/// </remarks>
+internal static class FeatureSwitches
+{
+    /// <summary>
+    /// The configuration property name for <see cref="IsDebugOutputEnabled"/>.
+    /// </summary>
+    private const string IsDynamicObjectsSupportEnabledPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
+
+    /// <summary>
+    /// The backing field for <see cref="IsDynamicObjectsSupportEnabled"/>.
+    /// </summary>
+    private static int _isDynamicObjectsSupportEnabled;
+
+    /// <summary>
+    /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
+    /// </summary>
+    public static bool IsDynamicObjectsSupportEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetConfigurationValue(IsDynamicObjectsSupportEnabledPropertyName, ref _isDynamicObjectsSupportEnabled);
+    }
+
+    /// <summary>
+    /// Gets a configuration value for a specified property.
+    /// </summary>
+    /// <param name="propertyName">The property name to retrieve the value for.</param>
+    /// <param name="cachedResult">The cached result for the target configuration value.</param>
+    /// <returns>The value of the specified configuration setting.</returns>
+    private static bool GetConfigurationValue(string propertyName, ref int cachedResult)
+    {
+        // The cached switch value has 3 states:
+        //   0: unknown.
+        //   1: true
+        //   -1: false
+        //
+        // This method doesn't need to worry about concurrent accesses to the cached result,
+        // as even if the configuration value is retrieved twice, that'll always be the same.
+        if (cachedResult < 0)
+        {
+            return false;
+        }
+
+        if (cachedResult > 0)
+        {
+            return true;
+        }
+
+        // Get the configuration switch value, or its default
+        if (!AppContext.TryGetSwitch(propertyName, out bool isEnabled))
+        {
+            isEnabled = GetDefaultConfigurationValue(propertyName);
+        }
+
+        // Update the cached result
+        cachedResult = isEnabled ? 1 : -1;
+
+        return isEnabled;
+    }
+
+    /// <summary>
+    /// Gets the default configuration value for a given feature switch.
+    /// </summary>
+    /// <param name="propertyName">The property name to retrieve the value for.</param>
+    /// <returns>The default value for the target <paramref name="propertyName"/>.</returns>
+    private static bool GetDefaultConfigurationValue(string propertyName)
+    {
+        if (propertyName == IsDynamicObjectsSupportEnabledPropertyName)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -65,30 +65,16 @@ internal static class FeatureSwitches
             return true;
         }
 
-        // Get the configuration switch value, or its default
+        // Get the configuration switch value, or its default.
+        // All feature switches have a default set in the .targets file.
         if (!AppContext.TryGetSwitch(propertyName, out bool isEnabled))
         {
-            isEnabled = GetDefaultConfigurationValue(propertyName);
+            isEnabled = false;
         }
 
         // Update the cached result
         cachedResult = isEnabled ? 1 : -1;
 
         return isEnabled;
-    }
-
-    /// <summary>
-    /// Gets the default configuration value for a given feature switch.
-    /// </summary>
-    /// <param name="propertyName">The property name to retrieve the value for.</param>
-    /// <returns>The default value for the target <paramref name="propertyName"/>.</returns>
-    private static bool GetDefaultConfigurationValue(string propertyName)
-    {
-        if (propertyName == IsDynamicObjectsSupportEnabledPropertyName)
-        {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="WinRT.Runtime">
+    <type fullname="WinRT.FeatureSwitches">
+
+      <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
+      <method signature="System.Boolean get_IsDynamicObjectsSupportEnabled()" body="stub" value="false" feature="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT" featurevalue="false"/>
+      <method signature="System.Boolean get_IsDynamicObjectsSupportEnabled()" body="stub" value="true" feature="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT" featurevalue="true"/>
+    </type>
+  </assembly>
+</linker>

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -108,7 +108,15 @@ namespace WinRT
             // It may be necessary to detect otherwise and return System.Object.
             if (runtimeClassName.StartsWith("<>f__AnonymousType".AsSpan(), StringComparison.Ordinal))
             {
-                return (typeof(System.Dynamic.ExpandoObject), 0);
+                if (FeatureSwitches.IsDynamicObjectsSupportEnabled)
+                {
+                    return (typeof(System.Dynamic.ExpandoObject), 0);
+                }
+
+                throw new NotSupportedException(
+                    $"""The requested runtime class name is "{runtimeClassName.ToString()}", which maps to a dynamic projected type. """ +
+                    """This can only be used when support for dynamic objects is enabled in the CsWinRT configuration. To enable it, """ +
+                    """make sure that the "CsWinRTEnableDynamicObjectsSupport" MSBuild property is not being set to 'false' anywhere.""");
             }
             // PropertySet and ValueSet can return IReference<String> but Nullable<String> is illegal
             else if (runtimeClassName.CompareTo("Windows.Foundation.IReference`1<String>".AsSpan(), StringComparison.Ordinal) == 0)

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -25,6 +25,11 @@
     <IsTrimmable>true</IsTrimmable>
     <DefineConstants>$(DefineConstants);CsWinRT_LANG_11_FEATURES</DefineConstants>
   </PropertyGroup>
+
+  <!-- Include the ILLink file (to properly trim configuration switches in publish builds) -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <EmbeddedResource Include="Configuration\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
+  </ItemGroup>
     
   <ItemGroup>
     <Compile Include="../cswinrt/strings/WinRT*.cs" Link="cswinrt/%(FileName)%(Extension)" />


### PR DESCRIPTION
### Closes #1434

### Overview

This PR includes the following changes:
- Adds a new `FeatureSwitches` class and the necessary infrastructure for custom feature switches
- Adds a new `CsWinRTEnableDynamicObjectsSupport` feature switch to disable support for dynamic objects
- Wires up the feature switches in the projections setup