### PR TITLE
Strong name sign source generator

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRT.SourceGenerator.csproj
+++ b/src/Authoring/WinRT.SourceGenerator/WinRT.SourceGenerator.csproj
@@ -15,6 +15,8 @@
     <Description>C#/WinRT Authoring Source Generator Preview $(VersionString)</Description>
     <AssemblyTitle>C#/WinRT Authoring Source Generator Preview v$(VersionString)</AssemblyTitle>
     <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)WinRT.Runtime\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As part of including the source generator in the Windows SDK projection package, making sure it is strong name signed so that we can put the public key in the FrameworkList file.