### PR TITLE
Fix bug in the AsStream extensions where the Length isn't properly updated on the IBuffer.

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -271,6 +271,41 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestBufferAsStreamUsingAsBufferWithOffset()
+        {
+            var arr = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            var buffer = arr.AsBuffer(1, 2);
+            Stream stream = buffer.AsStream();
+            Assert.True(stream != null);
+            Assert.True(stream.Length == 2);
+
+            stream.Write(new byte[] { 0x05, 0x06 });
+            Assert.True(stream.Length == 2);
+            Assert.True(buffer.Length == 2);
+
+            Assert.Equal((byte)0x05, arr[1]);
+            Assert.Equal((byte)0x06, arr[2]);
+        }
+
+        [Fact]
+        public void TestBufferAsStreamUsingAsBufferWithOffsetAndCapacity()
+        {
+            var arr = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            var buffer = arr.AsBuffer(1, 2, 3);
+            Stream stream = buffer.AsStream();
+            Assert.True(stream != null);
+            Assert.True(stream.Length == 2);
+
+            stream.Write(new byte[] { 0x05, 0x06, 0x07 });
+            Assert.True(stream.Length == 3);
+            Assert.True(buffer.Length == 3);
+
+            Assert.Equal((byte)0x05, arr[1]);
+            Assert.Equal((byte)0x06, arr[2]);
+            Assert.Equal((byte)0x07, arr[3]);
+        }
+
+        [Fact]
         public void TestBufferAsStreamWithEmptyBuffer()
         {
             var buffer = new Windows.Storage.Streams.Buffer(0);

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -271,12 +271,35 @@ namespace UnitTest
         }
 
         [Fact]
-        public void TestBufferAsStreamWithEmptyBuffer1()
+        public void TestBufferAsStreamWithEmptyBuffer()
         {
             var buffer = new Windows.Storage.Streams.Buffer(0);
             Stream stream = buffer.AsStream();
             Assert.True(stream != null);
             Assert.True(stream.Length == 0);
+        }
+
+        [Fact]
+        public void TestBufferAsStreamRead()
+        {
+            var arr = new byte[] { 0x01, 0x02 };
+            Stream stream = arr.AsBuffer().AsStream();
+            Assert.True(stream != null);
+            Assert.True(stream.Length == 2);
+            int byte1 = stream.ReadByte();
+            Assert.Equal(0x01, byte1);
+        }
+
+        [Fact]
+        public void TestBufferAsStreamWrite()
+        {
+            var buffer = new Windows.Storage.Streams.Buffer(2);
+            Stream stream = buffer.AsStream();
+            Assert.True(stream != null);
+            Assert.True(stream.Length == 0);
+            stream.WriteByte(0x01);
+            Assert.True(stream.Length == 1);
+            Assert.True(buffer.Length == 1);
         }
 
         [Fact]

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -8,6 +8,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using global::Windows.Foundation;
     using global::Windows.Storage.Streams;
     /// <summary>
@@ -465,6 +467,63 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 : base(dataPtr, (long)sourceBuffer.Length, (long)sourceBuffer.Capacity, FileAccess.ReadWrite)
             {
                 _sourceBuffer = sourceBuffer;
+            }
+
+            public override void SetLength(long value)
+            {
+                base.SetLength(value);
+
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                base.Write(buffer, offset, count);
+
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
+            }
+
+#if NET
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                base.Write(buffer);
+
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
+            }
+#endif
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await base.WriteAsync(buffer, offset, count, cancellationToken);
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
+            }
+
+#if NET
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                await base.WriteAsync(buffer, cancellationToken);
+
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
+            }
+#endif
+
+            public override void WriteByte(byte value)
+            {
+                base.WriteByte(value);
+
+                // Length is limited by Capacity which should be a valid value.
+                // Therefore this cast is safe.
+                _sourceBuffer.Length = (uint)Length;
             }
         }  // class WindowsRuntimeBufferUnmanagedMemoryStream
 


### PR DESCRIPTION
If you write to an IBuffer via the AsStream() method and you increase the length, the length of the underlying IBuffer doesn't update.