### PR TITLE
Remove almost all LINQ uses

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -183,6 +183,7 @@ namespace WinRT
                 entries.AddRange(winrtExposedClassAttribute.GetExposedInterfaces());
                 if (type.IsClass)
                 {
+                    // Manual helper to save binary size (no LINQ, no lambdas) and get better performance
                     static bool GetHasCustomIMarshalInterface(List<ComInterfaceEntry> entries)
                     {
                         foreach (ref readonly ComInterfaceEntry entry in CollectionsMarshal.AsSpan(entries))
@@ -567,6 +568,7 @@ namespace WinRT
 
             if (staticallyDeterminedType != null && staticallyDeterminedType != typeof(object))
             {
+                // Manual helper to save binary size (no LINQ, no lambdas) and get better performance
                 static bool HasAnyTypeMatches(Type[] interfaceTypes, Type targetType)
                 {
                     Type genericTargetType = targetType.GetGenericTypeDefinition();

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -184,7 +183,20 @@ namespace WinRT
                 entries.AddRange(winrtExposedClassAttribute.GetExposedInterfaces());
                 if (type.IsClass)
                 {
-                    hasCustomIMarshalInterface = entries.Any(entry => entry.IID == ABI.WinRT.Interop.IMarshal.IID);
+                    static bool GetHasCustomIMarshalInterface(List<ComInterfaceEntry> entries)
+                    {
+                        foreach (ref readonly ComInterfaceEntry entry in CollectionsMarshal.AsSpan(entries))
+                        {
+                            if (entry.IID == ABI.WinRT.Interop.IMarshal.IID)
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    hasCustomIMarshalInterface = GetHasCustomIMarshalInterface(entries);
                 }
             }
             else if (type == typeof(global::System.EventHandler))
@@ -555,6 +567,21 @@ namespace WinRT
 
             if (staticallyDeterminedType != null && staticallyDeterminedType != typeof(object))
             {
+                static bool HasAnyTypeMatches(Type[] interfaceTypes, Type targetType)
+                {
+                    Type genericTargetType = targetType.GetGenericTypeDefinition();
+
+                    foreach (Type interfaceType in interfaceTypes)
+                    {
+                        if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == genericTargetType)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
                 // We have a static type which we can use to construct the object.  But, we can't just use it for all scenarios
                 // and primarily use it for tear off scenarios and for scenarios where runtimeclass isn't accurate.
                 // For instance if the static type is an interface, we return an IInspectable to represent the interface.
@@ -566,7 +593,7 @@ namespace WinRT
                 if (!(implementationType != null &&
                     (staticallyDeterminedType == implementationType ||
                      staticallyDeterminedType.IsAssignableFrom(implementationType) ||
-                     staticallyDeterminedType.IsGenericType && implementationType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == staticallyDeterminedType.GetGenericTypeDefinition()))))
+                     staticallyDeterminedType.IsGenericType && HasAnyTypeMatches(implementationType.GetInterfaces(), staticallyDeterminedType))))
                 {
                     return staticallyDeterminedType;
                 }

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 
@@ -392,7 +391,21 @@ namespace WinRT
 
             var visitedTypes = visitedTypesInstance ??= new Stack<VisitedType>();
 
-            if (visitedTypes.Any(visited => visited.Type == type))
+            // Manual helper to save binary size (no LINQ, no lambdas) and get better performance
+            static bool HasAnyVisitedTypes(Stack<VisitedType> visitedTypes, Type type)
+            {
+                foreach (VisitedType visitedType in visitedTypes)
+                {
+                    if (visitedType.Type == type)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            if (HasAnyVisitedTypes(visitedTypes, type))
             {
                 // In this case, we've already visited the type when recursing through generic parameters.
                 // Try to fall back to object if the parameter is covariant and the argument is compatable with object.


### PR DESCRIPTION
This PR removes all LINQ uses (except one `ToArray()` call) from CsWinRT. It leaves the use in the NS2.0 projections and in a couple of custom mapping types that are now optional, meaning they're already pay-for play anyway, so that's fine.