### PR TITLE
Fix nullable and IPropertySet scenarios

### DIFF
--- a/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
+++ b/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
@@ -1,4 +1,5 @@
-﻿using Windows.Foundation;
+﻿using System;
+using Windows.Foundation;
 
 // Static function calls and create RCW for existing object.
 IStringable[] a = new IStringable[] {
@@ -18,4 +19,10 @@ foreach (var str in a)
 // Class function call
 result += (int)(a[1] as Windows.Data.Json.JsonValue).GetNumber();
 
-return result == 16 ? 100 : 101;
+var enumVal = TestComponentCSharp.Class.BoxedEnum;
+if (enumVal is TestComponentCSharp.EnumValue val && val == TestComponentCSharp.EnumValue.Two)
+{
+    result += 1;
+}
+
+return result == 17 ? 100 : 101;

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -131,6 +131,11 @@ namespace TestComponentCSharp
         static Int32 NumObjects{ get; };
     }
 
+    interface IDerivedGenericInterface requires Microsoft.UI.Xaml.Input.ICommand, Microsoft.UI.Xaml.Interop.INotifyCollectionChanged, Windows.Foundation.Collections.IPropertySet
+    {
+        Int32 Number;
+    }
+
     interface ISingleton
     {
         Int32 IntProperty;

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -486,6 +486,11 @@ namespace WinRT
             };
         }
 
+        internal static void AddToBoxedValueCache(object obj, IInspectable inspectable)
+        {
+            _boxedValueReferenceCache.Add(obj, inspectable);
+        }
+
         private static Func<IInspectable, object> CreateCustomTypeMappingFactory(Type customTypeHelperType)
         {
             var fromAbiMethod = customTypeHelperType.GetMethod("FromAbi", BindingFlags.Public | BindingFlags.Static);
@@ -569,12 +574,24 @@ namespace WinRT
             return CreateFactoryForImplementationType(runtimeClassName, implementationType);
         }
 
-        internal static Type GetRuntimeClassForTypeCreation(IInspectable inspectable, Type staticallyDeterminedType)
+        internal static Type GetRuntimeClassForTypeCreation(IInspectable inspectable, Type staticallyDeterminedType, out bool isNullable)
         {
+            isNullable = false;
             string runtimeClassName = inspectable.GetRuntimeClassName(noThrow: true);
             Type implementationType = null;
             if (!string.IsNullOrEmpty(runtimeClassName))
             {
+                // Check if this is a nullable type where there are no references to the nullable version, but
+                // there is to the actual type.
+                if (runtimeClassName.StartsWith("Windows.Foundation.IReference`1<", StringComparison.Ordinal))
+                {
+                    // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
+                    runtimeClassName = runtimeClassName.Substring(32, runtimeClassName.Length - 33);
+                    implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
+                    isNullable = true;
+                    return implementationType;
+                }
+
                 implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
             }
 
@@ -611,6 +628,18 @@ namespace WinRT
                 {
                     return staticallyDeterminedType;
                 }
+            }
+
+            // Check if this is a nullable type where there are no references to the nullable version, but
+            // there is to the actual type.
+            if (implementationType == null && 
+                !string.IsNullOrEmpty(runtimeClassName) && 
+                runtimeClassName.StartsWith("Windows.Foundation.IReference`1<", StringComparison.Ordinal))
+            {
+                // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
+                runtimeClassName = runtimeClassName.Substring(32, runtimeClassName.Length - 33);
+                implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
+                isNullable = true;
             }
 
             return implementationType;

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -585,11 +585,9 @@ namespace WinRT
                 // there is to the actual type.
                 if (runtimeClassName.StartsWith("Windows.Foundation.IReference`1<", StringComparison.Ordinal))
                 {
-                    // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
-                    runtimeClassName = runtimeClassName.Substring(32, runtimeClassName.Length - 33);
-                    implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
                     isNullable = true;
-                    return implementationType;
+                    // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
+                    return TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName.Substring(32, runtimeClassName.Length - 33));
                 }
 
                 implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
@@ -628,18 +626,6 @@ namespace WinRT
                 {
                     return staticallyDeterminedType;
                 }
-            }
-
-            // Check if this is a nullable type where there are no references to the nullable version, but
-            // there is to the actual type.
-            if (implementationType == null && 
-                !string.IsNullOrEmpty(runtimeClassName) && 
-                runtimeClassName.StartsWith("Windows.Foundation.IReference`1<", StringComparison.Ordinal))
-            {
-                // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
-                runtimeClassName = runtimeClassName.Substring(32, runtimeClassName.Length - 33);
-                implementationType = TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName);
-                isNullable = true;
             }
 
             return implementationType;

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -444,13 +444,13 @@ namespace WinRT
 
         public static bool RegisterDelegateFactory(Type implementationType, Func<IntPtr, object> delegateFactory) => DelegateFactoryCache.TryAdd(implementationType, delegateFactory);
 
-        private static Func<IInspectable, object> CreateNullableTFactory(Type implementationType)
+        internal static Func<IInspectable, object> CreateNullableTFactory(Type implementationType)
         {
             var getValueMethod = implementationType.GetHelperType().GetMethod("GetValue", BindingFlags.Static | BindingFlags.Public);
             return (IInspectable obj) => getValueMethod.Invoke(null, new[] { obj });
         }
 
-        private static Func<IInspectable, object> CreateAbiNullableTFactory(
+        internal static Func<IInspectable, object> CreateAbiNullableTFactory(
 #if NET
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 #endif
@@ -476,7 +476,7 @@ namespace WinRT
         // This is done to avoid pointer reuse until GC cleans up the boxed object
         private static readonly ConditionalWeakTable<object, IInspectable> _boxedValueReferenceCache = new();
 
-        private static Func<IInspectable, object> CreateReferenceCachingFactory(Func<IInspectable, object> internalFactory)
+        internal static Func<IInspectable, object> CreateReferenceCachingFactory(Func<IInspectable, object> internalFactory)
         {
             return inspectable =>
             {
@@ -484,11 +484,6 @@ namespace WinRT
                 _boxedValueReferenceCache.Add(resultingObject, inspectable);
                 return resultingObject;
             };
-        }
-
-        internal static void AddToBoxedValueCache(object obj, IInspectable inspectable)
-        {
-            _boxedValueReferenceCache.Add(obj, inspectable);
         }
 
         private static Func<IInspectable, object> CreateCustomTypeMappingFactory(Type customTypeHelperType)
@@ -518,17 +513,28 @@ namespace WinRT
                 return (IInspectable obj) => obj;
             }
 
-            if (implementationType == typeof(ABI.System.Nullable_string))
+            if (implementationType == typeof(string) || 
+                implementationType == typeof(Type) ||
+                implementationType == typeof(Exception) || 
+                implementationType.IsDelegate())
             {
-                return CreateReferenceCachingFactory(ABI.System.Nullable_string.GetValue);
+                return ABI.System.NullableType.GetValueFactory(implementationType);
             }
-            else if (implementationType == typeof(ABI.System.Nullable_Type))
+
+            if (implementationType.IsValueType)
             {
-                return CreateReferenceCachingFactory(ABI.System.Nullable_Type.GetValue);
-            }
-            else if (implementationType == typeof(ABI.System.Nullable_Exception))
-            {
-                return CreateReferenceCachingFactory(ABI.System.Nullable_Exception.GetValue);
+                if (implementationType.IsGenericType && implementationType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
+                {
+                    return CreateReferenceCachingFactory(CreateKeyValuePairFactory(implementationType));
+                }
+                else if (implementationType.IsNullableT())
+                {
+                    return ABI.System.NullableType.GetValueFactory(implementationType.GetGenericArguments()[0]);
+                }
+                else
+                {
+                    return ABI.System.NullableType.GetValueFactory(implementationType);
+                }
             }
 
             var customHelperType = Projections.FindCustomHelperTypeMapping(implementationType, true);
@@ -537,36 +543,7 @@ namespace WinRT
                 return CreateReferenceCachingFactory(CreateCustomTypeMappingFactory(customHelperType));
             }
 
-            if (implementationType.IsGenericType && implementationType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
-            {
-                return CreateReferenceCachingFactory(CreateKeyValuePairFactory(implementationType));
-            }
-
-            if (implementationType.IsValueType)
-            {
-                if (implementationType.IsNullableT())
-                {
-                    return CreateReferenceCachingFactory(CreateNullableTFactory(implementationType));
-                }
-                else
-                {
-#if NET
-                    if (!RuntimeFeature.IsDynamicCodeCompiled)
-                    {
-                        throw new NotSupportedException($"Cannot create an RCW factory for implementation type '{implementationType}'.");
-                    }
-#endif
-
-#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                    return CreateReferenceCachingFactory(CreateNullableTFactory(typeof(System.Nullable<>).MakeGenericType(implementationType)));
-#pragma warning restore IL3050
-                }
-            }
-            else if (implementationType.IsAbiNullableDelegate())
-            {
-                return CreateReferenceCachingFactory(CreateAbiNullableTFactory(implementationType));
-            }
-            else if (implementationType.IsIReferenceArray())
+            if (implementationType.IsIReferenceArray())
             {
                 return CreateReferenceCachingFactory(CreateArrayFactory(implementationType));
             }
@@ -574,9 +551,8 @@ namespace WinRT
             return CreateFactoryForImplementationType(runtimeClassName, implementationType);
         }
 
-        internal static Type GetRuntimeClassForTypeCreation(IInspectable inspectable, Type staticallyDeterminedType, out bool isNullable)
+        internal static Type GetRuntimeClassForTypeCreation(IInspectable inspectable, Type staticallyDeterminedType)
         {
-            isNullable = false;
             string runtimeClassName = inspectable.GetRuntimeClassName(noThrow: true);
             Type implementationType = null;
             if (!string.IsNullOrEmpty(runtimeClassName))
@@ -585,7 +561,6 @@ namespace WinRT
                 // there is to the actual type.
                 if (runtimeClassName.StartsWith("Windows.Foundation.IReference`1<", StringComparison.Ordinal))
                 {
-                    isNullable = true;
                     // runtimeClassName is of format Windows.Foundation.IReference`1<type>.
                     return TypeNameSupport.FindRcwTypeByNameCached(runtimeClassName.Substring(32, runtimeClassName.Length - 33));
                 }

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -588,7 +588,7 @@ namespace WinRT
                         return ComWrappersSupport.GetTypedRcwFactory(ComWrappersSupport.CreateRCWType)(inspectable);
                     }
 
-                    Type runtimeClassType = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType, out var isNullable);
+                    Type runtimeClassType = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType);
                     if (runtimeClassType == null)
                     {
                         // If the external IInspectable has not implemented GetRuntimeClassName,
@@ -596,14 +596,7 @@ namespace WinRT
                         return inspectable;
                     }
 
