### PR TITLE
Use typeof(DllModule).Assembly for faster resolution

### DIFF
--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -47,7 +47,7 @@ namespace WinRT
 #if NET
             if (moduleHandle == IntPtr.Zero)
             {
-                NativeLibrary.TryLoad(fileName, Assembly.GetExecutingAssembly(), null, out moduleHandle);
+                NativeLibrary.TryLoad(fileName, typeof(DllModule).Assembly, null, out moduleHandle);
             }
 #endif
             if (moduleHandle == IntPtr.Zero)


### PR DESCRIPTION
Now that `ActivationFactory` is in WinRT.Runtime, we can use `typeof(Foo).Assembly` for faster resolution.