### PR TITLE
Remove inputs which are not files from CsWinRTGenerateProjection target.

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -81,7 +81,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="CsWinRTGenerateProjection"
           DependsOnTargets="CsWinRTPrepareProjection;CsWinRTRemoveWinMDReferences"
           Condition="'$(CsWinRTGenerateProjection)' == 'true'"
-          Inputs="$(MSBuildAllProjects);@(CsWinRTInputs);$(CsWinRTExe);$(CsWinRTExcludes);$(CsWinRTIncludes);$(CsWinRTExcludesPrivate);$(CsWinRTIncludesPrivate);$(CsWinRTFilters);$(CsWinRTWindowsMetadata)"
+          Inputs="$(MSBuildAllProjects);@(CsWinRTInputs);$(CsWinRTExe)"
           Outputs="$(CsWinRTGeneratedFilesDir)cswinrt.rsp">
 
     <PropertyGroup>


### PR DESCRIPTION
The msbuild [documentation ](https://learn.microsoft.com/en-us/visualstudio/msbuild/target-element-msbuild?view=vs-2022) states that the `Inputs` property of a target must be a list of files. However,  `$(CsWinRTExcludes);$(CsWinRTIncludes);$(CsWinRTExcludesPrivate);$(CsWinRTIncludesPrivate);$(CsWinRTFilters);$(CsWinRTWindowsMetadata)` are not files, so the target does not run incrementally as the non-files are always absent.

I think it's just safe to just remove these, if they are changed then a project file or targets file will have changed, which should trigger the correct incremental build behavior.