### PR TITLE
Add [WinRTImplementationTypeRcwFactory] type

### DIFF
--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -152,6 +152,9 @@ namespace WinRT
         internal Type WinRTExposedTypeDetails { get; }
     }
 
+    /// <summary>
+    /// An attributes used for generated RCW types, to expose a factory method for them.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 #if EMBED
@@ -161,6 +164,11 @@ namespace WinRT
 #endif
     abstract class WinRTImplementationTypeRcwFactoryAttribute : Attribute
     {
+        /// <summary>
+        /// Creates a new instance of a given RCW type, from an input <see cref="IInspectable"/> object.
+        /// </summary>
+        /// <param name="inspectable">The native <see cref="IInspectable"/> object to use to construct the RCW instance.</param>
+        /// <returns>The resulting RCW instance wrapping the same native object as <paramref name="inspectable"/>.</returns>
         public abstract object CreateInstance(IInspectable inspectable);
     }
 

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -152,6 +152,18 @@ namespace WinRT
         internal Type WinRTExposedTypeDetails { get; }
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+#if EMBED
+    internal
+#else
+    public
+#endif
+    abstract class WinRTImplementationTypeRcwFactoryAttribute : Attribute
+    {
+        public abstract object CreateInstance(IInspectable inspectable);
+    }
+
 #endif
 }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -492,12 +492,7 @@ namespace WinRT
             };
         }
 
-        internal static Func<IInspectable, object> CreateTypedRcwFactory(
-#if NET
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
-            Type implementationType,
-            string runtimeClassName = null)
+        internal static Func<IInspectable, object> CreateTypedRcwFactory(Type implementationType, string runtimeClassName = null)
         {
             // If runtime class name is empty or "Object", then just use IInspectable.
             if (implementationType == null || implementationType == typeof(object))
@@ -554,9 +549,6 @@ namespace WinRT
             return CreateFactoryForImplementationType(runtimeClassName, implementationType);
         }
 
-#if NET
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
         internal static Type GetRuntimeClassForTypeCreation(IInspectable inspectable, Type staticallyDeterminedType)
         {
             string runtimeClassName = inspectable.GetRuntimeClassName(noThrow: true);

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -228,6 +228,14 @@ namespace WinRT
                 return attribute.CreateInstance;
             }
 
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                throw new NotSupportedException(
+                    $"Cannot create an RCW factory for implementation type '{implementationType}', because it doesn't have " +
+                    "a [WinRTImplementationTypeRcwFactory] derived attribute on it. The fallback path for older projections " +
+                    "is not trim-safe, and isn't supported in AOT environments. Make sure to reference updated projections.");
+            }
+
             return CreateRcwFallback(implementationType);
 
             [SuppressMessage("Trimming", "IL2070", Justification = "This fallback path is not trim-safe by design (to avoid annotations).")]

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -39,7 +39,6 @@ namespace WinRT
         internal static readonly ConditionalWeakTable<Type, InspectableInfo> InspectableInfoTable = new();
         
         [ThreadStatic]
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         internal static Type CreateRCWType;
 
         private static ComWrappers _comWrappers;
@@ -87,12 +86,12 @@ namespace WinRT
             return InspectableInfoTable.GetValue(_this.GetType(), o => PregenerateNativeTypeInformation(o).inspectableInfo);
         }
 
-        public static T CreateRcwForComObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(IntPtr ptr)
+        public static T CreateRcwForComObject<T>(IntPtr ptr)
         {
             return CreateRcwForComObject<T>(ptr, true);
         }
 
