### PR TITLE
Address issues discovered after fixing AOT warnings

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.vcxproj
@@ -216,7 +216,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>X64;NDEBUG;AOT;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -259,6 +259,8 @@ TEST(AuthoringTest, Arrays)
         EXPECT_EQ(arr2[idx], idx + 1);
     }
 
+    // Array marshaling on AOT needs dynamic code.
+#ifndef AOT
     std::array<BasicStruct, 2> basicStructArr;
     basicStructArr[0] = basicClass.GetBasicStruct();
     basicStructArr[1].X = 4;
@@ -272,6 +274,7 @@ TEST(AuthoringTest, Arrays)
     EXPECT_EQ(result[1].X, basicStructArr[1].X);
     EXPECT_EQ(result[1].Y, basicStructArr[1].Y);
     EXPECT_EQ(result[1].Value, basicStructArr[1].Value);
+#endif
 }
 
 TEST(AuthoringTest, CustomTypes)

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -156,6 +156,15 @@ namespace WinRT
 
         public static void RegisterAuthoringMetadataTypeLookup(Func<Type, Type> authoringMetadataTypeLookup) => TypeExtensions.RegisterAuthoringMetadataTypeLookup(authoringMetadataTypeLookup);
 
+        public static void RegisterHelperType(
+            Type type,
+#if NET
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods |
+                                        DynamicallyAccessedMemberTypes.PublicNestedTypes |
+                                        DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
+            Type helperType) => TypeExtensions.HelperTypeCache.TryAdd(type, helperType);
+
         internal static List<ComInterfaceEntry> GetInterfaceTableEntries(Type type)
         {
             var entries = new List<ComInterfaceEntry>();

--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -52,6 +52,13 @@ namespace WinRT
                 return "string";
             }
 
+            if (type.IsGenericType)
+            {
+                var args = type.GetGenericArguments().Select(t => GetSignature(t));
+                var genericHelperType = type.GetGenericTypeDefinition().FindHelperType() ?? type;
+                return "pinterface({" + genericHelperType.GUID + "};" + string.Join(";", args) + ")";
+            }
+
             var helperType = type.FindHelperType();
             if (helperType != null)
             {
@@ -114,12 +121,6 @@ namespace WinRT
             // For built-in system interfaces that are custom type mapped, we use the helper type to get the guid.
             // For others, either the type itself or the helper type has the same guid and can be used.
             type = type.IsInterface ? (helperType ?? type) : type;
-
-            if (type.IsGenericType)
-            {
-                var args = type.GetGenericArguments().Select(t => GetSignature(t));
-                return "pinterface({" + GetGUID(type) + "};" + String.Join(";", args) + ")";
-            }
 
             if (type.IsDelegate())
             {

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -139,4 +139,5 @@ MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference
 TypesMustExist : Type 'WinRT.ActivationFactory' does not exist in the reference but it does exist in the implementation.
 CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the reference.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr)' in the implementation but not the reference.
-Total Issues: 140
+MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterHelperType(System.Type, System.Type)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 141

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -188,7 +188,7 @@ namespace WinRT
                     return null;
                 }
 
-                if (publicType.IsGenericType)
+                if (publicType.IsGenericType && !publicType.IsGenericTypeDefinition)
                 {
                     if (CustomTypeToHelperTypeMappings.TryGetValue(publicType, out Type specializedAbiType))
                     {

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -49,11 +49,6 @@ namespace ABI.System
 #endif
     static class EventHandlerMethods<T, TAbi> where TAbi : unmanaged
     {
-        static EventHandlerMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.EventHandler<T>), typeof(global::ABI.System.EventHandler<T>));
-        }
-
         public unsafe static bool InitRcwHelper(delegate*<IObjectReference, object, T, void> invoke)
         {
             if (EventHandlerMethods<T>._Invoke == null)
@@ -126,6 +121,9 @@ namespace ABI.System
 
         static unsafe EventHandler()
         {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.EventHandler<T>), typeof(global::ABI.System.EventHandler<T>));
+            ComWrappersSupport.RegisterDelegateFactory(typeof(global::System.EventHandler<T>), CreateRcw);
+
 #if NET
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
@@ -157,8 +155,6 @@ namespace ABI.System
                 ((IntPtr*)AbiToProjectionVftablePtr)[3] = Marshal.GetFunctionPointerForDelegate(AbiInvokeDelegate);
 #pragma warning restore IL3050
             }