-                    if (isNullable)
-                    {
-                        return ABI.System.NullableObject.GetValue(runtimeClassType, inspectable);
-                    }
-                    else
-                    {
-                        return ComWrappersSupport.GetTypedRcwFactory(runtimeClassType)(inspectable);
-                    }
+                    return ComWrappersSupport.GetTypedRcwFactory(runtimeClassType)(inspectable);
                 }
                 else if (Marshal.QueryInterface(externalComObject, ref weakReferenceIID, out ptr) == 0)
                 {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -588,7 +588,7 @@ namespace WinRT
                         return ComWrappersSupport.GetTypedRcwFactory(ComWrappersSupport.CreateRCWType)(inspectable);
                     }
 
-                    Type runtimeClassType = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType);
+                    Type runtimeClassType = ComWrappersSupport.GetRuntimeClassForTypeCreation(inspectable, ComWrappersSupport.CreateRCWType, out var isNullable);
                     if (runtimeClassType == null)
                     {
                         // If the external IInspectable has not implemented GetRuntimeClassName,
@@ -596,7 +596,14 @@ namespace WinRT
                         return inspectable;
                     }
 
-                    return ComWrappersSupport.GetTypedRcwFactory(runtimeClassType)(inspectable);
+                    if (isNullable)
+                    {
+                        return ABI.System.NullableObject.GetValue(runtimeClassType, inspectable);
+                    }
+                    else
+                    {
+                        return ComWrappersSupport.GetTypedRcwFactory(runtimeClassType)(inspectable);
+                    }
                 }
                 else if (Marshal.QueryInterface(externalComObject, ref weakReferenceIID, out ptr) == 0)
                 {

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -62,9 +62,8 @@ namespace WinRT
                     }
                     else
                     {
-                        Type runtimeClassType = GetRuntimeClassForTypeCreation(inspectable, typeof(T), out var isNullable);
-                        runtimeWrapper = runtimeClassType == null ? inspectable : 
-                          (isNullable ? ABI.System.NullableObject.GetValue(runtimeClassType, inspectable) : GetTypedRcwFactory(runtimeClassType)(inspectable));
+                        Type runtimeClassType = GetRuntimeClassForTypeCreation(inspectable, typeof(T));
+                        runtimeWrapper = runtimeClassType == null ? inspectable : TypedObjectFactoryCacheForType.GetOrAdd(runtimeClassType, classType => CreateTypedRcwFactory(classType))(inspectable);
                     }
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -60,8 +60,9 @@ namespace WinRT
                     }
                     else
                     {
-                        Type runtimeClassType = GetRuntimeClassForTypeCreation(inspectable, typeof(T));
-                        runtimeWrapper = runtimeClassType == null ? inspectable : TypedObjectFactoryCacheForType.GetOrAdd(runtimeClassType, classType => CreateTypedRcwFactory(classType))(inspectable);
+                        Type runtimeClassType = GetRuntimeClassForTypeCreation(inspectable, typeof(T), out var isNullable);
+                        runtimeWrapper = runtimeClassType == null ? inspectable : 
+                          (isNullable ? ABI.System.NullableObject.GetValue(runtimeClassType, inspectable) : TypedObjectFactoryCacheForType.GetOrAdd(runtimeClassType, classType => CreateTypedRcwFactory(classType))(inspectable));
                     }
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1389,6 +1389,16 @@ namespace WinRT
         private static Type HelperType => _HelperType ??= typeof(T).GetHelperType();
 
         private static Func<T, IObjectReference> _CreateMarshaler;
+
+        // We are here using CreateIID on the projected type rather than GetIID on the helper type
+        // This allows us to avoid needing to do MakeGenericType calls or 
+        // registration of helper types for projected generic types like System.Nullable<>.
+        // By using CreateIID with the projected type, we are still able to get the IID
+        // but at the same time don't need the generic instance of the helper type to do so.
+        // In addition, other than for that, we don't need the helper type in MarshalInterface.
+        // This does mean we are doing the PIID calculation here instead of using the cached
+        // one in the helper type, but we are also caching it here too so it should be only
+        // one additional call.
         private static object _Iid;
         private static Guid IID => (Guid)(_Iid ??= GuidGenerator.CreateIID(typeof(T)));
 

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -8,6 +8,11 @@ MembersMustExist : Member 'public System.ValueTuple<System.Int32, System.IntPtr>
 MembersMustExist : Member 'public System.ValueTuple<System.Int32, System.IntPtr> ABI.System.EventHandler<T>.GetAbiArray(System.Object)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.System.EventHandlerMethods<T, TAbi>' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.System.IDisposableMethods' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'ABI.System.IServiceProviderMethods' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.System.Nullable<T>.As<A>()' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.System.Nullable<T>.As<A>()' in the implementation but not the reference.
+MembersMustExist : Member 'public T ABI.System.Nullable<T>.GetValue(WinRT.IInspectable)' does not exist in the reference but it does exist in the implementation.
+CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the reference.
 MembersMustExist : Member 'public void ABI.System.Uri.CopyAbiArray(System.Uri[], System.Object)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.MarshalInterfaceHelper<System.Uri>.MarshalerArray ABI.System.Uri.CreateMarshalerArray(System.Uri[])' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void ABI.System.Uri.DisposeMarshalerArray(WinRT.MarshalInterfaceHelper<System.Uri>.MarshalerArray)' does not exist in the reference but it does exist in the implementation.
@@ -64,6 +69,8 @@ TypesMustExist : Type 'ABI.System.Collections.Generic.IReadOnlyListMethods<T, TA
 MembersMustExist : Member 'public System.IntPtr System.IntPtr ABI.System.Collections.Generic.KeyValuePair<K, V>.AbiToProjectionVftablePtr' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'protected WinRT.ObjectReference<WinRT.Interop.IUnknownVftbl> WinRT.ObjectReference<WinRT.Interop.IUnknownVftbl> ABI.System.Collections.Generic.KeyValuePair<K, V>._obj' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void ABI.System.Collections.Generic.KeyValuePair<K, V>..ctor(WinRT.ObjectReference<WinRT.Interop.IUnknownVftbl>)' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.System.Collections.Generic.KeyValuePair<K, V>.As<A>()' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.System.Collections.Generic.KeyValuePair<K, V>.As<A>()' in the implementation but not the reference.
 MembersMustExist : Member 'public void ABI.System.Collections.Generic.KeyValuePair<K, V>.CopyAbiArray(System.Collections.Generic.KeyValuePair<K, V>[], System.Object)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public ABI.System.Collections.Generic.KeyValuePair<K, V> ABI.System.Collections.Generic.KeyValuePair<K, V>.op_Implicit(WinRT.ObjectReference<WinRT.Interop.IUnknownVftbl>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReference<WinRT.Interop.IUnknownVftbl> ABI.System.Collections.Generic.KeyValuePair<K, V>._FromAbi(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
@@ -109,36 +116,35 @@ MembersMustExist : Member 'public System.ComponentModel.PropertyChangedEventHand
 MembersMustExist : Member 'public System.ValueTuple<System.Int32, System.IntPtr> ABI.System.ComponentModel.PropertyChangedEventHandler.FromManagedArray(System.ComponentModel.PropertyChangedEventHandler[])' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.ValueTuple<System.Int32, System.IntPtr> ABI.System.ComponentModel.PropertyChangedEventHandler.GetAbiArray(System.Object)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'ABI.System.Windows.Input.ICommandMethods' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.As<A>()' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.As<A>()' in the implementation but not the reference.
 TypesMustExist : Type 'ABI.WinRT.Interop.IActivationFactoryMethods' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'WinRT.WinRTExposedTypeAttribute' exists on 'Windows.Foundation.Point' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WinRTExposedTypeAttribute' exists on 'Windows.Foundation.Rect' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WinRTExposedTypeAttribute' exists on 'Windows.Foundation.Size' in the implementation but not the reference.
+TypesMustExist : Type 'WinRT.ActivationFactory' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterAuthoringMetadataTypeLookup(System.Func<System.Type, System.Type>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterComInterfaceEntries(System.Type, System.Runtime.InteropServices.ComWrappers.ComInterfaceEntry[])' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean WinRT.ComWrappersSupport.RegisterDelegateFactory(System.Type, System.Func<System.IntPtr, System.Object>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterHelperType(System.Type, System.Type)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterTypeComInterfaceEntriesLookup(System.Func<System.Type, System.Runtime.InteropServices.ComWrappers.ComInterfaceEntry[]>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean WinRT.ComWrappersSupport.RegisterTypedRcwFactory(System.Type, System.Func<WinRT.IInspectable, System.Object>)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.DelegateTypeDetails<T>' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'WinRT.WinRTExposedTypeAttribute' exists on 'WinRT.EventRegistrationToken' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeHelperTypeAttribute' exists on 'WinRT.EventRegistrationToken' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'WinRT.WindowsRuntimeTypeAttribute' exists on 'WinRT.EventRegistrationToken' in the implementation but not the reference.
+TypesMustExist : Type 'WinRT.EventRegistrationTokenTable<T>' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsFreeThreaded.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsInCurrentContext.get()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.IWinRTExposedTypeDetails' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.MarshalInspectable<T>.CopyAbiArray(T[], System.Object)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.ReadOnlySpan<System.Char> WinRT.MarshalString.FromAbiUnsafe(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.StructTypeDetails<T, TAbi>' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public void WinRT.WindowsRuntimeTypeAttribute..ctor(System.String, System.String)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribute.GuidSignature.get()' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public T ABI.System.Nullable<T>.GetValue(WinRT.IInspectable)' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.EventRegistrationTokenTable<T>' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsFreeThreaded.get()' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.IsInCurrentContext.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.Attach(System.IntPtr, System.Guid)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, System.Guid)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public WinRT.ObjectReference<T> WinRT.ObjectReference<T>.FromAbi(System.IntPtr, T, System.Guid)' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.ActivationFactory' does not exist in the reference but it does exist in the implementation.
-CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' on 'ABI.System.Type.FromAbi(ABI.System.Type)' changed from '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2057", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the implementation to '[UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification="Any types which are trimmed are not used by managed user code and there is fallback logic to handle that.")]' in the reference.
-CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.MarshalDelegate.FromAbi<T>(System.IntPtr)' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.ObjectReferenceWrapperAttribute' in the implementation but not the reference.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterDataErrorsChangedEventArgsMapping()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterDateTimeOffsetMapping()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterEventHandlerMapping()' does not exist in the reference but it does exist in the implementation.
@@ -198,16 +204,10 @@ MembersMustExist : Member 'public void WinRT.Projections.RegisterUriMapping()' d
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector2Mapping()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector3Mapping()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.Projections.RegisterVector4Mapping()' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.Interop.IID' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.StructTypeDetails<T, TAbi>' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public void WinRT.WindowsRuntimeTypeAttribute..ctor(System.String, System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.String WinRT.WindowsRuntimeTypeAttribute.GuidSignature.get()' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.WinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTImplementationTypeRcwFactoryAttribute' does not exist in the reference but it does exist in the implementation.
-CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.ObjectReferenceWrapperAttribute' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.System.Nullable<T>.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.System.Nullable<T>.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.System.Collections.Generic.KeyValuePair<K, V>.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.System.Collections.Generic.KeyValuePair<K, V>.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.As<A>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
-CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
-MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterHelperType(System.Type, System.Type)' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.Interop.IID' does not exist in the reference but it does exist in the implementation.
 Total Issues: 211

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -61,21 +61,6 @@ namespace WinRT
             RegisterCustomAbiTypeMappingNoLock(typeof(EventRegistrationToken), typeof(ABI.WinRT.EventRegistrationToken), "Windows.Foundation.EventRegistrationToken");
             
             RegisterCustomAbiTypeMappingNoLock(typeof(Nullable<>), typeof(ABI.System.Nullable<>), "Windows.Foundation.IReference`1");
