### PR TITLE
Fixing issues discovered during validation

### DIFF
--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -163,6 +163,18 @@ namespace GuidPatch
                 getterMethodGensToCacheTypeGens[guidDataGetterMethod.GenericParameters[i]] = cacheType.GenericParameters[i];
             }
 
+            var instantiatedCacheType = new GenericInstanceType(cacheType);
+            foreach (var arg in guidDataGetterMethod.GenericParameters)
+            {
+                instantiatedCacheType.GenericArguments.Add(arg);
+            }
+
+            var selfInstantiatedCacheType = new GenericInstanceType(cacheType);
+            foreach (var param in cacheType.GenericParameters)
+            {
+                selfInstantiatedCacheType.GenericArguments.Add(param);
+            }
+
             var cacheField = new FieldDefinition("iidData", FieldAttributes.Static | FieldAttributes.Assembly, new ArrayType(module.ImportReference(module.TypeSystem.Byte)));
             cacheType.Fields.Add(cacheField);
             implementationDetailsType.NestedTypes.Add(cacheType);
@@ -173,7 +185,7 @@ namespace GuidPatch
 
             // In the body of the getter method, return the cache data
             var getterIL = guidDataGetterMethod.Body.GetILProcessor();
-            getterIL.Emit(OpCodes.Ldsfld, new FieldReference(cacheField.Name, cacheField.FieldType, cacheType));
+            getterIL.Emit(OpCodes.Ldsfld, new FieldReference(cacheField.Name, cacheField.FieldType, instantiatedCacheType));
             getterIL.Emit(OpCodes.Newobj, readOnlySpanOfByteArrayCtor);
             getterIL.Emit(OpCodes.Ret);
 
@@ -586,7 +598,7 @@ namespace GuidPatch
             il.Emit(OpCodes.Stloc, spanTemp);
             il.Emit(OpCodes.Ldloca, spanTemp);
             il.Emit(OpCodes.Call, toArrayMethod);
-            il.Emit(OpCodes.Stsfld, new FieldReference(cacheField.Name, cacheField.FieldType, cacheType));
+            il.Emit(OpCodes.Stsfld, new FieldReference(cacheField.Name, cacheField.FieldType, selfInstantiatedCacheType));
             il.Emit(OpCodes.Ret);
         }
     }

--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -163,18 +163,6 @@ namespace GuidPatch
                 getterMethodGensToCacheTypeGens[guidDataGetterMethod.GenericParameters[i]] = cacheType.GenericParameters[i];
             }
 
-            var instantiatedCacheType = new GenericInstanceType(cacheType);
-            foreach (var arg in guidDataGetterMethod.GenericParameters)
-            {
-                instantiatedCacheType.GenericArguments.Add(arg);
-            }
-
-            var selfInstantiatedCacheType = new GenericInstanceType(cacheType);
-            foreach (var param in cacheType.GenericParameters)
-            {
-                selfInstantiatedCacheType.GenericArguments.Add(param);
-            }
-
             var cacheField = new FieldDefinition("iidData", FieldAttributes.Static | FieldAttributes.Assembly, new ArrayType(module.ImportReference(module.TypeSystem.Byte)));
             cacheType.Fields.Add(cacheField);
             implementationDetailsType.NestedTypes.Add(cacheType);
@@ -185,7 +173,7 @@ namespace GuidPatch
 
             // In the body of the getter method, return the cache data
             var getterIL = guidDataGetterMethod.Body.GetILProcessor();
-            getterIL.Emit(OpCodes.Ldsfld, new FieldReference(cacheField.Name, cacheField.FieldType, instantiatedCacheType));
+            getterIL.Emit(OpCodes.Ldsfld, new FieldReference(cacheField.Name, cacheField.FieldType, cacheType));
             getterIL.Emit(OpCodes.Newobj, readOnlySpanOfByteArrayCtor);
             getterIL.Emit(OpCodes.Ret);
 
@@ -598,7 +586,7 @@ namespace GuidPatch
             il.Emit(OpCodes.Stloc, spanTemp);
             il.Emit(OpCodes.Ldloca, spanTemp);
             il.Emit(OpCodes.Call, toArrayMethod);
