### PR TITLE
Remove ComponentActivationFactory types

### DIFF
--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -27,9 +27,9 @@ namespace WinRT.Interop
         /// Activates an instance of the target WinRT type.
         /// </summary>
         /// <returns>The resulting instance.</returns>
-        /// <exception cref="NotSupportedException">
-        /// Thrown if the operation is not supported by the activation factory type. For instance,
-        /// that is the case is the associated type is static or does not have a default constructor.
+        /// <exception cref="NotImplementedException">
+        /// Thrown if the operation is not available on the activation factory type in use. For instance,
+        /// that is the case if the associated type is static or does not have a default constructor.
         /// </exception>
         IntPtr ActivateInstance();
     }

--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -10,6 +10,9 @@ using WinRT.Interop;
 
 namespace WinRT.Interop
 {
+    /// <summary>
+    /// An interface for managed objects representing activation factories for WinRT types.
+    /// </summary>
     [WindowsRuntimeType]
     [Guid("00000035-0000-0000-C000-000000000046")]
     [WindowsRuntimeHelperType(typeof(global::ABI.WinRT.Interop.IActivationFactory))]
@@ -20,6 +23,14 @@ namespace WinRT.Interop
 #endif
     interface IActivationFactory
     {
+        /// <summary>
+        /// Activates an instance of the target WinRT type.
+        /// </summary>
+        /// <returns>The resulting instance.</returns>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the operation is not supported by the activation factory type. For instance,
+        /// that is the case is the associated type is static or does not have a default constructor.
+        /// </exception>
         IntPtr ActivateInstance();
     }
 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9632,7 +9632,7 @@ bind_list<write_parameter_name_with_modifier>(", ", signature.params())
             ? w.write_temp(R"(% comp = new %();
 
     return MarshalInspectable<%>.FromManaged(comp);)", type_name, type_name, type_name)
-            : "throw new NotSupportedException();";
+            : "throw new NotImplementedException();";
 
         w.write(R"(
 %

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9623,13 +9623,20 @@ bind_list<write_parameter_name_with_modifier>(", ", signature.params())
     void write_factory_class(writer& w, TypeDef const& type)
     {
         auto factory_type_name = write_type_name_temp(w, type, "%ServerActivationFactory", typedef_name_type::CCW);
-        auto base_class = (is_static(type) || !has_default_constructor(type)) ?
-            "ComponentActivationFactory" : write_type_name_temp(w, type, "ActivatableComponentActivationFactory<%>", typedef_name_type::Projected);
+        auto is_activatable = !is_static(type) && has_default_constructor(type);
         auto type_name = write_type_name_temp(w, type, "%", typedef_name_type::Projected);
+
+        // If the type is activatable, we implement IActivationFactory by creating an
+        // instance and marshalling it to IntPtr. Otherwise, we just throw an exception.
+        auto activate_instance_body = is_activatable
+            ? w.write_temp(R"(% comp = new %();
+
+    return MarshalInspectable<%>.FromManaged(comp);)", type_name, type_name, type_name)
+            : "throw new NotSupportedException();";
 
         w.write(R"(
 %
-internal class % : %%
+internal class % : IActivationFactory%
 {
 
 static %()
@@ -9654,18 +9661,23 @@ public static ObjectReference<I> ActivateInstance<
     return ObjectReference<IInspectable.Vftbl>.Attach(ref instance).As<I>();
 }
 
+public IntPtr ActivateInstance()
+{
+    %
+}
+
 %
 }
 )",
 bind<write_winrt_exposed_type_attribute>(type, true),
 factory_type_name,
-base_class,
 bind<write_factory_class_inheritance>(type),
 factory_type_name,
 type_name,
 factory_type_name,
 factory_type_name,
 factory_type_name,
+activate_instance_body,
 bind<write_factory_class_members>(type)
 );
     }

--- a/src/cswinrt/strings/WinRT.cs
+++ b/src/cswinrt/strings/WinRT.cs
@@ -19,23 +19,6 @@ using WinRT.Interop;
 
 namespace WinRT
 {
-    internal class ComponentActivationFactory : global::WinRT.Interop.IActivationFactory
-    {
-        public IntPtr ActivateInstance()
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    internal class ActivatableComponentActivationFactory<T> : ComponentActivationFactory, global::WinRT.Interop.IActivationFactory where T : class, new()
-    {
-        public new IntPtr ActivateInstance()
-        {
-            T comp = new T();
-            return MarshalInspectable<T>.FromManaged(comp);
-        }
-    }
-
 #pragma warning disable CA2002
 
     // Registration state and delegate cached separately to survive EventSource garbage collection


### PR DESCRIPTION
These two types weren't really doing anything. We can just implement the interface directly instead. It's also marginally better because creating the type directly is faster in some cases than going through the generated `Activator.CreateInstance` call.