### PR TITLE
Remove [ObjectReferenceWrapper] on .NET 6+

### DIFF
--- a/src/Projections/Test/TestHost.ProbeByHost.cs
+++ b/src/Projections/Test/TestHost.ProbeByHost.cs
@@ -22,7 +22,9 @@ namespace Windows.Foundation
 
 namespace ABI.Windows.Foundation
 {
+#if !NET6_0
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("00000035-0000-0000-c000-000000000046")]
     internal class IActivationFactory : global::Windows.Foundation.IActivationFactory
     {

--- a/src/Projections/Test/TestHost.ProbeByHost.cs
+++ b/src/Projections/Test/TestHost.ProbeByHost.cs
@@ -22,7 +22,7 @@ namespace Windows.Foundation
 
 namespace ABI.Windows.Foundation
 {
-#if !NET6_0
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
 #endif
     [Guid("00000035-0000-0000-c000-000000000046")]

--- a/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
+++ b/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
@@ -22,7 +22,9 @@ namespace Windows.Foundation
 
 namespace ABI.Windows.Foundation
 {
+#if !NET6_0
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("00000035-0000-0000-c000-000000000046")]
     internal class IActivationFactory : global::Windows.Foundation.IActivationFactory
     {

--- a/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
+++ b/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
@@ -22,7 +22,7 @@ namespace Windows.Foundation
 
 namespace ABI.Windows.Foundation
 {
-#if !NET6_0
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
 #endif
     [Guid("00000035-0000-0000-c000-000000000046")]

--- a/src/WinRT.Runtime/ApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.txt
@@ -16,4 +16,7 @@ MembersMustExist : Member 'protected System.Boolean System.Boolean WinRT.IObject
 MembersMustExist : Member 'protected void WinRT.IObjectReference.Dispose(System.Boolean)' does not exist in the implementation but it does exist in the contract.
 CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the contract to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterCustomAbiTypeMapping(System.Type, System.Type, System.String, System.Boolean)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 17
+CannotRemoveAttribute : Attribute 'WinRT.ObjectReferenceWrapperAttribute' exists on 'ABI.System.Nullable<T>' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'WinRT.ObjectReferenceWrapperAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'WinRT.ObjectReferenceWrapperAttribute' exists on 'WinRT.IInspectable' in the contract but not the implementation.
+Total Issues: 120

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -31,6 +31,9 @@ namespace WinRT
         public Type DefaultInterface { get; }
     }
 
+#if NET
+    [Obsolete("This attribute is only used for the .NET Standard 2.0 projections.")]
+#endif
     [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 #if EMBED

--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -20,7 +20,9 @@ namespace WinRT
     }
 
     // IInspectable
-    [ObjectReferenceWrapper(nameof(_obj))]
+#if !NET
+    [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("AF86E2E0-B12D-4c6a-9C5A-D7AA65101E90")]
 #if EMBED
     internal

--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -78,7 +78,9 @@ namespace ABI.WinRT.Interop
         }
     }
 
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("00000035-0000-0000-C000-000000000046")]
 #if EMBED
     internal

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -200,4 +200,5 @@ MembersMustExist : Member 'public void WinRT.Projections.RegisterVector3Mapping(
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector4Mapping()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.Interop.IID' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTImplementationTypeRcwFactoryAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 201
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.ObjectReferenceWrapperAttribute' in the implementation but not the reference.
+Total Issues: 202

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -22,8 +22,9 @@ namespace ABI.Microsoft.UI.Xaml.Data
         public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> put_PropertyName_1 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_put_PropertyName_1;
     }
 
-
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("62D0BD1E-B85F-5FCC-842A-7CB0DDA37FE5")]
     internal unsafe sealed class WinRTDataErrorsChangedEventArgsRuntimeClassFactory
     {

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -175,8 +175,8 @@ namespace ABI.System
             return new global::System.EventHandler<T>(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr, PIID)).Invoke);
         }
 
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 #if !NET
+        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
         private sealed class NativeDelegateWrapper
 #else
         private sealed class NativeDelegateWrapper : IWinRTObject
