### PR TITLE
Add WinRTRuntimeClassName attribute for use in scenarios where we previously used interface name

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -905,6 +905,13 @@ namespace Generator
             StringBuilder source = new();
             string classPrefix = isComponentGenerator ? "Authoring" : "";
 
+            // The generated lookup table is based on lookup by string rather than type to avoid 2 different issues:
+            //
+            //     1) We can run into nested private types which we can't reference from here but still need to be able to create the vtable for.
+            //     2) While looking for a type in the lookup table, you can trigger module initializers for other modules
+            //        referenced and that can run into issues because they can have their own lookup tables that
+            //        get registered in their module initializer, but will fail to due to the reader writer lock we have around it
+            //        (i.e. we are traversing the lookup tables here while one is being registered).
             var hasRuntimeClasNameEntries = value.vtableAttributes.Any(v => !string.IsNullOrEmpty(v.RuntimeClassName));
             if (value.vtableAttributes.Any())
             {

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -118,11 +118,6 @@ namespace Generator
             {
                 return ToFullyQualifiedString(type);
             }
-            else if (GeneratorHelper.MappedCSharpTypes.ContainsKey(metadataName))
-            {
-                var mapping = GeneratorHelper.MappedCSharpTypes[metadataName].GetMapping();
-                return mapping.Item1 + "." + mapping.Item2;
-            }
             else if (type.SpecialType == SpecialType.System_Object)
             {
                 return "Object";
@@ -134,6 +129,11 @@ namespace Generator
             else if (type.SpecialType == SpecialType.System_SByte)
             {
                 return "Int8";
+            }
+            else if (GeneratorHelper.MappedCSharpTypes.ContainsKey(metadataName))
+            {
+                var mapping = GeneratorHelper.MappedCSharpTypes[metadataName].GetMapping();
+                return mapping.Item1 + "." + mapping.Item2;
             }
             else if (type.SpecialType != SpecialType.None)
             {

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -174,8 +174,10 @@ namespace Generator
             }
 
             // If the attribute is already placed on the type, don't generate a new one as we will
-            // use the specified one.
-            var checkForRuntimeClasName = !GeneratorHelper.HasWinRTRuntimeClassNameAttribute(symbol);
+            // use the specified one.  Also for authoring scenarios where we call this for authored WinRT types,
+            // don't generate the runtimeclass name for them as we will rely on the full name for them as we do today.
+            var checkForRuntimeClasName = !GeneratorHelper.HasWinRTRuntimeClassNameAttribute(symbol) && 
+                (!isAuthoring || (isAuthoring && !isWinRTType(symbol)));
             INamedTypeSymbol interfaceToUseForRuntimeClassName = null;
             foreach (var iface in symbol.AllInterfaces)
             {

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -907,7 +907,7 @@ namespace Generator
 
             // The generated lookup table is based on lookup by string rather than type to avoid 2 different issues:
             //
-            //     1) We can run into nested private types which we can't reference from here but still need to be able to create the vtable for.
+            //     1) We can run into nested private types in generics which we can't reference from here but still need to be able to create the vtable for.
             //     2) While looking for a type in the lookup table, you can trigger module initializers for other modules
             //        referenced and that can run into issues because they can have their own lookup tables that
             //        get registered in their module initializer, but will fail to due to the reader writer lock we have around it

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -314,10 +314,15 @@ namespace Generator
                 Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTExposedTypeAttribute") == 0);
         }
 
-        public static bool HasWinRTRuntimeClassNameAttribute(ISymbol type)
+        public static bool HasWinRTRuntimeClassNameAttribute(ISymbol type, Compilation compilation)
         {
-            return type.GetAttributes().
-                Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTRuntimeClassNameAttribute") == 0);
+            var winrtRuntimeClassNameAttribute = compilation.GetTypeByMetadataName("WinRT.WinRTRuntimeClassNameAttribute");
+            if (winrtRuntimeClassNameAttribute is null)
+            {
+                return false;
+            }
+
+            return HasAttributeWithType(type, winrtRuntimeClassNameAttribute);
         }
 
         public static bool IsWinRTType(MemberDeclarationSyntax node)

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -314,6 +314,12 @@ namespace Generator
                 Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTExposedTypeAttribute") == 0);
         }
 
+        public static bool HasWinRTRuntimeClassNameAttribute(ISymbol type)
+        {
+            return type.GetAttributes().
+                Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTRuntimeClassNameAttribute") == 0);
+        }
+
         public static bool IsWinRTType(MemberDeclarationSyntax node)
         {
             bool isProjectedType = node.AttributeLists.SelectMany(list => list.Attributes).
@@ -759,6 +765,7 @@ namespace Generator
 
             throw new ArgumentException();
         }
+
         public static string EscapeTypeNameForIdentifier(string typeName)
         {
             return Regex.Replace(typeName, """[(\ |:<>,\.)]""", "_");

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2703,7 +2703,7 @@ namespace Generator
                     symbol.TypeKind == TypeKind.Class && 
                     !symbol.IsStatic)
                 {
-                    vtableAttributesToAdd.Add(WinRTAotSourceGenerator.GetVtableAttributeToAdd(symbol, IsWinRTType, context.Compilation.Assembly, context.Compilation.HasImplicitConversion, true, typeDeclaration.DefaultInterface));
+                    vtableAttributesToAdd.Add(WinRTAotSourceGenerator.GetVtableAttributeToAdd(symbol, IsWinRTType, context.Compilation, true, typeDeclaration.DefaultInterface));
                     WinRTAotSourceGenerator.AddVtableAdapterTypeForKnownInterface(symbol, context.Compilation, IsWinRTType, vtableAttributesToAddOnLookupTable);
                 }
             }

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2703,7 +2703,7 @@ namespace Generator
                     symbol.TypeKind == TypeKind.Class && 
                     !symbol.IsStatic)
                 {
-                    vtableAttributesToAdd.Add(WinRTAotSourceGenerator.GetVtableAttributeToAdd(symbol, IsWinRTType, context.Compilation.Assembly, true, typeDeclaration.DefaultInterface));
+                    vtableAttributesToAdd.Add(WinRTAotSourceGenerator.GetVtableAttributeToAdd(symbol, IsWinRTType, context.Compilation.Assembly, context.Compilation.HasImplicitConversion, true, typeDeclaration.DefaultInterface));
                     WinRTAotSourceGenerator.AddVtableAdapterTypeForKnownInterface(symbol, context.Compilation, IsWinRTType, vtableAttributesToAddOnLookupTable);
                 }
             }

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -677,3 +677,22 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface2.get()))[3])(internalInterface2.get(), &number), S_OK);
     EXPECT_EQ(number, 123);
 }
