### PR TITLE
Add 'CsWinRTEnableIReferenceSupport' feature switch

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -251,6 +251,7 @@ $(CsWinRTInternalProjection)
     <CsWinRTUseExceptionResourceKeys Condition="'$(CsWinRTUseExceptionResourceKeys)' == ''">false</CsWinRTUseExceptionResourceKeys>
     <CsWinRTEnableDefaultCustomTypeMappings Condition="'$(CsWinRTEnableDefaultCustomTypeMappings)' == ''">true</CsWinRTEnableDefaultCustomTypeMappings>
     <CsWinRTEnableICustomPropertyProviderSupport Condition="'$(CsWinRTEnableICustomPropertyProviderSupport)' == ''">true</CsWinRTEnableICustomPropertyProviderSupport>
+    <CsWinRTEnableIReferenceSupport Condition="'$(CsWinRTEnableIReferenceSupport)' == ''">true</CsWinRTEnableIReferenceSupport>
   </PropertyGroup>
 
   <!--
@@ -277,6 +278,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT"
                                     Value="$(CsWinRTEnableICustomPropertyProviderSupport)"
+                                    Trim="true" />
+    
+    <!-- CSWINRT_ENABLE_IREFERENCE_SUPPORT switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_IREFERENCE_SUPPORT"
+                                    Value="$(CsWinRTEnableIReferenceSupport)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -616,6 +616,11 @@ namespace WinRT
 
         private static ComInterfaceEntry ProvideIReference(Type type)
         {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                throw new NotSupportedException("Support for 'IReference<T>' is not enabled.");
+            }
+
             if (type == typeof(int))
             {
                 return new ComInterfaceEntry
@@ -888,6 +893,11 @@ namespace WinRT
 
         private static ComInterfaceEntry ProvideIReferenceArray(Type arrayType)
         {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                throw new NotSupportedException("Support for 'IReferenceArray<T>' is not enabled.");
+            }
+
             Type type = arrayType.GetElementType();
             if (type == typeof(int))
             {

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -108,7 +108,7 @@ internal static class FeatureSwitches
     }
 
     /// <summary>
-    /// Gets a value indicating whether or not <c>IReference&lt;T&gt;</c> and <c>IReferenceArray&lt;T&gt;</c> CCW implementations should be supported (defaults to <see langword="true"/>).
+    /// Gets a value indicating whether or not <c>IReference&lt;T&gt;</c>, <c>IReferenceArray&lt;T&gt;</c> and <c>IPropertyValue</c> CCW implementations should be supported (defaults to <see langword="true"/>).
     /// </summary>
     public static bool EnableIReferenceSupport
     {

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -42,6 +42,11 @@ internal static class FeatureSwitches
     private const string EnableICustomPropertyProviderSupportPropertyName = "CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT";
 
     /// <summary>
+    /// The configuration property name for <see cref="EnableIReferenceSupport"/>.
+    /// </summary>
+    private const string EnableIReferenceSupportPropertyName = "CSWINRT_ENABLE_IREFERENCE_SUPPORT";
+
+    /// <summary>
     /// The backing field for <see cref="IsDynamicObjectsSupportEnabled"/>.
     /// </summary>
     private static int _isDynamicObjectsSupportEnabled;
@@ -60,6 +65,11 @@ internal static class FeatureSwitches
     /// The backing field for <see cref="EnableICustomPropertyProviderSupport"/>.
     /// </summary>
     private static int _enableICustomPropertyProviderSupport;
+
+    /// <summary>
+    /// The backing field for <see cref="EnableIReferenceSupport"/>.
+    /// </summary>
+    private static int _enableIReferenceSupport;
 
     /// <summary>
     /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
@@ -95,6 +105,15 @@ internal static class FeatureSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetConfigurationValue(EnableICustomPropertyProviderSupportPropertyName, ref _enableICustomPropertyProviderSupport, true);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not <c>IReference&lt;T&gt;</c> and <c>IReferenceArray&lt;T&gt;</c> CCW implementations should be supported (defaults to <see langword="true"/>).
+    /// </summary>
+    public static bool EnableIReferenceSupport
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetConfigurationValue(EnableIReferenceSupportPropertyName, ref _enableIReferenceSupport, true);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -17,6 +17,10 @@
       <!-- CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT switch -->
       <method signature="System.Boolean get_EnableICustomPropertyProviderSupport()" body="stub" value="false" feature="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT" featurevalue="false"/>
       <method signature="System.Boolean get_EnableICustomPropertyProviderSupport()" body="stub" value="true" feature="CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT" featurevalue="true"/>
+
+      <!-- CSWINRT_ENABLE_IREFERENCE_SUPPORT switch -->
+      <method signature="System.Boolean get_EnableIReferenceSupport()" body="stub" value="false" feature="CSWINRT_ENABLE_IREFERENCE_SUPPORT" featurevalue="false"/>
+      <method signature="System.Boolean get_EnableIReferenceSupport()" body="stub" value="true" feature="CSWINRT_ENABLE_IREFERENCE_SUPPORT" featurevalue="true"/>
     </type>
   </assembly>
 

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -462,28 +462,25 @@ namespace ABI.System
             Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[3];
             int count = 0;
 
-            entries[0] = new ComWrappers.ComInterfaceEntry
+            entries[count++] = new ComWrappers.ComInterfaceEntry
             {
                 IID = IID,
                 Vtable = AbiToProjectionVftablePtr
             };
-            count++;
-
-            entries[1] = new ComWrappers.ComInterfaceEntry
-            {
-                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-            };
-            count++;
 
             if (FeatureSwitches.EnableIReferenceSupport)
             {
-                entries[2] = new ComWrappers.ComInterfaceEntry
+                entries[count++] = new ComWrappers.ComInterfaceEntry
+                {
+                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+                };
+
+                entries[count++] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = Nullable_EventHandler.IID,
                     Vtable = Nullable_EventHandler.AbiToProjectionVftablePtr
                 };
-                count++;
             }
 
             return entries.Slice(0, count).ToArray();

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -456,26 +456,37 @@ namespace ABI.System
         }
 
 #if NET
