### PR TITLE
Ensure the FactoryObjectReference also holds a pointer to the context callback.

### DIFF
--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -9,17 +9,7 @@ namespace WinRT
 {
     static partial class Context
     {
-        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
-        private static extern int CoGetObjectContext(ref Guid riid, out IntPtr ppv);
-
         private static readonly Guid IID_ICallbackWithNoReentrancyToApplicationSTA = new(0x0A299774, 0x3E4E, 0xFC42, 0x1D, 0x9D, 0x72, 0xCE, 0xE1, 0x05, 0xCA, 0x57);
-
-        public static IntPtr GetContextCallback()
-        {
-            Guid riid = ABI.WinRT.Interop.IContextCallback.IID;
-            Marshal.ThrowExceptionForHR(CoGetObjectContext(ref riid, out IntPtr contextCallbackPtr));
-            return contextCallbackPtr;
-        }
 
         // Calls the given callback in the right context.
         // On any exception, calls onFail callback if any set.
@@ -49,11 +39,6 @@ namespace WinRT
             {
                 onFailCallback?.Invoke();
             }
-        }
-
-        public static void DisposeContextCallback(IntPtr contextCallbackPtr)
-        {
-            MarshalInspectable<object>.DisposeAbi(contextCallbackPtr);
         }
     }
 }


### PR DESCRIPTION
Fixes #1112. Testing showed this was still reproducing after earlier changes. Looks like we need to hold on to the context callback or this to fully be resolved. 