### PR TITLE
Add option to disable IDynamicInterfaceCastable support

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -234,9 +234,10 @@ $(CsWinRTInternalProjection)
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>
 
-  <!-- Default values for all custom CsWinRT runtimem feature switches -->
+  <!-- Default values for all custom CsWinRT runtime feature switches -->
   <PropertyGroup>
     <CsWinRTEnableDynamicObjectsSupport Condition="'$(CsWinRTEnableDynamicObjectsSupport)' == ''">true</CsWinRTEnableDynamicObjectsSupport>
+    <CsWinRTEnableDynamicInterfaceCastableSupport Condition="'$(CsWinRTEnableDynamicInterfaceCastableSupport)' == ''">true</CsWinRTEnableDynamicInterfaceCastableSupport>
   </PropertyGroup>
 
   <!--
@@ -248,6 +249,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT"
                                     Value="$(CsWinRTEnableDynamicObjectsSupport)"
+                                    Trim="true" />
+
+    <!-- CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT"
+                                    Value="$(CsWinRTEnableDynamicInterfaceCastableSupport)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -22,14 +22,24 @@ namespace WinRT;
 internal static class FeatureSwitches
 {
     /// <summary>
-    /// The configuration property name for <see cref="IsDebugOutputEnabled"/>.
+    /// The configuration property name for <see cref="IsDynamicObjectsSupportEnabled"/>.
     /// </summary>
     private const string IsDynamicObjectsSupportEnabledPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
+
+    /// <summary>
+    /// The configuration property name for <see cref="IsDynamicInterfaceCastableSupportEnabled"/>.
+    /// </summary>
+    private const string IsDynamicInterfaceCastableSupportEnabledPropertyName = "CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT";
 
     /// <summary>
     /// The backing field for <see cref="IsDynamicObjectsSupportEnabled"/>.
     /// </summary>
     private static int _isDynamicObjectsSupportEnabled;
+
+    /// <summary>
+    /// The backing field for <see cref="IsDynamicInterfaceCastableSupportEnabled"/>.
+    /// </summary>
+    private static int _isDynamicInterfaceCastableSupportEnabled;
 
     /// <summary>
     /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
@@ -38,6 +48,15 @@ internal static class FeatureSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetConfigurationValue(IsDynamicObjectsSupportEnabledPropertyName, ref _isDynamicObjectsSupportEnabled);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not support for <see cref="System.Runtime.InteropServices.IDynamicInterfaceCastable"/> is enabled (defaults to <see langword="true"/>).
+    /// </summary>
+    public static bool IsDynamicInterfaceCastableSupportEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetConfigurationValue(IsDynamicInterfaceCastableSupportEnabledPropertyName, ref _isDynamicInterfaceCastableSupportEnabled);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -5,6 +5,10 @@
       <!-- CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT switch -->
       <method signature="System.Boolean get_IsDynamicObjectsSupportEnabled()" body="stub" value="false" feature="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT" featurevalue="false"/>
       <method signature="System.Boolean get_IsDynamicObjectsSupportEnabled()" body="stub" value="true" feature="CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT" featurevalue="true"/>
+        
+      <!-- CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT switch -->
+      <method signature="System.Boolean get_IsDynamicInterfaceCastableSupportEnabled()" body="stub" value="false" feature="CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT" featurevalue="false"/>
+      <method signature="System.Boolean get_IsDynamicInterfaceCastableSupportEnabled()" body="stub" value="true" feature="CSWINRT_DYNAMIC_INTERFACE_CASTABLE_SUPPORT" featurevalue="true"/>
     </type>
   </assembly>
 </linker>

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -25,9 +25,7 @@ namespace WinRT
         {
             if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
             {
-                throw new NotSupportedException(
-                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
-                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+                return false;
             }
 
             if (QueryInterfaceCache.ContainsKey(interfaceType))
@@ -159,6 +157,9 @@ namespace WinRT
 
         RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
         {
+            // If the feature switch is disabled, this method shouldn't really ever be called, as it should
+            // only be invoked by the IDIC mechanism after a successful call to IsInterfaceImplemented. But
+            // when the feature switch is disabled, that method will just always return false for all types.
             if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
             {
                 throw new NotSupportedException(

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -23,6 +23,13 @@ namespace WinRT
 
         bool IsInterfaceImplementedFallback(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             if (QueryInterfaceCache.ContainsKey(interfaceType))
             {
                 return true;
@@ -152,6 +159,13 @@ namespace WinRT
 
         RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             var type = Type.GetTypeFromHandle(interfaceType);
             var helperType = type.GetHelperType();
             if (helperType.IsInterface)
@@ -171,6 +185,13 @@ namespace WinRT
 
         IObjectReference GetObjectReferenceForTypeFallback(RuntimeTypeHandle type)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             if (IsInterfaceImplemented(type, true))
             {
                 return QueryInterfaceCache[type];
@@ -189,11 +210,6 @@ namespace WinRT
         {
             if (NativeObject.Resurrect())
             {
-                foreach (var cached in QueryInterfaceCache)
-                {
-                    cached.Value.Resurrect();
-                }
-
                 // Delegates store their agile reference as an additional type data.
                 // These should be recreated when instances are resurrect.
                 if (AdditionalTypeData.TryGetValue(typeof(AgileReference).TypeHandle, out var agileObj))

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -96,6 +96,14 @@ namespace ABI.WinRT.Interop
         [UnmanagedCallersOnly]
         private static int Do_Abi_Resolve(IntPtr thisPtr, Guid* riid, IntPtr* objectReference)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                *objectReference = default;
+
+                // COR_E_NOTSUPPORTED
+                return unchecked((int)0x80131515);
+            }
+
             IObjectReference _objectReference = default;
 
             *objectReference = default;
@@ -114,6 +122,13 @@ namespace ABI.WinRT.Interop
 
         IObjectReference global::WinRT.Interop.IAgileReference.Resolve(Guid riid)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IAgileReference).TypeHandle);
             return IAgileReferenceMethods.Resolve(_obj, riid);
         }

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -138,6 +138,13 @@ namespace ABI.WinRT.Interop
 
         global::WinRT.Interop.IWeakReference global::WinRT.Interop.IWeakReferenceSource.GetWeakReference()
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IWeakReferenceSource).TypeHandle);
             return IWeakReferenceSourceMethods.GetWeakReference(_obj);
         }
@@ -184,6 +191,13 @@ namespace ABI.WinRT.Interop
 
         IObjectReference global::WinRT.Interop.IWeakReference.Resolve(Guid riid)
         {
+            if (!FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                throw new NotSupportedException(
+                    """Support for IDynamicInterfaceCastable functionality is disabled. If it is required, make sure that """ +
+                    """the "CsWinRTEnableDynamicInterfaceCastableSupport" MSBuild property is not being set to 'false' anywhere.""");
+            }
+
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IWeakReference).TypeHandle);
             var ThisPtr = _obj.ThisPtr;
 

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -103,10 +103,17 @@ namespace WinRT
             CustomTypeToHelperTypeMappings.Add(typeof(Microsoft.UI.Xaml.Interop.IBindableVector), typeof(ABI.System.Collections.IList));
 
 #if NET
-            CustomTypeToHelperTypeMappings.Add(typeof(ICollection<>), typeof(ABI.System.Collections.Generic.ICollection<>));
-            CustomTypeToHelperTypeMappings.Add(typeof(IReadOnlyCollection<>), typeof(ABI.System.Collections.Generic.IReadOnlyCollection<>));
-            CustomTypeToHelperTypeMappings.Add(typeof(ICollection), typeof(ABI.System.Collections.ICollection));
+            // All of these custom type mappings rely on IDynamicInterfaceCastable support, and will just not work if that's disabled.
+            // In that scenario, we can avoid registering these types in the first place (since they would not be functional anyway).
+            // This further imporves trimming and allows all of the transitive dependencies of these types to also be removed.
+            if (FeatureSwitches.IsDynamicInterfaceCastableSupportEnabled)
+            {
+                CustomTypeToHelperTypeMappings.Add(typeof(ICollection<>), typeof(ABI.System.Collections.Generic.ICollection<>));
+                CustomTypeToHelperTypeMappings.Add(typeof(IReadOnlyCollection<>), typeof(ABI.System.Collections.Generic.IReadOnlyCollection<>));
+                CustomTypeToHelperTypeMappings.Add(typeof(ICollection), typeof(ABI.System.Collections.ICollection));
+            }
 #endif
+
             RegisterCustomAbiTypeMappingNoLock(typeof(EventHandler), typeof(ABI.System.EventHandler));
 
             CustomTypeToAbiTypeNameMappings.Add(typeof(System.Type), "Windows.UI.Xaml.Interop.TypeName");


### PR DESCRIPTION
This PR builds on top of #1435 and adds an option to disable the `IDynamicInterfaceCastable` support. This causes all stub methods to initialize the interface cache to get rooted for all projection types (even if IDIC is never actually used), and most importantly, the IDIC support isn't AOT-safe anyway, as it makes heavy use of `MakeGenericType/Method`.