-            RegisterCustomAbiTypeMappingNoLock(typeof(int?), typeof(ABI.System.Nullable_int), "Windows.Foundation.IReference`1<Int32>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(byte?), typeof(ABI.System.Nullable_byte), "Windows.Foundation.IReference`1<UInt8>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(sbyte?), typeof(ABI.System.Nullable_sbyte), "Windows.Foundation.IReference`1<Int8>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(short?), typeof(ABI.System.Nullable_short), "Windows.Foundation.IReference`1<Int16>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(ushort?), typeof(ABI.System.Nullable_ushort), "Windows.Foundation.IReference`1<UInt16>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(uint?), typeof(ABI.System.Nullable_uint), "Windows.Foundation.IReference`1<UInt32>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(long?), typeof(ABI.System.Nullable_long), "Windows.Foundation.IReference`1<Int64>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(ulong?), typeof(ABI.System.Nullable_ulong), "Windows.Foundation.IReference`1<UInt64>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(float?), typeof(ABI.System.Nullable_float), "Windows.Foundation.IReference`1<Single>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(double?), typeof(ABI.System.Nullable_double), "Windows.Foundation.IReference`1<Double>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(char?), typeof(ABI.System.Nullable_char), "Windows.Foundation.IReference`1<Char16>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(bool?), typeof(ABI.System.Nullable_bool), "Windows.Foundation.IReference`1<Boolean>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(Guid?), typeof(ABI.System.Nullable_guid), "Windows.Foundation.IReference`1<Guid>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(DateTimeOffset?), typeof(ABI.System.Nullable_DateTimeOffset), "Windows.Foundation.IReference`1<Windows.Foundation.DateTime>");
-            RegisterCustomAbiTypeMappingNoLock(typeof(TimeSpan?), typeof(ABI.System.Nullable_TimeSpan), "Windows.Foundation.IReference`1<TimeSpan>");
 
             RegisterCustomAbiTypeMappingNoLock(typeof(DateTimeOffset), typeof(ABI.System.DateTimeOffset), "Windows.Foundation.DateTime");
             RegisterCustomAbiTypeMappingNoLock(typeof(Exception), typeof(ABI.System.Exception), "Windows.Foundation.HResult");

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using ABI.System.ComponentModel;
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -18,6 +19,61 @@ namespace ABI.System.Windows.Input
         public static global::System.Guid IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0x42, 0x35, 0xAF, 0xE5, 0x67, 0xCA, 0x81, 0x40, 0x99, 0x5B, 0x70, 0x9D, 0xD1, 0x37, 0x92, 0xDF }));
 
         public static IntPtr AbiToProjectionVftablePtr => ICommand.Vftbl.AbiToProjectionVftablePtr;
+
+        public static unsafe bool CanExecute(IObjectReference obj, object parameter)
+        {
+            var ThisPtr = obj.ThisPtr;
+            ObjectReferenceValue __parameter = default;
+            byte __retval = default;
+            try
+            {
+                __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, byte*, int>**)ThisPtr)[8](ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), &__retval));
+                return __retval != 0;
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
+            }
+        }
+
+        public static unsafe void Execute(IObjectReference obj, object parameter)
+        {
+            var ThisPtr = obj.ThisPtr;
+            ObjectReferenceValue __parameter = default;
+            try
+            {
+                __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)ThisPtr)[9](ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
+            }
+            finally
+            {
+                MarshalInspectable<object>.DisposeMarshaler(__parameter);
+            }
+        }
+
+        private volatile static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventHandlerEventSource> _CanExecuteChanged;
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventHandlerEventSource> MakeCanExecuteChangedTable()
+        {
+            global::System.Threading.Interlocked.CompareExchange(ref _CanExecuteChanged, new(), null);
+            return _CanExecuteChanged;
+        }
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventHandlerEventSource> CanExecuteChanged => _CanExecuteChanged ?? MakeCanExecuteChangedTable();
+
+        public static unsafe (global::System.Action<global::System.EventHandler>,
+                              global::System.Action<global::System.EventHandler>)
+            Get_CanExecuteChanged(IObjectReference obj, object thisObj)
+        {
+            var eventSource = CanExecuteChanged.GetValue(thisObj, (key) =>
+            {
+                var ThisPtr = obj.ThisPtr;
+
+                return new EventHandlerEventSource(obj,
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>**)ThisPtr)[6],
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>**)ThisPtr)[7]);
+            });
+            return eventSource.EventActions;
+        }
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -49,8 +105,7 @@ namespace ABI.System.Windows.Input
                 {
                     IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
 
-                    _add_CanExecuteChanged_0 = (delegate* unmanaged<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*,
-                    int>)&Do_Abi_add_CanExecuteChanged_0,
+                    _add_CanExecuteChanged_0 = (delegate* unmanaged<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>)&Do_Abi_add_CanExecuteChanged_0,
                     _remove_CanExecuteChanged_1 = (delegate* unmanaged<IntPtr, global::WinRT.EventRegistrationToken, int>)&Do_Abi_remove_CanExecuteChanged_1,
                     _CanExecute_2 = (delegate* unmanaged<IntPtr, IntPtr, byte*, int>)&Do_Abi_CanExecute_2,
                     _Execute_3 = (delegate* unmanaged<IntPtr, IntPtr, int>)&Do_Abi_Execute_3,
@@ -149,57 +204,35 @@ namespace ABI.System.Windows.Input
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static EventHandlerEventSource _CanExecuteChanged(IWinRTObject _this)
+        private static (global::System.Action<global::System.EventHandler>,
+                        global::System.Action<global::System.EventHandler>)
+            _CanExecuteChanged(IWinRTObject _this)
         {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle));
-
-            return (EventHandlerEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.Windows.Input.ICommand).TypeHandle,
-                () => new EventHandlerEventSource(_obj, _obj.Vftbl.add_CanExecuteChanged_0, _obj.Vftbl.remove_CanExecuteChanged_1));
+            var _obj = _this.GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle);
+            return ICommandMethods.Get_CanExecuteChanged(_obj, _this);
         }
 
         unsafe bool global::System.Windows.Input.ICommand.CanExecute(object parameter)
         {
-            ObjectReferenceValue __parameter = default;
-            byte __retval = default;
-            try
-            {
-                var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle));
-                var ThisPtr = _obj.ThisPtr;
-                __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), &__retval));
-                return __retval != 0;
-            }
-            finally
-            {
-                MarshalInspectable<object>.DisposeMarshaler(__parameter);
-            }
+            var obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle);
+            return ICommandMethods.CanExecute(obj, parameter);
         }
 
         unsafe void global::System.Windows.Input.ICommand.Execute(object parameter)
         {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle));
-            var ThisPtr = _obj.ThisPtr;
-            ObjectReferenceValue __parameter = default;
-            try
-            {
-                __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
-            }
-            finally
-            {
-                MarshalInspectable<object>.DisposeMarshaler(__parameter);
-            }
+            var obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Windows.Input.ICommand).TypeHandle);
+            ICommandMethods.Execute(obj, parameter);
         }
 
         event global::System.EventHandler global::System.Windows.Input.ICommand.CanExecuteChanged
         {
             add
             {
-                _CanExecuteChanged((IWinRTObject)this).Subscribe(value);
+                _CanExecuteChanged((IWinRTObject)this).Item1(value);
             }
             remove
             {
-                _CanExecuteChanged((IWinRTObject)this).Unsubscribe(value);
+                _CanExecuteChanged((IWinRTObject)this).Item2(value);
             }
         }
     }

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
@@ -26,7 +26,7 @@ namespace ABI.System.Collections.Specialized
 
         public static unsafe (Action<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>, Action<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>) Get_CollectionChanged(IObjectReference obj, object thisObj)
         {
-            var eventSource = _CollectionChanged.GetValue(thisObj, (key) =>
+            var eventSource = CollectionChanged.GetValue(thisObj, (key) =>
             {
                 var ThisPtr = obj.ThisPtr;
 
@@ -127,7 +127,7 @@ namespace ABI.System.Collections.Specialized
 
         private static (Action<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>, Action<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler>) _CollectionChanged(IWinRTObject _this)
         {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle));
+            var _obj = _this.GetObjectReferenceForType(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle);
             return INotifyCollectionChangedMethods.Get_CollectionChanged(_obj, _this);
         }
 

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using ABI.System.Collections.Specialized;
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -19,6 +20,61 @@ namespace ABI.System.ComponentModel
         public static global::System.Guid IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0xCC, 0xC2, 0xE6, 0x0E, 0x3E, 0x27, 0x7D, 0x56, 0xBC, 0x0A, 0x1D, 0xD8, 0x7E, 0xE5, 0x1E, 0xBA }));
 
         public static IntPtr AbiToProjectionVftablePtr => INotifyDataErrorInfo.Vftbl.AbiToProjectionVftablePtr;