-
-            ComWrappersSupport.RegisterDelegateFactory(typeof(global::System.EventHandler<T>), CreateRcw);
         }
 
         public static global::System.Delegate AbiInvokeDelegate { get; }

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -49,6 +49,11 @@ namespace ABI.System
 #endif
     static class EventHandlerMethods<T, TAbi> where TAbi : unmanaged
     {
+        static EventHandlerMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.EventHandler<T>), typeof(global::ABI.System.EventHandler<T>));
+        }
+
         public unsafe static bool InitRcwHelper(delegate*<IObjectReference, object, T, void> invoke)
         {
             if (EventHandlerMethods<T>._Invoke == null)

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -252,6 +252,8 @@ namespace ABI.System.Collections.Generic
     {
         unsafe static IDictionaryMethods()
         {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IDictionary<K, V>));
+
             // Early return to ensure things are trimmed correctly on NAOT.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
@@ -695,11 +697,6 @@ namespace ABI.System.Collections.Generic
         internal unsafe static delegate*<IObjectReference, global::System.Collections.Generic.IReadOnlyDictionary<K, V>> _GetView;
         internal unsafe static delegate*<IObjectReference, K, V, bool> _Insert;
         internal unsafe static delegate*<IObjectReference, K, void> _Remove;
-
-        static IDictionaryMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IDictionary<K, V>));
-        }
 
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K, V> lookup,

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -696,6 +696,11 @@ namespace ABI.System.Collections.Generic
         internal unsafe static delegate*<IObjectReference, K, V, bool> _Insert;
         internal unsafe static delegate*<IObjectReference, K, void> _Remove;
 
+        static IDictionaryMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IDictionary<K, V>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K, V> lookup,
             delegate*<IObjectReference, K, bool> hasKey,
@@ -855,6 +860,9 @@ namespace ABI.System.Collections.Generic
                 return false;
             }
 
+            // Register generic helper types referenced in CCW.
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
+
             return true;
         }
 
@@ -876,20 +884,15 @@ namespace ABI.System.Collections.Generic
                 new IDictionary_Delegates.Clear_6(Do_Abi_Clear_6)
             };
 
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 7));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-            ((IntPtr*)abiToProjectionVftablePtr)[8] = Marshal.GetFunctionPointerForDelegate(DelegateCache[2]);
-            ((IntPtr*)abiToProjectionVftablePtr)[9] = Marshal.GetFunctionPointerForDelegate(DelegateCache[3]);
-            ((IntPtr*)abiToProjectionVftablePtr)[10] = Marshal.GetFunctionPointerForDelegate(DelegateCache[4]);
-            ((IntPtr*)abiToProjectionVftablePtr)[11] = Marshal.GetFunctionPointerForDelegate(DelegateCache[5]);
-            ((IntPtr*)abiToProjectionVftablePtr)[12] = Marshal.GetFunctionPointerForDelegate(DelegateCache[6]);
-
-            if (!IDictionaryMethods<K, V>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, VAbi*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[1]),
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, byte*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[2]),
+                (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[3]),
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, VAbi, byte*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[4]),
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[5]),
+                (delegate* unmanaged[Stdcall]<IntPtr, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[6])
+            );
         }
 
         private static unsafe int Do_Abi_Lookup_0(void* thisPtr, KAbi key, VAbi* __return_value__)

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -260,6 +260,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IEnumerableMethods<T, TAbi> where TAbi : unmanaged
     {
+        static IEnumerableMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerable<T>), typeof(global::ABI.System.Collections.Generic.IEnumerable<T>));
+        }
+
         public unsafe static bool InitRcwHelper(delegate*<IObjectReference, global::System.Collections.Generic.IEnumerator<T>> first)
         {
             if (ABI.Windows.Foundation.Collections.IIterableMethods<T>._RcwHelperInitialized)
@@ -294,6 +299,9 @@ namespace ABI.System.Collections.Generic
                 return false;
             }
 
+            // Register generic helper types referenced in CCW.
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerator<T>), typeof(global::ABI.System.Collections.Generic.IEnumerator<T>));
+
             return true;
         }
 
