### PR TITLE
Minor performance improvements to MarshalBlittable<T>

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -458,10 +458,17 @@ namespace WinRT
 #pragma warning disable CS8500 // We know that T is unmanaged
             var byte_length = length * sizeof(T);
 #pragma warning restore CS8500
+#if NET
+            fixed (byte* pArrayData = &MemoryMarshal.GetArrayDataReference(array))
+            {
+                Buffer.MemoryCopy(pArrayData, data.ToPointer(), byte_length, byte_length);
+            }
+#else
             var array_handle = GCHandle.Alloc(array, GCHandleType.Pinned);
             var array_data = array_handle.AddrOfPinnedObject();
             Buffer.MemoryCopy(array_data.ToPointer(), data.ToPointer(), byte_length, byte_length);
             array_handle.Free();
+#endif
         }
 
         public static void DisposeMarshalerArray(object box)

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -440,7 +440,9 @@ namespace WinRT
                 return (0, IntPtr.Zero);
             }
             var length = array.Length;
-            var byte_length = length * Marshal.SizeOf<T>();
+#pragma warning disable CS8500 // We know that T is unmanaged
+            var byte_length = length * sizeof(T);
+#pragma warning restore CS8500
             var data = Marshal.AllocCoTaskMem(byte_length);
             CopyManagedArray(array, data);
             return (length, data);
@@ -453,7 +455,9 @@ namespace WinRT
                 return;
             }
             var length = array.Length;
-            var byte_length = length * Marshal.SizeOf<T>();
+#pragma warning disable CS8500 // We know that T is unmanaged
+            var byte_length = length * sizeof(T);
+#pragma warning restore CS8500
             var array_handle = GCHandle.Alloc(array, GCHandleType.Pinned);
             var array_data = array_handle.AddrOfPinnedObject();
             Buffer.MemoryCopy(array_data.ToPointer(), data.ToPointer(), byte_length, byte_length);


### PR DESCRIPTION
This PR includes a couple of performance improvements to `MarshalBlittable<T>`:
- Use `sizeof(T)` instead of `Marshal.SizeOf<T>`
- On .NET 6+, replace a temporary pinned `GCHandle` with `MemoryMarshal.GetArrayDataReference`