### PR TITLE
Reduce enum stubs codegen with NativeAOT

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1709,10 +1709,14 @@ namespace WinRT
     internal static class Marshaler
     {
         internal static Func<object, object> ReturnParameterFunc = (object box) => box;
-        internal static unsafe Action<object, IntPtr> CopyIntEnumFunc = 
-            (object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
-        internal static unsafe Action<object, IntPtr> CopyUIntEnumFunc =
-            (object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
+
+        internal static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
+
+        internal static unsafe void CopyIntEnum<T>(T value, IntPtr dest) => *(int*)dest.ToPointer() = (int)(object)value;
+
+        internal static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
+
+        internal static unsafe void CopyUIntEnum<T>(T value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)(object)value;
     }
 
 #if EMBED
@@ -1900,13 +1904,13 @@ namespace WinRT
                         // For marshaling non-blittable enum arrays via MarshalNonBlittable
                         if (typeof(T).GetEnumUnderlyingType() == typeof(int))
                         {
-                            CopyAbi = Marshaler.CopyIntEnumFunc;
-                            CopyManaged = (T value, IntPtr dest) => Marshaler.CopyIntEnumFunc(value, dest);
+                            CopyAbi = Marshaler.CopyIntEnum;
+                            CopyManaged = Marshaler.CopyIntEnum;
                         }
                         else
                         {
-                            CopyAbi = Marshaler.CopyUIntEnumFunc;
-                            CopyManaged = (T value, IntPtr dest) => Marshaler.CopyUIntEnumFunc(value, dest);
+                            CopyAbi = Marshaler.CopyUIntEnum;
+                            CopyManaged = Marshaler.CopyUIntEnum;
                         }
                     }
                     CreateMarshalerArray = (T[] array) => MarshalBlittable<T>.CreateMarshalerArray(array);

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1708,15 +1708,21 @@ namespace WinRT
 
     internal static class Marshaler
     {
-        internal static Func<object, object> ReturnParameterFunc = (object box) => box;
+        internal static readonly Func<object, object> ReturnParameterFunc = ReturnParameter;
+        internal static readonly Action<object, IntPtr> CopyIntEnumFunc = CopyIntEnum;
+        internal static readonly Action<object, IntPtr> CopyIntEnumDirectFunc = CopyIntEnumDirect;
+        internal static readonly Action<object, IntPtr> CopyUIntEnumFunc = CopyUIntEnum;
+        internal static readonly Action<object, IntPtr> CopyUIntEnumDirectFunc = CopyUIntEnumDirect;
 
-        internal static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
+        private static object ReturnParameter(object arg) => arg;
 
-        internal static unsafe void CopyIntEnumDirect(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)value;
+        private static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
 
-        internal static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
+        private static unsafe void CopyIntEnumDirect(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)value;
 
-        internal static unsafe void CopyUIntEnumDirect(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)value;
+        private static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
+
+        private static unsafe void CopyUIntEnumDirect(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)value;
     }
 
 #if EMBED

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1712,11 +1712,11 @@ namespace WinRT
 
         internal static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
 
-        internal static unsafe void CopyIntEnum<T>(T value, IntPtr dest) => *(int*)dest.ToPointer() = (int)(object)value;
+        internal static unsafe void CopyIntEnumDirect(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)value;
 
         internal static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
 
-        internal static unsafe void CopyUIntEnum<T>(T value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)(object)value;
+        internal static unsafe void CopyUIntEnumDirect(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)value;
     }
 
 #if EMBED
@@ -1904,13 +1904,13 @@ namespace WinRT
                         // For marshaling non-blittable enum arrays via MarshalNonBlittable
                         if (typeof(T).GetEnumUnderlyingType() == typeof(int))
                         {
-                            CopyAbi = Marshaler.CopyIntEnum;
-                            CopyManaged = Marshaler.CopyIntEnum;
+                            CopyAbi = Marshaler.CopyIntEnumFunc;
+                            CopyManaged = Marshaler.CopyIntEnumDirectFunc.WithTypedT1<T>();
                         }
                         else
                         {
-                            CopyAbi = Marshaler.CopyUIntEnum;
-                            CopyManaged = Marshaler.CopyUIntEnum;
+                            CopyAbi = Marshaler.CopyUIntEnumFunc;
+                            CopyManaged = Marshaler.CopyUIntEnumDirectFunc.WithTypedT1<T>();
                         }
                     }
                     CreateMarshalerArray = (T[] array) => MarshalBlittable<T>.CreateMarshalerArray(array);

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -47,6 +47,11 @@ namespace WinRT
             return action.InvokeWithMarshaler2Support;
         }
 
+        public static Action<T, IntPtr> WithTypedT1<T>(this Action<object, IntPtr> action)
+        {
+            return action.InvokeWithTypedT1;
+        }
+
         public static Func<object, TResult> WithObjectT<T, TResult>(this Func<T, TResult> function)
         {
             return function.InvokeWithObjectT;
@@ -97,6 +102,11 @@ namespace WinRT
         private static void InvokeWithObjectParams<T>(this Action<T> func, object arg)
         {
             func.Invoke((T)arg);
+        }
+
+        private static void InvokeWithTypedT1<T>(this Action<object, IntPtr> action, T arg1, IntPtr arg2)
+        {
+            action.Invoke(arg1, arg2);
         }
     }
 


### PR DESCRIPTION
This PR includes some optimizations to reduce the codegen a bit more for `Marshaler<T>` with enum types.
It also is a little performance optimizations in that all shared stubs are now properly cached with `beforefieldinit` too.