+        [SkipLocalsInit]
         internal static ComWrappers.ComInterfaceEntry[] GetExposedInterfaces()
         {
-            return new ComWrappers.ComInterfaceEntry[]
+            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[3];
+            int count = 0;
+
+            entries[0] = new ComWrappers.ComInterfaceEntry
             {
-                new ComWrappers.ComInterfaceEntry
-                {
-                    IID = IID,
-                    Vtable = AbiToProjectionVftablePtr
-                },
-                new ComWrappers.ComInterfaceEntry
-                {
-                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-                },
-                new ComWrappers.ComInterfaceEntry
+                IID = IID,
+                Vtable = AbiToProjectionVftablePtr
+            };
+            count++;
+
+            entries[1] = new ComWrappers.ComInterfaceEntry
+            {
+                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+            };
+            count++;
+
+            if (FeatureSwitches.EnableIReferenceSupport)
+            {
+                entries[2] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = Nullable_EventHandler.IID,
                     Vtable = Nullable_EventHandler.AbiToProjectionVftablePtr
-                }
-            };
+                };
+                count++;
+            }
+
+            return entries.Slice(0, count).ToArray();
         }
 #endif
     }

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ABI.System;
 using WinRT;
 using WinRT.Interop;
 
@@ -2250,8 +2249,10 @@ namespace ABI.System
 
         public static ComWrappers.ComInterfaceEntry[] GetExposedInterfaces(ComWrappers.ComInterfaceEntry delegateInterface)
         {
-            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
+            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[3];
             int count = 0;
+
+            entries[count++] = delegateInterface;
 
             if (FeatureSwitches.EnableIReferenceSupport)
             {

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2196,21 +2196,19 @@ namespace ABI.System
             Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
             int count = 0;
 
-            entries[0] = new ComWrappers.ComInterfaceEntry
-            {
-                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-            };
-            count++;
-
             if (FeatureSwitches.EnableIReferenceSupport)
             {
-                entries[1] = new ComWrappers.ComInterfaceEntry
+                entries[count++] = new ComWrappers.ComInterfaceEntry
+                {
+                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+                };
+
+                entries[count++] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = PIID,
                     Vtable = ABI.Windows.Foundation.BoxedValueIReferenceImpl<T, TAbi>.AbiToProjectionVftablePtr
                 };
-                count++;
             }
 
             return entries.Slice(0, count).ToArray();
@@ -2255,21 +2253,19 @@ namespace ABI.System
             Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
             int count = 0;
 
-            entries[0] = new ComWrappers.ComInterfaceEntry
-            {
-                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-            };
-            count++;
-
             if (FeatureSwitches.EnableIReferenceSupport)
             {
-                entries[1] = new ComWrappers.ComInterfaceEntry
+                entries[count++] = new ComWrappers.ComInterfaceEntry
+                {
+                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+                };
+
+                entries[count++] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = PIID,
                     Vtable = ABI.System.Nullable_Delegate<T>.AbiToProjectionVftablePtr
                 };
-                count++;
             }
 
             return entries.Slice(0, count).ToArray();

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using ABI.System;
 using WinRT;
 using WinRT.Interop;
 