-            il.Emit(OpCodes.Stsfld, new FieldReference(cacheField.Name, cacheField.FieldType, selfInstantiatedCacheType));
+            il.Emit(OpCodes.Stsfld, new FieldReference(cacheField.Name, cacheField.FieldType, cacheType));
             il.Emit(OpCodes.Ret);
         }
     }

--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -163,16 +163,24 @@ namespace GuidPatch
                 getterMethodGensToCacheTypeGens[guidDataGetterMethod.GenericParameters[i]] = cacheType.GenericParameters[i];
             }
 
-            var instantiatedCacheType = new GenericInstanceType(cacheType);
-            foreach (var arg in guidDataGetterMethod.GenericParameters)
-            {
-                instantiatedCacheType.GenericArguments.Add(arg);
-            }
+            TypeReference instantiatedCacheType = cacheType;
+            TypeReference selfInstantiatedCacheType = cacheType;
 
-            var selfInstantiatedCacheType = new GenericInstanceType(cacheType);
-            foreach (var param in cacheType.GenericParameters)
+            if (cacheType.GenericParameters.Count != 0)
             {
-                selfInstantiatedCacheType.GenericArguments.Add(param);
+                var instantiatedCacheTypeTemp = new GenericInstanceType(cacheType);
+                foreach (var arg in guidDataGetterMethod.GenericParameters)
+                {
+                    instantiatedCacheTypeTemp.GenericArguments.Add(arg);
+                }
+                instantiatedCacheType = instantiatedCacheTypeTemp;
+
+                var selfInstantiatedCacheTypeTemp = new GenericInstanceType(cacheType);
+                foreach (var param in cacheType.GenericParameters)
+                {
+                    selfInstantiatedCacheTypeTemp.GenericArguments.Add(param);
+                }
+                selfInstantiatedCacheType = selfInstantiatedCacheTypeTemp;
             }
 
             var cacheField = new FieldDefinition("iidData", FieldAttributes.Static | FieldAttributes.Assembly, new ArrayType(module.ImportReference(module.TypeSystem.Byte)));

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -10320,7 +10320,7 @@ bind<write_event_invoke_args>(invokeMethodSig));
 
     void write_generic_type_instantiation(writer& w, generic_type_instance instance, std::vector<std::string>& rcwFunctions, std::vector<std::string>& vtableFunctions)
     {
-        auto get_invoke_info = [&](MethodDef const& method)
+        auto get_invoke_info = [&](MethodDef const& method, bool isDelegate = false)
         {
             return w.write_temp("(*(delegate* unmanaged[Stdcall]<%, int>**)ThisPtr)[%]",
                 bind([&](writer& w) {
@@ -10331,7 +10331,7 @@ bind<write_event_invoke_args>(invokeMethodSig));
 
                     write_abi_parameter_types_pointer(w, method_signature{ method });
                 }),
-                get_vmethod_index(instance.generic_type, method) + INSPECTABLE_METHOD_COUNT);
+                isDelegate ? 3 : get_vmethod_index(instance.generic_type, method) + INSPECTABLE_METHOD_COUNT);
         };
 
         if (get_category(instance.generic_type) == category::delegate_type)
@@ -10345,7 +10345,7 @@ bind<write_event_invoke_args>(invokeMethodSig));
             {
                 rcwFunctions.emplace_back(method.Name());
 
-                auto invoke_target = get_invoke_info(method);
+                auto invoke_target = get_invoke_info(method, true);
                 w.write(R"(
 private static unsafe % %(IObjectReference _obj%%)
 {


### PR DESCRIPTION
Previous fixes to IID optimizer discovered issues where some of the generated class had incorrect IL.  This was particularly in cases where the generic was known but is a custom type mapping like Nullable<Vector3>.  This handles them by detecting if it is a generic or not before figuring out how to do a field access of the iidData field.

The generic instantiation classes for delegates were assuming they were IInspectable based when it isn't.  This addresses that by fixing the vtable index.