### PR TITLE
Trim out more legacy projections fallback paths

### DIFF
--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -127,17 +126,9 @@ namespace WinRT
                 return "delegate({" + GetGUID(type) + "})";
             }
 
-#if NET
-            if (RuntimeFeature.IsDynamicCodeCompiled)
-#endif
+            if (type.IsClass && Projections.TryGetDefaultInterfaceTypeForRuntimeClassType(type, out Type iface))
             {
-                // Using TryGetDefaultInterfaceTypeForRuntimeClassType is just a fallback path for legacy projections,
-                // which is not supported for AOT. Because of that, if we are in fact running on NativeAOT, we can
-                // just allow trimming out this entire path, as it should never be reached in that case anyway.
-                if (type.IsClass && Projections.TryGetDefaultInterfaceTypeForRuntimeClassType(type, out Type iface))
-                {
-                    return "rc(" + type.FullName + ";" + GetSignature(iface) + ")";
-                }
+                return "rc(" + type.FullName + ";" + GetSignature(iface) + ")";
             }
 
             return "{" + type.GUID.ToString() + "}";

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -52,6 +52,15 @@ namespace WinRT
                     return GetHelperTypeFromAttribute(helperTypeAtribute, type);
                 }
 
+#if NET
+                // Using AOT requires using updated projections, which would never let the code below
+                // be reached (as it's just a fallback path for legacy projections). So we can trim it.
+                if (!RuntimeFeature.IsDynamicCodeCompiled)
+                {
+                    return null;
+                }
+#endif
+
                 return FindHelperTypeFallback(type);
             });
 
@@ -244,13 +253,10 @@ namespace WinRT
                     {
                         return null;
                     }
-                    else
 #endif
-                    {
-                        // Fallback code path for back compat with previously generated projections
-                        // running without AOT.
-                        return GetAuthoringMetadataTypeFallback(type);
-                    }
+                    // Fallback code path for back compat with previously generated projections
+                    // running without AOT.
+                    return GetAuthoringMetadataTypeFallback(type);
                 });
         }
 

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -52,6 +52,16 @@ namespace WinRT
                     return GetHelperTypeFromAttribute(helperTypeAtribute, type);
                 }
 
+                var authoringMetadaType = type.GetAuthoringMetadataType();
+                if (authoringMetadaType is not null)
+                {
+                    helperTypeAtribute = authoringMetadaType.GetCustomAttribute<WindowsRuntimeHelperTypeAttribute>();
+                    if (helperTypeAtribute is not null)
+                    {
+                        return GetHelperTypeFromAttribute(helperTypeAtribute, type);
+                    }
+                }
+
 #if NET
                 // Using AOT requires using updated projections, which would never let the code below
                 // be reached (as it's just a fallback path for legacy projections). So we can trim it.


### PR DESCRIPTION
This PR just allows completely trimming out some fallback paths for legacy projections. These should never be reached when using NativeAOT, and even if they were, old projections are not supported in AOT scenarios anyway, so no point in keeping this.