### PR TITLE
Optimize AsTask when the underlying IAsyncOperation is wrapping a task.

### DIFF
--- a/src/cswinrt/cswinrt.vcxproj
+++ b/src/cswinrt/cswinrt.vcxproj
@@ -77,6 +77,7 @@
     <None Include="strings\additions\Windows.Foundation\AsyncInfo.cs" />
     <None Include="strings\additions\Windows.Foundation\AsyncInfoIdGenerator.cs" />
     <None Include="strings\additions\Windows.Foundation\ExceptionDispatchHelper.cs" />
+    <None Include="strings\additions\Windows.Foundation\ITaskAwareAsyncInfo.cs" />
     <None Include="strings\additions\Windows.Foundation\TaskToAsyncActionAdapter.cs" />
     <None Include="strings\additions\Windows.Foundation\TaskToAsyncActionWithProgressAdapter.cs" />
     <None Include="strings\additions\Windows.Foundation\TaskToAsyncInfoAdapter.cs" />

--- a/src/cswinrt/cswinrt.vcxproj.filters
+++ b/src/cswinrt/cswinrt.vcxproj.filters
@@ -171,6 +171,9 @@
     <None Include="strings\ComInteropHelpers.cs">
       <Filter>strings</Filter>
     </None>
+    <None Include="strings\additions\Windows.Foundation\ITaskAwareAsyncInfo.cs">
+      <Filter>strings\additions\Windows.Foundation</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="WinRT.Interop.idl" />

--- a/src/cswinrt/strings/additions/Windows.Foundation/ITaskAwareAsyncInfo.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/ITaskAwareAsyncInfo.cs
@@ -1,0 +1,7 @@
+namespace System.Threading.Tasks
+{
+    internal interface ITaskAwareAsyncInfo
+    {
+        Task Task { get; }
+    }
+}

--- a/src/cswinrt/strings/additions/Windows.Foundation/TaskToAsyncInfoAdapter.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/TaskToAsyncInfoAdapter.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks
     [global::System.Runtime.Versioning.SupportedOSPlatform("windows10.0.10240.0")]
 #endif
     internal partial class TaskToAsyncInfoAdapter<TCompletedHandler, TProgressHandler, TResult, TProgressInfo>
-                                                                                : IAsyncInfo, IProgress<TProgressInfo>
+                                                                                : IAsyncInfo, IProgress<TProgressInfo>, ITaskAwareAsyncInfo
                                                                                 where TCompletedHandler : class
                                                                                 where TProgressHandler : class
     {
@@ -367,7 +367,7 @@ namespace System.Threading.Tasks
         }
 
 
-        internal Task Task
+        Task ITaskAwareAsyncInfo.Task
         {
             get
             {

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -25,12 +25,14 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
+#if NET
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task)
             {
                 return cancellationToken.CanBeCanceled ?
                     task.WaitAsync(cancellationToken) :
                     task;
             }
+#endif
 
             switch (source.Status)
             {
@@ -67,12 +69,14 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
+#if NET
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task)
             {
                 return cancellationToken.CanBeCanceled ?
                     task.WaitAsync(cancellationToken) :
                     task;
             }
+#endif
 
             switch (source.Status)
             {
@@ -109,6 +113,7 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
+#if NET
             // fast path is underlying asyncInfo is Task and no IProgress provided
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task && progress == null)
             {
@@ -116,6 +121,7 @@ namespace System
                     task.WaitAsync(cancellationToken) :
                     task;
             }
+#endif
 
             switch (source.Status)
             {
@@ -173,6 +179,7 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
+#if NET
             // fast path is underlying asyncInfo is Task and no IProgress provided
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task && progress == null)
             {
@@ -180,6 +187,7 @@ namespace System
                     task.WaitAsync(cancellationToken) :
                     task;
             }
+#endif
 
             switch (source.Status)
             {

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -27,7 +27,9 @@ namespace System
 
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task)
             {
-                return task;
+                return cancellationToken.CanBeCanceled ?
+                    task.WaitAsync(cancellationToken) :
+                    task;
             }
 
             switch (source.Status)
@@ -67,7 +69,9 @@ namespace System
 
             if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task)
             {
-                return task;
+                return cancellationToken.CanBeCanceled ?
+                    task.WaitAsync(cancellationToken) :
+                    task;
             }
 
             switch (source.Status)
@@ -105,9 +109,12 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task)
+            // fast path is underlying asyncInfo is Task and no IProgress provided
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task && progress == null)
             {
-                return task;
+                return cancellationToken.CanBeCanceled ?
+                    task.WaitAsync(cancellationToken) :
+                    task;
             }
 
             switch (source.Status)
@@ -166,9 +173,12 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task)
+            // fast path is underlying asyncInfo is Task and no IProgress provided
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task && progress == null)
             {
-                return task;
+                return cancellationToken.CanBeCanceled ?
+                    task.WaitAsync(cancellationToken) :
+                    task;
             }
 
             switch (source.Status)

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -25,8 +25,10 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            // TODO: Handle the scenario where the 'IAsyncAction' is actually a task (i.e. originated from native code
-            // but projected into an IAsyncAction)
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task)
+            {
+                return task;
+            }
 
             switch (source.Status)
             {
@@ -63,8 +65,10 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            // TODO: Handle the scenario where the 'IAsyncOperation' is actually a task (i.e. originated from native code
-            // but projected into an IAsyncOperation)
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task)
+            {
+                return task;
+            }
 
             switch (source.Status)
             {
@@ -101,8 +105,10 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            // TODO: Handle the scenario where the 'IAsyncActionWithProgress' is actually a task (i.e. originated from native code
-            // but projected into an IAsyncActionWithProgress)
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task task)
+            {
+                return task;
+            }
 
             switch (source.Status)
             {
@@ -160,8 +166,10 @@ namespace System
                 throw new ArgumentNullException(nameof(source));
             }
 
-            // TODO: Handle the scenario where the 'IAsyncOperationWithProgress' is actually a task (i.e. originated from native code
-            // but projected into an IAsyncOperationWithProgress)
+            if (source is ITaskAwareAsyncInfo asyncInfo && asyncInfo.Task is Task<TResult> task)
+            {
+                return task;
+            }
 
             switch (source.Status)
             {


### PR DESCRIPTION
No need for all the wrapping. This is similar to various IBuffer optimizations.