-        private static T CreateRcwForComObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(IntPtr ptr, bool tryUseCache)
+        private static T CreateRcwForComObject<T>(IntPtr ptr, bool tryUseCache)
         {
             if (ptr == IntPtr.Zero)
             {
@@ -199,11 +198,11 @@ namespace WinRT
             ComWrappers = wrappers;
         }
 
-        internal static Func<IInspectable, object> GetTypedRcwFactory([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, classType => CreateTypedRcwFactory(classType));
+        internal static Func<IInspectable, object> GetTypedRcwFactory(Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, classType => CreateTypedRcwFactory(classType));
 
         public static bool RegisterTypedRcwFactory(Type implementationType, Func<IInspectable, object> rcwFactory) => TypedObjectFactoryCacheForType.TryAdd(implementationType, rcwFactory);
 
-        private static Func<IInspectable, object> CreateFactoryForImplementationType(string runtimeClassName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type implementationType)
+        private static Func<IInspectable, object> CreateFactoryForImplementationType(string runtimeClassName, Type implementationType)
         {
             if (implementationType.IsGenericType)
             {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -219,7 +219,9 @@ namespace WinRT
                 return obj => obj;
             }
 
-            var attribute = implementationType.GetCustomAttribute<WinRTImplementationTypeRcwFactoryAttribute>();
+            // We never look for attributes on base types, since each [WinRTImplementationTypeRcwFactory] type acts as
+            // a factory type specifically for the annotated implementation type, so it has to be on that derived type.
+            var attribute = implementationType.GetCustomAttribute<WinRTImplementationTypeRcwFactoryAttribute>(inherit: false);
 
             // For update projections, get the derived [WinRTImplementationTypeRcwFactory]
             // attribute instance and use its overridden 'CreateInstance' method as factory.

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -229,10 +229,19 @@ namespace WinRT
                 return attribute.CreateInstance;
             }
 
-            throw new NotSupportedException("Temporarily not supported");
+            return CreateRcwFallback(implementationType);
 
-            // var constructor = implementationType.GetConstructor(BindingFlags.NonPublic | BindingFlags.CreateInstance | BindingFlags.Instance, null, new[] { typeof(IObjectReference) }, null);
-            // return (IInspectable obj) => constructor.Invoke(new[] { obj.ObjRef });
+            [SuppressMessage("Trimming", "IL2070", Justification = "This fallback path is not trim-safe by design (to avoid annotations).")]
+            static Func<IInspectable, object> CreateRcwFallback(Type implementationType)
+            {
+                var constructor = implementationType.GetConstructor(
+                    bindingAttr: BindingFlags.NonPublic | BindingFlags.CreateInstance | BindingFlags.Instance,
+                    binder: null,
+                    types: new[] { typeof(IObjectReference) },
+                    modifiers: null);
+
+                return (IInspectable obj) => constructor.Invoke(new[] { obj.ObjRef });
+            }
 
             [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
             static Type GetGenericImplType(Type implementationType)

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -220,8 +220,19 @@ namespace WinRT
                 return obj => obj;
             }
 
-            var constructor = implementationType.GetConstructor(BindingFlags.NonPublic | BindingFlags.CreateInstance | BindingFlags.Instance, null, new[] { typeof(IObjectReference) }, null);
-            return (IInspectable obj) => constructor.Invoke(new[] { obj.ObjRef });
+            var attribute = implementationType.GetCustomAttribute<WinRTImplementationTypeRcwFactoryAttribute>();
+
+            // For update projections, get the derived [WinRTImplementationTypeRcwFactory]
+            // attribute instance and use its overridden 'CreateInstance' method as factory.
+            if (attribute is not null)
+            {
+                return attribute.CreateInstance;
+            }
+
+            throw new NotSupportedException("Temporarily not supported");
+
+            // var constructor = implementationType.GetConstructor(BindingFlags.NonPublic | BindingFlags.CreateInstance | BindingFlags.Instance, null, new[] { typeof(IObjectReference) }, null);
+            // return (IInspectable obj) => constructor.Invoke(new[] { obj.ObjRef });
 
             [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
             static Type GetGenericImplType(Type implementationType)

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1700,10 +1700,6 @@ namespace WinRT
             return ComWrappersSupport.CreateCCWForObjectForMarshaling(o, delegateIID);
         }
 
-#if NET
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091",
-            Justification = "Preserving constructors is not necessary when creating RCWs for delegates, as they go through the factory methods in the helper types.")]
-#endif
         public static T FromAbi<T>(IntPtr nativeDelegate)
             where T : Delegate
         {

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -199,4 +199,5 @@ MembersMustExist : Member 'public void WinRT.Projections.RegisterVector2Mapping(
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector3Mapping()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector4Mapping()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IID' does not exist in the reference but it does exist in the implementation.
-Total Issues: 200
+TypesMustExist : Type 'WinRT.WinRTImplementationTypeRcwFactoryAttribute' does not exist in the reference but it does exist in the implementation.
+Total Issues: 201

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -44,9 +44,6 @@ namespace WinRT
             projectionTypeNameToBaseTypeNameMappings.Add(typeNameToBaseTypeNameMapping);
         }
 
