### PR TITLE
Skip unnecessary method group delegate cache

### DIFF
--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -484,7 +484,7 @@ _ => null
 [System.Runtime.CompilerServices.ModuleInitializer]
 internal static void InitializeAuthoringTypeMapping()
 {
-ComWrappersSupport.RegisterAuthoringMetadataTypeLookup(GetMetadataTypeMapping);
+ComWrappersSupport.RegisterAuthoringMetadataTypeLookup(new Func<Type, Type>(GetMetadataTypeMapping));
 }
 }
 })",


### PR DESCRIPTION
This delegate is only used once from a module initializer, no need for the generated caching type and field.