### PR TITLE
Move IActivationFactoryMethods.ActivateInstance into WinRT.Runtime

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2138,7 +2138,7 @@ ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
             auto objrefname = w.write_temp("%", bind<write_objref_type_name>(class_type));
 
             w.write(R"(
-public %() : this(%(WinRT.IActivationFactoryMethods.ActivateInstance<IUnknownVftbl>(%)))
+public %() : this(%(global::ABI.WinRT.Interop.IActivationFactoryMethods.ActivateInstanceUnsafe(%)))
 {
 ComWrappersSupport.RegisterObjectForInterface(this, ThisPtr);
 %

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -19,23 +19,6 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    internal static class IActivationFactoryMethods
-    {
-        public static unsafe ObjectReference<I> ActivateInstance<I>(IObjectReference obj)
-        {
-            IntPtr instancePtr;
-            global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)obj.ThisPtr)[6](obj.ThisPtr, &instancePtr));
-            try
-            {
-                return ComWrappersSupport.GetObjectReferenceForInterface<I>(instancePtr);
-            }
-            finally
-            {
-                MarshalInspectable<object>.DisposeAbi(instancePtr);
-            }
-        }
-    }
-
     internal class ComponentActivationFactory : global::WinRT.Interop.IActivationFactory
     {
         public IntPtr ActivateInstance()


### PR DESCRIPTION
This PR moves `IActivationFactoryMethods.ActivateInstance` into WinRT.Runtime to avoid duplication. Also:
- Fixes a potential memory corruption issue (instance wasn't being kept alive)
- Adds documentation
- Removes unnecessary generic type parameter