@@ -302,15 +310,7 @@ namespace ABI.System.Collections.Generic
         internal static unsafe void InitFallbackCCWVtable()
         {
             DelegateCache = new IEnumerable_Delegates.First_0_Abi(Do_Abi_First_0);
-
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 1));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache);
-
-            if (!IEnumerableMethods<T>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw((delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache));
         }
 
         private static unsafe int Do_Abi_First_0(IntPtr thisPtr, IntPtr* __return_value__)
@@ -590,6 +590,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IEnumeratorMethods<T, TAbi> where TAbi : unmanaged
     {
+        static IEnumeratorMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerator<T>), typeof(global::ABI.System.Collections.Generic.IEnumerator<T>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, T> getCurrent,
             delegate*<IObjectReference, T[], uint> getMany)
@@ -673,17 +678,12 @@ namespace ABI.System.Collections.Generic
                 new IEnumerator_Delegates.GetMany_3_Abi(Do_Abi_GetMany_3)
             };
 
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 4));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-            ((IntPtr*)abiToProjectionVftablePtr)[8] = Marshal.GetFunctionPointerForDelegate(DelegateCache[2]);
-            ((IntPtr*)abiToProjectionVftablePtr)[9] = Marshal.GetFunctionPointerForDelegate(DelegateCache[3]);
-
-            if (!IEnumeratorMethods<T>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, TAbi*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[1]),
+                (delegate* unmanaged[Stdcall]<IntPtr, byte*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[2]),
+                (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>) Marshal.GetFunctionPointerForDelegate(DelegateCache[3])
+            );
         }
 
         private static unsafe int Do_Abi_MoveNext_2(IntPtr thisPtr, byte* __return_value__)

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -220,6 +220,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IEnumerableMethods<T>
     {
+        static IEnumerableMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerable<T>), typeof(global::ABI.System.Collections.Generic.IEnumerable<T>));
+        }
+
         public static global::System.Collections.Generic.IEnumerator<T> GetEnumerator(IObjectReference obj)
         {
             var first = ABI.Windows.Foundation.Collections.IIterableMethods<T>.First(obj);
@@ -260,11 +265,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IEnumerableMethods<T, TAbi> where TAbi : unmanaged
     {
-        static IEnumerableMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerable<T>), typeof(global::ABI.System.Collections.Generic.IEnumerable<T>));
-        }
-
         public unsafe static bool InitRcwHelper(delegate*<IObjectReference, global::System.Collections.Generic.IEnumerator<T>> first)
         {
             if (ABI.Windows.Foundation.Collections.IIterableMethods<T>._RcwHelperInitialized)
@@ -512,6 +512,8 @@ namespace ABI.System.Collections.Generic
     {
         unsafe static IEnumeratorMethods()
         {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerator<T>), typeof(global::ABI.System.Collections.Generic.IEnumerator<T>));
+
             // Early return to ensure things are trimmed correctly on NAOT.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
@@ -590,11 +592,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IEnumeratorMethods<T, TAbi> where TAbi : unmanaged
     {
-        static IEnumeratorMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IEnumerator<T>), typeof(global::ABI.System.Collections.Generic.IEnumerator<T>));
-        }
-
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, T> getCurrent,
             delegate*<IObjectReference, T[], uint> getMany)

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -159,6 +159,8 @@ namespace ABI.System.Collections.Generic
     {
         unsafe static IListMethods()
         {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IList<T>), typeof(global::ABI.System.Collections.Generic.IList<T>));
+
             // Early return to ensure things are trimmed correctly on NAOT.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
@@ -440,11 +442,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IListMethods<T, TAbi> where TAbi : unmanaged
     {
-        static IListMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IList<T>), typeof(global::ABI.System.Collections.Generic.IList<T>));
-        }
-
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, uint, T> getAt,
             delegate*<IObjectReference, global::System.Collections.Generic.IReadOnlyList<T>> getView,

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -440,6 +440,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IListMethods<T, TAbi> where TAbi : unmanaged
     {
+        static IListMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IList<T>), typeof(global::ABI.System.Collections.Generic.IList<T>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, uint, T> getAt,
             delegate*<IObjectReference, global::System.Collections.Generic.IReadOnlyList<T>> getView,
@@ -626,6 +631,8 @@ namespace ABI.System.Collections.Generic
                 return false;
             }
 
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyList<T>), typeof(global::ABI.System.Collections.Generic.IReadOnlyList<T>));
+
             return true;
         }
 
