### PR TITLE
Fix TFM check in generated activation factories

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -52,20 +52,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     
     <PropertyGroup>
       <CsWinRTAuthoringInputs>$(CsWinRTAuthoringInputs) @(CsWinRTAuthoringDistinctWinMDs->'"%(FullPath)"', ' ') </CsWinRTAuthoringInputs>
-    </PropertyGroup>
-
-    <!--
-      Make sure 'CsWinRTExeTFM' is set in authoring scenarios as well. The items in this
-      group should be kept in sync with the ones in 'Microsoft.Windows.CsWinRT.targets'.
-    -->
-    <PropertyGroup>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 6">net6.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 7">net7.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">net8.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
-    </PropertyGroup>
-    
+    </PropertyGroup>    
   </Target>
 
   <!--

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -27,6 +27,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTEnableLogging" />
     <CompilerVisibleProperty Include="CsWinRTGeneratedFilesDir" />
     <CompilerVisibleProperty Include="CsWinRTExe" />
+    <CompilerVisibleProperty Include="CsWinRTExeTFM" />
     <CompilerVisibleProperty Include="CsWinRTKeepGeneratedSources" />
     <CompilerVisibleProperty Include="CsWinRTWindowsMetadata" />
     <CompilerVisibleProperty Include="CsWinRTGenerateProjection" />

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -53,6 +53,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <CsWinRTAuthoringInputs>$(CsWinRTAuthoringInputs) @(CsWinRTAuthoringDistinctWinMDs->'"%(FullPath)"', ' ') </CsWinRTAuthoringInputs>
     </PropertyGroup>
+
+    <!--
+      Make sure 'CsWinRTExeTFM' is set in authoring scenarios as well. The items in this
+      group should be kept in sync with the ones in 'Microsoft.Windows.CsWinRT.targets'.
+    -->
+    <PropertyGroup>
+      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
+      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 6">net6.0</CsWinRTExeTFM>
+      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 7">net7.0</CsWinRTExeTFM>
+      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">net8.0</CsWinRTExeTFM>
+      <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
+    </PropertyGroup>
     
   </Target>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -25,6 +25,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' != 'true'">false</CsWinRTAotExportsEnabled>
+
+    <!--
+      These properties are defined in this property group and not in the 'CsWinRTGenerateProjection'
+      target, because they are also needed in authoring scenarios (which will not run that target).
+    -->
+    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
+    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 6">net6.0</CsWinRTExeTFM>
+    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 7">net7.0</CsWinRTExeTFM>
+    <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">net8.0</CsWinRTExeTFM>
+    <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
   </PropertyGroup>
 
   <ItemGroup>
@@ -159,16 +169,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CsWinRTInternalProjection Condition="'$(CsWinRTPrivateProjection)' == 'true'">-internal</CsWinRTInternalProjection>
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
       <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
-
-      <!--
-        These 'CsWinRTExeTFM' properties should be kept in sync with the ones in ''Microsoft.Windows.CsWinRT.Authoring.targets'.
-        This list is used when generating projections, and the other one is used by the authoring source generator instead.
-      -->
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 6">net6.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 7">net7.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">net8.0</CsWinRTExeTFM>
-      <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
 
       <CsWinRTParams Condition="'$(CsWinRTParams)' == ''">
 $(CsWinRTCommandVerbosity)

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -159,6 +159,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CsWinRTInternalProjection Condition="'$(CsWinRTPrivateProjection)' == 'true'">-internal</CsWinRTInternalProjection>
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
       <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
+
+      <!--
+        These 'CsWinRTExeTFM' properties should be kept in sync with the ones in ''Microsoft.Windows.CsWinRT.Authoring.targets'.
+        This list is used when generating projections, and the other one is used by the authoring source generator instead.
+      -->
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5">net5.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 6">net6.0</CsWinRTExeTFM>
       <CsWinRTExeTFM Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 7">net7.0</CsWinRTExeTFM>

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -49,7 +49,7 @@ namespace Generator
             return tempFolder;
         }
 
-        private void GenerateSources(string csWinRTExeTFM)
+        private void GenerateSources()
         {
             string cswinrtExe = context.GetCsWinRTExe();
             string assemblyName = context.GetAssemblyName();
@@ -57,6 +57,7 @@ namespace Generator
             string outputDir = GetTempFolder(true);
             string windowsMetadata = context.GetCsWinRTWindowsMetadata();
             string winmds = context.GetCsWinRTDependentMetadata();
+            string csWinRTExeTFM = context.GetCsWinRTExeTFM();
 
             string arguments = string.Format(
                 "-component -input \"{0}\" -input {1} -include {2} -output \"{3}\" -input {4} -target {5} -verbose",
@@ -167,7 +168,7 @@ namespace Generator
                 GenerateWinMD(metadataBuilder);
                 if (!context.ShouldGenerateWinMDOnly())
                 {
-                    GenerateSources(context.GetCsWinRTExeTFM());
+                    GenerateSources();
                     writer.GenerateWinRTExposedClassAttributes(context);
                 }
             }

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -49,7 +49,7 @@ namespace Generator
             return tempFolder;
         }
 
-        private void GenerateSources()
+        private void GenerateSources(string csWinRTExeTFM)
         {
             string cswinrtExe = context.GetCsWinRTExe();
             string assemblyName = context.GetAssemblyName();
@@ -59,12 +59,13 @@ namespace Generator
             string winmds = context.GetCsWinRTDependentMetadata();
 
             string arguments = string.Format(
-                "-component -input \"{0}\" -input {1} -include {2} -output \"{3}\" -input {4} -verbose",
+                "-component -input \"{0}\" -input {1} -include {2} -output \"{3}\" -input {4} -target {5} -verbose",
                 winmdFile,
                 windowsMetadata,
                 assemblyName,
                 outputDir,
-                winmds);
+                winmds,
+                csWinRTExeTFM);
             Logger.Log("Running " + cswinrtExe + " " + arguments);
 
             var processInfo = new ProcessStartInfo
@@ -166,7 +167,7 @@ namespace Generator
                 GenerateWinMD(metadataBuilder);
                 if (!context.ShouldGenerateWinMDOnly())
                 {
-                    GenerateSources();
+                    GenerateSources(context.GetCsWinRTExeTFM());
                     writer.GenerateWinRTExposedClassAttributes(context);
                 }
             }

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -74,6 +74,12 @@ namespace Generator
             return generatedFilesDir;
         }
 
+        public static string GetCsWinRTExeTFM(this GeneratorExecutionContext context)
+        {
+            context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.CsWinRTExeTFM", out var csWinRTExeTFM);
+            return csWinRTExeTFM;
+        }
+
         public static bool IsCsWinRTComponent(this GeneratorExecutionContext context)
         {
             if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.CsWinRTComponent", out var isCsWinRTComponentStr))

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -96,7 +96,7 @@ Where <spec> is one or more of:
             throw usage_exception();
         }
         settings.netstandard_compat = target == "netstandard2.0";
-        settings.net7_0_or_greater = target == "net7.0" || target == "net8.0";
+        settings.net7_0_or_greater = starts_with(target, "net7.0") || starts_with(target, "net8.0");
         settings.component = args.exists("component");
         settings.internal = args.exists("internal");
         settings.embedded = args.exists("embedded");


### PR DESCRIPTION
Fixes the .NET 7 checks in the code writer, which was causing legacy code to always be generated.
Draft until I can actually double-check that this does in fact fix the issue.