### PR TITLE
Seal IObjectReference.TryAs<T> method

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.txt
@@ -11,4 +11,5 @@ MembersMustExist : Member 'public System.Delegate System.Delegate ABI.System.Col
 TypesMustExist : Type 'ABI.System.Collections.Specialized.INotifyCollectionChanged' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'ABI.System.ComponentModel.INotifyDataErrorInfo' does not exist in the implementation but it does exist in the contract.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' exists on 'System.Type WinRT.Marshaler<T>.AbiType' in the contract but not the implementation.
-Total Issues: 12
+CannotMakeMemberNonVirtual : Member 'public System.Int32 WinRT.IObjectReference.TryAs<T>(System.Guid, WinRT.ObjectReference<T>)' is non-virtual in the implementation but is virtual in the contract.
+Total Issues: 13


### PR DESCRIPTION
This PR seals `IObjectReference.TryAs<T>`, which was bloating the binary size due to combinatorial generics:

![image](https://github.com/microsoft/CsWinRT/assets/10199417/4e8fa75b-5455-4f57-8653-8e2ec404d22f)

Should also be faster, given that the GVM dispatch isn't exactly the best.