@@ -654,25 +661,20 @@ namespace ABI.System.Collections.Generic
                 new IList_Delegates.ReplaceAll_11(Do_Abi_ReplaceAll_11)
             };
 
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 12));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-            ((IntPtr*)abiToProjectionVftablePtr)[8] = Marshal.GetFunctionPointerForDelegate(DelegateCache[2]);
-            ((IntPtr*)abiToProjectionVftablePtr)[9] = Marshal.GetFunctionPointerForDelegate(DelegateCache[3]);
-            ((IntPtr*)abiToProjectionVftablePtr)[10] = Marshal.GetFunctionPointerForDelegate(DelegateCache[4]);
-            ((IntPtr*)abiToProjectionVftablePtr)[11] = Marshal.GetFunctionPointerForDelegate(DelegateCache[5]);
-            ((IntPtr*)abiToProjectionVftablePtr)[12] = Marshal.GetFunctionPointerForDelegate(DelegateCache[6]);
-            ((IntPtr*)abiToProjectionVftablePtr)[13] = Marshal.GetFunctionPointerForDelegate(DelegateCache[7]);
-            ((IntPtr*)abiToProjectionVftablePtr)[14] = Marshal.GetFunctionPointerForDelegate(DelegateCache[8]);
-            ((IntPtr*)abiToProjectionVftablePtr)[15] = Marshal.GetFunctionPointerForDelegate(DelegateCache[9]);
-            ((IntPtr*)abiToProjectionVftablePtr)[16] = Marshal.GetFunctionPointerForDelegate(DelegateCache[10]);
-            ((IntPtr*)abiToProjectionVftablePtr)[17] = Marshal.GetFunctionPointerForDelegate(DelegateCache[11]);
-
-            if (!IListMethods<T>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, TAbi*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[1]),
+                (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[2]),
+                (delegate* unmanaged[Stdcall]<IntPtr, TAbi, uint*, byte*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[3]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, TAbi, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[4]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, TAbi, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[5]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[6]),
+                (delegate* unmanaged[Stdcall]<IntPtr, TAbi, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[7]),
+                (delegate* unmanaged[Stdcall]<IntPtr, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[8]),
+                (delegate* unmanaged[Stdcall]<IntPtr, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[9]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, int, IntPtr, uint*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[10]),
+                (delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[11])
+            );
         }
 
         private static unsafe int Do_Abi_GetAt_0(void* thisPtr, uint index, TAbi* __return_value__)

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -441,6 +441,12 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IReadOnlyDictionaryMethods<K, KAbi, V, VAbi> where KAbi : unmanaged where VAbi : unmanaged
     {
+        static IReadOnlyDictionaryMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
+            ComWrappersSupport.RegisterHelperType(typeof(global::Windows.Foundation.Collections.IMapView<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K, V> lookup,
             delegate*<IObjectReference, K, bool> hasKey,
@@ -559,17 +565,12 @@ namespace ABI.System.Collections.Generic
                 new IReadOnlyDictionary_Delegates.Split_3_Abi(Do_Abi_Split_3),
             };
 
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 4));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-            ((IntPtr*)abiToProjectionVftablePtr)[8] = Marshal.GetFunctionPointerForDelegate(DelegateCache[2]);
-            ((IntPtr*)abiToProjectionVftablePtr)[9] = Marshal.GetFunctionPointerForDelegate(DelegateCache[3]);
-
-            if (!IReadOnlyDictionaryMethods<K, V>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, VAbi*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[1]),
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi, byte*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[2]),
+                (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, IntPtr*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[3])
+            );
         }
 
         private static unsafe int Do_Abi_Lookup_0(IntPtr thisPtr, KAbi key, VAbi* __return_value__)

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -184,6 +184,9 @@ namespace ABI.System.Collections.Generic
     {
         unsafe static IReadOnlyDictionaryMethods()
         {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
+            ComWrappersSupport.RegisterHelperType(typeof(global::Windows.Foundation.Collections.IMapView<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
+
             // Early return to ensure things are trimmed correctly on NAOT.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
@@ -441,12 +444,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IReadOnlyDictionaryMethods<K, KAbi, V, VAbi> where KAbi : unmanaged where VAbi : unmanaged
     {
-        static IReadOnlyDictionaryMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
-            ComWrappersSupport.RegisterHelperType(typeof(global::Windows.Foundation.Collections.IMapView<K, V>), typeof(global::ABI.System.Collections.Generic.IReadOnlyDictionary<K, V>));
-        }
-
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K, V> lookup,
             delegate*<IObjectReference, K, bool> hasKey,

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -270,6 +270,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IReadOnlyListMethods<T,TAbi> where TAbi: unmanaged
     {
+        static IReadOnlyListMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyList<T>), typeof(global::ABI.System.Collections.Generic.IReadOnlyList<T>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, uint, T> getAt,
             delegate*<IObjectReference, T, out uint, bool> indexOf,
@@ -383,17 +388,12 @@ namespace ABI.System.Collections.Generic
                 new IReadOnlyList_Delegates.GetMany_3_Abi(Do_Abi_GetMany_3)
             };
 
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 4));
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-            ((IntPtr*)abiToProjectionVftablePtr)[8] = Marshal.GetFunctionPointerForDelegate(DelegateCache[2]);
-            ((IntPtr*)abiToProjectionVftablePtr)[9] = Marshal.GetFunctionPointerForDelegate(DelegateCache[3]);
-
-            if (!IReadOnlyListMethods<T>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, TAbi*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[1]),
+                (delegate* unmanaged[Stdcall]<IntPtr, TAbi, uint*, byte*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[2]),
+                (delegate* unmanaged[Stdcall]<IntPtr, uint, int, IntPtr, uint*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[3])
+            );
         }
 
         private static unsafe int Do_Abi_GetAt_0(IntPtr thisPtr, uint index, TAbi* __return_value__)

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -202,6 +202,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IReadOnlyListMethods<T>
     {
+        static IReadOnlyListMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyList<T>), typeof(global::ABI.System.Collections.Generic.IReadOnlyList<T>));
+        }
+
         public static int get_Count(IObjectReference obj)
         {
             uint size = ABI.Windows.Foundation.Collections.IVectorViewMethods<T>.get_Size(obj);
@@ -270,11 +275,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class IReadOnlyListMethods<T,TAbi> where TAbi: unmanaged
     {
-        static IReadOnlyListMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.IReadOnlyList<T>), typeof(global::ABI.System.Collections.Generic.IReadOnlyList<T>));
-        }
-
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, uint, T> getAt,
             delegate*<IObjectReference, T, out uint, bool> indexOf,

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -109,6 +109,11 @@ namespace ABI.System.Collections.Generic
 #endif
     static class KeyValuePairMethods<K, KAbi, V, VAbi> where KAbi : unmanaged where VAbi : unmanaged
     {
+        static KeyValuePairMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.KeyValuePair<K, V>), typeof(global::ABI.System.Collections.Generic.KeyValuePair<K, V>));
+        }
+
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K> getKey,
             delegate*<IObjectReference, V> getValue)