+
+TEST(AuthoringTest, GetRuntimeClassName)
+{
+    CustomDictionary2 dictionary;
+    EXPECT_EQ(winrt::get_class_name(dictionary), L"AuthoringTest.CustomDictionary2");
+
+    DisposableClass disposed;
+    EXPECT_EQ(winrt::get_class_name(disposed), L"AuthoringTest.DisposableClass");
+
+    TestMixedWinRTCOMWrapper wrapper;
+    EXPECT_EQ(winrt::get_class_name(wrapper), L"AuthoringTest.TestMixedWinRTCOMWrapper");
+
+    TestClass testClass;
+    testClass.SetNonProjectedDisposableObject();
+    EXPECT_EQ(winrt::get_class_name(testClass.DisposableObject()), L"Windows.Foundation.IClosable");
+
+    testClass.SetProjectedDisposableObject();
+    EXPECT_EQ(winrt::get_class_name(testClass.DisposableObject()), L"AuthoringTest.DisposableClass");
+}

--- a/src/Tests/FunctionalTests/CCW/Program.cs
+++ b/src/Tests/FunctionalTests/CCW/Program.cs
@@ -5,6 +5,8 @@ using WinRT;
 using System.Collections.Generic;
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using System.Runtime.InteropServices;
 
 var managedProperties = new ManagedProperties(42);
 var instance = new Class();
@@ -31,6 +33,11 @@ ccw.TryAs<IUnknownVftbl>(IID_IUriHandler, out var uriHandlerCCW);
 if (uriHandlerCCW == null)
 {
     return 103;
+}
+
+if (!CheckRuntimeClassName(ccw, "TestComponentCSharp.IProperties1"))
+{
+    return 119;
 }
 
 // Ensure that interfaces on the vtable / object don't get trimmed even if unused.
@@ -88,6 +95,11 @@ if (properties2CCW == null)
     return 110;
 }
 
+if (!CheckRuntimeClassName(ccw, "TestComponentCSharp.IProperties2"))
+{
+    return 120;
+}
+
 Guid IID_IlistInt = new("B939AF5B-B45D-5489-9149-61442C1905FE");
 Guid IID_IEnumerable = new("036D2C08-DF29-41AF-8AA2-D774BE62BA6F");
 var intList = new ManagedIntList();
