### PR TITLE
Fix IL2091 warnings in generated activation factories

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9653,10 +9653,15 @@ public static IntPtr Make()
 }
 
 static readonly % _factory = new %();
-public static ObjectReference<I> ActivateInstance<I>()
+public static ObjectReference<I> ActivateInstance<
+#if NET5_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
+    I>()
 {
-IntPtr instance = _factory.ActivateInstance();
-return ObjectReference<IInspectable.Vftbl>.Attach(ref instance).As<I>();
+    IntPtr instance = _factory.ActivateInstance();
+
+    return ObjectReference<IInspectable.Vftbl>.Attach(ref instance).As<I>();
 }
 
 %

--- a/src/cswinrt/type_writers.h
+++ b/src/cswinrt/type_writers.h
@@ -47,6 +47,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
This fixes the following error in authoring scenarios:

> "WinRT.SourceGenerator\Generator.SourceGenerator\MinimalWinRTComponentTest.cs(84,20): warning IL2091: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicConstructors', 'DynamicallyAccessedMemberTypes.PublicFields' in 'WinRT.IObjectReference.As\<T>()'. The generic parameter 'I' of 'ABI.Impl.MinimalWinRTComponentTest.HelloWorldEffectServerActivationFactory.ActivateInstance\<I>()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."

The method is unused, but at least this will fix the warning and make it trim-safe in case anyone actually needs it.