### PR TITLE
Omit non public methods from preserved metadata

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -445,13 +445,13 @@ namespace WinRT
 
         private static Func<IInspectable, object> CreateAbiNullableTFactory(
 #if NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 #endif
             Type implementationType)
         {
             // This method is only called when 'implementationType' has been validated to be some ABI.System.Nullable_Delegate<T>.
             // As such, we know that the type definitely has a method with signature 'static Nullable GetValue(IInspectable)'.
-            var getValueMethod = implementationType.GetMethod("GetValue", BindingFlags.Static | BindingFlags.NonPublic);
+            var getValueMethod = implementationType.GetMethod("GetValue", BindingFlags.Static | BindingFlags.Public);
 
             return (Func<IInspectable, object>)getValueMethod.CreateDelegate(typeof(Func<IInspectable, object>));
         }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -439,7 +439,7 @@ namespace WinRT
 
         private static Func<IInspectable, object> CreateNullableTFactory(Type implementationType)
         {
-            var getValueMethod = implementationType.GetHelperType().GetMethod("GetValue", BindingFlags.Static | BindingFlags.NonPublic);
+            var getValueMethod = implementationType.GetHelperType().GetMethod("GetValue", BindingFlags.Static | BindingFlags.Public);
             return (IInspectable obj) => getValueMethod.Invoke(null, new[] { obj });
         }
 
@@ -481,7 +481,7 @@ namespace WinRT
 
         private static Func<IInspectable, object> CreateCustomTypeMappingFactory(Type customTypeHelperType)
         {
-            var fromAbiMethod = customTypeHelperType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            var fromAbiMethod = customTypeHelperType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static);
             if (fromAbiMethod is null)
             {
                 throw new MissingMethodException();

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1082,8 +1082,7 @@ namespace WinRT
             DynamicallyAccessedMemberTypes.PublicFields | 
             DynamicallyAccessedMemberTypes.NonPublicFields | 
             DynamicallyAccessedMemberTypes.PublicNestedTypes |
-            DynamicallyAccessedMemberTypes.PublicMethods |
-            DynamicallyAccessedMemberTypes.NonPublicMethods)]
+            DynamicallyAccessedMemberTypes.PublicMethods)]
 #endif
         private static readonly Type HelperType = typeof(T).GetHelperType();
         private static Func<T, IObjectReference> _ToAbi;
@@ -1254,7 +1253,7 @@ namespace WinRT
             Type helperType = Projections.FindCustomHelperTypeMapping(publicType, true);
             if (helperType != null)
             {
-                var createMarshaler = helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                var createMarshaler = helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.Static);
                 return (IObjectReference) createMarshaler.Invoke(null, new[] { (object) o });
             }
 
@@ -1286,7 +1285,7 @@ namespace WinRT
             Type helperType = Projections.FindCustomHelperTypeMapping(publicType, true);
             if (helperType != null)
             {
-                var createMarshaler = helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                var createMarshaler = helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.Static);
                 return ((ObjectReferenceValue)createMarshaler.Invoke(null, new[] { (object)o }));
             }
 
@@ -1547,7 +1546,7 @@ namespace WinRT
                     if (AbiType != null)
                     {
                         // Could still be blittable and the 'ABI.*' type exists for other reasons (e.g. it's a mapped type)
-                        if (AbiType.GetMethod("FromAbi", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static) == null)
+                        if (AbiType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static) == null)
                         {
                             AbiType = null;
                         }

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -129,4 +129,5 @@ TypesMustExist : Type 'WinRT.StructTypeDetails<T, TAbi>' does not exist in the r
 MembersMustExist : Member 'public void WinRT.WindowsRuntimeTypeAttribute..ctor(System.String, System.String)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribute.GuidSignature.get()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 130
