### PR TITLE
Rewrite MarshalGeneric<T> to minimize binary size on NativeAOT

### DIFF
--- a/src/WinRT.Runtime/FundamentalMarshalers.cs
+++ b/src/WinRT.Runtime/FundamentalMarshalers.cs
@@ -5,6 +5,45 @@ using System;
 
 namespace ABI.System
 {
+    /// <summary>
+    /// Non-generic marshalling stubs used from <see cref="global::WinRT.MarshalGeneric{T}"/>.
+    /// This avoids the generic instantiations for all additional stubs for these ABI types.
+    /// </summary>
+    internal static class NonBlittableMarshallingStubs
+    {
+        // This can be shared for all DisposeMarshaler and DisposeAbi methods for these ABI types.
+        // None of these has any special logic that needs to run when those two APIs are invoked.
+        public static readonly Action<object> NoOpFunc = NoOp;
+
+        public static object Boolean_CreateMarshaler(bool value) => Boolean.CreateMarshaler(value);
+        public static object Boolean_GetAbi(object value) => Boolean.GetAbi((bool)value);
+        public static bool Boolean_FromAbi(object abi) => Boolean.FromAbi((byte)abi);
+        public static void Boolean_CopyAbi(object value, IntPtr dest) => Boolean.CopyAbi((bool)value, dest);
+        public static object Boolean_FromManaged(bool value) => Boolean.FromManaged(value);
+
+        public static object Char_CreateMarshaler(char value) => Char.CreateMarshaler(value);
+        public static object Char_GetAbi(object value) => Char.GetAbi((char)value);
+        public static char Char_FromAbi(object abi) => Char.FromAbi((ushort)abi);
+        public static void Char_CopyAbi(object value, IntPtr dest) => Char.CopyAbi((char)value, dest);
+        public static object Char_FromManaged(char value) => Char.FromManaged(value);
+
+        public static object TimeSpan_CreateMarshaler(global::System.TimeSpan value) => TimeSpan.CreateMarshaler(value);
+        public static object TimeSpan_GetAbi(object value) => TimeSpan.GetAbi((TimeSpan.Marshaler)value);
+        public static global::System.TimeSpan TimeSpan_FromAbi(object abi) => TimeSpan.FromAbi((TimeSpan)abi);
+        public static void TimeSpan_CopyAbi(object value, IntPtr dest) => TimeSpan.CopyAbi((TimeSpan.Marshaler)value, dest);
+        public static object TimeSpan_FromManaged(global::System.TimeSpan value) => TimeSpan.FromManaged(value);
+
+        public static object DateTimeOffset_CreateMarshaler(global::System.DateTimeOffset value) => DateTimeOffset.CreateMarshaler(value);
+        public static object DateTimeOffset_GetAbi(object value) => DateTimeOffset.GetAbi((DateTimeOffset.Marshaler)value);
+        public static global::System.DateTimeOffset DateTimeOffset_FromAbi(object abi) => DateTimeOffset.FromAbi((DateTimeOffset)abi);
+        public static unsafe void DateTimeOffset_CopyAbi(object value, IntPtr dest) => DateTimeOffset.CopyAbi((DateTimeOffset.Marshaler)value, dest);
+        public static object DateTimeOffset_FromManaged(global::System.DateTimeOffset value) => DateTimeOffset.FromManaged(value);
+
+        private static void NoOp(object obj)
+        {
+        }
+    }
+
     internal struct Boolean
     {
         public static bool CreateMarshaler(bool value) => value;

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -580,15 +580,36 @@ namespace WinRT
             else if (typeof(T) == typeof(bool))
             {
                 // Same as above, but we do have an ABI type
+                HelperType = typeof(global::ABI.System.Boolean);
                 AbiType = typeof(byte);
+                MarshalerType = typeof(bool);
+                MarshalByObjectReferenceValueSupported = false;
+                CreateMarshaler = (Func<T, object>)(object)((Func<bool, bool>)global::ABI.System.Boolean.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler2 = CreateMarshaler;
+                GetAbi = ((Func<bool, byte>)global::ABI.System.Boolean.GetAbi).WithObjectParams();
+                FromAbi = (Func<object, T>)(object)((Func<byte, bool>)global::ABI.System.Boolean.FromAbi).WithObjectT();
+                CopyAbi = ((Action<bool, IntPtr>)global::ABI.System.Boolean.CopyAbi).WithObjectT1();
+                FromManaged = (Func<T, object>)(object)((Func<bool, byte>)global::ABI.System.Boolean.FromManaged).WithObjectTResult();
+                CopyManaged = (Action<T, IntPtr>)(object)(Action<bool, IntPtr>)global::ABI.System.Boolean.CopyManaged;
+                DisposeMarshaler = ((Action<bool>)global::ABI.System.Boolean.DisposeMarshaler).WithObjectParams();
+                DisposeAbi = ((Action<byte>)global::ABI.System.Boolean.DisposeAbi).WithObjectParams();
 
-                return;
             }
             else if (typeof(T) == typeof(char))
             {
+                HelperType = typeof(global::ABI.System.Char);
                 AbiType = typeof(ushort);
-
-                return;
+                MarshalerType = typeof(char);
+                MarshalByObjectReferenceValueSupported = false;
+                CreateMarshaler = (Func<T, object>)(object)((Func<char, char>)global::ABI.System.Char.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler2 = CreateMarshaler;
+                GetAbi = ((Func<char, ushort>)global::ABI.System.Char.GetAbi).WithObjectParams();
+                FromAbi = (Func<object, T>)(object)((Func<ushort, char>)global::ABI.System.Char.FromAbi).WithObjectT();
+                CopyAbi = ((Action<char, IntPtr>)global::ABI.System.Char.CopyAbi).WithObjectT1();
+                FromManaged = (Func<T, object>)(object)((Func<char, ushort>)global::ABI.System.Char.FromManaged).WithObjectTResult();
+                CopyManaged = (Action<T, IntPtr>)(object)(Action<char, IntPtr>)global::ABI.System.Char.CopyManaged;
+                DisposeMarshaler = ((Action<char>)global::ABI.System.Char.DisposeMarshaler).WithObjectParams();
+                DisposeAbi = ((Action<ushort>)global::ABI.System.Char.DisposeAbi).WithObjectParams();
             }
             else if (typeof(T) == typeof(TimeSpan))
             {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -563,30 +563,30 @@ namespace WinRT
                 AbiType = typeof(byte);
                 MarshalerType = typeof(bool);
                 // MarshalByObjectReferenceValueSupported = false; (same as default value, we can always skip this field write)
-                CreateMarshaler = (Func<T, object>)(object)((Func<bool, bool>)global::ABI.System.Boolean.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_CreateMarshaler;
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ((Func<bool, byte>)global::ABI.System.Boolean.GetAbi).WithObjectParams();
-                FromAbi = (Func<object, T>)(object)((Func<byte, bool>)global::ABI.System.Boolean.FromAbi).WithObjectT();
-                CopyAbi = ((Action<bool, IntPtr>)global::ABI.System.Boolean.CopyAbi).WithObjectT1();
-                FromManaged = (Func<T, object>)(object)((Func<bool, byte>)global::ABI.System.Boolean.FromManaged).WithObjectTResult();
-                CopyManaged = (Action<T, IntPtr>)(object)(Action<bool, IntPtr>)global::ABI.System.Boolean.CopyManaged;
-                DisposeMarshaler = ((Action<bool>)global::ABI.System.Boolean.DisposeMarshaler).WithObjectParams();
-                DisposeAbi = ((Action<byte>)global::ABI.System.Boolean.DisposeAbi).WithObjectParams();
+                GetAbi = ABI.System.NonBlittableMarshallingStubs.Boolean_GetAbi;
+                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_FromAbi;
+                CopyAbi = ABI.System.NonBlittableMarshallingStubs.Boolean_CopyAbi;
+                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_FromManaged;
+                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.Boolean.CopyManaged;
+                DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
             else if (typeof(T) == typeof(char))
             {
                 HelperType = typeof(global::ABI.System.Char);
                 AbiType = typeof(ushort);
                 MarshalerType = typeof(char);
-                CreateMarshaler = (Func<T, object>)(object)((Func<char, char>)global::ABI.System.Char.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Char_CreateMarshaler;
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ((Func<char, ushort>)global::ABI.System.Char.GetAbi).WithObjectParams();
-                FromAbi = (Func<object, T>)(object)((Func<ushort, char>)global::ABI.System.Char.FromAbi).WithObjectT();
-                CopyAbi = ((Action<char, IntPtr>)global::ABI.System.Char.CopyAbi).WithObjectT1();
-                FromManaged = (Func<T, object>)(object)((Func<char, ushort>)global::ABI.System.Char.FromManaged).WithObjectTResult();
-                CopyManaged = (Action<T, IntPtr>)(object)(Action<char, IntPtr>)global::ABI.System.Char.CopyManaged;
-                DisposeMarshaler = ((Action<char>)global::ABI.System.Char.DisposeMarshaler).WithObjectParams();
-                DisposeAbi = ((Action<ushort>)global::ABI.System.Char.DisposeAbi).WithObjectParams();
+                GetAbi = ABI.System.NonBlittableMarshallingStubs.Char_GetAbi;
+                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.Char_FromAbi;
+                CopyAbi = ABI.System.NonBlittableMarshallingStubs.Char_CopyAbi;
+                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Char_FromManaged;
+                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.Char.CopyManaged;
+                DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
             else if (typeof(T) == typeof(TimeSpan))
             {
@@ -594,15 +594,15 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.TimeSpan);
                 AbiType = typeof(global::ABI.System.TimeSpan);
                 MarshalerType = typeof(global::ABI.System.TimeSpan.Marshaler);
-                CreateMarshaler = (Func<T, object>)(object)((Func<global::System.TimeSpan, global::ABI.System.TimeSpan.Marshaler>)global::ABI.System.TimeSpan.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_CreateMarshaler;
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ((Func<global::ABI.System.TimeSpan.Marshaler, global::ABI.System.TimeSpan>)global::ABI.System.TimeSpan.GetAbi).WithObjectParams();
-                FromAbi = (Func<object, T>)(object)((Func<global::ABI.System.TimeSpan, global::System.TimeSpan>)global::ABI.System.TimeSpan.FromAbi).WithObjectT();
-                CopyAbi = ((Action<global::ABI.System.TimeSpan.Marshaler, IntPtr>)global::ABI.System.TimeSpan.CopyAbi).WithObjectT1();
-                FromManaged = (Func<T, object>)(object)((Func<global::System.TimeSpan, global::ABI.System.TimeSpan>)global::ABI.System.TimeSpan.FromManaged).WithObjectTResult();
-                CopyManaged = (Action<T, IntPtr>)(object)(Action<global::System.TimeSpan, IntPtr>)global::ABI.System.TimeSpan.CopyManaged;
-                DisposeMarshaler = ((Action<global::ABI.System.TimeSpan.Marshaler>)global::ABI.System.TimeSpan.DisposeMarshaler).WithObjectParams();
-                DisposeAbi = ((Action<global::ABI.System.TimeSpan>)global::ABI.System.TimeSpan.DisposeAbi).WithObjectParams();
+                GetAbi = ABI.System.NonBlittableMarshallingStubs.TimeSpan_GetAbi;
+                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromAbi;
+                CopyAbi = ABI.System.NonBlittableMarshallingStubs.TimeSpan_CopyAbi;
+                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromManaged;
+                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.TimeSpan.CopyManaged;
+                DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
             else if (typeof(T) == typeof(DateTimeOffset))
             {
@@ -611,15 +611,15 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.DateTimeOffset);
                 AbiType = typeof(global::ABI.System.DateTimeOffset);
                 MarshalerType = typeof(global::ABI.System.DateTimeOffset.Marshaler);
-                CreateMarshaler = (Func<T, object>)(object)((Func<global::System.DateTimeOffset, global::ABI.System.DateTimeOffset.Marshaler>)global::ABI.System.DateTimeOffset.CreateMarshaler).WithObjectTResult();
+                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CreateMarshaler;
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ((Func<global::ABI.System.DateTimeOffset.Marshaler, global::ABI.System.DateTimeOffset>)global::ABI.System.DateTimeOffset.GetAbi).WithObjectParams();
-                FromAbi = (Func<object, T>)(object)((Func<global::ABI.System.DateTimeOffset, global::System.DateTimeOffset>)global::ABI.System.DateTimeOffset.FromAbi).WithObjectT();
-                CopyAbi = ((Action<global::ABI.System.DateTimeOffset.Marshaler, IntPtr>)global::ABI.System.DateTimeOffset.CopyAbi).WithObjectT1();
-                FromManaged = (Func<T, object>)(object)((Func<global::System.DateTimeOffset, global::ABI.System.DateTimeOffset>)global::ABI.System.DateTimeOffset.FromManaged).WithObjectTResult();
-                CopyManaged = (Action<T, IntPtr>)(object)(Action<global::System.DateTimeOffset, IntPtr>)global::ABI.System.DateTimeOffset.CopyManaged;
-                DisposeMarshaler = ((Action<global::ABI.System.DateTimeOffset.Marshaler>)global::ABI.System.DateTimeOffset.DisposeMarshaler).WithObjectParams();
-                DisposeAbi = ((Action<global::ABI.System.DateTimeOffset>)global::ABI.System.DateTimeOffset.DisposeAbi).WithObjectParams();
+                GetAbi = ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_GetAbi;
+                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromAbi;
+                CopyAbi = ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CopyAbi;
+                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromManaged;
+                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.DateTimeOffset.CopyManaged;
+                DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
             else if (typeof(T).IsValueType)
             {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -790,7 +790,53 @@ namespace WinRT
 #endif
     class MarshalNonBlittable<T> : MarshalGeneric<T>
     {
-        private static readonly new Type AbiType = typeof(T).IsEnum ? Enum.GetUnderlyingType(typeof(T)) : MarshalGeneric<T>.AbiType;
+        private static readonly new Type AbiType = GetAbiType();
+
+        private static Type GetAbiType()
+        {
+            if (typeof(T).IsEnum)
+            {
+                return Enum.GetUnderlyingType(typeof(T));
+            }
+
+            // These types are actually blittable, but this marshaller is still constructed elsewhere.
+            // Just return null instead of using MarshalGeneric<T>, to avoid constructing that too.
+            if (typeof(T) == typeof(int) ||
+                typeof(T) == typeof(byte) ||
+                typeof(T) == typeof(bool) ||
+                typeof(T) == typeof(sbyte) ||
+                typeof(T) == typeof(short) ||
+                typeof(T) == typeof(ushort) ||
+                typeof(T) == typeof(char) ||
+                typeof(T) == typeof(uint) ||
+                typeof(T) == typeof(long) ||
+                typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(float) ||
+                typeof(T) == typeof(double) ||
+                typeof(T) == typeof(Guid) ||
+                typeof(T) == typeof(global::System.TimeSpan) ||
+                typeof(T) == typeof(global::Windows.Foundation.Point) ||
+                typeof(T) == typeof(global::Windows.Foundation.Rect) ||
+                typeof(T) == typeof(global::Windows.Foundation.Size) ||
+                typeof(T) == typeof(global::System.Numerics.Matrix3x2) ||
+                typeof(T) == typeof(global::System.Numerics.Matrix4x4) ||
+                typeof(T) == typeof(global::System.Numerics.Plane) ||
+                typeof(T) == typeof(global::System.Numerics.Quaternion) ||
+                typeof(T) == typeof(global::System.Numerics.Vector2) ||
+                typeof(T) == typeof(global::System.Numerics.Vector3) ||
+                typeof(T) == typeof(global::System.Numerics.Vector4))
+            {
+                return null;
+            }
+
+            if (typeof(T) == typeof(DateTimeOffset))
+            {
+                return typeof(global::ABI.System.DateTimeOffset);
+            }
+
+            // Fallback path with the original logic
+            return typeof(T).GetAbiType();
+        }
 
         public struct MarshalerArray
         {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1690,26 +1690,6 @@ namespace WinRT
                 DisposeMarshalerArray = MarshalString.DisposeMarshalerArray;
                 DisposeAbiArray = MarshalString.DisposeAbiArray;
             }
-            else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
-            {
-                AbiType = typeof(IntPtr);
-                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler2;
-                CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
-                GetAbi = MarshalGeneric<T>.GetAbi;
-                CopyAbi = MarshalGeneric<T>.CopyAbi;
-                FromAbi = MarshalGeneric<T>.FromAbi;
-                FromManaged = MarshalGeneric<T>.FromManaged;
-                CopyManaged = MarshalGeneric<T>.CopyManaged;
-                DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
-                DisposeAbi = MarshalGeneric<T>.DisposeAbi;
-                CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
-                GetAbiArray = MarshalGeneric<T>.GetAbiArray;
-                FromAbiArray = MarshalGeneric<T>.FromAbiArray;
-                FromManagedArray = MarshalGeneric<T>.FromManagedArray;
-                CopyManagedArray = MarshalGenericHelper<T>.CopyManagedArray;
-                DisposeMarshalerArray = MarshalInterface<T>.DisposeMarshalerArray;
-                DisposeAbiArray = MarshalInterface<T>.DisposeAbiArray;
-            }
             else if (typeof(T) == typeof(Type))
             {
                 AbiType = typeof(ABI.System.Type);
@@ -1844,6 +1824,29 @@ namespace WinRT
                 CopyManagedArray = MarshalInspectable<T>.CopyManagedArray;
                 DisposeMarshalerArray = MarshalInspectable<T>.DisposeMarshalerArray;
                 DisposeAbiArray = MarshalInspectable<T>.DisposeAbiArray;
+            }
+            else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
+            {
+                // This check for KeyValuePair<,> types cannot be statically determined, so we move it
+                // down to still allow the linker to see more possible branches before. This should
+                // avoid constructing all of these MarshalGeneric<T> types when not actually needed.
+                AbiType = typeof(IntPtr);
+                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler2;
+                CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
+                GetAbi = MarshalGeneric<T>.GetAbi;
+                CopyAbi = MarshalGeneric<T>.CopyAbi;
+                FromAbi = MarshalGeneric<T>.FromAbi;
+                FromManaged = MarshalGeneric<T>.FromManaged;
+                CopyManaged = MarshalGeneric<T>.CopyManaged;
+                DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
+                DisposeAbi = MarshalGeneric<T>.DisposeAbi;
+                CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
+                GetAbiArray = MarshalGeneric<T>.GetAbiArray;
+                FromAbiArray = MarshalGeneric<T>.FromAbiArray;
+                FromManagedArray = MarshalGeneric<T>.FromManagedArray;
+                CopyManagedArray = MarshalGenericHelper<T>.CopyManagedArray;
+                DisposeMarshalerArray = MarshalInterface<T>.DisposeMarshalerArray;
+                DisposeAbiArray = MarshalInterface<T>.DisposeAbiArray;
             }
             else // delegate, class 
             {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -688,12 +688,12 @@ namespace WinRT
                 CreateMarshaler2 = MarshalByObjectReferenceValueSupported
                     ? HelperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T, ObjectReferenceValue>>().WithObjectTResult()
                     : CreateMarshaler;
-                GetAbi = HelperType.GetMethod("GetAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<IObjectReference, IntPtr>>().WithObjectParams();
+                GetAbi = HelperType.GetMethod("GetAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<IObjectReference, IntPtr>>().WithMarshaler2Support();
                 CopyAbi = null; // Not used for class types
                 FromAbi = HelperType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<IntPtr, T>>().WithObjectT();
                 FromManaged = HelperType.GetMethod("FromManaged", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T, IntPtr>>().WithObjectTResult();
                 CopyManaged = null; // Also not used for class types
-                DisposeMarshaler = HelperType.GetMethod("DisposeMarshaler", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Action<IObjectReference>>().WithObjectParams();
+                DisposeMarshaler = HelperType.GetMethod("DisposeMarshaler", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Action<IObjectReference>>().WithMarshaler2Support();
                 DisposeAbi = HelperType.GetMethod("DisposeAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Action<IntPtr>>().WithObjectParams();
                 CreateMarshalerArray = HelperType.GetMethod("CreateMarshalerArray", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T[], MarshalInterfaceHelper<T>.MarshalerArray>>().WithObjectTResult();
                 GetAbiArray = HelperType.GetMethod("GetAbiArray", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<object, (int, IntPtr)>>();

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -810,9 +810,10 @@ namespace WinRT
                 return Enum.GetUnderlyingType(typeof(T));
             }
 
-            // These 3 types are true non blittable types that are valid to use here
+            // These 4 types are true non blittable types that are valid to use here
             if (typeof(T) == typeof(bool)) return typeof(byte);
             if (typeof(T) == typeof(char)) return typeof(ushort);
+            if (typeof(T) == typeof(global::System.TimeSpan)) return typeof(global::ABI.System.TimeSpan);
             if (typeof(T) == typeof(DateTimeOffset)) return typeof(global::ABI.System.DateTimeOffset);
 
             // These types are actually blittable, but this marshaller is still constructed elsewhere.
@@ -828,7 +829,6 @@ namespace WinRT
                 typeof(T) == typeof(float) ||
                 typeof(T) == typeof(double) ||
                 typeof(T) == typeof(Guid) ||
-                typeof(T) == typeof(global::System.TimeSpan) ||
                 typeof(T) == typeof(global::Windows.Foundation.Point) ||
                 typeof(T) == typeof(global::Windows.Foundation.Rect) ||
                 typeof(T) == typeof(global::Windows.Foundation.Size) ||

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1787,6 +1787,36 @@ namespace WinRT
                 {
                     AbiType = typeof(global::ABI.System.DateTimeOffset);
                 }
+                else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
+                {
+                    // This check for KeyValuePair<,> types cannot be statically determined, so we move it
+                    // down to still allow the linker to see more possible branches before. This should
+                    // avoid constructing all of these MarshalGeneric<T> types when not actually needed.
+                    // Because this is a more specific case of the value type check, which is already
+                    // recognized by the linker, we can put it here to further improve trimming. We just
+                    // also set the ref type and then return because if we do have a KeyValuePair<,> type,
+                    // we have already set all the marshalling delegates we need, and we can just stop here.
+                    AbiType = typeof(IntPtr);
+                    CreateMarshaler = MarshalGeneric<T>.CreateMarshaler2;
+                    CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
+                    GetAbi = MarshalGeneric<T>.GetAbi;
+                    CopyAbi = MarshalGeneric<T>.CopyAbi;
+                    FromAbi = MarshalGeneric<T>.FromAbi;
+                    FromManaged = MarshalGeneric<T>.FromManaged;
+                    CopyManaged = MarshalGeneric<T>.CopyManaged;
+                    DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
+                    DisposeAbi = MarshalGeneric<T>.DisposeAbi;
+                    CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
+                    GetAbiArray = MarshalGeneric<T>.GetAbiArray;
+                    FromAbiArray = MarshalGeneric<T>.FromAbiArray;
+                    FromManagedArray = MarshalGeneric<T>.FromManagedArray;
+                    CopyManagedArray = MarshalGenericHelper<T>.CopyManagedArray;
+                    DisposeMarshalerArray = MarshalInterface<T>.DisposeMarshalerArray;
+                    DisposeAbiArray = MarshalInterface<T>.DisposeAbiArray;
+                    RefAbiType = AbiType.MakeByRefType();
+
+                    return;
+                }
                 else
                 {
                     AbiType = typeof(T).FindHelperType();
@@ -1891,29 +1921,6 @@ namespace WinRT
                 CopyManagedArray = MarshalInspectable<T>.CopyManagedArray;
                 DisposeMarshalerArray = MarshalInspectable<T>.DisposeMarshalerArray;
                 DisposeAbiArray = MarshalInspectable<T>.DisposeAbiArray;
-            }
-            else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
-            {
-                // This check for KeyValuePair<,> types cannot be statically determined, so we move it
-                // down to still allow the linker to see more possible branches before. This should
-                // avoid constructing all of these MarshalGeneric<T> types when not actually needed.
-                AbiType = typeof(IntPtr);
-                CreateMarshaler = MarshalGeneric<T>.CreateMarshaler2;
-                CreateMarshaler2 = MarshalGeneric<T>.CreateMarshaler2;
-                GetAbi = MarshalGeneric<T>.GetAbi;
-                CopyAbi = MarshalGeneric<T>.CopyAbi;
-                FromAbi = MarshalGeneric<T>.FromAbi;
-                FromManaged = MarshalGeneric<T>.FromManaged;
-                CopyManaged = MarshalGeneric<T>.CopyManaged;
-                DisposeMarshaler = MarshalGeneric<T>.DisposeMarshaler;
-                DisposeAbi = MarshalGeneric<T>.DisposeAbi;
-                CreateMarshalerArray = MarshalGeneric<T>.CreateMarshalerArray;
-                GetAbiArray = MarshalGeneric<T>.GetAbiArray;
-                FromAbiArray = MarshalGeneric<T>.FromAbiArray;
-                FromManagedArray = MarshalGeneric<T>.FromManagedArray;
-                CopyManagedArray = MarshalGenericHelper<T>.CopyManagedArray;
-                DisposeMarshalerArray = MarshalInterface<T>.DisposeMarshalerArray;
-                DisposeAbiArray = MarshalInterface<T>.DisposeAbiArray;
             }
             else // delegate, class 
             {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -562,14 +562,17 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.Boolean);
                 AbiType = typeof(byte);
                 MarshalerType = typeof(bool);
-                // MarshalByObjectReferenceValueSupported = false; (same as default value, we can always skip this field write)
-                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_CreateMarshaler;
+
+                // Note: we're deliberately using object creation expressions here to create the delegates, rather than using
+                // method group expressions. This prevents Roslyn from generating a class to store a cached instance. This is
+                // not needed, because we're executing each of these paths once, and already caching the resulting delegates.
+                CreateMarshaler = (Func<T, object>)(object)new Func<bool, object>(ABI.System.NonBlittableMarshallingStubs.Boolean_CreateMarshaler);
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ABI.System.NonBlittableMarshallingStubs.Boolean_GetAbi;
-                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_FromAbi;
-                CopyAbi = ABI.System.NonBlittableMarshallingStubs.Boolean_CopyAbi;
-                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Boolean_FromManaged;
-                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.Boolean.CopyManaged;
+                GetAbi = new Func<object, object>(ABI.System.NonBlittableMarshallingStubs.Boolean_GetAbi);
+                FromAbi = (Func<object, T>)(object)new Func<object, bool>(ABI.System.NonBlittableMarshallingStubs.Boolean_FromAbi);
+                CopyAbi = new Action<object, IntPtr>(ABI.System.NonBlittableMarshallingStubs.Boolean_CopyAbi);
+                FromManaged = (Func<T, object>)(object)new Func<bool, object>(ABI.System.NonBlittableMarshallingStubs.Boolean_FromManaged);
+                CopyManaged = (Action<T, IntPtr>)(object)new Action<bool, IntPtr>(ABI.System.Boolean.CopyManaged);
                 DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
                 DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
@@ -578,13 +581,13 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.Char);
                 AbiType = typeof(ushort);
                 MarshalerType = typeof(char);
-                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Char_CreateMarshaler;
+                CreateMarshaler = (Func<T, object>)(object)new Func<char, object>(ABI.System.NonBlittableMarshallingStubs.Char_CreateMarshaler);
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ABI.System.NonBlittableMarshallingStubs.Char_GetAbi;
-                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.Char_FromAbi;
-                CopyAbi = ABI.System.NonBlittableMarshallingStubs.Char_CopyAbi;
-                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.Char_FromManaged;
-                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.Char.CopyManaged;
+                GetAbi = new Func<object, object>(ABI.System.NonBlittableMarshallingStubs.Char_GetAbi);
+                FromAbi = (Func<object, T>)(object)new Func<object, char>(ABI.System.NonBlittableMarshallingStubs.Char_FromAbi);
+                CopyAbi = new Action<object, IntPtr>(ABI.System.NonBlittableMarshallingStubs.Char_CopyAbi);
+                FromManaged = (Func<T, object>)(object)new Func<char, object>(ABI.System.NonBlittableMarshallingStubs.Char_FromManaged);
+                CopyManaged = (Action<T, IntPtr>)(object)new Action<char, IntPtr>(ABI.System.Char.CopyManaged);
                 DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
                 DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
@@ -594,13 +597,13 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.TimeSpan);
                 AbiType = typeof(global::ABI.System.TimeSpan);
                 MarshalerType = typeof(global::ABI.System.TimeSpan.Marshaler);
-                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_CreateMarshaler;
+                CreateMarshaler = (Func<T, object>)(object)new Func<TimeSpan, object>(ABI.System.NonBlittableMarshallingStubs.TimeSpan_CreateMarshaler);
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ABI.System.NonBlittableMarshallingStubs.TimeSpan_GetAbi;
-                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromAbi;
-                CopyAbi = ABI.System.NonBlittableMarshallingStubs.TimeSpan_CopyAbi;
-                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromManaged;
-                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.TimeSpan.CopyManaged;
+                GetAbi = new Func<object, object>(ABI.System.NonBlittableMarshallingStubs.TimeSpan_GetAbi);
+                FromAbi = (Func<object, T>)(object)new Func<object, TimeSpan>(ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromAbi);
+                CopyAbi = new Action<object, IntPtr>(ABI.System.NonBlittableMarshallingStubs.TimeSpan_CopyAbi);
+                FromManaged = (Func<T, object>)(object)new Func<TimeSpan, object>(ABI.System.NonBlittableMarshallingStubs.TimeSpan_FromManaged);
+                CopyManaged = (Action<T, IntPtr>)(object)new Action<TimeSpan, IntPtr>(ABI.System.TimeSpan.CopyManaged);
                 DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
                 DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
@@ -611,13 +614,13 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.DateTimeOffset);
                 AbiType = typeof(global::ABI.System.DateTimeOffset);
                 MarshalerType = typeof(global::ABI.System.DateTimeOffset.Marshaler);
-                CreateMarshaler = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CreateMarshaler;
+                CreateMarshaler = (Func<T, object>)(object)new Func<DateTimeOffset, object>(ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CreateMarshaler);
                 CreateMarshaler2 = CreateMarshaler;
-                GetAbi = ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_GetAbi;
-                FromAbi = (Func<object, T>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromAbi;
-                CopyAbi = ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CopyAbi;
-                FromManaged = (Func<T, object>)(object)ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromManaged;
-                CopyManaged = (Action<T, IntPtr>)(object)ABI.System.DateTimeOffset.CopyManaged;
+                GetAbi = new Func<object, object>(ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_GetAbi);
+                FromAbi = (Func<object, T>)(object)new Func<object, DateTimeOffset>(ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromAbi);
+                CopyAbi = new Action<object, IntPtr>(ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_CopyAbi);
+                FromManaged = (Func<T, object>)(object)new Func<DateTimeOffset, object>(ABI.System.NonBlittableMarshallingStubs.DateTimeOffset_FromManaged);
+                CopyManaged = (Action<T, IntPtr>)(object)new Action<DateTimeOffset, IntPtr>(ABI.System.DateTimeOffset.CopyManaged);
                 DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
                 DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -514,51 +514,30 @@ namespace WinRT
             if (typeof(T) == typeof(global::System.Numerics.Vector2))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Vector2);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Vector3))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Vector3);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Vector4))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Vector4);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Plane))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Plane);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Matrix3x2))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Matrix3x2);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Matrix4x4))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Matrix4x4);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(global::System.Numerics.Quaternion))
             {
                 HelperType = typeof(global::ABI.System.Numerics.Quaternion);
-                AbiType = null;
-                MarshalerType = null;
-                MarshalByObjectReferenceValueSupported = false;
             }
             else if (typeof(T) == typeof(int) ||
                      typeof(T) == typeof(byte) ||
@@ -583,7 +562,7 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.Boolean);
                 AbiType = typeof(byte);
                 MarshalerType = typeof(bool);