@@ -219,23 +224,10 @@ namespace ABI.System.Collections.Generic
                 global::System.Delegate.CreateDelegate(get_Value_1_Type, typeof(KeyValuePairMethods<K, KAbi, V, VAbi>).GetMethod(nameof(Do_Abi_get_Value_1), BindingFlags.NonPublic | BindingFlags.Static)),
             };
 
-#if NET
-            var abiToProjectionVftablePtr = (IntPtr)NativeMemory.AllocZeroed((nuint)(sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 2));
-#else
-            var abiToProjectionVftablePtr = (IntPtr)Marshal.AllocCoTaskMem((sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 2));
-#endif
-            *(IInspectable.Vftbl*)abiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
-            ((IntPtr*)abiToProjectionVftablePtr)[6] = Marshal.GetFunctionPointerForDelegate(DelegateCache[0]);
-            ((IntPtr*)abiToProjectionVftablePtr)[7] = Marshal.GetFunctionPointerForDelegate(DelegateCache[1]);
-
-            if (!KeyValuePairMethods<K, V>.TryInitCCWVtable(abiToProjectionVftablePtr))
-            {
-#if NET
-                NativeMemory.Free((void*)abiToProjectionVftablePtr);
-#else
-                Marshal.FreeCoTaskMem(abiToProjectionVftablePtr);
-#endif
-            }
+            InitCcw(
+                (delegate* unmanaged[Stdcall]<IntPtr, KAbi*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[0]),
+                (delegate* unmanaged[Stdcall]<IntPtr, VAbi*, int>)Marshal.GetFunctionPointerForDelegate(DelegateCache[1])
+            );
         }
 
         private static unsafe int Do_Abi_get_Key_0(IntPtr thisPtr, KAbi* __return_value__)

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -41,6 +41,11 @@ namespace ABI.System.Collections.Generic
         internal volatile unsafe static delegate*<IObjectReference, V> _GetValue;
         internal volatile static bool _RcwHelperInitialized;
 