+MembersMustExist : Member 'public T ABI.System.Nullable<T>.GetValue(WinRT.IInspectable)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 131

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -117,7 +117,6 @@ namespace WinRT
 #if NET
             [DynamicallyAccessedMembers(
                 DynamicallyAccessedMemberTypes.PublicMethods |
-                DynamicallyAccessedMemberTypes.NonPublicMethods |
                 DynamicallyAccessedMemberTypes.PublicNestedTypes |
                 DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
@@ -141,7 +140,6 @@ namespace WinRT
 #if NET
             [DynamicallyAccessedMembers(
                 DynamicallyAccessedMemberTypes.PublicMethods |
-                DynamicallyAccessedMemberTypes.NonPublicMethods |
                 DynamicallyAccessedMemberTypes.PublicNestedTypes |
                 DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
@@ -165,7 +163,6 @@ namespace WinRT
 #if NET
             [DynamicallyAccessedMembers(
                 DynamicallyAccessedMemberTypes.PublicMethods |
-                DynamicallyAccessedMemberTypes.NonPublicMethods |
                 DynamicallyAccessedMemberTypes.PublicNestedTypes)]
 #endif
             Type abiType)
@@ -177,7 +174,6 @@ namespace WinRT
 #if NET
         [return: DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods |
-            DynamicallyAccessedMemberTypes.NonPublicMethods |
             DynamicallyAccessedMemberTypes.PublicNestedTypes |
             DynamicallyAccessedMemberTypes.PublicFields)]
 #endif

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -110,7 +110,7 @@ namespace ABI.Windows.Foundation
             return wrapper.Value;
         }
 
-        internal static unsafe object GetValue(IInspectable inspectable)
+        public static unsafe object GetValue(IInspectable inspectable)
         {
             IntPtr referenceArrayPtr = IntPtr.Zero;
             int __retval_length = default;

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -118,7 +118,7 @@ namespace ABI.Windows.Foundation
             return wrapper.Value;
         }
 
-        internal static object GetValue(IInspectable inspectable)
+        public static object GetValue(IInspectable inspectable)
         {
             var array = new IReferenceArray<T>(inspectable.ObjRef);
             return array.Value;

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2064,7 +2064,7 @@ namespace ABI.System
 
         public static Guid PIID = GuidGenerator.CreateIID(typeof(Nullable<T>));
 
-        unsafe internal static Nullable GetValue(IInspectable inspectable)
+        public static unsafe Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -414,7 +414,7 @@ namespace ABI.System
             _obj = obj;
         }
 
-        internal static unsafe T GetValue(IInspectable inspectable)
+        public static unsafe T GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -571,7 +571,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static int GetValue(IInspectable inspectable)
+        public static unsafe int GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -648,7 +648,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static Nullable GetValue(IInspectable inspectable)
+        public static unsafe Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;
@@ -726,7 +726,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static byte GetValue(IInspectable inspectable)
+        public static unsafe byte GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -803,7 +803,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static sbyte GetValue(IInspectable inspectable)
+        public static unsafe sbyte GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -880,7 +880,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static short GetValue(IInspectable inspectable)
+        public static unsafe short GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -957,7 +957,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static ushort GetValue(IInspectable inspectable)
+        public static unsafe ushort GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1034,7 +1034,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static uint GetValue(IInspectable inspectable)
+        public static unsafe uint GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1111,7 +1111,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static long GetValue(IInspectable inspectable)
+        public static unsafe long GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1188,7 +1188,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static ulong GetValue(IInspectable inspectable)
+        public static unsafe ulong GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1265,7 +1265,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static float GetValue(IInspectable inspectable)
+        public static unsafe float GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1342,7 +1342,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static double GetValue(IInspectable inspectable)
+        public static unsafe double GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1419,7 +1419,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static char GetValue(IInspectable inspectable)
+        public static unsafe char GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1496,7 +1496,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static bool GetValue(IInspectable inspectable)
+        public static unsafe bool GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1573,7 +1573,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static Guid GetValue(IInspectable inspectable)
+        public static unsafe Guid GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             try
@@ -1650,7 +1650,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static global::System.DateTimeOffset GetValue(IInspectable inspectable)
+        public static unsafe global::System.DateTimeOffset GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             DateTimeOffset __retval = default;
@@ -1728,7 +1728,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static global::System.TimeSpan GetValue(IInspectable inspectable)
+        public static unsafe global::System.TimeSpan GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             TimeSpan __retval = default;
@@ -1867,7 +1867,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static Nullable GetValue(IInspectable inspectable)
+        public static unsafe Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             Type __retval = default;
@@ -1945,7 +1945,7 @@ namespace ABI.System
             }
         }
 
-        unsafe internal static Nullable GetValue(IInspectable inspectable)
+        public static unsafe Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             Exception __retval = default;
@@ -2007,7 +2007,7 @@ namespace ABI.System
             return 0;
         }
 
-        unsafe internal static Nullable GetValue(IInspectable inspectable)
+        public static unsafe Nullable GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -21,7 +21,6 @@ namespace WinRT
 
 #if NET
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods |
-                                            DynamicallyAccessedMemberTypes.NonPublicMethods |
                                             DynamicallyAccessedMemberTypes.PublicNestedTypes | 
                                             DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
@@ -30,7 +29,6 @@ namespace WinRT
             return HelperTypeCache.GetOrAdd(type,
 #if NET
             [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods |
-                                                DynamicallyAccessedMemberTypes.NonPublicMethods |
                                                 DynamicallyAccessedMemberTypes.PublicNestedTypes | 
                                                 DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
@@ -93,7 +91,6 @@ namespace WinRT
 
 #if NET
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | 
-                                            DynamicallyAccessedMemberTypes.NonPublicMethods |
                                             DynamicallyAccessedMemberTypes.PublicNestedTypes |
                                             DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
@@ -152,25 +149,26 @@ namespace WinRT
 
         public static Type GetAbiType(this Type type)
         {
-            return type.GetHelperType().GetMethod("GetAbi", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).ReturnType;
+            return type.GetHelperType().GetMethod("GetAbi", BindingFlags.Public | BindingFlags.Static).ReturnType;
         }
 
         public static Type GetMarshalerType(this Type type)
         {
-            return type.GetHelperType().GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).ReturnType;
+            return type.GetHelperType().GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.Static).ReturnType;
         }
 
         internal static Type GetMarshaler2Type(this Type type)
         {
             var helperType = type.GetHelperType();
-            var createMarshaler = helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static) ??
-                helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            var createMarshaler =
+                helperType.GetMethod("CreateMarshaler2", BindingFlags.Public | BindingFlags.Static) ??
+                helperType.GetMethod("CreateMarshaler", BindingFlags.Public | BindingFlags.Static);
             return createMarshaler.ReturnType;
         }
 
         internal static Type GetMarshalerArrayType(this Type type)
         {
-            return type.GetHelperType().GetMethod("CreateMarshalerArray", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.ReturnType;
+            return type.GetHelperType().GetMethod("CreateMarshalerArray", BindingFlags.Public | BindingFlags.Static)?.ReturnType;
         }
 
         public static bool IsDelegate(this Type type)


### PR DESCRIPTION
This PR stops preserving reflection metadata for non public methods of helper types, given that they're:
1. All public anyway (from the generated projections, or from internal helpers that have been updated accordingly)
2. All other code was also just using `PublicMethods` as data flow annotations (which also produced warnings)

Also including a couple of very minor tweaks to some delegate creations, while at it.