+
+        public static unsafe bool get_HasErrors(IObjectReference obj)
+        {
+            var ThisPtr = obj.ThisPtr;
+            byte __retval = default;
+            global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[6](ThisPtr, &__retval));
+            return __retval != 0;
+        }
+
+        public static unsafe global::System.Collections.IEnumerable GetErrors(IObjectReference obj, string propertyName)
+        {
+            var ThisPtr = obj.ThisPtr;
+            IntPtr __retval = default;
+            try
+            {
+                MarshalString.Pinnable __propertyName = new(propertyName);
+                fixed (void* ___propertyName = __propertyName)
+                {
+                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>**)ThisPtr)[9](
+                        ThisPtr,
+                        MarshalString.GetAbi(ref __propertyName),
+                        &__retval));
+                    return (global::ABI.System.Collections.Generic.IEnumerable<object>)(object)IInspectable.FromAbi(__retval);
+                }
+            }
+            finally
+            {
+                global::ABI.System.Collections.Generic.IEnumerable<object>.DisposeAbi(__retval);
+            }
+        }
+
+        private volatile static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>> _ErrorsChanged;
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>> MakeErrorsChangedTable()
+        {
+            global::System.Threading.Interlocked.CompareExchange(ref _ErrorsChanged, new(), null);
+            return _ErrorsChanged;
+        }
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>> ErrorsChanged => _ErrorsChanged ?? MakeErrorsChangedTable();
+
+
+        public static unsafe (global::System.Action<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>, 
+                              global::System.Action<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>) 
+            Get_ErrorsChanged(IObjectReference obj, object thisObj)
+        {
+            var eventSource = ErrorsChanged.GetValue(thisObj, (key) =>
+            {
+                var ThisPtr = obj.ThisPtr;
+
+                return new EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>(obj,
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>**)ThisPtr)[7],
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>**)ThisPtr)[8],
+                    0);
+            });
+            return eventSource.EventActions;
+        }
     }
 
     [DynamicInterfaceCastableImplementation]
@@ -145,53 +201,33 @@ namespace ABI.System.ComponentModel
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> _ErrorsChanged(IWinRTObject _this)
+        private static (global::System.Action<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>, 
+                        global::System.Action<global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>>)
+            _ErrorsChanged(IWinRTObject _this)
         {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)_this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle));
-            var ThisPtr = _obj.ThisPtr;
-            return (EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.Specialized.INotifyCollectionChanged).TypeHandle,
-                () => new EventSource__EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs>(_obj,
-                    _obj.Vftbl.add_ErrorsChanged_1,
-                    _obj.Vftbl.remove_ErrorsChanged_2,
-                    0));
+            var _obj = _this.GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle);
+            return INotifyDataErrorInfoMethods.Get_ErrorsChanged(_obj, _this);
         }
 
         unsafe global::System.Collections.IEnumerable global::System.ComponentModel.INotifyDataErrorInfo.GetErrors(string propertyName)
         {
-            var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle));
-            var ThisPtr = _obj.ThisPtr;
-            IntPtr __retval = default;
-            try
-            {
-                MarshalString.Pinnable __propertyName = new(propertyName);
-                fixed (void* ___propertyName = __propertyName)
-                {
-                    global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetErrors_3(ThisPtr, MarshalString.GetAbi(ref __propertyName), &__retval));
-                    return (global::ABI.System.Collections.Generic.IEnumerable<object>)(object)IInspectable.FromAbi(__retval);
-                }
-            }
-            finally
-            {
-                global::ABI.System.Collections.Generic.IEnumerable<object>.DisposeAbi(__retval);
-            }
+            var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle);
+            return INotifyDataErrorInfoMethods.GetErrors(_obj, propertyName);
         }
 
         unsafe bool global::System.ComponentModel.INotifyDataErrorInfo.HasErrors
         {
             get
             {
-                var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle));
-                var ThisPtr = _obj.ThisPtr;
-                byte __retval = default;
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_HasErrors_0(ThisPtr, &__retval));
-                return __retval != 0;
+                var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyDataErrorInfo).TypeHandle);
+                return INotifyDataErrorInfoMethods.get_HasErrors(_obj);
             }
         }
 
         event global::System.EventHandler<global::System.ComponentModel.DataErrorsChangedEventArgs> global::System.ComponentModel.INotifyDataErrorInfo.ErrorsChanged
         {
-            add => _ErrorsChanged((IWinRTObject)this).Subscribe(value);
-            remove => _ErrorsChanged((IWinRTObject)this).Unsubscribe(value);
+            add => _ErrorsChanged((IWinRTObject)this).Item1(value);
+            remove => _ErrorsChanged((IWinRTObject)this).Item2(value);
         }
     }
     

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
@@ -17,6 +17,29 @@ namespace ABI.System.ComponentModel
         public static global::System.Guid IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0x01, 0x76, 0xB1, 0x90, 0x65, 0xB0, 0x6E, 0x58, 0x83, 0xD9, 0x9A, 0xDC, 0x3A, 0x69, 0x52, 0x84 }));
 
         public static IntPtr AbiToProjectionVftablePtr => INotifyPropertyChanged.Vftbl.AbiToProjectionVftablePtr;
+
+        private volatile static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, PropertyChangedEventSource> _PropertyChanged;
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, PropertyChangedEventSource> MakePropertyChangedTable()
+        {
+            global::System.Threading.Interlocked.CompareExchange(ref _PropertyChanged, new(), null);
+            return _PropertyChanged;
+        }
+        private static global::System.Runtime.CompilerServices.ConditionalWeakTable<object, PropertyChangedEventSource> PropertyChanged => _PropertyChanged ?? MakePropertyChangedTable();
+
+        public static unsafe (global::System.Action<global::System.ComponentModel.PropertyChangedEventHandler>,
+                              global::System.Action<global::System.ComponentModel.PropertyChangedEventHandler>)
+            Get_PropertyChanged(IObjectReference obj, object thisObj)
+        {
+            var eventSource = PropertyChanged.GetValue(thisObj, (key) =>
+            {
+                var ThisPtr = obj.ThisPtr;
+
+                return new PropertyChangedEventSource(obj,
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, global::WinRT.EventRegistrationToken*, int>**)ThisPtr)[6],
+                    (*(delegate* unmanaged[Stdcall]<IntPtr, global::WinRT.EventRegistrationToken, int>**)ThisPtr)[7]);
+            });
+            return eventSource.EventActions;
+        }
     }
 
     [DynamicInterfaceCastableImplementation]
@@ -101,19 +124,18 @@ namespace ABI.System.ComponentModel
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
 
-        private static PropertyChangedEventSource _PropertyChanged(IWinRTObject _this)
+        private static (global::System.Action<global::System.ComponentModel.PropertyChangedEventHandler>,
+                        global::System.Action<global::System.ComponentModel.PropertyChangedEventHandler>)
+            _PropertyChanged(IWinRTObject _this)
         {
-            var _obj = (ObjectReference<Vftbl>)_this.GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle);
-            
-            return (PropertyChangedEventSource)_this.GetOrCreateTypeHelperData(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle,
-                () => new PropertyChangedEventSource(_obj, _obj.Vftbl.add_PropertyChanged_0, _obj.Vftbl.remove_PropertyChanged_1));
+            var _obj = _this.GetObjectReferenceForType(typeof(global::System.ComponentModel.INotifyPropertyChanged).TypeHandle);
+            return INotifyPropertyChangedMethods.Get_PropertyChanged(_obj, _this);
         }
 
         event global::System.ComponentModel.PropertyChangedEventHandler global::System.ComponentModel.INotifyPropertyChanged.PropertyChanged
         {
-            add => _PropertyChanged((IWinRTObject)this).Subscribe(value);
-            remove => _PropertyChanged((IWinRTObject)this).Unsubscribe(value);
+            add => _PropertyChanged((IWinRTObject)this).Item1(value);
+            remove => _PropertyChanged((IWinRTObject)this).Item2(value);
         }
-
     }
 }

--- a/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
@@ -2,69 +2,35 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
 
 namespace ABI.System
 {
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [Guid("68B3A2DF-8173-539F-B524-C8A2348F5AFB")]
-    [DynamicInterfaceCastableImplementation]
-    internal unsafe interface IServiceProvider : global::System.IServiceProvider
+#if EMBED
+    internal
+#else
+    public
+#endif
+    static class IServiceProviderMethods
     {
-        [Guid("68B3A2DF-8173-539F-B524-C8A2348F5AFB")]
-#pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
-        public struct Vftbl
-#pragma warning restore CA2257
-        {
-            internal IInspectable.Vftbl IInspectableVftbl;
+        public static global::System.Guid IID { get; } = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0xDF, 0xA2, 0xB3, 0x68, 0x73, 0x81, 0x9F, 0x53, 0xB5, 0x24, 0xC8, 0xA2, 0x34, 0x8F, 0x5A, 0xFB }));
 
-            public delegate* unmanaged<IntPtr, global::ABI.System.Type, IntPtr*, int> GetService_0;
+        public static IntPtr AbiToProjectionVftablePtr => IServiceProvider.AbiToProjectionVftablePtr;
 
-            public static readonly IntPtr AbiToProjectionVftablePtr;
-
-            static unsafe Vftbl()
-            {
-                AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(global::WinRT.IInspectable.Vftbl) + sizeof(IntPtr) * 4);
-                (*(Vftbl*)AbiToProjectionVftablePtr) = new Vftbl
-                {
-                    IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,
-                    GetService_0 = (delegate* unmanaged<IntPtr, global::ABI.System.Type, IntPtr*, int>)&Do_Abi_GetService_0
-                };
-            }
-
-            [UnmanagedCallersOnly]
-            private static unsafe int Do_Abi_GetService_0(IntPtr thisPtr, global::ABI.System.Type type, IntPtr* result)
-            {
-                object __result = default;
-
-                *result = default;
-
-                try
-                {
-                    __result = global::WinRT.ComWrappersSupport.FindObject<global::System.IServiceProvider>(thisPtr).GetService(global::ABI.System.Type.FromAbi(type));
-                    *result = MarshalInspectable<object>.FromManaged(__result);
-                }
-                catch (global::System.Exception __exception__)
-                {
-                    global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
-                    return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
-                }
-                return 0;
-            }
-        }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
-
-        unsafe object global::System.IServiceProvider.GetService(global::System.Type type)
+        public static unsafe object GetService(IObjectReference obj, global::System.Type type)
         {
             global::ABI.System.Type.Marshaler __type = default;
             IntPtr __retval = default;
             try
             {
-                var _obj = ((ObjectReference<Vftbl>)((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.IServiceProvider).TypeHandle));
-                var ThisPtr = _obj.ThisPtr;
+                var ThisPtr = obj.ThisPtr;
                 __type = global::ABI.System.Type.CreateMarshaler(type);
-                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetService_0(ThisPtr, global::ABI.System.Type.GetAbi(__type), &__retval));
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, global::ABI.System.Type, IntPtr*, int>**)ThisPtr)[6](
+                    ThisPtr,
+                    global::ABI.System.Type.GetAbi(__type),
+                    &__retval));
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
@@ -72,6 +38,47 @@ namespace ABI.System
                 global::ABI.System.Type.DisposeMarshaler(__type);
                 MarshalInspectable<object>.DisposeAbi(__retval);
             }
