### PR TITLE
Allow authoring scenarios to make use of abstract classes in their implementation

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -25,6 +25,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' != 'true'">false</CsWinRTAotExportsEnabled>
+    <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(TargetPlatformVersion)</CsWinRTWindowsMetadata>    
   </PropertyGroup>
 
   <ItemGroup>
@@ -104,8 +106,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   -->
       <CsWinRTCommand>"$(CsWinRTExe)" %40"$(CsWinRTResponseFile)"</CsWinRTCommand>
       <CsWinRTCommandPrivateProjection>"$(CsWinRTExe)" %40"$(CsWinRTResponseFilePrivateProjection)"</CsWinRTCommandPrivateProjection>
-      <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
-      <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(TargetPlatformVersion)</CsWinRTWindowsMetadata>
       <CsWinRTWindowsMetadataInput Condition="'$(CsWinRTWindowsMetadata)' != ''">-input $(CsWinRTWindowsMetadata)</CsWinRTWindowsMetadataInput>
     </PropertyGroup>
 

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2016,7 +2016,9 @@ namespace Generator
                     TypeAttributes.BeforeFieldInit;
 
                 // extends
-                if (type.BaseType != null)
+                // WinRT doesn't support projecting abstract classes.
+                // If the base class is one, ignore it.
+                if (type.BaseType != null && !type.BaseType.IsAbstract)
                 {
                     baseType = GetTypeReference(type.BaseType);
                 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1474,6 +1474,10 @@ namespace AuthoringTest
         }
     }
 
+    public sealed class TestCollection : CollectionBase
+    {
+    }
+
     public partial interface IPartialInterface
     {
         public string GetNumberAsString();


### PR DESCRIPTION
Abstract classes are not a concept in WinRT but authors of WinRT components may want to implement their components where they make of use abstract classes as their base class and might be public.  Given we don't need to worry about projecting them, this PR allows for this scenario by ignoring the base type if it is abstract.

Also fixing an issue where `CsWinRTWindowsMetadata` was never set in authoring scenarios because it was set as part of a target and thereby the source generator was getting an empty value.