### PR TITLE
Drop [DynamicallyAccessedMembers] from Marshaler<T>.AbiType

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.txt
@@ -10,4 +10,5 @@ MembersMustExist : Member 'public System.Delegate System.Delegate ABI.System.Col
 MembersMustExist : Member 'public System.Delegate System.Delegate ABI.System.Collections.Generic.KeyValuePair<K, V>.Vftbl.get_Value_1' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'ABI.System.Collections.Specialized.INotifyCollectionChanged' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'ABI.System.ComponentModel.INotifyDataErrorInfo' does not exist in the implementation but it does exist in the contract.
-Total Issues: 11
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' exists on 'System.Type WinRT.Marshaler<T>.AbiType' in the contract but not the implementation.
+Total Issues: 12

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1811,14 +1811,16 @@ namespace WinRT
                 }
                 else
                 {
-                    AbiType = typeof(T).FindHelperType();
-                    if (AbiType != null)
+                    Type abiType = typeof(T).FindHelperType();
+
+                    // Could still be blittable and the 'ABI.*' type exists for other reasons (e.g. it's a mapped type)
+                    if (abiType?.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static) is null)
                     {
-                        // Could still be blittable and the 'ABI.*' type exists for other reasons (e.g. it's a mapped type)
-                        if (AbiType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static) == null)
-                        {
-                            AbiType = null;
-                        }
+                        AbiType = null;
+                    }
+                    else
+                    {
+                        AbiType = abiType;
                     }
                 }
 
@@ -1964,9 +1966,6 @@ namespace WinRT
             RefAbiType = AbiType.MakeByRefType();
         }
 
-#if NET
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-#endif
         public static readonly Type AbiType;
         public static readonly Type RefAbiType;
         public static readonly Func<T, object> CreateMarshaler;


### PR DESCRIPTION
Related to https://github.com/microsoft/CsWinRT/pull/1460#issuecomment-1903537019. This PR drops the `[DynamicallyAccessedMembers]` use from `Marshaler<T>.AbiType`, which was not needed and was causing a lot of unnecessary stuff to be preserved unnecessarily (for explicit `T` types that were not helper types). The public members for the helper types are already preserved separately, and this attribute was only used to suppress warnings within the static constructor. I've changed the logic there to just flow the annitations through a local variable instead.