+        }
+    }
+
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [Guid("68B3A2DF-8173-539F-B524-C8A2348F5AFB")]
+    [DynamicInterfaceCastableImplementation]
+    internal unsafe interface IServiceProvider : global::System.IServiceProvider
+    {
+        public static readonly IntPtr AbiToProjectionVftablePtr;
+
+        static unsafe IServiceProvider()
+        {
+            AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(IServiceProvider), sizeof(IInspectable.Vftbl) + sizeof(IntPtr) * 1);
+            *(IInspectable.Vftbl*)AbiToProjectionVftablePtr = IInspectable.Vftbl.AbiToProjectionVftable;
+            ((delegate* unmanaged[Stdcall]<IntPtr, global::ABI.System.Type, IntPtr*, int>*)AbiToProjectionVftablePtr)[6] = &Do_Abi_GetService_0;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+        private static unsafe int Do_Abi_GetService_0(IntPtr thisPtr, global::ABI.System.Type type, IntPtr* result)
+        {
+            object __result = default;
+
+            *result = default;
+
+            try
+            {
+                __result = global::WinRT.ComWrappersSupport.FindObject<global::System.IServiceProvider>(thisPtr).GetService(global::ABI.System.Type.FromAbi(type));
+                *result = MarshalInspectable<object>.FromManaged(__result);
+            }
+            catch (global::System.Exception __exception__)
+            {
+                global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
+                return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+            }
+            return 0;
+        }
+
+        unsafe object global::System.IServiceProvider.GetService(global::System.Type type)
+        {
+            var obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.IServiceProvider).TypeHandle);
+            return IServiceProviderMethods.GetService(obj, type);
         }
     }
 

--- a/src/WinRT.Runtime/Projections/IServiceProvider.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IServiceProvider.netstandard2.0.cs
@@ -30,7 +30,7 @@ namespace ABI.System
 
             static unsafe Vftbl()
             {
-                AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 4);
+                AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), Marshal.SizeOf<global::WinRT.IInspectable.Vftbl>() + sizeof(IntPtr) * 1);
                 (*(Vftbl*)AbiToProjectionVftablePtr) = new Vftbl
                 {
                     IInspectableVftbl = global::WinRT.IInspectable.Vftbl.AbiToProjectionVftable,

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2304,8 +2304,14 @@ namespace ABI.System
                     throw new NotSupportedException($"Failed to get the value from nullable with type '{type}'.");
                 }
 #endif
-
-                return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable).MakeGenericType(type))(inspectable);
+                if (type.IsDelegate())
+                {
+                    return ComWrappersSupport.GetTypedRcwFactory(typeof(ABI.System.Nullable_Delegate<>).MakeGenericType(type))(inspectable);
+                }
+                else
+                {
+                    return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable<>).MakeGenericType(type))(inspectable);
+                }
             }
         }
     }

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2242,9 +2242,33 @@ namespace ABI.System
     {
         public static object GetValue(global::System.Type type, IInspectable inspectable)
         {
-            object obj = GetValue(type, inspectable);
-            ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
-            return obj;
+            object obj;
+#if NET
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                obj = GetValue(type, inspectable);
+                ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
+                return obj;
+            }
+#endif
+
+            obj = GetValue(type, inspectable);
+            if (obj != null)
+            {
+                ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
+                return obj;
+            } // fallback for .NET standard and pre-existing projections.
+            else
+            {
+                if (type.IsDelegate())
+                {
+                    return ComWrappersSupport.GetTypedRcwFactory(typeof(Nullable_Delegate<>).MakeGenericType(type))(inspectable);
+                }
+                else
+                {
+                    return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable<>).MakeGenericType(type))(inspectable);
+                }
+            }
 
             static object GetValue(global::System.Type type, IInspectable inspectable)
             {
@@ -2304,14 +2328,8 @@ namespace ABI.System
                     throw new NotSupportedException($"Failed to get the value from nullable with type '{type}'.");
                 }
 #endif
-                if (type.IsDelegate())
-                {
-                    return ComWrappersSupport.GetTypedRcwFactory(typeof(ABI.System.Nullable_Delegate<>).MakeGenericType(type))(inspectable);
-                }
-                else
-                {
-                    return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable<>).MakeGenericType(type))(inspectable);
-                }
+
+                return null;
             }
         }
     }

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -404,6 +404,7 @@ namespace ABI.System
             if (typeof(T) == typeof(float)) return Nullable_float.IID;
             if (typeof(T) == typeof(double)) return Nullable_double.IID;
             if (typeof(T) == typeof(Guid)) return Nullable_guid.IID;
+            if (typeof(T) == typeof(global::System.Type)) return Nullable_Type.IID;
             if (typeof(T) == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.IID;
             if (typeof(T) == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.IID;
             if (typeof(T) == typeof(global::Windows.Foundation.Point)) return IReferenceIIDs.IReferenceOfPoint_IID;
@@ -2149,6 +2150,23 @@ namespace ABI.System
         {
             return GuidGenerator.CreateIIDForGenericType("pinterface({61c17706-2d65-11e0-9ae8-d48564015472};enum(" + enumType.FullName + ";i4))");
         }
+
+        internal static unsafe object GetValue(global::System.Type enumType, IInspectable inspectable)
+        {
+            var IID = GetIID(enumType);
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                int __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return Enum.ToObject(enumType, __retval);
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
     }
 
     internal static class Nullable_FlagsEnum
@@ -2194,6 +2212,23 @@ namespace ABI.System
         {
             return GuidGenerator.CreateIIDForGenericType("pinterface({61c17706-2d65-11e0-9ae8-d48564015472};enum(" + enumType.FullName + ";u4))");
         }
+
+        internal static unsafe object GetValue(global::System.Type enumType, IInspectable inspectable)
+        {
+            var IID = GetIID(enumType);
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                uint __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return Enum.ToObject(enumType, __retval);
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
     }
 
     internal static class Nullable_Delegates
@@ -2201,6 +2236,52 @@ namespace ABI.System
         public unsafe delegate int GetValueDelegate(IntPtr thisPtr, IntPtr* value);
         public unsafe delegate int GetValueDelegateAbi(void* thisPtr, void* value);
         public unsafe delegate int GetValueDelegateAbiDateTimeOffset(void* ptr, DateTimeOffset* result);
+    }
+
+    internal static class NullableObject
+    {
+        public static object GetValue(global::System.Type type, IInspectable inspectable)
+        {
+            object obj = GetValue(type, inspectable);
+            ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
+            return obj;
+
+            static object GetValue(global::System.Type type, IInspectable inspectable)
+            {
+                if (type == typeof(string)) return Nullable_string.GetValue(inspectable);
+                if (type == typeof(int)) return Nullable_int.GetValue(inspectable);
+                if (type == typeof(byte)) return Nullable_byte.GetValue(inspectable);
+                if (type == typeof(bool)) return Nullable_bool.GetValue(inspectable);
+                if (type == typeof(sbyte)) return Nullable_sbyte.GetValue(inspectable);
+                if (type == typeof(short)) return Nullable_short.GetValue(inspectable);
+                if (type == typeof(ushort)) return Nullable_ushort.GetValue(inspectable);
+                if (type == typeof(char)) return Nullable_char.GetValue(inspectable);
+                if (type == typeof(uint)) return Nullable_uint.GetValue(inspectable);
+                if (type == typeof(long)) return Nullable_long.GetValue(inspectable);
+                if (type == typeof(ulong)) return Nullable_ulong.GetValue(inspectable);
+                if (type == typeof(float)) return Nullable_float.GetValue(inspectable);
+                if (type == typeof(double)) return Nullable_double.GetValue(inspectable);
+                if (type == typeof(Guid)) return Nullable_guid.GetValue(inspectable);
+                if (type == typeof(global::System.Type)) return Nullable_Type.GetValue(inspectable);
+                if (type == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.GetValue(inspectable);
+                if (type == typeof(global::System.Exception)) return Nullable_Exception.GetValue(inspectable);
+                if (type == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.GetValue(inspectable);
+                if (type == typeof(global::Windows.Foundation.Point)) return Nullable<global::Windows.Foundation.Point>.GetValue(inspectable);
+                if (type == typeof(global::Windows.Foundation.Size)) return Nullable<global::Windows.Foundation.Size>.GetValue(inspectable);
+                if (type == typeof(global::Windows.Foundation.Rect)) return Nullable<global::Windows.Foundation.Rect>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Matrix3x2)) return Nullable<global::System.Numerics.Matrix3x2>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Matrix4x4)) return Nullable<global::System.Numerics.Matrix4x4>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Plane)) return Nullable<global::System.Numerics.Plane>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Quaternion)) return Nullable<global::System.Numerics.Quaternion>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Vector2)) return Nullable<global::System.Numerics.Vector2>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Vector3)) return Nullable<global::System.Numerics.Vector3>.GetValue(inspectable);
+                if (type == typeof(global::System.Numerics.Vector4)) return Nullable<global::System.Numerics.Vector4>.GetValue(inspectable);
+                if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(int)) return Nullable_IntEnum.GetValue(type, inspectable);
+                if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(uint)) return Nullable_FlagsEnum.GetValue(type, inspectable);
+
+                return ComWrappersSupport.GetTypedRcwFactory(type)(inspectable);
+            }
+        }
     }
 
     internal static class IReferenceSignatures

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -386,17 +386,7 @@ namespace ABI.System
             }
         }
 
-        public static readonly Guid PIID = CreatePIID();
-
-        private static Guid CreatePIID()
-        {
-            var iid = NullableType.GetIIDForBuiltInType(typeof(T));
-            if (iid == default)
-            {
-                iid = GuidGenerator.CreateIID(typeof(Nullable<T>));
-            }
-            return iid;
-        }
+        public static readonly Guid PIID = NullableType.GetIID<T>();
 
         public static implicit operator Nullable<T>(IObjectReference obj) => (obj != null) ? new Nullable<T>(obj) : null;
         public static implicit operator Nullable<T>(ObjectReference<Vftbl> obj) => (obj != null) ? new Nullable<T>(obj) : null;
