### PR TITLE
Obsolete Marshaler<T>.RefAbiType on .NET 6+

### DIFF
--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1853,7 +1853,9 @@ namespace WinRT
                     CopyManagedArray = MarshalGenericHelper<T>.CopyManagedArray;
                     DisposeMarshalerArray = MarshalInterface<T>.DisposeMarshalerArray;
                     DisposeAbiArray = MarshalInterface<T>.DisposeAbiArray;
+#if !NET
                     RefAbiType = AbiType.MakeByRefType();
+#endif
 
                     return;
                 }
@@ -2011,10 +2013,16 @@ namespace WinRT
                 DisposeMarshalerArray = MarshalGeneric<T>.DisposeMarshalerArray;
                 DisposeAbiArray = MarshalGeneric<T>.DisposeAbiArray;
             }
+
+#if !NET
             RefAbiType = AbiType.MakeByRefType();
+#endif
         }
 
         public static readonly Type AbiType;
+#if NET
+        [Obsolete(AttributeMessages.GenericDeprecatedMessage)]
+#endif
         public static readonly Type RefAbiType;
         public static readonly Func<T, object> CreateMarshaler;
         internal static readonly Func<T, object> CreateMarshaler2;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -209,4 +209,5 @@ CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribut
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.As<A>()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.AsType<T>()' in the implementation but not the reference.
-Total Issues: 210
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'System.Type WinRT.Marshaler<T>.RefAbiType' in the implementation but not the reference.
+Total Issues: 211


### PR DESCRIPTION
This property is never used on .NET and it's rooting some type builder stuff. Obsoleting it and disabling it.