-                MarshalByObjectReferenceValueSupported = false;
+                // MarshalByObjectReferenceValueSupported = false; (same as default value, we can always skip this field write)
                 CreateMarshaler = (Func<T, object>)(object)((Func<bool, bool>)global::ABI.System.Boolean.CreateMarshaler).WithObjectTResult();
                 CreateMarshaler2 = CreateMarshaler;
                 GetAbi = ((Func<bool, byte>)global::ABI.System.Boolean.GetAbi).WithObjectParams();
@@ -593,14 +572,12 @@ namespace WinRT
                 CopyManaged = (Action<T, IntPtr>)(object)(Action<bool, IntPtr>)global::ABI.System.Boolean.CopyManaged;
                 DisposeMarshaler = ((Action<bool>)global::ABI.System.Boolean.DisposeMarshaler).WithObjectParams();
                 DisposeAbi = ((Action<byte>)global::ABI.System.Boolean.DisposeAbi).WithObjectParams();
-
             }
             else if (typeof(T) == typeof(char))
             {
                 HelperType = typeof(global::ABI.System.Char);
                 AbiType = typeof(ushort);
                 MarshalerType = typeof(char);
-                MarshalByObjectReferenceValueSupported = false;
                 CreateMarshaler = (Func<T, object>)(object)((Func<char, char>)global::ABI.System.Char.CreateMarshaler).WithObjectTResult();
                 CreateMarshaler2 = CreateMarshaler;
                 GetAbi = ((Func<char, ushort>)global::ABI.System.Char.GetAbi).WithObjectParams();
@@ -617,7 +594,6 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.TimeSpan);
                 AbiType = typeof(global::ABI.System.TimeSpan);
                 MarshalerType = typeof(global::ABI.System.TimeSpan.Marshaler);