@@ -2008,7 +1998,7 @@ namespace ABI.System
 
     internal static class NullableBlittable<T> where T: unmanaged
     {
-        private readonly static Guid IID = NullableType.GetIIDForBuiltInType(typeof(T));
+        private readonly static Guid IID = NullableType.GetIID<T>();
 
         public static unsafe object GetValue(IInspectable inspectable)
         {
@@ -2029,36 +2019,36 @@ namespace ABI.System
 
     internal static class NullableType
     {
-        internal static Guid GetIIDForBuiltInType(global::System.Type type)
+        internal static Guid GetIID<T>()
         {
-            if (type == typeof(int)) return Nullable_int.IID;
-            if (type == typeof(byte)) return Nullable_byte.IID;
-            if (type == typeof(bool)) return Nullable_bool.IID;
-            if (type == typeof(sbyte)) return Nullable_sbyte.IID;
-            if (type == typeof(short)) return Nullable_short.IID;
-            if (type == typeof(ushort)) return Nullable_ushort.IID;
-            if (type == typeof(char)) return Nullable_char.IID;
-            if (type == typeof(uint)) return Nullable_uint.IID;
-            if (type == typeof(long)) return Nullable_long.IID;
-            if (type == typeof(ulong)) return Nullable_ulong.IID;
-            if (type == typeof(float)) return Nullable_float.IID;
-            if (type == typeof(double)) return Nullable_double.IID;
-            if (type == typeof(Guid)) return Nullable_guid.IID;
-            if (type == typeof(global::System.Type)) return Nullable_Type.IID;
-            if (type == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.IID;
-            if (type == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.IID;
-            if (type == typeof(global::Windows.Foundation.Point)) return IReferenceIIDs.IReferenceOfPoint_IID;
-            if (type == typeof(global::Windows.Foundation.Size)) return IReferenceIIDs.IReferenceOfSize_IID;
-            if (type == typeof(global::Windows.Foundation.Rect)) return IReferenceIIDs.IReferenceOfRect_IID;
-            if (type == typeof(global::System.Numerics.Matrix3x2)) return IReferenceIIDs.IReferenceMatrix3x2_IID;
-            if (type == typeof(global::System.Numerics.Matrix4x4)) return IReferenceIIDs.IReferenceMatrix4x4_IID;
-            if (type == typeof(global::System.Numerics.Plane)) return IReferenceIIDs.IReferencePlane_IID;
-            if (type == typeof(global::System.Numerics.Quaternion)) return IReferenceIIDs.IReferenceQuaternion_IID;
-            if (type == typeof(global::System.Numerics.Vector2)) return IReferenceIIDs.IReferenceVector2_IID;
-            if (type == typeof(global::System.Numerics.Vector3)) return IReferenceIIDs.IReferenceVector3_IID;
-            if (type == typeof(global::System.Numerics.Vector4)) return IReferenceIIDs.IReferenceVector4_IID;
+            if (typeof(T) == typeof(int)) return Nullable_int.IID;
+            if (typeof(T) == typeof(byte)) return Nullable_byte.IID;
+            if (typeof(T) == typeof(bool)) return Nullable_bool.IID;
+            if (typeof(T) == typeof(sbyte)) return Nullable_sbyte.IID;
+            if (typeof(T) == typeof(short)) return Nullable_short.IID;
+            if (typeof(T) == typeof(ushort)) return Nullable_ushort.IID;
+            if (typeof(T) == typeof(char)) return Nullable_char.IID;
+            if (typeof(T) == typeof(uint)) return Nullable_uint.IID;
+            if (typeof(T) == typeof(long)) return Nullable_long.IID;
+            if (typeof(T) == typeof(ulong)) return Nullable_ulong.IID;
+            if (typeof(T) == typeof(float)) return Nullable_float.IID;
+            if (typeof(T) == typeof(double)) return Nullable_double.IID;
+            if (typeof(T) == typeof(Guid)) return Nullable_guid.IID;
+            if (typeof(T) == typeof(global::System.Type)) return Nullable_Type.IID;
+            if (typeof(T) == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.IID;
+            if (typeof(T) == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.IID;
+            if (typeof(T) == typeof(global::Windows.Foundation.Point)) return IReferenceIIDs.IReferenceOfPoint_IID;
+            if (typeof(T) == typeof(global::Windows.Foundation.Size)) return IReferenceIIDs.IReferenceOfSize_IID;
+            if (typeof(T) == typeof(global::Windows.Foundation.Rect)) return IReferenceIIDs.IReferenceOfRect_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Matrix3x2)) return IReferenceIIDs.IReferenceMatrix3x2_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Matrix4x4)) return IReferenceIIDs.IReferenceMatrix4x4_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Plane)) return IReferenceIIDs.IReferencePlane_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Quaternion)) return IReferenceIIDs.IReferenceQuaternion_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Vector2)) return IReferenceIIDs.IReferenceVector2_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Vector3)) return IReferenceIIDs.IReferenceVector3_IID;
+            if (typeof(T) == typeof(global::System.Numerics.Vector4)) return IReferenceIIDs.IReferenceVector4_IID;
 
-            return default;
+            return GuidGenerator.CreateIID(typeof(Nullable<T>));
         }
 
         public static Func<IInspectable, object> GetValueFactory(global::System.Type type)

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2262,11 +2262,15 @@ namespace ABI.System
             {
                 if (type.IsDelegate())
                 {
+#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
                     return ComWrappersSupport.GetTypedRcwFactory(typeof(Nullable_Delegate<>).MakeGenericType(type))(inspectable);
+#pragma warning restore IL3050
                 }
                 else
                 {
+#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
                     return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable<>).MakeGenericType(type))(inspectable);
+#pragma warning restore IL3050
                 }
             }
 

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -390,36 +390,12 @@ namespace ABI.System
 
         private static Guid CreatePIID()
         {
-#if NET
-            if (typeof(T) == typeof(int)) return Nullable_int.IID;
-            if (typeof(T) == typeof(byte)) return Nullable_byte.IID;
-            if (typeof(T) == typeof(bool)) return Nullable_bool.IID;
-            if (typeof(T) == typeof(sbyte)) return Nullable_sbyte.IID;
-            if (typeof(T) == typeof(short)) return Nullable_short.IID;
-            if (typeof(T) == typeof(ushort)) return Nullable_ushort.IID;
-            if (typeof(T) == typeof(char)) return Nullable_char.IID;
-            if (typeof(T) == typeof(uint)) return Nullable_uint.IID;
-            if (typeof(T) == typeof(long)) return Nullable_long.IID;
-            if (typeof(T) == typeof(ulong)) return Nullable_ulong.IID;
-            if (typeof(T) == typeof(float)) return Nullable_float.IID;
-            if (typeof(T) == typeof(double)) return Nullable_double.IID;
-            if (typeof(T) == typeof(Guid)) return Nullable_guid.IID;
-            if (typeof(T) == typeof(global::System.Type)) return Nullable_Type.IID;
-            if (typeof(T) == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.IID;
-            if (typeof(T) == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.IID;
-            if (typeof(T) == typeof(global::Windows.Foundation.Point)) return IReferenceIIDs.IReferenceOfPoint_IID;
-            if (typeof(T) == typeof(global::Windows.Foundation.Size)) return IReferenceIIDs.IReferenceOfSize_IID;
-            if (typeof(T) == typeof(global::Windows.Foundation.Rect)) return IReferenceIIDs.IReferenceOfRect_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Matrix3x2)) return IReferenceIIDs.IReferenceMatrix3x2_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Matrix4x4)) return IReferenceIIDs.IReferenceMatrix4x4_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Plane)) return IReferenceIIDs.IReferencePlane_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Quaternion)) return IReferenceIIDs.IReferenceQuaternion_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Vector2)) return IReferenceIIDs.IReferenceVector2_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Vector3)) return IReferenceIIDs.IReferenceVector3_IID;
-            if (typeof(T) == typeof(global::System.Numerics.Vector4)) return IReferenceIIDs.IReferenceVector4_IID;
-#endif
-
-            return GuidGenerator.CreateIID(typeof(Nullable<T>));
+            var iid = NullableType.GetIIDForBuiltInType(typeof(T));
+            if (iid == default)
+            {
+                iid = GuidGenerator.CreateIID(typeof(Nullable<T>));
+            }
+            return iid;
         }
 
         public static implicit operator Nullable<T>(IObjectReference obj) => (obj != null) ? new Nullable<T>(obj) : null;
@@ -595,22 +571,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe int GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                int __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("fd416dfb-2a07-52eb-aae3-dfce14116c05")]
@@ -750,22 +710,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe byte GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                byte __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("95500129-fbf6-5afc-89df-70642d741990")]
@@ -825,22 +769,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe sbyte GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                sbyte __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, sbyte*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -904,22 +832,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe short GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                short __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, short*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("5ab7d2c3-6b62-5e71-a4b6-2d49c4f238fd")]
@@ -979,22 +891,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe ushort GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                ushort __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, ushort*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -1058,22 +954,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe uint GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                uint __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("4dda9e24-e69f-5c6a-a0a6-93427365af2a")]
@@ -1133,22 +1013,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe long GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                long __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, long*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -1212,22 +1076,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe ulong GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                ulong __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, ulong*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("719cc2ba-3e76-5def-9f1a-38d85a145ea8")]
@@ -1287,22 +1135,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe float GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                float __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, float*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -1366,22 +1198,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe double GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                double __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, double*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("fb393ef3-bbac-5bd5-9144-84f23576f415")]
@@ -1441,22 +1257,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe char GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                char __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, char*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -1520,22 +1320,6 @@ namespace ABI.System
                 return 0;
             }
         }
-
-        public static unsafe bool GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                bool __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, bool*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
-            }
-        }
     }
 
     [Guid("7d50f649-632c-51f9-849a-ee49428933ea")]
@@ -1595,22 +1379,6 @@ namespace ABI.System
                     return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
                 }
                 return 0;
-            }
-        }
-
-        public static unsafe Guid GetValue(IInspectable inspectable)
-        {
-            IntPtr nullablePtr = IntPtr.Zero;
-            try
-            {
-                Guid __retval = default;
-                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
-                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, int>**)nullablePtr)[6](nullablePtr, &__retval));
-                return __retval;
-            }
-            finally
-            {
-                Marshal.Release(nullablePtr);
             }
         }
     }
@@ -1675,7 +1443,7 @@ namespace ABI.System
             }
         }
 
-        public static unsafe global::System.DateTimeOffset GetValue(IInspectable inspectable)
+        public static unsafe object GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             DateTimeOffset __retval = default;
@@ -1753,7 +1521,7 @@ namespace ABI.System
             }
         }
 
-        public static unsafe global::System.TimeSpan GetValue(IInspectable inspectable)
+        public static unsafe object GetValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             TimeSpan __retval = default;
@@ -2238,103 +2006,136 @@ namespace ABI.System
         public unsafe delegate int GetValueDelegateAbiDateTimeOffset(void* ptr, DateTimeOffset* result);
     }
 
