### PR TITLE
Add support for IBuffer.AsMemory() and Memory.AsBuffer().

### DIFF
--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -614,7 +614,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             public override Span<byte> GetSpan()
             {
                 IntPtr sourcePtr = _buffer.GetPointerAtOffset(0);
-                return new Span<byte>((byte*)sourcePtr.ToPointer(), (int)_buffer.Length);
+                return new Span<byte>((byte*)sourcePtr.ToPointer(), (int)_buffer.Capacity);
             }
 
             public override MemoryHandle Pin(int elementIndex = 0)


### PR DESCRIPTION
Contributes to #824

WindowsRuntimeBuffer is now internally represented by a ```Memory<byte>``` instead of a ```byte[]```. Also simplified a few codepaths to use the CopyTo functionality from Span<T>.

```AsMemory()``` follows the approach taken by ```ToArray()``` in that the capacity of the ```IBuffer``` is ignored and the Memory represents the length of the buffer.