### PR TITLE
Rewrite event registration token logic to improve performance, trimming

### DIFF
--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -1041,7 +1041,7 @@ namespace WinRT
     // An event registration token table stores mappings from delegates to event tokens, in order to support
     // sourcing WinRT style events from managed code.
     internal sealed class EventRegistrationTokenTable<T>
-        where T : class, global::System.Delegate
+        where T : global::System.Delegate
     {
         /// <summary>
         /// The hashcode of the delegate type, being set in the upper 32 bits of the registration tokens.

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -1130,7 +1130,7 @@ namespace WinRT
         {
             // If the token doesn't have the upper 32 bits set to the hashcode of the delegate
             // type in use, we know that the token cannot possibly have a registered handler.
-            if ((uint)(((ulong)token.Value >> 32) & 0x00000000FFFFFFFFU) != (uint)TypeOfTHashCode)
+            if ((int)((ulong)token.Value >> 32) != TypeOfTHashCode)
             {
                 handler = null;
 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -1040,8 +1040,14 @@ namespace WinRT
 
     // An event registration token table stores mappings from delegates to event tokens, in order to support
     // sourcing WinRT style events from managed code.
-    internal sealed class EventRegistrationTokenTable<T> where T : class, global::System.Delegate
+    internal sealed class EventRegistrationTokenTable<T>
+        where T : class, global::System.Delegate
     {
+        /// <summary>
+        /// The hashcode of the delegate type, being set in the upper 32 bits of the registration tokens.
+        /// </summary>
+        private static readonly int TypeOfTHashCode = typeof(T).GetHashCode();
+
         // Note this dictionary is also used as the synchronization object for this table
         private readonly Dictionary<EventRegistrationToken, T> m_tokens = new Dictionary<EventRegistrationToken, T>();
 
@@ -1140,7 +1146,7 @@ namespace WinRT
                 handlerHashCode = (uint)handler.GetHashCode();
             }
 
-            ulong tokenValue = ((ulong)(uint)typeof(T).GetHashCode() << 32) | handlerHashCode;
+            ulong tokenValue = ((ulong)(uint)TypeOfTHashCode << 32) | handlerHashCode;
             return new EventRegistrationToken { Value = (long)tokenValue };
         }
 

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -1115,7 +1115,7 @@ namespace WinRT
             //   1. Is quickly obtained from the handler instance (in this case, it doesn't depend on it at all).
             //   2. Uses bits in the upper 32 bits of the 64 bit value, in order to avoid bugs where code
             //      may assume the value is really just 32 bits.
-            //   3. Uuses bits in the bottom 32 bits of the 64 bit value, in order to ensure that code doesn't
+            //   3. Uses bits in the bottom 32 bits of the 64 bit value, in order to ensure that code doesn't
             //      take a dependency on them always being 0.
             //
             // The simple algorithm chosen here is to simply assign the upper 32 bits the metadata token of the
@@ -1165,6 +1165,12 @@ namespace WinRT
         {
             // If the token doesn't have the upper 32 bits set to the hashcode of the delegate
             // type in use, we know that the token cannot possibly have a registered handler.
+            //
+            // Note that both here right after the right shift by 32 bits (since we want to read
+            // the upper 32 bits to compare against the T hashcode) and below (where we want to
+            // read the lower 32 bits to use as lookup index into our dictionary), we're just
+            // casting to int as a simple and efficient way of truncating the input 64 bit value.
+            // That is, '(int)i64' is the same as '(int)(i64 & 0xFFFFFFFF)', but more readable.
             if ((int)((ulong)token.Value >> 32) != TypeOfTHashCode)
             {
                 handler = null;

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -1070,7 +1070,15 @@ namespace WinRT
         private readonly Dictionary<int, object> m_tokens = new Dictionary<int, object>();
 
         // The current counter used for the low 32 bits of the registration tokens.
-        private int m_low32Bits = 0x42424242;
+        // We explicit use [int.MinValue, int.MaxValue] as the range, as this value
+        // is expected to eventually wrap around, and we don't want to lose the
+        // additional possible range of negative values (there's no reason for that).
+        private int m_low32Bits =
+#if NET6_0_OR_GREATER
+            Random.Shared.Next(int.MinValue, int.MaxValue);
+#else
+            new Random().Next(int.MinValue, int.MaxValue);
+#endif
 
         public EventRegistrationToken AddEventHandler(T handler)
         {
@@ -1184,7 +1192,7 @@ namespace WinRT
 
                     return true;
                 }
-#endif                
+#endif
             }
 
             handler = null;


### PR DESCRIPTION
This PR rewrites the logic to compute event registration tokens, see: https://github.com/dotnet/runtime/issues/96947.
This is both faster, and allows NativeAOT to trim signficantly more stuff, as it makes all delegate targets non-reflectable.