-    internal static class NullableObject
+    internal static class NullableBlittable<T> where T: unmanaged
     {
-        public static object GetValue(global::System.Type type, IInspectable inspectable)
+        private readonly static Guid IID = NullableType.GetIIDForBuiltInType(typeof(T));
+
+        public static unsafe object GetValue(IInspectable inspectable)
         {
-            object obj;
+            IntPtr nullablePtr = IntPtr.Zero;
+            try
+            {
+                T __retval = default;
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in IID), out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return __retval;
+            }
+            finally
+            {
+                Marshal.Release(nullablePtr);
+            }
+        }
+    }
+
+    internal static class NullableType
+    {
+        internal static Guid GetIIDForBuiltInType(global::System.Type type)
+        {
+            if (type == typeof(int)) return Nullable_int.IID;
+            if (type == typeof(byte)) return Nullable_byte.IID;
+            if (type == typeof(bool)) return Nullable_bool.IID;
+            if (type == typeof(sbyte)) return Nullable_sbyte.IID;
+            if (type == typeof(short)) return Nullable_short.IID;
+            if (type == typeof(ushort)) return Nullable_ushort.IID;
+            if (type == typeof(char)) return Nullable_char.IID;
+            if (type == typeof(uint)) return Nullable_uint.IID;
+            if (type == typeof(long)) return Nullable_long.IID;
+            if (type == typeof(ulong)) return Nullable_ulong.IID;
+            if (type == typeof(float)) return Nullable_float.IID;
+            if (type == typeof(double)) return Nullable_double.IID;
+            if (type == typeof(Guid)) return Nullable_guid.IID;
+            if (type == typeof(global::System.Type)) return Nullable_Type.IID;
+            if (type == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.IID;
+            if (type == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.IID;
+            if (type == typeof(global::Windows.Foundation.Point)) return IReferenceIIDs.IReferenceOfPoint_IID;
+            if (type == typeof(global::Windows.Foundation.Size)) return IReferenceIIDs.IReferenceOfSize_IID;
+            if (type == typeof(global::Windows.Foundation.Rect)) return IReferenceIIDs.IReferenceOfRect_IID;
+            if (type == typeof(global::System.Numerics.Matrix3x2)) return IReferenceIIDs.IReferenceMatrix3x2_IID;
+            if (type == typeof(global::System.Numerics.Matrix4x4)) return IReferenceIIDs.IReferenceMatrix4x4_IID;
+            if (type == typeof(global::System.Numerics.Plane)) return IReferenceIIDs.IReferencePlane_IID;
+            if (type == typeof(global::System.Numerics.Quaternion)) return IReferenceIIDs.IReferenceQuaternion_IID;
+            if (type == typeof(global::System.Numerics.Vector2)) return IReferenceIIDs.IReferenceVector2_IID;
+            if (type == typeof(global::System.Numerics.Vector3)) return IReferenceIIDs.IReferenceVector3_IID;
+            if (type == typeof(global::System.Numerics.Vector4)) return IReferenceIIDs.IReferenceVector4_IID;
+
+            return default;
+        }
+
+        public static Func<IInspectable, object> GetValueFactory(global::System.Type type)
+        {
+            return ComWrappersSupport.CreateReferenceCachingFactory(GetValueFactoryInternal(type));
+        }
+
+        private static Func<IInspectable, object> GetValueFactoryInternal(global::System.Type type)
+        {
+            if (type == typeof(string)) return Nullable_string.GetValue;
+            if (type == typeof(int)) return NullableBlittable<int>.GetValue;
+            if (type == typeof(byte)) return NullableBlittable<byte>.GetValue;
+            if (type == typeof(bool)) return NullableBlittable<bool>.GetValue;
+            if (type == typeof(sbyte)) return NullableBlittable<sbyte>.GetValue;
+            if (type == typeof(short)) return NullableBlittable<short>.GetValue;
+            if (type == typeof(ushort)) return NullableBlittable<ushort>.GetValue;
+            if (type == typeof(char)) return NullableBlittable<char>.GetValue;
+            if (type == typeof(uint)) return NullableBlittable<uint>.GetValue;
+            if (type == typeof(long)) return NullableBlittable<long>.GetValue;
+            if (type == typeof(ulong)) return NullableBlittable<ulong>.GetValue;
+            if (type == typeof(float)) return NullableBlittable<float>.GetValue;
+            if (type == typeof(double)) return NullableBlittable<double>.GetValue;
+            if (type == typeof(Guid)) return NullableBlittable<Guid>.GetValue;
+            if (type == typeof(global::System.Type)) return Nullable_Type.GetValue;
+            if (type == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.GetValue;
+            if (type == typeof(global::System.Exception)) return Nullable_Exception.GetValue;
+            if (type == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.GetValue;
+            if (type == typeof(global::Windows.Foundation.Point)) return NullableBlittable<global::Windows.Foundation.Point>.GetValue;
+            if (type == typeof(global::Windows.Foundation.Size)) return NullableBlittable<global::Windows.Foundation.Size>.GetValue;
+            if (type == typeof(global::Windows.Foundation.Rect)) return NullableBlittable<global::Windows.Foundation.Rect>.GetValue;
+            if (type == typeof(global::System.Numerics.Matrix3x2)) return NullableBlittable<global::System.Numerics.Matrix3x2>.GetValue;
+            if (type == typeof(global::System.Numerics.Matrix4x4)) return NullableBlittable<global::System.Numerics.Matrix4x4>.GetValue;
+            if (type == typeof(global::System.Numerics.Plane)) return NullableBlittable<global::System.Numerics.Plane>.GetValue;
+            if (type == typeof(global::System.Numerics.Quaternion)) return NullableBlittable<global::System.Numerics.Quaternion>.GetValue;
+            if (type == typeof(global::System.Numerics.Vector2)) return NullableBlittable<global::System.Numerics.Vector2>.GetValue;
+            if (type == typeof(global::System.Numerics.Vector3)) return NullableBlittable<global::System.Numerics.Vector3>.GetValue;
+            if (type == typeof(global::System.Numerics.Vector4)) return NullableBlittable<global::System.Numerics.Vector4>.GetValue;
+            if (type == typeof(global::System.EventHandler)) return Nullable_EventHandler.GetValue;
+            if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(int)) return (inspectable) => Nullable_IntEnum.GetValue(type, inspectable);
+            if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(uint)) return (inspectable) => Nullable_FlagsEnum.GetValue(type, inspectable);
+
 #if NET
+            var winrtExposedClassAttribute = type.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+            if (winrtExposedClassAttribute == null)
+            {
+                var authoringMetadaType = type.GetAuthoringMetadataType();
+                if (authoringMetadaType != null)
+                {
+                    winrtExposedClassAttribute = authoringMetadaType.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+                }
+            }
+
+            if (winrtExposedClassAttribute != null && winrtExposedClassAttribute.WinRTExposedTypeDetails != null)
+            {
+                if (Activator.CreateInstance(winrtExposedClassAttribute.WinRTExposedTypeDetails) is IWinRTNullableTypeDetails nullableTypeDetails)
+                {
+                    return nullableTypeDetails.GetNullableValue;
+                }
+            }
+
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
-                obj = GetValue(type, inspectable);
-                ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
-                return obj;
+                throw new NotSupportedException($"Failed to get the value from nullable with type '{type}'.");
             }
 #endif
 
-            obj = GetValue(type, inspectable);
-            if (obj != null)
+            // Fallback for .NET standard and pre-existing projections.
+#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
+            if (type.IsDelegate())
             {
-                ComWrappersSupport.AddToBoxedValueCache(obj, inspectable);
-                return obj;
-            } // fallback for .NET standard and pre-existing projections.
+                return ComWrappersSupport.CreateAbiNullableTFactory(typeof(Nullable_Delegate<>).MakeGenericType(type));
+            }
             else
             {
-                if (type.IsDelegate())
-                {
-#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                    return ComWrappersSupport.GetTypedRcwFactory(typeof(Nullable_Delegate<>).MakeGenericType(type))(inspectable);
-#pragma warning restore IL3050
-                }
-                else
-                {
-#pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                    return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable<>).MakeGenericType(type))(inspectable);
-#pragma warning restore IL3050
-                }
+                return ComWrappersSupport.CreateNullableTFactory(typeof(global::System.Nullable<>).MakeGenericType(type));
             }
-
-            static object GetValue(global::System.Type type, IInspectable inspectable)
-            {
-                if (type == typeof(string)) return Nullable_string.GetValue(inspectable);
-                if (type == typeof(int)) return Nullable_int.GetValue(inspectable);
-                if (type == typeof(byte)) return Nullable_byte.GetValue(inspectable);
-                if (type == typeof(bool)) return Nullable_bool.GetValue(inspectable);
-                if (type == typeof(sbyte)) return Nullable_sbyte.GetValue(inspectable);
-                if (type == typeof(short)) return Nullable_short.GetValue(inspectable);
-                if (type == typeof(ushort)) return Nullable_ushort.GetValue(inspectable);
-                if (type == typeof(char)) return Nullable_char.GetValue(inspectable);
-                if (type == typeof(uint)) return Nullable_uint.GetValue(inspectable);
-                if (type == typeof(long)) return Nullable_long.GetValue(inspectable);
-                if (type == typeof(ulong)) return Nullable_ulong.GetValue(inspectable);
-                if (type == typeof(float)) return Nullable_float.GetValue(inspectable);
-                if (type == typeof(double)) return Nullable_double.GetValue(inspectable);
-                if (type == typeof(Guid)) return Nullable_guid.GetValue(inspectable);
-                if (type == typeof(global::System.Type)) return Nullable_Type.GetValue(inspectable);
-                if (type == typeof(global::System.TimeSpan)) return Nullable_TimeSpan.GetValue(inspectable);
-                if (type == typeof(global::System.Exception)) return Nullable_Exception.GetValue(inspectable);
-                if (type == typeof(global::System.DateTimeOffset)) return Nullable_DateTimeOffset.GetValue(inspectable);
-                if (type == typeof(global::Windows.Foundation.Point)) return Nullable<global::Windows.Foundation.Point>.GetValue(inspectable);
-                if (type == typeof(global::Windows.Foundation.Size)) return Nullable<global::Windows.Foundation.Size>.GetValue(inspectable);
-                if (type == typeof(global::Windows.Foundation.Rect)) return Nullable<global::Windows.Foundation.Rect>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Matrix3x2)) return Nullable<global::System.Numerics.Matrix3x2>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Matrix4x4)) return Nullable<global::System.Numerics.Matrix4x4>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Plane)) return Nullable<global::System.Numerics.Plane>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Quaternion)) return Nullable<global::System.Numerics.Quaternion>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Vector2)) return Nullable<global::System.Numerics.Vector2>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Vector3)) return Nullable<global::System.Numerics.Vector3>.GetValue(inspectable);
-                if (type == typeof(global::System.Numerics.Vector4)) return Nullable<global::System.Numerics.Vector4>.GetValue(inspectable);
-                if (type == typeof(global::System.EventHandler)) return Nullable_EventHandler.GetValue(inspectable);
-                if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(int)) return Nullable_IntEnum.GetValue(type, inspectable);
-                if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(uint)) return Nullable_FlagsEnum.GetValue(type, inspectable);
-
-#if NET
-                var winrtExposedClassAttribute = type.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
-                if (winrtExposedClassAttribute == null)
-                {
-                    var authoringMetadaType = type.GetAuthoringMetadataType();
-                    if (authoringMetadaType != null)
-                    {
-                        winrtExposedClassAttribute = authoringMetadaType.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
-                    }
-                }
-
-                if (winrtExposedClassAttribute != null && winrtExposedClassAttribute.WinRTExposedTypeDetails != null)
-                {                    
-                    if (Activator.CreateInstance(winrtExposedClassAttribute.WinRTExposedTypeDetails) is IWinRTNullableTypeDetails nullableTypeDetails)
-                    {
-                        return nullableTypeDetails.GetNullableValue(inspectable);
-                    }
-                }
-
-                if (!RuntimeFeature.IsDynamicCodeCompiled)
-                {
-                    throw new NotSupportedException($"Failed to get the value from nullable with type '{type}'.");
-                }
-#endif
-
-                return null;
-            }
+#pragma warning restore IL3050
         }
     }
 