@@ -102,6 +114,11 @@ ccw.TryAs<IUnknownVftbl>(IID_IEnumerable, out var enumerableCCW);
 if (enumerableCCW == null)
 {
     return 112;
+}
+
+if (!CheckRuntimeClassName(ccw, "Windows.Foundation.Collections.IVector`1<Int32>"))
+{
+    return 121;
 }
 
 Guid IID_IEnumerableDerived = new ("A70EC662-9975-51BB-9A28-82A876E01177");
@@ -127,6 +144,11 @@ if (enumerableRequiredTwo == null)
     return 115;
 }
 
+if (!CheckRuntimeClassName(ccw, "Windows.Foundation.Collections.IVector`1<TestComponent.Derived>"))
+{
+    return 122;
+}
+
 var nestedClass = TestClass2.GetInstance();
 ccw = MarshalInspectable<object>.CreateMarshaler(nestedClass);
 ccw.TryAs<IUnknownVftbl>(IID_IProperties2, out properties2CCW);
@@ -146,6 +168,19 @@ if (properties2CCW == null)
 var managedWarningClassList = new List<ManagedWarningClass>();
 instance.BindableIterableProperty = managedWarningClassList;
 
+var customCommand = new CustomCommand() as ICommand;
+ccw = MarshalInspectable<object>.CreateMarshaler(customCommand);
+ccw.TryAs<IUnknownVftbl>(ABI.System.Windows.Input.ICommandMethods.IID, out var commandCCW);
+if (commandCCW == null)
+{
+    return 118;
+}
+
+if (!CheckRuntimeClassName(ccw, "Microsoft.UI.Xaml.Input.ICommand"))
+{
+    return 123;
+}
+
 // These scenarios aren't supported today on AOT, but testing to ensure they
 // compile without issues.  They should still work fine outside of AOT.
 try
@@ -162,6 +197,40 @@ catch(Exception)
 }
 
 return 100;
+
+
+[DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", CallingConvention = CallingConvention.StdCall)]
+static extern unsafe char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
+
+[DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", CallingConvention = CallingConvention.StdCall)]
+static extern int WindowsDeleteString(IntPtr hstring);
+
+unsafe bool CheckRuntimeClassName(IObjectReference objRef, string expected)
+{
+    objRef.TryAs<IInspectable.Vftbl>(IID.IID_IInspectable, out var inspectable);
+    if (inspectable == null)
+    {
+        return false;
+    }
+
+    IntPtr __retval = default;
+    try
+    {
+        var hr = inspectable.Vftbl.GetRuntimeClassName(inspectable.ThisPtr, &__retval);
+        if (hr != 0)
+        {
+            return false;
+        }
+
+        uint length;
+        char* buffer = WindowsGetStringRawBuffer(__retval, &length);
+        return expected == new string(buffer, 0, (int)length);
+    }
+    finally
+    {
+        WindowsDeleteString(__retval);
+    }
+}
 
 sealed partial class ManagedProperties : IProperties1, IUriHandler
 {
@@ -392,5 +461,20 @@ partial class TestClass2
     internal static IProperties2 GetGenericInstance()
     {
         return new GenericNestedTestClass<int>();
+    }
+}
+
+sealed partial class CustomCommand : ICommand
+{
+    public event EventHandler CanExecuteChanged;
+
+    public bool CanExecute(object parameter)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Execute(object parameter)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -175,6 +175,34 @@ namespace WinRT
         public abstract object CreateInstance(IInspectable inspectable);
     }
 
+    /// <summary>
+    /// An attributes used to explicitly indicate ther runtime class name to use for WinRT exposed types.
+    /// </summary>
+    /// <remarks>This attribute is emitted by the CsWinRT generator for non-authored types implementing WinRT interfaces.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+#if EMBED
+    internal
+#else
+    public
+#endif
+    sealed class WinRTRuntimeClassNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Creates a new <see cref="WinRTRuntimeClassNameAttribute"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="runtimeClassName">The runtime class name to use.</param>
+        public WinRTRuntimeClassNameAttribute(string runtimeClassName)
+        {
+            RuntimeClassName = runtimeClassName;
+        }
+
+        /// <summary>
+        /// Gets the runtime class name for the current instance.
+        /// </summary>
+        public string RuntimeClassName { get; }
+    }
+
 #endif
 }
 

