### PR TITLE
Hard-code the numeric scalar types in CoerceValue and simplify enum marshalling to remove any usage of Convert.ChangeType.

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1720,11 +1720,11 @@ namespace WinRT
 
         private static object ReturnParameter(object arg) => arg;
 
-        private static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)Convert.ChangeType(value, typeof(int));
+        private static unsafe void CopyIntEnum(object value, IntPtr dest) => *(int*)dest.ToPointer() = Convert.ToInt32(value);
 
         private static unsafe void CopyIntEnumDirect(object value, IntPtr dest) => *(int*)dest.ToPointer() = (int)value;
 
-        private static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)Convert.ChangeType(value, typeof(uint));
+        private static unsafe void CopyUIntEnum(object value, IntPtr dest) => *(uint*)dest.ToPointer() = Convert.ToUInt32(value);
 
         private static unsafe void CopyUIntEnumDirect(object value, IntPtr dest) => *(uint*)dest.ToPointer() = (uint)value;
     }

--- a/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
@@ -325,12 +326,46 @@ namespace ABI.Windows.Foundation
                 {
                     return (T)(object)guid.ToString("D", global::System.Globalization.CultureInfo.InvariantCulture);
                 }
+                else if (typeof(T) == typeof(byte))
+                {
+                    return (T)(object)Convert.ToByte(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(short))
+                {
+                    return (T)(object)Convert.ToInt16(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(ushort))
+                {
+                    return (T)(object)Convert.ToUInt16(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(int))
+                {
+                    return (T)(object)Convert.ToInt32(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(uint))
+                {
+                    return (T)(object)Convert.ToUInt32(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(long))
+                {
+                    return (T)(object)Convert.ToInt64(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(ulong))
+                {
+                    return (T)(object)Convert.ToUInt64(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(float))
+                {
+                    return (T)(object)Convert.ToSingle(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    return (T)(object)Convert.ToDouble(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
                 else
                 {
-                    if (NumericScalarTypes.TryGetValue(typeof(T), out _))
-                    {
-                        return (T)Convert.ChangeType(value, typeof(T), global::System.Globalization.CultureInfo.InvariantCulture);
-                    }
+                    Debug.Assert(!NumericScalarTypes.ContainsKey(typeof(T)));
+                    throw new InvalidCastException("", TYPE_E_TYPEMISMATCH);
                 }
             }
             catch (FormatException)

--- a/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
@@ -327,12 +327,46 @@ namespace ABI.Windows.Foundation
                 {
                     return (T)(object)guid.ToString("D", global::System.Globalization.CultureInfo.InvariantCulture);
                 }
+                else if (typeof(T) == typeof(byte))
+                {
+                    return (T)(object)Convert.ToByte(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(short))
+                {
+                    return (T)(object)Convert.ToInt16(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(ushort))
+                {
+                    return (T)(object)Convert.ToUInt16(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(int))
+                {
+                    return (T)(object)Convert.ToInt32(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(uint))
+                {
+                    return (T)(object)Convert.ToUInt32(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(long))
+                {
+                    return (T)(object)Convert.ToInt64(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(ulong))
+                {
+                    return (T)(object)Convert.ToUInt64(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(float))
+                {
+                    return (T)(object)Convert.ToSingle(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    return (T)(object)Convert.ToDouble(value, global::System.Globalization.CultureInfo.InvariantCulture);
+                }
                 else
                 {
-                    if (NumericScalarTypes.TryGetValue(typeof(T), out _))
-                    {
-                        return (T)Convert.ChangeType(value, typeof(T), global::System.Globalization.CultureInfo.InvariantCulture);
-                    }
+                    Debug.Assert(!NumericScalarTypes.ContainsKey(typeof(T)));
+                    throw new InvalidCastException("", TYPE_E_TYPEMISMATCH);
                 }
             }
             catch (FormatException)

--- a/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;


### PR DESCRIPTION
Convert.ChangeType was rooting a significant amount of code that would never be used (such as string.IConvertible.ToDateTime).

This PR will allow us to trim a significant amount of code in many cases (IConvertible isn't a commonly used type nowadays).