### PR TITLE
Add 'CsWinRTEnableICustomPropertyProviderSupport' feature switch

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -250,6 +250,7 @@ $(CsWinRTInternalProjection)
     <CsWinRTEnableDynamicObjectsSupport Condition="'$(CsWinRTEnableDynamicObjectsSupport)' == ''">true</CsWinRTEnableDynamicObjectsSupport>
     <CsWinRTUseExceptionResourceKeys Condition="'$(CsWinRTUseExceptionResourceKeys)' == ''">false</CsWinRTUseExceptionResourceKeys>
     <CsWinRTEnableDefaultCustomTypeMappings Condition="'$(CsWinRTEnableDefaultCustomTypeMappings)' == ''">true</CsWinRTEnableDefaultCustomTypeMappings>
+    <CsWinRTEnableICustomPropertyProviderSupport Condition="'$(CsWinRTEnableICustomPropertyProviderSupport)' == ''">true</CsWinRTEnableICustomPropertyProviderSupport>
   </PropertyGroup>
 
   <!--
@@ -271,6 +272,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS"
                                     Value="$(CsWinRTEnableDefaultCustomTypeMappings)"
+                                    Trim="true" />
+
+    <!-- CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT"
+                                    Value="$(CsWinRTEnableICustomPropertyProviderSupport)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -316,11 +316,14 @@ namespace WinRT
                 Vtable = ManagedIStringableVftbl.AbiToProjectionVftablePtr
             });
 
-            entries.Add(new ComInterfaceEntry
+            if (FeatureSwitches.EnableICustomPropertyProviderSupport)
             {
-                IID = ManagedCustomPropertyProviderVftbl.IID,
-                Vtable = ManagedCustomPropertyProviderVftbl.AbiToProjectionVftablePtr
-            });
+                entries.Add(new ComInterfaceEntry
+                {
+                    IID = ManagedCustomPropertyProviderVftbl.IID,
+                    Vtable = ManagedCustomPropertyProviderVftbl.AbiToProjectionVftablePtr
+                });
+            }
 
             entries.Add(new ComInterfaceEntry
             {

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -37,6 +37,11 @@ internal static class FeatureSwitches
     private const string EnableDefaultCustomTypeMappingsPropertyName = "CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS";
 
     /// <summary>
+    /// The configuration property name for <see cref="EnableICustomPropertyProviderSupport"/>.
+    /// </summary>
+    private const string EnableICustomPropertyProviderSupportPropertyName = "CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT";
+
+    /// <summary>
     /// The backing field for <see cref="IsDynamicObjectsSupportEnabled"/>.
     /// </summary>
     private static int _isDynamicObjectsSupportEnabled;
@@ -50,6 +55,11 @@ internal static class FeatureSwitches
     /// The backing field for <see cref="EnableDefaultCustomTypeMappings"/>.
     /// </summary>
     private static int _enableDefaultCustomTypeMappings;
+
+    /// <summary>
+    /// The backing field for <see cref="EnableICustomPropertyProviderSupport"/>.
+    /// </summary>
+    private static int _enableICustomPropertyProviderSupport;
 
     /// <summary>
     /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
@@ -76,6 +86,15 @@ internal static class FeatureSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetConfigurationValue(EnableDefaultCustomTypeMappingsPropertyName, ref _enableDefaultCustomTypeMappings, true);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not <see cref="ABI.Microsoft.UI.Xaml.Data.ManagedCustomPropertyProviderVftbl"/> should be enabled (defaults to <see langword="true"/>).
+    /// </summary>
+    public static bool EnableICustomPropertyProviderSupport
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetConfigurationValue(EnableICustomPropertyProviderSupportPropertyName, ref _enableICustomPropertyProviderSupport, true);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -13,6 +13,10 @@
       <!-- CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS switch -->
       <method signature="System.Boolean get_EnableDefaultCustomTypeMappings()" body="stub" value="false" feature="CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS" featurevalue="false"/>
       <method signature="System.Boolean get_EnableDefaultCustomTypeMappings()" body="stub" value="true" feature="CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS" featurevalue="true"/>
+
+      <!-- CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT switch -->
+      <method signature="System.Boolean get_EnableICustomPropertyProviderSupport()" body="stub" value="false" feature="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT" featurevalue="false"/>
+      <method signature="System.Boolean get_EnableICustomPropertyProviderSupport()" body="stub" value="true" feature="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT" featurevalue="true"/>
     </type>
   </assembly>
 

--- a/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
@@ -387,13 +387,4 @@ namespace ABI.Microsoft.UI.Xaml.Data
             return 0;
         }
     }
-
-    internal static class ICustomPropertyProvider_Delegates
-    {
-        public unsafe delegate int GetCustomProperty_0(IntPtr thisPtr, IntPtr name, IntPtr* result);
-        public unsafe delegate int GetIndexedProperty_1(IntPtr thisPtr, IntPtr name, global::ABI.System.Type type, IntPtr* result);
-        public unsafe delegate int GetStringRepresentation_2(IntPtr thisPtr, IntPtr* result);
-        public unsafe delegate int get_Type_3(IntPtr thisPtr, global::ABI.System.Type* value);
-    }
-
 }


### PR DESCRIPTION
While checking #1557, I noticed some very annoying traces in sizoscope:

![image](https://github.com/microsoft/CsWinRT/assets/10199417/90877322-c40d-480c-b207-85fd203caf0b)

None of this is needed if you're just building a minimal component, but it's rooted by default.
This PR adds a new 'CsWinRTEnableICustomPropertyProviderSupport feature switch to allow opting out.
The default is the current behavior (ie. support enabled), so no semantics changes are introduced in this PR.