@@ -2366,6 +2167,9 @@ namespace ABI.System
         internal static readonly Guid IReferenceVector3_IID = new(new ReadOnlySpan<byte>(new byte[] { 0xff, 0x70, 0xe7, 0x1e, 0x54, 0xc9, 0xca, 0x59, 0xa7, 0x54, 0x61, 0x99, 0xa9, 0xbe, 0x28, 0x2c }));
         internal static readonly Guid IReferenceVector4_IID = new(new ReadOnlySpan<byte>(new byte[] { 0xc9, 0x43, 0xe8, 0xa5, 0x20, 0xed, 0x39, 0x53, 0x8f, 0x8d, 0x9f, 0xe4, 0x04, 0xcf, 0x36, 0x54 }));
 #else
+        internal static readonly Guid IReferenceOfPoint_IID = new(0x84F14C22, 0xA00A, 0x5272, 0x8D, 0x3D, 0x82, 0x11, 0x2E, 0x66, 0xDF, 0x00);
+        internal static readonly Guid IReferenceOfSize_IID = new(0x61723086, 0x8E53, 0x5276, 0x9F, 0x36, 0x2A, 0x4B, 0xB9, 0x3E, 0x2B, 0x75);
+        internal static readonly Guid IReferenceOfRect_IID = new(0x80423F11, 0x054F, 0x5EAC, 0xAF, 0xD3, 0x63, 0xB6, 0xCE, 0x15, 0xE7, 0x7B);
         internal static readonly Guid IReferenceMatrix3x2_IID = new(0x76358cfd, 0x2cbd, 0x525b, 0xa4, 0x9e, 0x90, 0xee, 0x18, 0x24, 0x7b, 0x71);
         internal static readonly Guid IReferenceMatrix4x4_IID = new(0xdacbffdc, 0x68ef, 0x5fd0, 0xb6, 0x57, 0x78, 0x2d, 0x0a, 0xc9, 0x80, 0x7e);
         internal static readonly Guid IReferencePlane_IID = new(0x46d542a1, 0x52f7, 0x58e7, 0xac, 0xfc, 0x9a, 0x6d, 0x36, 0x4d, 0xa0, 0x22);
@@ -2382,7 +2186,7 @@ namespace ABI.System
 {
     internal interface IWinRTNullableTypeDetails
     {
-        ABI.System.Nullable GetNullableValue(IInspectable inspectable);
+        object GetNullableValue(IInspectable inspectable);
     }
 
     public sealed class StructTypeDetails<T, TAbi> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T: struct where TAbi : unmanaged
@@ -2406,7 +2210,7 @@ namespace ABI.System
             };
         }
 
-        unsafe ABI.System.Nullable IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
+        unsafe object IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             TAbi __retval = default;
@@ -2416,11 +2220,11 @@ namespace ABI.System
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)nullablePtr)[6](nullablePtr, &__retval));
                 if (typeof(T) == typeof(TAbi))
                 {
-                    return new ABI.System.Nullable(__retval);
+                    return __retval;
                 }
                 else 
                 {
-                    return new ABI.System.Nullable(Marshaler<T>.FromAbi(__retval));
+                    return Marshaler<T>.FromAbi(__retval);
                 }
             }
             finally
@@ -2460,7 +2264,7 @@ namespace ABI.System
 
         public abstract ComWrappers.ComInterfaceEntry GetDelegateInterface();
 
-        unsafe ABI.System.Nullable IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
+        unsafe object IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
         {
             IntPtr nullablePtr = IntPtr.Zero;
             IntPtr __retval = default;

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2276,10 +2276,36 @@ namespace ABI.System
                 if (type == typeof(global::System.Numerics.Vector2)) return Nullable<global::System.Numerics.Vector2>.GetValue(inspectable);
                 if (type == typeof(global::System.Numerics.Vector3)) return Nullable<global::System.Numerics.Vector3>.GetValue(inspectable);
                 if (type == typeof(global::System.Numerics.Vector4)) return Nullable<global::System.Numerics.Vector4>.GetValue(inspectable);
+                if (type == typeof(global::System.EventHandler)) return Nullable_EventHandler.GetValue(inspectable);
                 if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(int)) return Nullable_IntEnum.GetValue(type, inspectable);
                 if (type.IsEnum && Enum.GetUnderlyingType(type) == typeof(uint)) return Nullable_FlagsEnum.GetValue(type, inspectable);
 
-                return ComWrappersSupport.GetTypedRcwFactory(type)(inspectable);
+#if NET
+                var winrtExposedClassAttribute = type.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+                if (winrtExposedClassAttribute == null)
+                {
+                    var authoringMetadaType = type.GetAuthoringMetadataType();
+                    if (authoringMetadaType != null)
+                    {
+                        winrtExposedClassAttribute = authoringMetadaType.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+                    }
+                }
+
+                if (winrtExposedClassAttribute != null && winrtExposedClassAttribute.WinRTExposedTypeDetails != null)
+                {                    
+                    if (Activator.CreateInstance(winrtExposedClassAttribute.WinRTExposedTypeDetails) is IWinRTNullableTypeDetails nullableTypeDetails)
+                    {
+                        return nullableTypeDetails.GetNullableValue(inspectable);
+                    }
+                }
+
+                if (!RuntimeFeature.IsDynamicCodeCompiled)
+                {
+                    throw new NotSupportedException($"Failed to get the value from nullable with type '{type}'.");
+                }
+#endif
+
+                return ComWrappersSupport.GetTypedRcwFactory(typeof(global::System.Nullable).MakeGenericType(type))(inspectable);
             }
         }
     }
@@ -2326,7 +2352,12 @@ namespace ABI.System
 #if NET
     namespace WinRT
 {
-    public sealed class StructTypeDetails<T, TAbi> : IWinRTExposedTypeDetails where T: struct where TAbi : unmanaged
+    internal interface IWinRTNullableTypeDetails
+    {
+        ABI.System.Nullable GetNullableValue(IInspectable inspectable);
+    }
+
+    public sealed class StructTypeDetails<T, TAbi> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T: struct where TAbi : unmanaged
     {
         private static readonly Guid PIID = GuidGenerator.CreateIID(typeof(ABI.System.Nullable<T>));
 
@@ -2346,9 +2377,33 @@ namespace ABI.System
                 }
             };
         }
+
+        unsafe ABI.System.Nullable IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            TAbi __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in PIID), out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                if (typeof(T) == typeof(TAbi))
+                {
+                    return new ABI.System.Nullable(__retval);
+                }
+                else 
+                {
+                    return new ABI.System.Nullable(Marshaler<T>.FromAbi(__retval));
+                }
+            }
+            finally
+            {
+                Marshaler<T>.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
     }
 
-    public abstract class DelegateTypeDetails<T> : IWinRTExposedTypeDetails where T : global::System.Delegate
+    public abstract class DelegateTypeDetails<T> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T : global::System.Delegate
     {
         private static readonly Guid PIID = GuidGenerator.CreateIID(typeof(ABI.System.Nullable<T>));
 
@@ -2376,6 +2431,23 @@ namespace ABI.System
         }
 
         public abstract ComWrappers.ComInterfaceEntry GetDelegateInterface();
+
+        unsafe ABI.System.Nullable IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
+        {
+            IntPtr nullablePtr = IntPtr.Zero;
+            IntPtr __retval = default;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR(Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in PIID), out nullablePtr));
+                ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)nullablePtr)[6](nullablePtr, &__retval));
+                return new ABI.System.Nullable(Marshaler<T>.FromAbi(__retval));
+            }
+            finally
+            {
+                Marshaler<T>.DisposeAbi(__retval);
+                Marshal.Release(nullablePtr);
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
- Refactor nullable to be better AOT friendly.  We now detect that we are getting a nullable runtimeclass and instead of trying to create an instance of the nullable type and its helper type, we figure out what it is a nullable of and use that to get the nullable value.  This way we avoid having to call `MakeGenericType` to create the nullable helper type.
- We also now use `WinRTExposedTypeDetails` which is placed as part of an attribute on structs and delegates to implement an interface which assists in handling resolving the nullable for that type.
- Changed `MarshalInterface` to reduce the dependency on the helper type.  We were mostly using it to get the IID and for some .NET standard scenarios.  We are able to get the IID using the projected type too so doing that instead as it leads to avoiding `MakeGenericType` calls.  With this change, we might be calculating the IID one additional time than we used to.
- `IPropertySet` is a non-generic interface that inherits other generic interfaces.  If we had a function return an instance of it and the class that implements it was trimmed, we were running into scenarios where the IDIC cast calls failed due to it was for a generic interface.  Addressing that issue by generating a fallback `impl class` for scenarios where we have interfaces implementing generic interfaces.  We were already doing this for generic interfaces, but we also now do it for this scenario too.  This allows to avoid IDIC casts and have the scenario work.
- As part of generating the `impl class`, it was found that depending on which interfaces you implement you can run into compiler errors due to `InterfaceTag` missing.  Given we are going away from `InterfaceTag` as it relied on IDIC casts, refactored most of the manually projected interfaces which didn't have the statics method class to have one and for it to instead use that.  There are still 2 left which will be addressed in another PR.