-#if NET
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
         public static Type FindRcwTypeByNameCached(string runtimeClassName)
         {
             // Try to get the given type name. If it is not found, the type might have been trimmed.
@@ -55,9 +52,6 @@ namespace WinRT
             if (rcwType is null)
             {
                 rcwType = baseRcwTypeCache.GetOrAdd(runtimeClassName,
-#if NET
-                    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
                     (runtimeClassName) =>
                     {
                         var resolvedBaseType = projectionTypeNameToBaseTypeNameMappings.Find((dict) => dict.ContainsKey(runtimeClassName))?[runtimeClassName];
@@ -73,15 +67,9 @@ namespace WinRT
         /// </summary>
         /// <param name="runtimeClassName">The runtime class name to attempt to parse.</param>
         /// <returns>The type, if found.  Null otherwise</returns>
-#if NET
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
         public static Type FindTypeByNameCached(string runtimeClassName)
         {
             return typeNameCache.GetOrAdd(runtimeClassName,
-#if NET
-                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
                 (runtimeClassName) =>
                 {
                     Type implementationType = null;
@@ -154,7 +142,6 @@ namespace WinRT
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Any types which are trimmed are not used by user code and there is fallback logic to handle that.")]
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 #endif
         private static Type FindTypeByNameCore(string runtimeClassName, Type[] genericTypes)
         {

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -101,9 +101,9 @@ namespace WinRT
                 }
 
                 throw new NotSupportedException(
-                    $"""The requested runtime class name is "{runtimeClassName.ToString()}", which maps to a dynamic projected type. """ +
-                    """This can only be used when support for dynamic objects is enabled in the CsWinRT configuration. To enable it, """ +
-                    """make sure that the "CsWinRTEnableDynamicObjectsSupport" MSBuild property is not being set to 'false' anywhere.""");
+                    $"The requested runtime class name is '{runtimeClassName.ToString()}', which maps to a dynamic projected type. " +
+                    "This can only be used when support for dynamic objects is enabled in the CsWinRT configuration. To enable it, " +
+                    "make sure that the 'CsWinRTEnableDynamicObjectsSupport' MSBuild property is not being set to 'false' anywhere.");
             }
             // PropertySet and ValueSet can return IReference<String> but Nullable<String> is illegal
             else if (runtimeClassName.CompareTo("Windows.Foundation.IReference`1<String>".AsSpan(), StringComparison.Ordinal) == 0)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8294,6 +8294,8 @@ private struct InterfaceTag<I>{};
 %
 %%
 }
+
+%
 )",
             bind<write_winrt_attribute>(type),
             bind<write_winrt_helper_type_attribute>(type),
@@ -8450,7 +8452,13 @@ global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, ob
                     }
                 }),
             bind<write_class_members>(type, false, false),
-            bind<write_custom_query_interface_impl>(type));
+            bind<write_custom_query_interface_impl>(type),
+            settings.netstandard_compat ? "" : w.write_temp(R"(
+internal sealed class %RcwFactoryAttribute : WinRTImplementationTypeRcwFactoryAttribute
+{
+    public override object CreateInstance(IInspectable inspectable)
+        => new %(inspectable.ObjRef);
+})", type_name, type_name));
     }
 
     void write_abi_class(writer& w, TypeDef const& type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8260,6 +8260,7 @@ _defaultLazy = new Lazy<%>(() => GetDefaultReference<%.Vftbl>());
         auto is_manually_gen_default_interface = is_manually_generated_iface(default_interface_typedef);
 
         w.write(R"(%%
+[%RcwFactoryAttribute]
 [global::WinRT.ProjectedRuntimeClass(typeof(%))]
 [global::WinRT.ObjectReferenceWrapper(nameof(_inner))]
 %% %class %%, IWinRTObject, IEquatable<%>
@@ -8295,10 +8296,15 @@ private struct InterfaceTag<I>{};
 %%
 }
 
-%
+internal sealed class %RcwFactoryAttribute : WinRTImplementationTypeRcwFactoryAttribute
+{
+    public override object CreateInstance(IInspectable inspectable)
+        => new %(inspectable.ObjRef);
+}
 )",
             bind<write_winrt_attribute>(type),
             bind<write_winrt_helper_type_attribute>(type),
+            type_name,
             default_interface_name,
             bind<write_type_custom_attributes>(type, true),
             internal_accessibility(),