+        static KeyValuePairMethods()
+        {
+            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.KeyValuePair<K, V>), typeof(global::ABI.System.Collections.Generic.KeyValuePair<K, V>));
+        }
+
         internal static unsafe bool EnsureInitialized()
         {
 #if NET
@@ -109,11 +114,6 @@ namespace ABI.System.Collections.Generic
 #endif
     static class KeyValuePairMethods<K, KAbi, V, VAbi> where KAbi : unmanaged where VAbi : unmanaged
     {
-        static KeyValuePairMethods()
-        {
-            ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.KeyValuePair<K, V>), typeof(global::ABI.System.Collections.Generic.KeyValuePair<K, V>));
-        }
-
         public unsafe static bool InitRcwHelper(
             delegate*<IObjectReference, K> getKey,
             delegate*<IObjectReference, V> getValue)

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -17,7 +17,7 @@ namespace WinRT
 #endif
     static class TypeExtensions
     {
-        private readonly static ConcurrentDictionary<Type, Type> HelperTypeCache = new ConcurrentDictionary<Type, Type>();
+        internal readonly static ConcurrentDictionary<Type, Type> HelperTypeCache = new ConcurrentDictionary<Type, Type>();
 
 #if NET
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods |

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -79,7 +79,7 @@ namespace WinRT
 #endif
             static Type GetHelperTypeFromAttribute(WindowsRuntimeHelperTypeAttribute helperTypeAtribute, Type type)
             {
-                if (type.IsGenericType)
+                if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 {
 #if NET
                     if (!RuntimeFeature.IsDynamicCodeCompiled)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -7412,6 +7412,7 @@ internal static global::System.Guid IID { get; } = new Guid(new byte[] { % });
 internal volatile static bool _RcwHelperInitialized;
 unsafe static @Methods()
 {
+ComWrappersSupport.RegisterHelperType(typeof(%), typeof(%));
 if (RuntimeFeature.IsDynamicCodeCompiled && !_RcwHelperInitialized)
 {
 var ensureInitializedFallback = (Func<bool>)typeof(@Methods<%>).MakeGenericType(%).
@@ -7422,6 +7423,8 @@ ensureInitializedFallback();
 }
 )",
                     iface.TypeName(),
+                    bind<write_type_name>(iface, typedef_name_type::Projected, false),
+                    bind<write_type_name>(iface, typedef_name_type::ABI, false),
                     iface.TypeName(),
                     bind([&](writer& w)
                     {
@@ -7533,11 +7536,6 @@ public static global::System.IntPtr AbiToProjectionVftablePtr => %.AbiToProjecti
                 w.write(R"(
 % static class %%
 {
-static @Methods()
-{
-ComWrappersSupport.RegisterHelperType(typeof(%), typeof(%));
-}
-
 public unsafe static bool InitRcwHelper(%)
 {
 if (%._RcwHelperInitialized)
@@ -7625,9 +7623,6 @@ NativeMemory.Free((void*)abiToProjectionVftablePtr);
                         write_generic_type_name(w, index++);
                         w.write("Abi : unmanaged");
                     }, iface.GenericParam()),
-                    iface.TypeName(),
-                    bind<write_type_name>(iface, typedef_name_type::Projected, false),
-                    bind<write_type_name>(iface, typedef_name_type::ABI, false),
                     [&](writer& w) {
                         bool write_delimiter = false;
                         for (auto& method : iface.MethodList())
@@ -9066,6 +9061,11 @@ internal static class %
 private static IntPtr abiToProjectionVftablePtr;
 internal static IntPtr AbiToProjectionVftablePtr => abiToProjectionVftablePtr;
 
+static @Methods()
+{
+ComWrappersSupport.RegisterHelperType(typeof(%), typeof(%));
+}
+
 internal static bool TryInitCCWVtable(IntPtr ptr)
 {
 bool success = global::System.Threading.Interlocked.CompareExchange(ref abiToProjectionVftablePtr, ptr, IntPtr.Zero) == IntPtr.Zero;
@@ -9123,6 +9123,9 @@ public static % Abi_Invoke(IntPtr thisPtr%%)
                             bind_list<write_projection_parameter_type>(", ", signature.params()),
                             signature.has_params() ? ", " : "",
                             bind<write_projection_return_type>(signature)),
+                    type.TypeName(),
+                    bind<write_type_name>(type, typedef_name_type::Projected, false),
+                    bind<write_type_name>(type, typedef_name_type::ABI, false),
                     bind<write_type_name>(type, typedef_name_type::ABI, false),
                     bind<write_type_name>(type, typedef_name_type::Projected, false),
                     bind<write_type_name>(type, typedef_name_type::Projected, false),

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6106,7 +6106,7 @@ return eventSource.EventActions;
                     auto guard{ w.push_generic_args(type) };
                     set_typedef_marshaler(type.generic_type);
 
-                    if (!settings.netstandard_compat && (!m.is_out() || get_category(type.generic_type) == category::delegate_type))
+                    if (!settings.netstandard_compat /* && (!m.is_out() || get_category(type.generic_type) == category::delegate_type) */)
                     {
                         auto generic_instantiation_class_name = get_generic_instantiation_class_type_name(w, type.generic_type);
                         if (!starts_with(generic_instantiation_class_name, "Windows_Foundation_IReference"))
@@ -7533,6 +7533,11 @@ public static global::System.IntPtr AbiToProjectionVftablePtr => %.AbiToProjecti
                 w.write(R"(
 % static class %%
 {
+static @Methods()
+{
+ComWrappersSupport.RegisterHelperType(typeof(%), typeof(%));
+}
+
 public unsafe static bool InitRcwHelper(%)
 {
 if (%._RcwHelperInitialized)
@@ -7620,6 +7625,9 @@ NativeMemory.Free((void*)abiToProjectionVftablePtr);
                         write_generic_type_name(w, index++);
                         w.write("Abi : unmanaged");
                     }, iface.GenericParam()),
+                    iface.TypeName(),
+                    bind<write_type_name>(iface, typedef_name_type::Projected, false),
+                    bind<write_type_name>(iface, typedef_name_type::ABI, false),
                     [&](writer& w) {
                         bool write_delimiter = false;
                         for (auto& method : iface.MethodList())

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -6106,7 +6106,7 @@ return eventSource.EventActions;
                     auto guard{ w.push_generic_args(type) };
                     set_typedef_marshaler(type.generic_type);
 
-                    if (!settings.netstandard_compat /* && (!m.is_out() || get_category(type.generic_type) == category::delegate_type) */)
+                    if (!settings.netstandard_compat)
                     {
                         auto generic_instantiation_class_name = get_generic_instantiation_class_type_name(w, type.generic_type);
                         if (!starts_with(generic_instantiation_class_name, "Windows_Foundation_IReference"))


### PR DESCRIPTION
This PR addresses the issues that came up after AOT checks were added to all our `MakeGenericType` calls.  The main issue that came up is the helper type for generic types can no longer be constructed.  This was addressed in two ways.
- For the scenarios that need it due to the `MarshalInterface` calls, the helper type is registered before it gets there via the `Methods` static classes in their static constructor which gets triggered as part of the generic type instantiations.
- The other scenario that needed it is IID creation where it found the helper type as part of determining the IID.  Given the IID we are getting from the helper type in generic type scenarios is for the unbound type, that code path has been changed to get the helper type for the unbound type instead which avoids the `MakeGenericType` calls.  The generic itself is still used as part of the IID generation but is done separately as it was before too as part of combining the signature that gets hashed.
- Array marshaling was also disabled so disabling the test for AOT for now until we figure out how much of an impact it is and if we need another way to handle it.