-                MarshalByObjectReferenceValueSupported = false;
                 CreateMarshaler = (Func<T, object>)(object)((Func<global::System.TimeSpan, global::ABI.System.TimeSpan.Marshaler>)global::ABI.System.TimeSpan.CreateMarshaler).WithObjectTResult();
                 CreateMarshaler2 = CreateMarshaler;
                 GetAbi = ((Func<global::ABI.System.TimeSpan.Marshaler, global::ABI.System.TimeSpan>)global::ABI.System.TimeSpan.GetAbi).WithObjectParams();
@@ -635,7 +611,6 @@ namespace WinRT
                 HelperType = typeof(global::ABI.System.DateTimeOffset);
                 AbiType = typeof(global::ABI.System.DateTimeOffset);
                 MarshalerType = typeof(global::ABI.System.DateTimeOffset.Marshaler);
-                MarshalByObjectReferenceValueSupported = false;
                 CreateMarshaler = (Func<T, object>)(object)((Func<global::System.DateTimeOffset, global::ABI.System.DateTimeOffset.Marshaler>)global::ABI.System.DateTimeOffset.CreateMarshaler).WithObjectTResult();
                 CreateMarshaler2 = CreateMarshaler;
                 GetAbi = ((Func<global::ABI.System.DateTimeOffset.Marshaler, global::ABI.System.DateTimeOffset>)global::ABI.System.DateTimeOffset.GetAbi).WithObjectParams();
