### PR TITLE
Suppress useless IL2080 warnings in fallback paths

### DIFF
--- a/src/WinRT.Runtime/AttributeMessages.net5.cs
+++ b/src/WinRT.Runtime/AttributeMessages.net5.cs
@@ -14,5 +14,10 @@
         /// Message for marshalling or generic code requiring <see cref="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute"/>.
         /// </summary>
         public const string MarshallingOrGenericInstantiationsRequiresDynamicCode = "The necessary marshalling code or generic instantiations might not be available.";
+
+        /// <summary>
+        /// Message for suppressing trim warnings for <see cref="System.Type.MakeGenericType"/> calls with ABI types as type arguments for <see langword="unmanaged"/> constrained type parameters.
+        /// </summary>
+        public const string AbiTypesNeverHaveConstructors = "All ABI types never have a constructor that would need to be accessed via reflection.";
     }
 }

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -262,7 +262,7 @@ namespace ABI.System.Collections.Generic
             }
 
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            InitFallbackCCWVTableIfNeeded();
+            InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 #if NET8_0_OR_GREATER
@@ -272,7 +272,7 @@ namespace ABI.System.Collections.Generic
             [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void InitFallbackCCWVTableIfNeeded()
+            static void InitRcwHelperFallbackIfNeeded()
             {
                 // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                 // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -1217,6 +1217,7 @@ namespace ABI.System.Collections.Generic
         }
 
         public static readonly IntPtr AbiToProjectionVftablePtr;
+        
         static IDictionary()
         {
             if (RuntimeFeature.IsDynamicCodeCompiled)
@@ -1229,6 +1230,9 @@ namespace ABI.System.Collections.Generic
 
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -261,16 +261,28 @@ namespace ABI.System.Collections.Generic
                 return;
             }
 
-            // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
-            // and due to that the function pointers haven't been initialized.
-            if (!IMapMethods<K, V>._RcwHelperInitialized)
-            {
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var initRcwHelperFallback = (Func<bool>)typeof(IDictionaryMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
-                    GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
-                    CreateDelegate(typeof(Func<bool>));
+            InitFallbackCCWVTableIfNeeded();
 #pragma warning restore IL3050
-                initRcwHelperFallback();
+
+#if NET8_0_OR_GREATER
+            [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+            [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void InitFallbackCCWVTableIfNeeded()
+            {
+                // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
+                // and due to that the function pointers haven't been initialized.
+                if (!IMapMethods<K, V>._RcwHelperInitialized)
+                {
+                    var initRcwHelperFallback = (Func<bool>)typeof(IDictionaryMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
+                        GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
+                        CreateDelegate(typeof(Func<bool>));
+                    initRcwHelperFallback();
+                }
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -529,7 +529,7 @@ namespace ABI.System.Collections.Generic
             }
 
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            InitFallbackCCWVTableIfNeeded();
+            InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 #if NET8_0_OR_GREATER
@@ -539,7 +539,7 @@ namespace ABI.System.Collections.Generic
             [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void InitFallbackCCWVTableIfNeeded()
+            static void InitRcwHelperFallbackIfNeeded()
             {
                 // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                 // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -377,6 +377,9 @@ namespace ABI.System.Collections.Generic
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
 #endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
                 {
@@ -1062,6 +1065,9 @@ namespace ABI.System.Collections.Generic
 
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -169,7 +169,7 @@ namespace ABI.System.Collections.Generic
             }
 
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            InitFallbackCCWVTableIfNeeded();
+            InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 #if NET8_0_OR_GREATER
@@ -179,7 +179,7 @@ namespace ABI.System.Collections.Generic
             [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void InitFallbackCCWVTableIfNeeded()
+            static void InitRcwHelperFallbackIfNeeded()
             {
                 // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                 // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -168,16 +168,28 @@ namespace ABI.System.Collections.Generic
                 return;
             }
 
-            // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
-            // and due to that the function pointers haven't been initialized.
-            if (!IVectorMethods<T>._RcwHelperInitialized)
-            {
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var initRcwHelperFallback = (Func<bool>)typeof(IListMethods<,>).MakeGenericType(typeof(T), Marshaler<T>.AbiType).
-                    GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
-                    CreateDelegate(typeof(Func<bool>));
+            InitFallbackCCWVTableIfNeeded();
 #pragma warning restore IL3050
-                initRcwHelperFallback();
+
+#if NET8_0_OR_GREATER
+            [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+            [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void InitFallbackCCWVTableIfNeeded()
+            {
+                // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
+                // and due to that the function pointers haven't been initialized.
+                if (!IVectorMethods<T>._RcwHelperInitialized)
+                {
+                    var initRcwHelperFallback = (Func<bool>)typeof(IListMethods<,>).MakeGenericType(typeof(T), Marshaler<T>.AbiType).
+                        GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
+                        CreateDelegate(typeof(Func<bool>));
+                    initRcwHelperFallback();
+                }
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -1348,6 +1348,9 @@ namespace ABI.System.Collections.Generic
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
 #endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
                 {

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -194,16 +194,28 @@ namespace ABI.System.Collections.Generic
                 return;
             }
 
-            // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
-            // and due to that the function pointers haven't been initialized.
-            if (!ABI.Windows.Foundation.Collections.IMapViewMethods<K, V>._RcwHelperInitialized)
-            {
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var initRcwHelperFallback = (Func<bool>)typeof(IReadOnlyDictionaryMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
-                    GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
-                    CreateDelegate(typeof(Func<bool>));
+            InitFallbackCCWVTableIfNeeded();
 #pragma warning restore IL3050
-                initRcwHelperFallback();
+
+#if NET8_0_OR_GREATER
+            [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+            [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void InitFallbackCCWVTableIfNeeded()
+            {
+                // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
+                // and due to that the function pointers haven't been initialized.
+                if (!ABI.Windows.Foundation.Collections.IMapViewMethods<K, V>._RcwHelperInitialized)
+                {
+                    var initRcwHelperFallback = (Func<bool>)typeof(IReadOnlyDictionaryMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
+                        GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
+                        CreateDelegate(typeof(Func<bool>));
+                    initRcwHelperFallback();
+                }
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -195,7 +195,7 @@ namespace ABI.System.Collections.Generic
             }
 
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            InitFallbackCCWVTableIfNeeded();
+            InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 #if NET8_0_OR_GREATER
@@ -205,7 +205,7 @@ namespace ABI.System.Collections.Generic
             [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void InitFallbackCCWVTableIfNeeded()
+            static void InitRcwHelperFallbackIfNeeded()
             {
                 // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                 // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -1073,6 +1073,9 @@ namespace ABI.System.Collections.Generic
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
 #endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
                 {

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -112,6 +112,9 @@ namespace ABI.Windows.Foundation.Collections
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
 #endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
                 {
@@ -636,6 +639,9 @@ namespace ABI.System.Collections.Generic
 
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -105,7 +105,7 @@ namespace ABI.Windows.Foundation.Collections
                 // Simple invocation guarded by a direct runtime feature check to help the linker.
                 // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                InitFallbackCCWVTableIfNeeded();
+                InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 
@@ -116,7 +116,7 @@ namespace ABI.Windows.Foundation.Collections
                 [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
-                static void InitFallbackCCWVTableIfNeeded()
+                static void InitRcwHelperFallbackIfNeeded()
                 {
                     // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                     // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -383,6 +383,9 @@ namespace ABI.System.Collections.Generic
 #if NET8_0_OR_GREATER
                 [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
 #endif
+#if NET
+                [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
                 {

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -59,7 +59,7 @@ namespace ABI.System.Collections.Generic
             }
 #endif
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            InitFallbackCCWVTableIfNeeded();
+            InitRcwHelperFallbackIfNeeded();
 #pragma warning restore IL3050
 
 #if NET8_0_OR_GREATER
@@ -69,7 +69,7 @@ namespace ABI.System.Collections.Generic
             [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void InitFallbackCCWVTableIfNeeded()
+            static void InitRcwHelperFallbackIfNeeded()
             {
                 // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
                 // and due to that the function pointers haven't been initialized.

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -58,17 +58,28 @@ namespace ABI.System.Collections.Generic
                 return true;
             }
 #endif
-
-            // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
-            // and due to that the function pointers haven't been initialized.
-            if (!_RcwHelperInitialized)
-            {
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var initRcwHelperFallback = (Func<bool>)typeof(KeyValuePairMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
-                    GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
-                    CreateDelegate(typeof(Func<bool>));
+            InitFallbackCCWVTableIfNeeded();
 #pragma warning restore IL3050
-                initRcwHelperFallback();
+
+#if NET8_0_OR_GREATER
+            [RequiresDynamicCode(AttributeMessages.MarshallingOrGenericInstantiationsRequiresDynamicCode)]
+#endif
+#if NET
+            [SuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+#endif
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void InitFallbackCCWVTableIfNeeded()
+            {
+                // Handle the compat scenario where the source generator wasn't used and IDIC hasn't been used yet
+                // and due to that the function pointers haven't been initialized.
+                if (!_RcwHelperInitialized)
+                {
+                    var initRcwHelperFallback = (Func<bool>)typeof(KeyValuePairMethods<,,,>).MakeGenericType(typeof(K), Marshaler<K>.AbiType, typeof(V), Marshaler<V>.AbiType).
+                        GetMethod("InitRcwHelperFallback", BindingFlags.NonPublic | BindingFlags.Static).
+                        CreateDelegate(typeof(Func<bool>));
+                    initRcwHelperFallback();
+                }
             }
 
             return true;


### PR DESCRIPTION
This PR suppresses a bunch of IL2080 warnings for `MakeGenericCalls` that we know are actually safe. The warnings come from the fact the ABI type arguments are passed to type parameters using the `unmanaged` constraint, which implies `struct`, which implies `new()`, which in turn implies `[DynamicallyAccessedMemebrs(PublicParameterlessConstructor)]`. Because we know that all our ABI types are just blittable and will never have a constructor, we can just safely suppress these warnings.

> [!NOTE]
> I recommend reviewing this **with whitespace hidden**.