@@ -345,8 +345,8 @@ namespace ABI.System
             return new global::System.EventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr, IID)).Invoke);
         }
 
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 #if !NET
+        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
         private sealed class NativeDelegateWrapper
 #else
         private sealed class NativeDelegateWrapper : IWinRTObject

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -85,7 +85,6 @@ namespace ABI.Windows.Foundation
         }
     }
 
-    [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
     [Guid("61C17707-2D65-11E0-9AE8-D48564015472")]
     internal sealed class IReferenceArray<T> : global::Windows.Foundation.IReferenceArray<T>
     {

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -10,7 +10,9 @@ using WinRT.Interop;
 
 namespace ABI.Microsoft.UI.Xaml.Interop
 {
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("DA049FF2-D2E0-5FE8-8C7B-F87F26060B6F")]
     internal sealed unsafe class INotifyCollectionChangedEventArgs
     {
@@ -109,7 +111,9 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         }
     }
 
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("5108EBA4-4892-5A20-8374-A96815E0FD27")]
     internal sealed unsafe class WinRTNotifyCollectionChangedEventArgsRuntimeClassFactory
     {

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -65,8 +65,8 @@ namespace ABI.System.Collections.Specialized
             return new global::System.Collections.Specialized.NotifyCollectionChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr, IID)).Invoke);
         }
 
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 #if !NET
+        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
         private sealed class NativeDelegateWrapper
 #else
         private sealed class NativeDelegateWrapper : IWinRTObject

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -218,7 +218,9 @@ namespace ABI.Windows.Foundation
 
 namespace ABI.System
 {
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("61C17706-2D65-11E0-9AE8-D48564015472")]
 #if EMBED
     internal

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -18,8 +18,9 @@ namespace ABI.Microsoft.UI.Xaml.Data
         public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_PropertyName_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_PropertyName_0;
     }
 
-
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("7C0C27A8-0B41-5070-B160-FC9AE960A36C")]
     internal sealed unsafe class WinRTPropertyChangedEventArgsRuntimeClassFactory
     {

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -64,8 +64,8 @@ namespace ABI.System.ComponentModel
             return new global::System.ComponentModel.PropertyChangedEventHandler(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IDelegateVftbl>(ptr, IID)).Invoke);
         }
 
-        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 #if !NET
+        [global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
         private sealed class NativeDelegateWrapper
 #else
         private sealed class NativeDelegateWrapper : IWinRTObject

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -36,8 +36,9 @@ namespace ABI.Windows.Foundation
 
 namespace ABI.System
 {
-
+#if !NET
     [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+#endif
     [Guid("44A9796F-723E-4FDF-A218-033E75B0C084")]
     internal sealed class WinRTUriRuntimeClassFactory
     {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8264,7 +8264,6 @@ _defaultLazy = new Lazy<%>(() => GetDefaultReference<%.Vftbl>());
 %
 [global::ABI.%.%RcwFactory]
 [global::WinRT.ProjectedRuntimeClass(typeof(%))]
-[global::WinRT.ObjectReferenceWrapper(nameof(_inner))]
 %% %class %%, IWinRTObject, IEquatable<%>
 {
 private IntPtr ThisPtr => _inner == null ? (((IWinRTObject)this).NativeObject).ThisPtr : _inner.ThisPtr;
@@ -8687,8 +8686,8 @@ public static % CreateRcw(IntPtr ptr)
 return new %(new NativeDelegateWrapper(ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(ptr, GuidGenerator.GetIID(typeof(@%)))).Invoke);
 }
 
-[global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 #if !NET
+[global::WinRT.ObjectReferenceWrapper(nameof(_nativeDelegate))]
 private sealed class NativeDelegateWrapper
 #else
 private sealed class NativeDelegateWrapper : IWinRTObject


### PR DESCRIPTION
This attribute is only needed downlevel (and it's not trim-safe). This PR marks it as obsolete on .NET 6+, makes it conditional in WinRT.Runtime, and stops generating it when targeting .NET 6+ by the code writer. Keeping the type for binary compatibility.