### PR TITLE
Add overloads for CopyTo for Span<byte>.

### DIFF
--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -612,9 +612,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
         }  // class WindowsRuntimeBufferUnmanagedMemoryStream
 
-        // 905a0fef-bc53-11df-8c49-001e4fc686da
-        private static readonly Guid IBufferByteAccess_IID = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0xEF, 0x0F, 0x5A, 0x90, 0x53, 0xBC, 0xDF, 0x11, 0x8C, 0x49, 0x00, 0x1E, 0x4F, 0xC6, 0x8, 0x6DA }));
-
         private static IntPtr GetPointerAtOffset(this IBuffer buffer, uint offset)
         {
             Debug.Assert(0 <= offset);
@@ -630,15 +627,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         private static Span<byte> GetSpanForCapacity(this IBuffer buffer, uint offset)
         {
             Debug.Assert(0 <= offset);
-            Debug.Assert(offset < buffer.Length);
+            Debug.Assert(offset < buffer.Capacity);
 
             unsafe
             {
                 IntPtr buffPtr = buffer.As<IBufferByteAccess>().Buffer;
-                return new Span<byte>((byte*)buffPtr + offset, (int)buffer.Capacity);
+                return new Span<byte>((byte*)buffPtr + offset, (int)(buffer.Capacity - offset));
             }
         }
-
 
         private static unsafe void MemCopy(IntPtr src, IntPtr dst, uint count)
         {

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// Copies the contents of <code>source</code> to <code>destination</code> starting at offset 0.
         /// This method does <em>NOT</em> update <code>destination.Length</code>.
         /// </summary>
-        /// <param name="source">Array to copy data from.</param>
+        /// <param name="source">Span to copy data from.</param>
         /// <param name="destination">The buffer to copy to.</param>
         public static void CopyTo(this Span<byte> source, IBuffer destination)
         {
@@ -81,8 +81,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// to <code>destination</code> starting at <code>destinationIndex</code>.
         /// This method does <em>NOT</em> update <code>destination.Length</code>.
         /// </summary>
-        /// <param name="source">Array to copy data from.</param>
-        /// <param name="sourceIndex">Position in the array from where to start copying.</param>
+        /// <param name="source">Span to copy data from.</param>
+        /// <param name="sourceIndex">Position in the span from where to start copying.</param>
         /// <param name="destination">The buffer to copy to.</param>
         /// <param name="destinationIndex">Position in the buffer to where to start copying.</param>
         /// <param name="count">The number of bytes to copy.</param>

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -194,6 +194,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Span<byte> srcSpan = source.TryGetUnderlyingData(out byte[] srcDataArr, out int srcOffset) ? srcDataArr.AsSpan(srcOffset + (int)sourceIndex, count) : source.GetSpanForCapacity(sourceIndex);
             srcSpan.CopyTo(destination);
+
+            GC.KeepAlive(source);
         }
 
 #endregion (IBuffer).CopyTo extensions for copying to a (Span<Byte>)
@@ -249,6 +251,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Span<byte> destSpan = destination.TryGetUnderlyingData(out byte[] destDataArr, out int destOffset) ? destDataArr.AsSpan(destOffset + (int)destinationIndex) : destination.GetSpanForCapacity(destinationIndex);
 
             srcSpan.CopyTo(destSpan);
+
+            GC.KeepAlive(source);
 
             // Update Length last to make sure the data is valid
             if (destinationIndex + count > destination.Length)
@@ -607,6 +611,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 _sourceBuffer.Length = (uint)Length;
             }
         }  // class WindowsRuntimeBufferUnmanagedMemoryStream
+
+        // 905a0fef-bc53-11df-8c49-001e4fc686da
+        private static readonly Guid IBufferByteAccess_IID = new Guid(new global::System.ReadOnlySpan<byte>(new byte[] { 0xEF, 0x0F, 0x5A, 0x90, 0x53, 0xBC, 0xDF, 0x11, 0x8C, 0x49, 0x00, 0x1E, 0x4F, 0xC6, 0x8, 0x6DA }));
 
         private static IntPtr GetPointerAtOffset(this IBuffer buffer, uint offset)
         {

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -456,12 +456,16 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
 
             IntPtr srcPtr = source.GetPointerAtOffset(byteOffset);
+
+            byte value = default;
             unsafe
             {
                 // Let's avoid an unnesecary call to Marshal.ReadByte():
                 byte* ptr = (byte*)srcPtr;
-                return *ptr;
+                value = *ptr;
             }
+            GC.KeepAlive(source);
+            return value;
         }
 
         #endregion Extensions for direct by-offset access to buffer data elements


### PR DESCRIPTION
Extracted from #1535 while we discuss the proper way of supporting Memory<byte>.