@@ -682,17 +657,16 @@ namespace WinRT
                 AbiType = typeof(T).GetAbiType();
                 MarshalerType = typeof(T).GetMarshalerType();
                 MarshalByObjectReferenceValueSupported = typeof(T).GetMarshaler2Type() == typeof(ObjectReferenceValue);
-
 #if NET
                 CreateMarshaler = HelperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T, IObjectReference>>();
                 CreateMarshaler2 = MarshalByObjectReferenceValueSupported
                     ? HelperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T, ObjectReferenceValue>>().WithObjectTResult()
                     : CreateMarshaler;
                 GetAbi = HelperType.GetMethod("GetAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<IObjectReference, IntPtr>>().WithMarshaler2Support();
-                CopyAbi = null; // Not used for class types
+                // CopyAbi = null; (Not used for class types)
                 FromAbi = HelperType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<IntPtr, T>>().WithObjectT();
                 FromManaged = HelperType.GetMethod("FromManaged", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T, IntPtr>>().WithObjectTResult();
-                CopyManaged = null; // Also not used for class types
+                // CopyManaged = null; (Also not used for class types)
                 DisposeMarshaler = HelperType.GetMethod("DisposeMarshaler", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Action<IObjectReference>>().WithMarshaler2Support();
                 DisposeAbi = HelperType.GetMethod("DisposeAbi", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Action<IntPtr>>().WithObjectParams();
                 CreateMarshalerArray = HelperType.GetMethod("CreateMarshalerArray", BindingFlags.Public | BindingFlags.Static)?.CreateDelegate<Func<T[], MarshalInterfaceHelper<T>.MarshalerArray>>().WithObjectTResult();
@@ -707,10 +681,10 @@ namespace WinRT
                 CreateMarshaler = fallback.CreateMarshaler;
                 CreateMarshaler2 = MarshalByObjectReferenceValueSupported ? fallback.CreateMarshaler2 : CreateMarshaler;
                 GetAbi = fallback.GetAbi;
-                CopyAbi = null;
+                // CopyAbi = null;
                 FromAbi = fallback.FromAbi;
                 FromManaged = fallback.FromManaged;
-                CopyManaged = null;
+                // CopyManaged = null;
                 DisposeMarshaler = fallback.DisposeMarshaler;
                 DisposeAbi = fallback.DisposeAbi;
                 CreateMarshalerArray = fallback.CreateMarshalerArray;

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -562,11 +562,9 @@ namespace WinRT
             }
             else if (typeof(T) == typeof(int) ||
                      typeof(T) == typeof(byte) ||
-                     typeof(T) == typeof(bool) ||
                      typeof(T) == typeof(sbyte) ||
                      typeof(T) == typeof(short) ||
                      typeof(T) == typeof(ushort) ||
-                     typeof(T) == typeof(char) ||
                      typeof(T) == typeof(uint) ||
                      typeof(T) == typeof(long) ||
                      typeof(T) == typeof(ulong) ||
@@ -577,6 +575,19 @@ namespace WinRT
                 // Special case some well known primitive types that we know might be constructed
                 // for this type, but not actually used. For these, we just keep all default values.
                 // No consumer would ever actually be trying to use this marshaller for these types.
+                return;
+            }
+            else if (typeof(T) == typeof(bool))
+            {
+                // Same as above, but we do have an ABI type
+                AbiType = typeof(byte);
+
+                return;
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                AbiType = typeof(ushort);
+
                 return;
             }
             else if (typeof(T) == typeof(TimeSpan))
@@ -799,15 +810,18 @@ namespace WinRT
                 return Enum.GetUnderlyingType(typeof(T));
             }
 
+            // These 3 types are true non blittable types that are valid to use here
+            if (typeof(T) == typeof(bool)) return typeof(byte);
+            if (typeof(T) == typeof(char)) return typeof(ushort);
+            if (typeof(T) == typeof(DateTimeOffset)) return typeof(global::ABI.System.DateTimeOffset);
+
             // These types are actually blittable, but this marshaller is still constructed elsewhere.
             // Just return null instead of using MarshalGeneric<T>, to avoid constructing that too.
             if (typeof(T) == typeof(int) ||
                 typeof(T) == typeof(byte) ||
-                typeof(T) == typeof(bool) ||
                 typeof(T) == typeof(sbyte) ||
                 typeof(T) == typeof(short) ||
                 typeof(T) == typeof(ushort) ||
-                typeof(T) == typeof(char) ||
                 typeof(T) == typeof(uint) ||
                 typeof(T) == typeof(long) ||
                 typeof(T) == typeof(ulong) ||
@@ -827,11 +841,6 @@ namespace WinRT
                 typeof(T) == typeof(global::System.Numerics.Vector4))
             {
                 return null;
-            }
-
-            if (typeof(T) == typeof(DateTimeOffset))
-            {
-                return typeof(global::ABI.System.DateTimeOffset);
             }
 
             // Fallback path with the original logic

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -705,12 +705,12 @@ namespace WinRT
                 MarshalGenericFallback<T> fallback = new(HelperType);
 
                 CreateMarshaler = fallback.CreateMarshaler;
-                CreateMarshaler2 = CreateMarshaler2 = MarshalByObjectReferenceValueSupported ? fallback.CreateMarshaler2 : CreateMarshaler;
+                CreateMarshaler2 = MarshalByObjectReferenceValueSupported ? fallback.CreateMarshaler2 : CreateMarshaler;
                 GetAbi = fallback.GetAbi;
-                CopyAbi = fallback.CopyAbi;
+                CopyAbi = null;
                 FromAbi = fallback.FromAbi;
                 FromManaged = fallback.FromManaged;
-                CopyManaged = fallback.CopyManaged;
+                CopyManaged = null;
                 DisposeMarshaler = fallback.DisposeMarshaler;
                 DisposeAbi = fallback.DisposeAbi;
                 CreateMarshalerArray = fallback.CreateMarshalerArray;

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -539,6 +539,18 @@ namespace WinRT
             {
                 HelperType = typeof(global::ABI.System.Numerics.Quaternion);
             }
+            else if (typeof(T) == typeof(global::Windows.Foundation.Size))
+            {
+                HelperType = typeof(global::ABI.Windows.Foundation.Size);
+            }
+            else if (typeof(T) == typeof(global::Windows.Foundation.Point))
+            {
+                HelperType = typeof(global::ABI.Windows.Foundation.Point);
+            }
+            else if (typeof(T) == typeof(global::Windows.Foundation.Rect))
+            {
+                HelperType = typeof(global::ABI.Windows.Foundation.Rect);
+            }
             else if (typeof(T) == typeof(int) ||
                      typeof(T) == typeof(byte) ||
                      typeof(T) == typeof(sbyte) ||

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1720,6 +1720,42 @@ namespace WinRT
                 {
                     AbiType = typeof(ushort);
                 }
+                else if (typeof(T) == typeof(int) ||
+                         typeof(T) == typeof(byte) ||
+                         typeof(T) == typeof(sbyte) ||
+                         typeof(T) == typeof(short) ||
+                         typeof(T) == typeof(ushort) ||
+                         typeof(T) == typeof(uint) ||
+                         typeof(T) == typeof(long) ||
+                         typeof(T) == typeof(ulong) ||
+                         typeof(T) == typeof(float) ||
+                         typeof(T) == typeof(double) ||
+                         typeof(T) == typeof(Guid) ||
+                         typeof(T) == typeof(global::Windows.Foundation.Point) ||
+                         typeof(T) == typeof(global::Windows.Foundation.Rect) ||
+                         typeof(T) == typeof(global::Windows.Foundation.Size) ||
+                         typeof(T) == typeof(global::System.Numerics.Matrix3x2) ||
+                         typeof(T) == typeof(global::System.Numerics.Matrix4x4) ||
+                         typeof(T) == typeof(global::System.Numerics.Plane) ||
+                         typeof(T) == typeof(global::System.Numerics.Quaternion) ||
+                         typeof(T) == typeof(global::System.Numerics.Vector2) ||
+                         typeof(T) == typeof(global::System.Numerics.Vector3) ||
+                         typeof(T) == typeof(global::System.Numerics.Vector4))
+                {
+                    // Manually handle well known primitive types and common types, as well
+                    // as two common projected types (below). This allows the linker to trim
+                    // all the non-taken branch below, which it wouldn't otherwise do, because
+                    // the path below with the fallback logic to check for ABI types is dynamic.
+                    AbiType = null;
+                }
+                else if (typeof(T) == typeof(global::System.TimeSpan))
+                {
+                    AbiType = typeof(global::ABI.System.TimeSpan);
+                }
+                else if (typeof(T) == typeof(global::System.DateTimeOffset))
+                {
+                    AbiType = typeof(global::ABI.System.DateTimeOffset);
+                }
                 else
                 {
                     AbiType = typeof(T).FindHelperType();

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -57,19 +57,9 @@ namespace WinRT
             return function.InvokeWithObjectTResult;
         }
 
-        public static Func<object, object> WithObjectParams<T, TResult>(this Func<T, TResult> func)
-        {
-            return func.InvokeWithObjectParams;
-        }
-
         public static Action<object> WithObjectParams<T>(this Action<T> action)
         {
             return action.InvokeWithObjectParams;
-        }
-
-        public static Action<object, T2> WithObjectT1<T1, T2>(this Action<T1, T2> action)
-        {
-            return action.InvokeWithObjectT1;
         }
 
         private static object InvokeWithMarshaler2Support(this Func<IObjectReference, IntPtr> func, object arg)
@@ -104,19 +94,9 @@ namespace WinRT
             return func.Invoke((T)arg);
         }
 
-        private static object InvokeWithObjectParams<T, TResult>(this Func<T, TResult> func, object arg)
-        {
-            return func.Invoke((T)arg);
-        }
-
         private static void InvokeWithObjectParams<T>(this Action<T> func, object arg)
         {
             func.Invoke((T)arg);
-        }
-
-        private static void InvokeWithObjectT1<T1, T2>(this Action<T1, T2> action, object arg1, T2 arg2)
-        {
-            action.Invoke((T1)arg1, arg2);
         }
     }
 


### PR DESCRIPTION
This PR completely rewrites `MarshalGeneric<T>`, to reduce the binary size. Currently there's over 200 KB just in delegate size coming from various generic instantiations for this class alone. Probably much more if we consider all the rest of the code. This PR changes the structure of the class to use a static constructor where we do trimmable type switches and also optimize for lots of well known cases for primitive types and other ABI types that we know will always get constructed. Additionally, I've also introduced a much more compact system of constructing delegates for the various generated methods on the helper types coming from the generated projections, which also skip all those generated closures.

Here's what sizoscope is showing on a minimal WinRT component, for reference:

![image](https://github.com/microsoft/CsWinRT/assets/10199417/53546de5-0d99-4f58-bcd3-34fc3289a388)