@@ -2189,21 +2190,30 @@ namespace ABI.System
     {
         private static readonly Guid PIID = ABI.System.Nullable<T>.PIID;
 
+        [SkipLocalsInit]
         public ComWrappers.ComInterfaceEntry[] GetExposedInterfaces()
         {
-            return new ComWrappers.ComInterfaceEntry[]
+            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
+            int count = 0;
+
+            entries[0] = new ComWrappers.ComInterfaceEntry
             {
-                new ComWrappers.ComInterfaceEntry
-                {
-                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-                },
-                new ComWrappers.ComInterfaceEntry
+                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+            };
+            count++;
+
+            if (FeatureSwitches.EnableIReferenceSupport)
+            {
+                entries[1] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = PIID,
                     Vtable = ABI.Windows.Foundation.BoxedValueIReferenceImpl<T, TAbi>.AbiToProjectionVftablePtr
-                }
-            };
+                };
+                count++;
+            }
+
+            return entries.Slice(0, count).ToArray();
         }
 
         unsafe object IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable)
@@ -2242,20 +2252,27 @@ namespace ABI.System
 
         public static ComWrappers.ComInterfaceEntry[] GetExposedInterfaces(ComWrappers.ComInterfaceEntry delegateInterface)
         {
-            return new ComWrappers.ComInterfaceEntry[]
+            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
+            int count = 0;
+
+            entries[0] = new ComWrappers.ComInterfaceEntry
             {
-                delegateInterface,
-                new ComWrappers.ComInterfaceEntry
-                {
-                    IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
-                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
-                },
-                new ComWrappers.ComInterfaceEntry
+                IID = ABI.Windows.Foundation.ManagedIPropertyValueImpl.IID,
+                Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+            };
+            count++;
+
+            if (FeatureSwitches.EnableIReferenceSupport)
+            {
+                entries[1] = new ComWrappers.ComInterfaceEntry
                 {
                     IID = PIID,
                     Vtable = ABI.System.Nullable_Delegate<T>.AbiToProjectionVftablePtr
-                }
-            };
+                };
+                count++;
+            }
+
+            return entries.Slice(0, count).ToArray();
         }
 
         public abstract ComWrappers.ComInterfaceEntry GetDelegateInterface();

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -248,6 +248,11 @@ namespace WinRT
 
         internal static bool ShouldProvideIReference(this Type type)
         {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                return false;
+            }
+
             return type.IsPrimitive ||
                 type == typeof(string) ||
                 type == typeof(Guid) ||

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -243,6 +243,14 @@ namespace WinRT
 
         internal static bool IsIReferenceArray(this Type type)
         {
+            // If support for 'IReference<T>' is disabled, we'll never instantiate any types implementing this interface. We
+            // can guard this check behind the feature switch to avoid making 'IReferenceArray<T>' reflectable, which will
+            // otherwise root some unnecessary code and metadata from the ABI implementation type.
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                return false;
+            }
+
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Windows.Foundation.IReferenceArray<>);
         }
 


### PR DESCRIPTION
This PR adds a new 'CsWinRTEnableIReferenceSupport' feature switch to trim out all `IReference*<T>` support.
Opening as draft until I get sizoscope diffs.