### PR TITLE
 Add DataTransferManger interop APIs

### DIFF
--- a/src/Tests/UnitTest/ComInteropTests.cs
+++ b/src/Tests/UnitTest/ComInteropTests.cs
@@ -161,5 +161,12 @@ namespace UnitTest
             Assert.Throws<COMException>(() => DisplayInformationInterop.GetForWindow(new IntPtr(0)));
             Assert.Throws<COMException>(() => DisplayInformationInterop.GetForMonitor(new IntPtr(0)));
         }
+
+        [Fact]
+        public void TestDataTransferManager()
+        {
+            Assert.Throws<COMException>(() => DataTransferManager.GetForWindow(new IntPtr(0)));
+            DataTransferManagerInterop.ShowShareUIForWindow(new IntPtr(0));
+        }
     }
 }

--- a/src/cswinrt/WinRT.Interop.idl
+++ b/src/cswinrt/WinRT.Interop.idl
@@ -17,7 +17,7 @@ namespace WinRT.Interop
         Int32 unused;
     };
 
-    // accountssettingspaneinterop.idl
+    // AccountsSettingsPaneInterop.idl
 #if UAC_VERSION > 2
     [uuid(D3EE12AD-3865-4362-9746-B75A682DF0E6), ProjectionInternal]
     interface IAccountsSettingsPaneInterop
@@ -34,7 +34,7 @@ namespace WinRT.Interop
     }
 #endif
 
-    // dragdropinterop.idl
+    // DragDropManagerInterop.idl
 #if UAC_VERSION > 0
     [uuid(5AD8CBA7-4C01-4DAC-9074-827894292D63), ProjectionInternal]
     interface IDragDropManagerInterop
@@ -45,7 +45,7 @@ namespace WinRT.Interop
     }
 #endif
 
-    // inputpaneinterop.idl
+    // InputPaneInterop.idl
 #if UAC_VERSION > 2
     [uuid(75CF2C57-9195-4931-8332-F0B409E916AF), ProjectionInternal]
     interface IInputPaneInterop
@@ -96,6 +96,7 @@ namespace WinRT.Interop
     }
 #endif
 
+    // RadialControllerConfigurationInterop.idl
 #if UAC_VERSION > 2
     [uuid(787cdaac-3186-476d-87e4-b9374a7b9970), ProjectionInternal]
     interface IRadialControllerConfigurationInterop
@@ -106,6 +107,7 @@ namespace WinRT.Interop
     }
 #endif
 
+    // RadialControllerIndependentInputSourceInterop.idl
 #if UAC_VERSION > 3
     [uuid(3D577EFF-4CEE-11E6-B535-001BDC06AB3B), ProjectionInternal]
     interface IRadialControllerIndependentInputSourceInterop
@@ -180,7 +182,7 @@ namespace WinRT.Interop
     }
 #endif
 
-    // WindowsGraphicsDisplayInterop.idl
+    // DisplayInformationInterop.idl
 #if UAC_VERSION > 14
     [uuid(7449121C-382B-4705-8DA7-A795BA482013), ProjectionInternal]
     interface IDisplayInformationStaticsInterop
@@ -188,9 +190,24 @@ namespace WinRT.Interop
         Object GetForWindow(
             HWND window,
             ref const GUID riid);
+
         Object GetForMonitor(
             HWND monitor,
             ref const GUID riid);
+    }
+#endif
+
+    // DataTransferManagerInterop.idl
+#if UAC_VERSION > 0
+    [uuid(3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8), ProjectionInternal]
+    interface IDataTransferManagerInterop
+    {
+        Object GetForWindow(
+            HWND appWindow,
+            ref const GUID riid);
+
+        void ShowShareUIForWindow(
+            HWND appWindow);
     }
 #endif
 }

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -1,4 +1,16 @@
-﻿#if UAC_VERSION_15
+﻿#if UAC_VERSION_19
+#define UAC_VERSION_18
+#endif
+#if UAC_VERSION_18
+#define UAC_VERSION_17
+#endif
+#if UAC_VERSION_17
+#define UAC_VERSION_16
+#endif
+#if UAC_VERSION_16
+#define UAC_VERSION_15
+#endif
+#if UAC_VERSION_15
 #define UAC_VERSION_14
 #endif
 #if UAC_VERSION_14
@@ -127,7 +139,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 {
 #if UAC_VERSION_1
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.22000.0")]
 #endif
 #if EMBED
     internal
@@ -232,9 +244,9 @@ namespace Windows.Media.PlayTo
 
 namespace Windows.Security.Credentials.UI
 {
-#if UAC_VERSION_1
+#if UAC_VERSION_14
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.22000.0")]
 #endif
 #if EMBED
     internal
@@ -258,7 +270,7 @@ namespace Windows.Security.Authentication.Web.Core
 {
 #if UAC_VERSION_1
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.20348.0")]
 #endif
 #if EMBED
     internal
@@ -288,7 +300,7 @@ namespace Windows.UI.ApplicationSettings
 {
 #if UAC_VERSION_1
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.20348.0")]
 #endif
 #if EMBED
     internal
@@ -393,7 +405,7 @@ namespace Windows.UI.Input.Spatial
 {
 #if UAC_VERSION_2
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10586.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.15063.0")]
 #endif
 #if EMBED
     internal
@@ -417,7 +429,7 @@ namespace Windows.UI.ViewManagement
 {
 #if UAC_VERSION_1
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.14393.0")]
 #endif
 #if EMBED
     internal
@@ -436,7 +448,7 @@ namespace Windows.UI.ViewManagement
     }
 
 #if NET
-    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.20348.0")]
 #endif
 #if EMBED
     internal
@@ -484,4 +496,32 @@ namespace Windows.Graphics.Display
         }
     }
 #endif
+}
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+#if UAC_VERSION_1
+#if NET
+    [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.10240.0")]
+#endif
+#if EMBED
+    internal
+#else
+    public
+#endif
+    static class DataTransferManagerInterop
+    {
+        private static IDataTransferManagerInterop dataTransferManagerInterop = DataTransferManager.As<IDataTransferManagerInterop>();
+
+        public static DataTransferManager GetForWindow(IntPtr appWindow)
+        {
+            Guid iid = GuidGenerator.CreateIID(typeof(IDataTransferManager));
+            return (DataTransferManager)dataTransferManagerInterop.GetForWindow(appWindow, iid);
+        }
+
+        public static void ShowShareUIForWindow(IntPtr appWindow)
+        {
+            dataTransferManagerInterop.ShowShareUIForWindow(appWindow);
+        }
+    }
 }


### PR DESCRIPTION
 Add DataTransferManger interop APIs
Update some interop api supported version(Because some of the minimum versions required for WinRT interface interoperability apis do not correspond to the official documentation)