### PR TITLE
Fix issue where RuntimeClassName for boxed type object was empty string

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2225,6 +2225,9 @@ namespace UnitTest
             Assert.Equal("Windows.Foundation.IReference`1<Int32>", Class.GetName(arr3.GetValue(0)));
             Assert.Equal(string.Empty, Class.GetName(arr4[0]));
             Assert.Equal("Windows.Foundation.IReference`1<Windows.Foundation.PropertyType>", Class.GetName(arr5.GetValue(0)));
+
+            Assert.Equal("Windows.Foundation.IReference`1<Windows.UI.Xaml.Interop.TypeName>", Class.GetName(typeof(IProperties1)));
+            Assert.Equal("Windows.Foundation.IReference`1<Windows.UI.Xaml.Interop.TypeName>", Class.GetName(typeof(Type)));
         }
 
         [Fact]
@@ -2310,6 +2313,13 @@ namespace UnitTest
             var typeName = Class.GetTypeNameForType(typeof(IList<int>));
 
             Assert.Equal("Windows.Foundation.Collections.IVector`1<Int32>", typeName);
+        }
+
+        [Fact]
+        public void TypeInfoType()
+        {
+            var typeName = Class.GetTypeNameForType(typeof(Type));
+            Assert.Equal("Windows.UI.Xaml.Interop.TypeName", typeName);
         }
 
         [Fact]

--- a/src/WinRT.Runtime/Projections/Type.cs
+++ b/src/WinRT.Runtime/Projections/Type.cs
@@ -73,7 +73,7 @@ namespace ABI.System
                 {
                     kind = TypeKind.Primitive;
                 }
-                else if (value == typeof(object) || value == typeof(string) || value == typeof(Guid) || value == typeof(System.Type))
+                else if (value == typeof(object) || value == typeof(string) || value == typeof(Guid) || value == typeof(global::System.Type))
                 {
                     kind = TypeKind.Metadata;
                 }

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -335,10 +335,14 @@ namespace WinRT
             {
                 builder.Append("Object");
             }
+            else if ((flags & TypeNameGenerationFlags.ForGetRuntimeClassName) != 0 && type.IsTypeOfType())
+            {
+                builder.Append("Windows.UI.Xaml.Interop.TypeName");
+            }
             else
             {
                 var projectedAbiTypeName = Projections.FindCustomAbiTypeNameForType(type);
-                if (projectedAbiTypeName is object)
+                if (projectedAbiTypeName is not null)
                 {
                     builder.Append(projectedAbiTypeName);
                 }


### PR DESCRIPTION
If someone called GetRuntimeClassName on a boxed type object, they previously got empty string.  This was because we saw the type as `System.RuntimeType` and didn't recognize that as a WinRT type.  This addresses it by checking for if the object derives from type and if so, returns the runtime class name for type.