@@ -8453,12 +8459,8 @@ global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, ob
                 }),
             bind<write_class_members>(type, false, false),
             bind<write_custom_query_interface_impl>(type),
-            settings.netstandard_compat ? "" : w.write_temp(R"(
-internal sealed class %RcwFactoryAttribute : WinRTImplementationTypeRcwFactoryAttribute
-{
-    public override object CreateInstance(IInspectable inspectable)
-        => new %(inspectable.ObjRef);
-})", type_name, type_name));
+            type_name,
+            type_name);
     }
 
     void write_abi_class(writer& w, TypeDef const& type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8481,7 +8481,8 @@ internal sealed class %RcwFactoryAttribute : global::WinRT.WinRTImplementationTy
     public override object CreateInstance(global::WinRT.IInspectable inspectable)
         => new %(inspectable.ObjRef);
 }
-)", type.TypeName(), write_type_name_temp(w, type));
+)", type.TypeName(), 
+    bind<write_type_name>(type, typedef_name_type::Projected, false));
     }
 
     void write_abi_class(writer& w, TypeDef const& type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8251,6 +8251,7 @@ _defaultLazy = new Lazy<%>(() => GetDefaultReference<%.Vftbl>());
             return;
         }
 
+        auto type_namespace = type.TypeNamespace();
         auto type_name = write_type_name_temp(w, type);
         auto default_interface_name = get_default_interface_name(w, type, false);
         auto base_semantics = get_type_semantics(type.Extends());
@@ -8259,8 +8260,9 @@ _defaultLazy = new Lazy<%>(() => GetDefaultReference<%.Vftbl>());
         auto default_interface_typedef = for_typedef(w, get_type_semantics(get_default_interface(type)), [&](auto&& iface) { return iface; });
         auto is_manually_gen_default_interface = is_manually_generated_iface(default_interface_typedef);
 
-        w.write(R"(%%
-[%RcwFactoryAttribute]
+        w.write(R"(%
+%
+[global::ABI.%.%RcwFactory]
 [global::WinRT.ProjectedRuntimeClass(typeof(%))]
 [global::WinRT.ObjectReferenceWrapper(nameof(_inner))]
 %% %class %%, IWinRTObject, IEquatable<%>
@@ -8295,16 +8297,11 @@ private struct InterfaceTag<I>{};
 %
 %%
 }
-
-internal sealed class %RcwFactoryAttribute : WinRTImplementationTypeRcwFactoryAttribute
-{
-    public override object CreateInstance(IInspectable inspectable)
-        => new %(inspectable.ObjRef);
-}
 )",
             bind<write_winrt_attribute>(type),
             bind<write_winrt_helper_type_attribute>(type),
-            type_name,
+            type_namespace,
+            type.TypeName(),
             default_interface_name,
             bind<write_type_custom_attributes>(type, true),
             internal_accessibility(),
@@ -8458,9 +8455,33 @@ global::System.Collections.Concurrent.ConcurrentDictionary<RuntimeTypeHandle, ob
                     }
                 }),
             bind<write_class_members>(type, false, false),
-            bind<write_custom_query_interface_impl>(type),
-            type_name,
-            type_name);
+            bind<write_custom_query_interface_impl>(type));
+    }
+
+    void write_winrt_implementation_type_rcw_factory_attribute_type(writer& w, TypeDef const& type)
+    {
+        if (settings.netstandard_compat)
+        {
+            return;
+        }
+
+        if (settings.component)
+        {
+            return;
+        }
+
+        if (is_static(type))
+        {
+            return;
+        }
+
+        w.write(R"([global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+internal sealed class %RcwFactoryAttribute : global::WinRT.WinRTImplementationTypeRcwFactoryAttribute
+{
+    public override object CreateInstance(global::WinRT.IInspectable inspectable)
+        => new %(inspectable.ObjRef);
+}
+)", type.TypeName(), write_type_name_temp(w, type));
     }
 
     void write_abi_class(writer& w, TypeDef const& type)

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -289,6 +289,7 @@ Where <spec> is one or more of:
                                         {
                                             write_winrt_exposed_type_class(w, type, true);
                                         }
+                                        write_winrt_implementation_type_rcw_factory_attribute_type(w, type);
                                         break;
                                     case category::delegate_type:
                                         write_abi_delegate(w, type);


### PR DESCRIPTION
This PR adds a new attribute to avoid reflection to create RCW instances. The attributes are the factories instead.