### PR TITLE
Move DynamicInvokeAbi into WinRT.Runtime

### DIFF
--- a/src/WinRT.Runtime/DelegateExtensions.cs
+++ b/src/WinRT.Runtime/DelegateExtensions.cs
@@ -2,11 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace WinRT
 {
-    internal static partial class DelegateExtensions
+    internal static class DelegateExtensions
     {
+        public static void DynamicInvokeAbi(this Delegate del, object[] invoke_params)
+        {
+            Marshal.ThrowExceptionForHR((int)del.DynamicInvoke(invoke_params));
+        }
+
         // These methods below can be used to efficiently change the signature of arbitrary delegate types
         // to one that has just 'object' as any of the type arguments, without the need to generate a new
         // closure and display class. The C# compiler will lower the method group expression over one of

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -4563,7 +4563,7 @@ event % %;)",
             }
             if (is_generic)
             {
-                w.write("%.DynamicInvokeAbi(__params);\n", invoke_target);
+                w.write("global::System.Runtime.InteropServices.Marshal.ThrowExceptionForHR((int)%.DynamicInvoke(__params));\n", invoke_target);
             }
             else if (!has_noexcept_attr)
             {

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -19,14 +19,6 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    internal static partial class DelegateExtensions
-    {
-        public static void DynamicInvokeAbi(this System.Delegate del, object[] invoke_params)
-        {
-            Marshal.ThrowExceptionForHR((int)del.DynamicInvoke(invoke_params));
-        }
-    }
-
     internal static class IActivationFactoryMethods
     {
         public static unsafe ObjectReference<I> ActivateInstance<I>(IObjectReference obj)


### PR DESCRIPTION
This PR just moves `DynamicInvokeAbi` into WinRT.Runtime and inlines it in the generated projections.