### PR TITLE
Suppress incorrect CA2257 warnings

### DIFF
--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -393,7 +393,9 @@ namespace ABI.System.Collections
     {
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IEnumerable));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class AdaptiveFromAbiHelper : FromAbiHelper, global::System.Collections.IEnumerable
+#pragma warning restore CA2257
         {
             private readonly Func<IWinRTObject, global::System.Collections.IEnumerator> _enumerator;
 
@@ -412,7 +414,9 @@ namespace ABI.System.Collections
             public override global::System.Collections.IEnumerator GetEnumerator() => _enumerator != null ? _enumerator(_winrtObject) : base.GetEnumerator();
         }
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public class FromAbiHelper : global::System.Collections.IEnumerable
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.IEnumerable _iterable;
             protected readonly IWinRTObject _winrtObject;
@@ -449,7 +453,9 @@ namespace ABI.System.Collections
             }
         }
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : IBindableIterable
+#pragma warning restore CA2257
         {
             private readonly IEnumerable m_enumerable;
 
@@ -565,7 +571,9 @@ namespace ABI.System.Collections
     {
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IList));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class FromAbiHelper : global::System.Collections.IList
+#pragma warning restore CA2257
         {
             private readonly global::Microsoft.UI.Xaml.Interop.IBindableVector _vector;
 
@@ -801,7 +809,9 @@ namespace ABI.System.Collections
             }
         }
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : IBindableVector
+#pragma warning restore CA2257
         {
             private global::System.Collections.IList _list;
 

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -26,7 +26,9 @@ namespace ABI.System.Windows.Input
     internal unsafe interface ICommand : global::System.Windows.Input.ICommand
     {
         [Guid("E5AF3542-CA67-4081-995B-709DD13792DF")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             private void* _add_CanExecuteChanged_0;

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -1094,7 +1094,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IDictionary<K, V>));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IMap<K, V>
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.Generic.IDictionary<K, V> _dictionary;
 
@@ -1184,7 +1186,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("3C2925FE-8519-45C1-AA79-197B6718C1C1")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -351,7 +351,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IEnumerable<T>));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         internal sealed class ToAbiHelper : global::Windows.Foundation.Collections.IIterable<T>
+#pragma warning restore CA2257
         {
             private readonly IEnumerable<T> m_enumerable;
 
@@ -389,7 +391,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("FAA585EA-6214-4217-AFDA-7F46DE5869B3")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 
@@ -938,7 +942,9 @@ namespace ABI.System.Collections.Generic
         // In IEnumerator<> scenarios, we use this as a helper for the implementation and don't actually use it to
         // create a CCW.
         [global::WinRT.WinRTExposedType(typeof(IBindableIteratorTypeDetails))]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IIterator<T>, global::Microsoft.UI.Xaml.Interop.IBindableIterator
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.Generic.IEnumerator<T> m_enumerator;
             private bool m_firstItem = true;
@@ -1064,7 +1070,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("6A79E863-4300-459A-9966-CBB660963EE1")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -1094,7 +1094,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IList<T>));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IVector<T>
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.Generic.IList<T> _list;
 
@@ -1308,7 +1310,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("913337E9-11A1-4345-A3A2-4E7F956E222D")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
@@ -48,7 +48,9 @@ namespace ABI.System.Collections.Specialized
     internal unsafe interface INotifyCollectionChanged : global::System.Collections.Specialized.INotifyCollectionChanged
     {
         [Guid("530155E1-28A5-5693-87CE-30724D95A06D")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -27,7 +27,9 @@ namespace ABI.System.ComponentModel
     internal unsafe interface INotifyDataErrorInfo : global::System.ComponentModel.INotifyDataErrorInfo
     {
         [Guid("0EE6C2CC-273E-567D-BC0A-1DD87EE51EBA")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2247
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             public delegate* unmanaged<IntPtr, byte*, int> get_HasErrors_0;

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
@@ -25,7 +25,9 @@ namespace ABI.System.ComponentModel
     {
         [Guid("90B17601-B065-586E-83D9-9ADC3A695284")]
         [StructLayout(LayoutKind.Sequential)]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
@@ -1292,7 +1292,9 @@ namespace ABI.Windows.Foundation
     internal unsafe interface IPropertyValue : global::Windows.Foundation.IPropertyValue
     {
         [Guid("4BD682DD-7554-40E9-9A9B-82654EDE7E62")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
             internal void* _get_Type_0;

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -978,7 +978,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IReadOnlyDictionary<K, V>));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IMapView<K, V>
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.Generic.IReadOnlyDictionary<K, V> _dictionary;
 
@@ -1053,7 +1055,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("E480CE40-A338-4ADA-ADCF-272272E48CB9")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -506,7 +506,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IReadOnlyList<T>));
 
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IVectorView<T>
+#pragma warning restore CA2257
         {
             private readonly global::System.Collections.Generic.IReadOnlyList<T> _list;
 
@@ -630,7 +632,9 @@ namespace ABI.System.Collections.Generic
         // This is left here for backwards compat purposes where older generated
         // projections can be using FindVftblType and using this to cast.
         [Guid("BBE1FA4C-B0E3-4583-BAEF-1F1B2E483E56")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public unsafe struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 

--- a/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
@@ -13,7 +13,9 @@ namespace ABI.System
     internal unsafe interface IServiceProvider : global::System.IServiceProvider
     {
         [Guid("68B3A2DF-8173-539F-B524-C8A2348F5AFB")]
+#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public struct Vftbl
+#pragma warning restore CA2257
         {
             internal IInspectable.Vftbl IInspectableVftbl;
 


### PR DESCRIPTION
This PR suppresses some incorrect CS2257 warnings that were polluting our build output. As per [the docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2257):
> "Since a type that implements `IDynamicInterfaceCastable` may not implement a dynamic interface in metadata, **calls to an instance interface member that is not an explicit implementation defined on this type are likely to fail at run time**. To avoid run-time errors, mark new interface members static."

This clearly doesn't apply to these cases, since these members were just nested types, and not something you can invoke.