### PR TITLE
Fix issue where RuntimeConfiguration defaults are not used

### DIFF
--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -57,7 +57,7 @@ internal static class FeatureSwitches
     public static bool IsDynamicObjectsSupportEnabled
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(IsDynamicObjectsSupportEnabledPropertyName, ref _isDynamicObjectsSupportEnabled);
+        get => GetConfigurationValue(IsDynamicObjectsSupportEnabledPropertyName, ref _isDynamicObjectsSupportEnabled, true);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ internal static class FeatureSwitches
     public static bool UseExceptionResourceKeys
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(UseExceptionResourceKeysPropertyName, ref _useExceptionResourceKeys);
+        get => GetConfigurationValue(UseExceptionResourceKeysPropertyName, ref _useExceptionResourceKeys, false);
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ internal static class FeatureSwitches
     public static bool EnableDefaultCustomTypeMappings
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnableDefaultCustomTypeMappingsPropertyName, ref _enableDefaultCustomTypeMappings);
+        get => GetConfigurationValue(EnableDefaultCustomTypeMappingsPropertyName, ref _enableDefaultCustomTypeMappings, true);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ internal static class FeatureSwitches
     /// <param name="propertyName">The property name to retrieve the value for.</param>
     /// <param name="cachedResult">The cached result for the target configuration value.</param>
     /// <returns>The value of the specified configuration setting.</returns>
-    private static bool GetConfigurationValue(string propertyName, ref int cachedResult)
+    private static bool GetConfigurationValue(string propertyName, ref int cachedResult, bool defaultValue)
     {
         // The cached switch value has 3 states:
         //   0: unknown.
@@ -107,7 +107,7 @@ internal static class FeatureSwitches
         // All feature switches have a default set in the .targets file.
         if (!AppContext.TryGetSwitch(propertyName, out bool isEnabled))
         {
-            isEnabled = false;
+            isEnabled = defaultValue;
         }
 
         // Update the cached result


### PR DESCRIPTION
In certain scenarios, the runtime configuration file may not be there.  When this happens, the defaults we set in msbuild do not take effect and we can end up defaulting to false.  This means all switches are disabled and can cause issues like custom type mappings not being enabled.  This addresses it by making the defaults in code so we can default to the correct value.