### PR TITLE
Stop preserving interfaces from MarshalInspectable<T>

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.txt
@@ -14,4 +14,5 @@ CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAc
 CannotMakeMemberNonVirtual : Member 'public System.Int32 WinRT.IObjectReference.TryAs<T>(System.Guid, WinRT.ObjectReference<T>)' is non-virtual in the implementation but is virtual in the contract.
 MembersMustExist : Member 'protected System.Boolean System.Boolean WinRT.IObjectReference.disposed' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected void WinRT.IObjectReference.Dispose(System.Boolean)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 15
+CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the contract to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation.
+Total Issues: 16

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -385,31 +385,37 @@ namespace WinRT
             return createRcwFunc;
         }
 
-        internal static Func<IntPtr, object> CreateDelegateFactory(Type type)
+        internal static Func<IntPtr, object> GetOrCreateDelegateFactory(Type type)
         {
-            return DelegateFactoryCache.GetOrAdd(type, (type) =>
-            {
-                var createRcwFunc = (Func<IntPtr, object>)type.GetHelperType().GetMethod("CreateRcw", BindingFlags.Public | BindingFlags.Static).
-                        CreateDelegate(typeof(Func<IntPtr, object>));
-                var iid = GuidGenerator.GetIID(type);
+            return DelegateFactoryCache.GetOrAdd(type, CreateDelegateFactory);
+        }
 
-                return (IntPtr externalComObject) =>
+#if NET
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067",
+            Justification = "The type is a delegate type, so 'GuidGenerator.GetIID' doesn't need to access public fields from it (it uses the helper type).")]
+#endif
+        private static Func<IntPtr, object> CreateDelegateFactory(Type type)
+        {
+            var createRcwFunc = (Func<IntPtr, object>)type.GetHelperType().GetMethod("CreateRcw", BindingFlags.Public | BindingFlags.Static).
+                    CreateDelegate(typeof(Func<IntPtr, object>));
+            var iid = GuidGenerator.GetIID(type);
+
+            return (IntPtr externalComObject) =>
+            {
+                // The CreateRCW function for delegates expect the pointer to be the delegate interface in CsWinRT 1.5.
+                // But CreateObject is passed the IUnknown interface. This would typically be fine for delegates as delegates
+                // don't implement interfaces and implementations typically have both the IUnknown vtable and the delegate
+                // vtable point to the same vtable.  But when the pointer is to a proxy, that can not be relied on.
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, ref iid, out var ptr));
+                try
                 {
-                    // The CreateRCW function for delegates expect the pointer to be the delegate interface in CsWinRT 1.5.
-                    // But CreateObject is passed the IUnknown interface. This would typically be fine for delegates as delegates
-                    // don't implement interfaces and implementations typically have both the IUnknown vtable and the delegate
-                    // vtable point to the same vtable.  But when the pointer is to a proxy, that can not be relied on.
-                    Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, ref iid, out var ptr));
-                    try
-                    {
-                        return createRcwFunc(ptr);
-                    }
-                    finally
-                    {
-                        Marshal.Release(ptr);
-                    }
-                };
-            });
+                    return createRcwFunc(ptr);
+                }
+                finally
+                {
+                    Marshal.Release(ptr);
+                }
+            };
         }
 
         public static bool RegisterDelegateFactory(Type implementationType, Func<IntPtr, object> delegateFactory) => DelegateFactoryCache.TryAdd(implementationType, delegateFactory);

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -181,9 +181,6 @@ namespace WinRT
         public static unsafe T FindObject<T>(IntPtr ptr)
             where T : class => ComInterfaceDispatch.GetInstance<T>((ComInterfaceDispatch*)ptr);
 
-        private static T FindDelegate<T>(IntPtr thisPtr)
-            where T : class, System.Delegate => FindObject<T>(thisPtr);
-
         public static IUnknownVftbl IUnknownVftbl => DefaultComWrappers.IUnknownVftbl;
         public static IntPtr IUnknownVftblPtr => DefaultComWrappers.IUnknownVftblPtr;
 
@@ -537,7 +534,7 @@ namespace WinRT
             {
                 if (ComWrappersSupport.CreateRCWType != null && ComWrappersSupport.CreateRCWType.IsDelegate())
                 {
-                    return ComWrappersSupport.CreateDelegateFactory(ComWrappersSupport.CreateRCWType)(externalComObject);
+                    return ComWrappersSupport.GetOrCreateDelegateFactory(ComWrappersSupport.CreateRCWType)(externalComObject);
                 }
                 else if (Marshal.QueryInterface(externalComObject, ref inspectableIID, out ptr) == 0)
                 {

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -48,7 +48,7 @@ namespace WinRT
                 object runtimeWrapper = null;
                 if (typeof(T).IsDelegate())
                 {
-                    runtimeWrapper = CreateDelegateFactory(typeof(T))(ptr);
+                    runtimeWrapper = GetOrCreateDelegateFactory(typeof(T))(ptr);
                 }
                 else if (identity.TryAs<IInspectable.Vftbl>(out var inspectableRef) == 0)
                 {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1499,14 +1499,16 @@ namespace WinRT
     public
 #endif
     static class MarshalInspectable<
-#if NET6_0_OR_GREATER
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#elif NET
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#if NET
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 #endif
         T>
     {
-        public static IObjectReference CreateMarshaler<V>(
+        public static IObjectReference CreateMarshaler<
+#if NET
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+#endif
+            V>(
             T o,
             Guid iid,
             bool unwrapObject = true)
@@ -1687,6 +1689,10 @@ namespace WinRT
             return ComWrappersSupport.CreateCCWForObjectForMarshaling(o, delegateIID);
         }
 
+#if NET
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091",
+            Justification = "Preserving constructors is not necessary when creating RCWs for delegates, as they go through the factory methods in the helper types.")]
+#endif
         public static T FromAbi<T>(IntPtr nativeDelegate)
             where T : Delegate
         {

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1700,14 +1700,13 @@ namespace WinRT
             {
                 return null;
             }
-            else if (IUnknownVftbl.IsReferenceToManagedObject(nativeDelegate))
+            
+            if (IUnknownVftbl.IsReferenceToManagedObject(nativeDelegate))
             {
                 return ComWrappersSupport.FindObject<T>(nativeDelegate);
             }
-            else
-            {
-                return ComWrappersSupport.CreateRcwForComObject<T>(nativeDelegate);
-            }
+
+            return ComWrappersSupport.CreateRcwForComObject<T>(nativeDelegate);
         }
     }
 

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -137,4 +137,6 @@ MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, System.Guid)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, T, System.Guid)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.ActivationFactory' does not exist in the reference but it does exist in the implementation.
-Total Issues: 138
+CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the reference.
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr)' in the implementation but not the reference.
+Total Issues: 140

--- a/src/WinRT.Runtime/Projections/Type.cs
+++ b/src/WinRT.Runtime/Projections/Type.cs
@@ -128,7 +128,7 @@ namespace ABI.System
         }
 
 #if NET
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057", 
             Justification = "Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]
 #endif
         public static global::System.Type FromAbi(Type value)


### PR DESCRIPTION
This PR includes a couple of small tweaks:
- Stop unnecessarily preserving interfaces for `MarshalInspectable<T>`
- Fix a couple of trimming annotations in `Marshalers.cs` and `Type.cs`