--- a/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
@@ -96,7 +96,7 @@ namespace ABI.WinRT.Interop
                 bool registerHandler =
                     !TryGetStateUnsafe(out state) ||
                     // We have a wrapper delegate, but no longer has any references from any event source.
-                    !state.HasComReferences();
+                    !state!.HasComReferences();
                 if (registerHandler)
                 {
                     state = CreateEventSourceState();
@@ -145,7 +145,7 @@ namespace ABI.WinRT.Interop
 
             lock (this)
             {
-                var oldEvent = state.targetDelegate;
+                var oldEvent = state!.targetDelegate;
                 state.targetDelegate = (TDelegate?)Delegate.Remove(state.targetDelegate, handler);
                 if (oldEvent is object && state.targetDelegate is null)
                 {

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -233,4 +233,5 @@ CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.Unconditional
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.IInspectable.As<I>()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.TypeExtensions.FindHelperType(System.Type)' in the implementation but not the reference.
 TypesMustExist : Type 'WinRT.WinRTRuntimeClassNameAttribute' does not exist in the reference but it does exist in the implementation.
-Total Issues: 235
+MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterTypeRuntimeClassNameLookup(System.Func<System.Type, System.String>)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 236

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -232,4 +232,5 @@ CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.Unconditional
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'ABI.WinRT.Interop.IActivationFactory.AsInterface<I>()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.IInspectable.As<I>()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.TypeExtensions.FindHelperType(System.Type)' in the implementation but not the reference.
-Total Issues: 234
+TypesMustExist : Type 'WinRT.WinRTRuntimeClassNameAttribute' does not exist in the reference but it does exist in the implementation.
+Total Issues: 235

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -71,7 +71,7 @@ namespace WinRT
             RegisterCustomAbiTypeMappingNoLock(typeof(PropertyChangedEventHandler), typeof(ABI.System.ComponentModel.PropertyChangedEventHandler), "Microsoft.UI.Xaml.Data.PropertyChangedEventHandler");
             RegisterCustomAbiTypeMappingNoLock(typeof(INotifyDataErrorInfo), typeof(ABI.System.ComponentModel.INotifyDataErrorInfo), "Microsoft.UI.Xaml.Data.INotifyDataErrorInfo");    
             RegisterCustomAbiTypeMappingNoLock(typeof(INotifyPropertyChanged), typeof(ABI.System.ComponentModel.INotifyPropertyChanged), "Microsoft.UI.Xaml.Data.INotifyPropertyChanged");
-            RegisterCustomAbiTypeMappingNoLock(typeof(ICommand), typeof(ABI.System.Windows.Input.ICommand), "Microsoft.UI.Xaml.Interop.ICommand");
+            RegisterCustomAbiTypeMappingNoLock(typeof(ICommand), typeof(ABI.System.Windows.Input.ICommand), "Microsoft.UI.Xaml.Input.ICommand");
             RegisterCustomAbiTypeMappingNoLock(typeof(IServiceProvider), typeof(ABI.System.IServiceProvider), "Microsoft.UI.Xaml.IXamlServiceProvider");
             RegisterCustomAbiTypeMappingNoLock(typeof(EventHandler<>), typeof(ABI.System.EventHandler<>), "Windows.Foundation.EventHandler`1");
 

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -428,7 +428,7 @@ namespace ABI.System.Collections
                 }
                 else
                 {
-                    [SuppressMessage("Trimming", "IL2070", Justification =
+                    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification =
                         """
                         'SomeType.GetInterfaces().Any(t => t.GetGenericTypeDefinition() == typeof(IEnumerable<>)' is safe,
                         provided you obtained someType from something like an analyzable 'Type.GetType' or 'object.GetType'


### PR DESCRIPTION
In scenarios where we have a type that isn't a WinRT type, but implements WinRT interfaces, we previously went through the interfaces and determined the most derived one to return as the runtime class name.  This is not trim friendly.  With these changes, we will do this in the AOT source generator rather than at runtime and instead at runtime lookup the attribute on the type.  This also allows the opportunity for someone in this scenario to specify their own class name if desired as today if there are multiple interfaces that don't inherit from each other, we will need to choose one and that might not be what is desired by the author.

In addition to the scenarios where we put the attribute on the type, there are a couple scenarios where the type isn't authored in the component but rather a system type.  To handle these scenarios, we use the lookup table similar to what we do in the CCW vtable scenario.