### PR TITLE
Fix IL2087 trim warning in 'ObjectReferenceWithContext<T>'

### DIFF
--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -110,7 +110,7 @@ namespace WinRT
                     int hr = _GetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId), &instancePtr);
                     if (hr == 0)
                     {
-                        var objRef = ObjectReference<IUnknownVftbl>.Attach(ref instancePtr);
+                        var objRef = ObjectReference<IUnknownVftbl>.Attach(ref instancePtr, IID.IID_IUnknown);
                         return (objRef, hr);
                     }
                     else
@@ -169,7 +169,7 @@ namespace WinRT
                     int hr = Platform.RoGetActivationFactory(MarshalString.GetAbi(ref __runtimeClassId), &iid, &instancePtr);
                     if (hr == 0)
                     {
-                        var objRef = ObjectReference<I>.Attach(ref instancePtr);
+                        var objRef = ObjectReference<I>.Attach(ref instancePtr, iid);
                         return (objRef, hr);
                     }
                     else
@@ -327,7 +327,7 @@ namespace WinRT
                     instancePtr = activationHandler(typeName, iid);
                     if (instancePtr != IntPtr.Zero)
                     {
-                        return ObjectReference<IUnknownVftbl>.Attach(ref instancePtr);
+                        return ObjectReference<IUnknownVftbl>.Attach(ref instancePtr, iid);
                     }
                 }
                 finally

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -67,7 +67,7 @@ namespace WinRT
                     &iid,
                     thisPtr,
                     &agileReference));
-                _agileReference = ObjectReference<IUnknownVftbl>.Attach(ref agileReference);
+                _agileReference = ObjectReference<IUnknownVftbl>.Attach(ref agileReference, IID.IID_IUnknown);
             }
             catch (TypeLoadException)
             {

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -106,7 +106,7 @@ namespace WinRT
         private static unsafe IGlobalInterfaceTable GetGitTable()
         {
             Guid gitClsid = CLSID_StdGlobalInterfaceTable;
-            Guid gitIid = ABI.WinRT.Interop.IGlobalInterfaceTable.IID;
+            Guid gitIid = IID.IID_IGlobalInterfaceTable;
             IntPtr gitPtr = default;
 
             try

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -94,7 +94,7 @@ namespace WinRT
                     {
                         Git.RevokeInterfaceFromGlobal(_cookie);
                     }
-                    catch(ArgumentException)
+                    catch (ArgumentException)
                     {
                         // Revoking cookie from GIT table may fail if apartment is gone.
                     }

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -113,9 +113,12 @@ namespace WinRT
 
         public static IObjectReference GetObjectReferenceForInterface(IntPtr externalComObject)
         {
-            return GetObjectReferenceForInterface<IUnknownVftbl>(externalComObject);
+            return GetObjectReferenceForInterface<IUnknownVftbl>(externalComObject, IID.IID_IUnknown);
         }
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         public static ObjectReference<T> GetObjectReferenceForInterface<T>(IntPtr externalComObject)
         {
             if (externalComObject == IntPtr.Zero)
@@ -1162,7 +1165,7 @@ namespace WinRT
         internal static ObjectReference<T> CreateCCWForObject<T>(object obj, Guid iid)
         {
             IntPtr ccw = CreateCCWForObjectForABI(obj, iid);
-            return ObjectReference<T>.Attach(ref ccw);
+            return ObjectReference<T>.Attach(ref ccw, iid);
         }
 
         internal static ObjectReferenceValue CreateCCWForObjectForMarshaling(object obj, Guid iid)

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -616,7 +616,7 @@ namespace WinRT
                 }
                 else if (Marshal.QueryInterface(externalComObject, ref inspectableIID, out ptr) == 0)
                 {
-                    var inspectableObjRef = ComWrappersSupport.GetObjectReferenceForInterface<IInspectable.Vftbl>(ptr);
+                    var inspectableObjRef = ComWrappersSupport.GetObjectReferenceForInterface<IInspectable.Vftbl>(ptr, IID.IID_IInspectable);
                     ComWrappersHelper.Init(inspectableObjRef);
 
                     IInspectable inspectable = new IInspectable(inspectableObjRef);

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -29,17 +29,31 @@ namespace WinRT
         // On any exception, calls onFail callback if any set.
         // If not set, exception is handled due to today we don't
         // have any scenario to propagate it from here.
-        public unsafe static void CallInContext(IntPtr contextCallbackPtr, IntPtr contextToken, Action callback, Action onFailCallback)
+        //
+        // On modern .NET, we can use function pointers to avoid the
+        // small binary size increase from all generated fields and
+        // logic to cache delegates, since we don't need any of that.
+        public unsafe static void CallInContext(
+            IntPtr contextCallbackPtr,
+            IntPtr contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+            delegate*<object, void> callback,
+            delegate*<object, void> onFailCallback,
+#else
+            Action<object> callback,
+            Action<object> onFailCallback,
+#endif
+            object state)
         {
             // Check if we are already on the same context, if so we do not need to switch.
             if(contextCallbackPtr == IntPtr.Zero || GetContextToken() == contextToken)
             {
-                callback();
+                callback(state);
                 return;
             }
 
 #if NET && CsWinRT_LANG_11_FEATURES
-            IContextCallbackVftbl.ContextCallback(contextCallbackPtr, callback, onFailCallback);
+            IContextCallbackVftbl.ContextCallback(contextCallbackPtr, callback, onFailCallback, state);
 #else
             ComCallData data = default;
             var contextCallback = new ABI.WinRT.Interop.IContextCallback(ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.FromAbi(contextCallbackPtr));
@@ -48,13 +62,13 @@ namespace WinRT
             {
                 contextCallback.ContextCallback(_ =>
                 {
-                    callback();
+                    callback(state);
                     return 0;
                 }, &data, IID.IID_ICallbackWithNoReentrancyToApplicationSTA, 5);
             } 
-            catch(Exception)
+            catch (Exception)
             {
-                onFailCallback?.Invoke();
+                onFailCallback?.Invoke(state);
             }
 #endif
         }

--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -122,7 +122,7 @@ namespace WinRT
         }
 
         public static IInspectable FromAbi(IntPtr thisPtr) =>
-            new IInspectable(ObjectReference<Vftbl>.FromAbi(thisPtr));
+            new IInspectable(ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_IInspectable));
 
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;

--- a/src/WinRT.Runtime/Interop/ExceptionErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Interop/ExceptionErrorInfo.net5.cs
@@ -242,7 +242,7 @@ namespace ABI.WinRT.Interop
 
                 GC.KeepAlive(obj);
 
-                return ObjectReference<IUnknownVftbl>.Attach(ref __return_value__);
+                return ObjectReference<IUnknownVftbl>.Attach(ref __return_value__, IID.IID_IUnknown);
             }
             finally
             {

--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -70,7 +70,7 @@ namespace ABI.WinRT.Interop
 
             try
             {
-                return ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(instancePtr);
+                return ComWrappersSupport.GetObjectReferenceForInterface<IUnknownVftbl>(instancePtr, global::WinRT.Interop.IID.IID_IUnknown);
             }
             finally
             {
@@ -142,7 +142,7 @@ namespace ABI.WinRT.Interop
                 return 0;
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_IActivationFactory);
 
         public static implicit operator IActivationFactory(IObjectReference obj) => (obj != null) ? new IActivationFactory(obj) : null;
         protected readonly ObjectReference<Vftbl> _obj;

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -134,7 +134,7 @@ namespace ABI.WinRT.Interop
     [Guid("00000146-0000-0000-C000-000000000046")]
     internal sealed unsafe class IGlobalInterfaceTable : global::WinRT.Interop.IGlobalInterfaceTable
     {
-        internal static readonly Guid IID = new(0x00000146, 0, 0, 0xc0, 0, 0, 0, 0, 0, 0, 0x46);
+        internal static readonly Guid IID = global::WinRT.Interop.IID.IID_IGlobalInterfaceTable;
 
         [Guid("00000146-0000-0000-C000-000000000046")]
         [StructLayout(LayoutKind.Sequential)]

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -72,7 +72,7 @@ namespace ABI.WinRT.Interop
                 ThisPtr, &riid, &ptr));
             try
             {
-                return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr);
+                return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr, riid);
             }
             finally
             {
@@ -149,7 +149,7 @@ namespace ABI.WinRT.Interop
             public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr*, int> GetInterfaceFromGlobal => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr*, int>)_GetInterfaceFromGlobal;
         }
 
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IGlobalInterfaceTable);
 
         public static implicit operator IGlobalInterfaceTable(IObjectReference obj) => (obj != null) ? new IGlobalInterfaceTable(obj) : null;
         public static implicit operator IGlobalInterfaceTable(ObjectReference<Vftbl> obj) => (obj != null) ? new IGlobalInterfaceTable(obj) : null;

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -18,6 +18,14 @@ namespace ABI.WinRT.Interop
     }
 
 #if NET && CsWinRT_LANG_11_FEATURES
+    internal unsafe struct CallbackData
+    {
+        public delegate*<object, void> Callback;
+        public object State;
+    }
+#endif
+
+#if NET && CsWinRT_LANG_11_FEATURES
     internal unsafe struct IContextCallbackVftbl
     {
 #pragma warning disable CS0649 // Native layout
@@ -25,34 +33,31 @@ namespace ABI.WinRT.Interop
         private delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4;
 #pragma warning restore CS0649
 
-        public static void ContextCallback(IntPtr contextCallbackPtr, Action callback, Action onFailCallback)
+        public static void ContextCallback(IntPtr contextCallbackPtr, delegate*<object, void> callback, delegate*<object, void> onFailCallback, object state)
         {
             ComCallData comCallData;
             comCallData.dwDispid = 0;
             comCallData.dwReserved = 0;
 
-            // Copy the callback into a local to make sure it really is a local that
-            // gets marked as address taken, rather than something that could potentially
-            // be inlined into the caller into some state machine or anything else not safe.
-            Action callbackAddressTaken = callback;
+            CallbackData callbackData;
+            callbackData.Callback = callback;
+            callbackData.State = state;
 
             // We can just store a pointer to the callback to invoke in the context,
             // so we don't need to allocate another closure or anything. The callback
             // will be kept alive automatically, because 'comCallData' is address exposed.
             // We only do this if we can use C# 11, and if we're on modern .NET, to be safe.
             // In the callback below, we can then just retrieve the Action again to invoke it.
-            comCallData.pUserDefined = (IntPtr)(void*)&callbackAddressTaken;
+            comCallData.pUserDefined = (IntPtr)(void*)&callbackData;
             
             [UnmanagedCallersOnly]
             static int InvokeCallback(ComCallData* comCallData)
             {
                 try
                 {
-                    // Dereference the pointer to Action and invoke it (see notes above).
-                    // Once again, the pointer is not to the Action object, but just to the
-                    // local *reference* to the object, which is pinned (as it's a local).
-                    // That means that there's no pinning to worry about either.
-                    ((Action*)comCallData->pUserDefined)->Invoke();
+                    CallbackData* callbackData = (CallbackData*)comCallData->pUserDefined;
+
+                    callbackData->Callback(callbackData->State);
 
                     return 0; // S_OK
                 }
@@ -74,7 +79,10 @@ namespace ABI.WinRT.Interop
 
             if (hresult < 0)
             {
-                onFailCallback?.Invoke();
+                if (onFailCallback is not null)
+                {
+                    onFailCallback(state);
+                }
             }
         }
     }

--- a/src/WinRT.Runtime/Interop/IID.g.cs
+++ b/src/WinRT.Runtime/Interop/IID.g.cs
@@ -216,7 +216,7 @@ namespace WinRT.Interop
         }
 
         /// <summary>The IID for <c>IMarshal</c> (00000003-0000-0000-C000-000000000046).</summary>
-        internal static ref readonly Guid IID_IMarshal
+        public static ref readonly Guid IID_IMarshal
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]   
             get

--- a/src/WinRT.Runtime/Interop/IID.g.cs
+++ b/src/WinRT.Runtime/Interop/IID.g.cs
@@ -439,5 +439,205 @@ namespace WinRT.Interop
                 return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
             }
         }
+
+        /// <summary>The IID for <c>PropertyChangedEventArgsRuntimeClassFactory</c> (7C0C27A8-0B41-5070-B160-FC9AE960A36C).</summary>
+        internal static ref readonly Guid IID_PropertyChangedEventArgsRuntimeClassFactory
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0xA8, 0x27, 0x0C, 0x7C,
+                    0x41, 0x0B,
+                    0x70, 0x50,
+                    0xB1,
+                    0x60,
+                    0xFC,
+                    0x9A,
+                    0xE9,
+                    0x60,
+                    0xA3,
+                    0x6C
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>DataErrorsChangedEventArgsRuntimeClassFactory</c> (62D0BD1E-B85F-5FCC-842A-7CB0DDA37FE5).</summary>
+        internal static ref readonly Guid IID_DataErrorsChangedEventArgsRuntimeClassFactory
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x1E, 0xBD, 0xD0, 0x62,
+                    0x5F, 0xB8,
+                    0xCC, 0x5F,
+                    0x84,
+                    0x2A,
+                    0x7C,
+                    0xB0,
+                    0xDD,
+                    0xA3,
+                    0x7F,
+                    0xE5
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>UriRuntimeClassFactory</c> (44A9796F-723E-4FDF-A218-033E75B0C084).</summary>
+        internal static ref readonly Guid IID_UriRuntimeClassFactory
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x6F, 0x79, 0xA9, 0x44,
+                    0x3E, 0x72,
+                    0xDF, 0x4F,
+                    0xA2,
+                    0x18,
+                    0x03,
+                    0x3E,
+                    0x75,
+                    0xB0,
+                    0xC0,
+                    0x84
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>INotifyDataErrorInfo</c> (0EE6C2CC-273E-567D-BC0A-1DD87EE51EBA).</summary>
+        internal static ref readonly Guid IID_INotifyDataErrorInfo
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0xCC, 0xC2, 0xE6, 0x0E,
+                    0x3E, 0x27,
+                    0x7D, 0x56,
+                    0xBC,
+                    0x0A,
+                    0x1D,
+                    0xD8,
+                    0x7E,
+                    0xE5,
+                    0x1E,
+                    0xBA
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>INotifyPropertyChanged</c> (90B17601-B065-586E-83D9-9ADC3A695284).</summary>
+        internal static ref readonly Guid IID_INotifyPropertyChanged
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x01, 0x76, 0xB1, 0x90,
+                    0x65, 0xB0,
+                    0x6E, 0x58,
+                    0x83,
+                    0xD9,
+                    0x9A,
+                    0xDC,
+                    0x3A,
+                    0x69,
+                    0x52,
+                    0x84
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>INotifyCollectionChanged</c> (530155E1-28A5-5693-87CE-30724D95A06D).</summary>
+        internal static ref readonly Guid IID_INotifyCollectionChanged
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0xE1, 0x55, 0x01, 0x53,
+                    0xA5, 0x28,
+                    0x93, 0x56,
+                    0x87,
+                    0xCE,
+                    0x30,
+                    0x72,
+                    0x4D,
+                    0x95,
+                    0xA0,
+                    0x6D
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>ICommand</c> (E5AF3542-CA67-4081-995B-709DD13792DF).</summary>
+        internal static ref readonly Guid IID_ICommand
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x42, 0x35, 0xAF, 0xE5,
+                    0x67, 0xCA,
+                    0x81, 0x40,
+                    0x99,
+                    0x5B,
+                    0x70,
+                    0x9D,
+                    0xD1,
+                    0x37,
+                    0x92,
+                    0xDF
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>IGlobalInterfaceTable</c> (00000146-0000-0000-C000-000000000046).</summary>
+        internal static ref readonly Guid IID_IGlobalInterfaceTable
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x46, 0x01, 0x00, 0x00,
+                    0x00, 0x00,
+                    0x00, 0x00,
+                    0xC0,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x46
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
     }
 }

--- a/src/WinRT.Runtime/Interop/IID.tt
+++ b/src/WinRT.Runtime/Interop/IID.tt
@@ -38,7 +38,15 @@ var entries = new (string Name, string IID, bool IsPublic)[]
     ("ILanguageExceptionErrorInfo", "04A2DBF3-DF83-116C-0946-0812ABF6E07D", false),
     ("IRestrictedErrorInfo", "82BA7092-4C88-427D-A7BC-16DD93FEB67E", false),
     ("INotifyCollectionChangedEventArgsFactory", "5108EBA4-4892-5A20-8374-A96815E0FD27", false),
-    ("INotifyCollectionChangedEventArgs", "DA049FF2-D2E0-5FE8-8C7B-F87F26060B6F", false)
+    ("INotifyCollectionChangedEventArgs", "DA049FF2-D2E0-5FE8-8C7B-F87F26060B6F", false),
+    ("PropertyChangedEventArgsRuntimeClassFactory", "7C0C27A8-0B41-5070-B160-FC9AE960A36C", false),
+    ("DataErrorsChangedEventArgsRuntimeClassFactory", "62D0BD1E-B85F-5FCC-842A-7CB0DDA37FE5", false),
+    ("UriRuntimeClassFactory", "44A9796F-723E-4FDF-A218-033E75B0C084", false),
+    ("INotifyDataErrorInfo", "0EE6C2CC-273E-567D-BC0A-1DD87EE51EBA", false),
+    ("INotifyPropertyChanged", "90B17601-B065-586E-83D9-9ADC3A695284", false),
+    ("INotifyCollectionChanged", "530155E1-28A5-5693-87CE-30724D95A06D", false),
+    ("ICommand", "E5AF3542-CA67-4081-995B-709DD13792DF", false),
+    ("IGlobalInterfaceTable", "00000146-0000-0000-C000-000000000046", false)
 };
 
 for (int i = 0; i < entries.Length; i++)

--- a/src/WinRT.Runtime/Interop/IID.tt
+++ b/src/WinRT.Runtime/Interop/IID.tt
@@ -30,7 +30,7 @@ var entries = new (string Name, string IID, bool IsPublic)[]
     ("IReferenceTrackerTarget", "64BD43F8-BFEE-4EC4-B7EB-2935158DAE21", false),
     ("IActivationFactory", "00000035-0000-0000-C000-000000000046", true),
     ("IAgileObject", "94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90", false),
-    ("IMarshal", "00000003-0000-0000-C000-000000000046", false),
+    ("IMarshal", "00000003-0000-0000-C000-000000000046", true),
     ("IContextCallback", "000001DA-0000-0000-C000-000000000046", false),
     ("ICallbackWithNoReentrancyToApplicationSTA", "0A299774-3E4E-FC42-1D9D-72CEE105CA57", false),
     ("IErrorInfo", "1CF2B120-547D-101B-8E65-08002B2BD119", false),

--- a/src/WinRT.Runtime/Interop/IMarshal.cs
+++ b/src/WinRT.Runtime/Interop/IMarshal.cs
@@ -143,7 +143,7 @@ namespace ABI.WinRT.Interop
                 {
                     IntPtr proxyPtr;
                     Marshal.ThrowExceptionForHR(Platform.CoCreateFreeThreadedMarshaler(IntPtr.Zero, &proxyPtr));
-                    using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref proxyPtr);
+                    using var objRef = ObjectReference<IUnknownVftbl>.Attach(ref proxyPtr, global::WinRT.Interop.IID.IID_IUnknown);
                     IMarshal proxy = new IMarshal(objRef);
                     t_freeThreadedMarshaler = proxy;
                 }
@@ -268,7 +268,7 @@ namespace ABI.WinRT.Interop
                 return 0;
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IMarshal);
 
         public static implicit operator IMarshal(IObjectReference obj) => (obj != null) ? new IMarshal(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -237,4 +237,8 @@ MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterTypeRunt
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.Projections.FindCustomHelperTypeMapping(System.Type, System.Boolean)' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
-Total Issues: 239
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute' exists on 'WinRT.ObjectReference<T>.Attach(System.IntPtr)' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute' exists on 'WinRT.ObjectReference<T>.FromAbi(System.IntPtr)' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute' exists on 'WinRT.ObjectReference<T>.FromAbi(System.IntPtr, T)' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute' exists on 'WinRT.ComWrappersSupport.GetObjectReferenceForInterface<T>(System.IntPtr)' in the implementation but not the reference.
+Total Issues: 242

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -199,13 +199,13 @@ namespace WinRT
             }
 
             // Normal path for IObjectReference or any IObjectReference<T>
-            return ObjectReference<T>.TryAs(this, iid, out objRef);            
+            return ObjectReference<T>.TryAs(this, iid, out objRef);
         }
 
         public virtual unsafe ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)
         {
             AddRef(true);
-            var objRef = ObjectReference<IUnknownVftbl>.Attach(ref ptr);
+            var objRef = ObjectReference<IUnknownVftbl>.Attach(ref ptr, IID.IID_IUnknown);
             objRef.IsAggregated = IsAggregated;
             objRef.PreventReleaseOnDispose = IsAggregated;
             objRef.ReferenceTrackerPtr = ReferenceTrackerPtr;
@@ -497,6 +497,9 @@ namespace WinRT
         {
         }
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         public static ObjectReference<T> Attach(ref IntPtr thisPtr)
         {
             if (thisPtr == IntPtr.Zero)
@@ -546,6 +549,9 @@ namespace WinRT
             }
         }
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         public static unsafe ObjectReference<T> FromAbi(IntPtr thisPtr, T vftblT)
         {
             if (thisPtr == IntPtr.Zero)
@@ -595,6 +601,9 @@ namespace WinRT
             }
         }
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         public static ObjectReference<T> FromAbi(IntPtr thisPtr)
         {
             if (thisPtr == IntPtr.Zero)
@@ -662,7 +671,7 @@ namespace WinRT
 
                 sourceRef.AddRefFromTrackerSource();
 
-                objRef = ObjectReference<T>.Attach(ref thatPtr);
+                objRef = Attach(ref thatPtr, iid);
                 objRef.IsAggregated = sourceRef.IsAggregated;
                 objRef.PreventReleaseOnDispose = sourceRef.IsAggregated;
                 objRef.ReferenceTrackerPtr = sourceRef.ReferenceTrackerPtr;
@@ -705,6 +714,9 @@ namespace WinRT
 
         private readonly Guid _iid;
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         internal ObjectReferenceWithContext(IntPtr thisPtr, IntPtr contextCallbackPtr, IntPtr contextToken)
             : base(thisPtr)
         {
@@ -712,12 +724,18 @@ namespace WinRT
             _contextToken = contextToken;
         }
 
+#if NET
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "This constructor is setting the '_iid' field directly.")]
+#endif
         internal ObjectReferenceWithContext(IntPtr thisPtr, IntPtr contextCallbackPtr, IntPtr contextToken, Guid iid)
             : this(thisPtr, contextCallbackPtr, contextToken)
         {
             _iid = iid;
         }
 
+#if NET
+        [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]
+#endif
         internal ObjectReferenceWithContext(IntPtr thisPtr, T vftblT, IntPtr contextCallbackPtr, IntPtr contextToken)
             : base(thisPtr, vftblT)
         {
@@ -725,6 +743,9 @@ namespace WinRT
             _contextToken = contextToken;
         }
 
+#if NET
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "This constructor is setting the '_iid' field directly.")]
+#endif
         internal ObjectReferenceWithContext(IntPtr thisPtr, T vftblT, IntPtr contextCallbackPtr, IntPtr contextToken, Guid iid)
             : this(thisPtr, vftblT, contextCallbackPtr, contextToken)
         {
@@ -778,6 +799,9 @@ namespace WinRT
 
             return Unsafe.As<ObjectReference<T>>(objectReference);
 
+#if NET
+            [UnconditionalSuppressMessage("Trimming", "IL2087", Justification = "The '_iid' field is only empty when using annotated APIs not trim-safe.")]
+#endif
             IObjectReference CreateForCurrentContext(IntPtr _)
             {
                 var agileReference = AgileReference;
@@ -822,7 +846,7 @@ namespace WinRT
         public override ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)
         {
             AddRef(true);
-            var objRef = new ObjectReferenceWithContext<IUnknownVftbl>(ptr, Context.GetContextCallback(), Context.GetContextToken())
+            var objRef = new ObjectReferenceWithContext<IUnknownVftbl>(ptr, Context.GetContextCallback(), Context.GetContextToken(), IID.IID_IUnknown)
             {
                 IsAggregated = IsAggregated,
                 PreventReleaseOnDispose = IsAggregated,

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -824,6 +824,15 @@ namespace WinRT
 
                 try
                 {
+#if NET
+                    // On NAOT, we can always assume the IID will not be empty, as the only way to reach that path is by
+                    // going through a trim-unsafe constructor, which is explicitly not supported in this configuration.
+                    if (!RuntimeFeature.IsDynamicCodeCompiled)
+                    {
+                        return agileReference.Get<T>(_iid);
+                    }
+#endif
+
                     if (_iid == Guid.Empty)
                     {
                         return agileReference.Get<T>(GuidGenerator.GetIID(typeof(T)));

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -698,17 +698,29 @@ namespace WinRT
         private volatile bool _isAgileReferenceSet;
         private volatile AgileReference __agileReference;
         private AgileReference AgileReference => _isAgileReferenceSet ? __agileReference : Make_AgileReference();
-        private AgileReference Make_AgileReference()
+        private unsafe AgileReference Make_AgileReference()
         {
-            Context.CallInContext(_contextCallbackPtr, _contextToken, InitAgileReference, null);
+            Context.CallInContext(
+                _contextCallbackPtr,
+                _contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+                &InitAgileReference,
+#else
+                InitAgileReference,
+#endif
+                null,
+                this);
 
             // Set after CallInContext callback given callback can fail to occur.
             _isAgileReferenceSet = true;
+
             return __agileReference;
 
-            void InitAgileReference()
+            static void InitAgileReference(object state)
             {
-                global::System.Threading.Interlocked.CompareExchange(ref __agileReference, new AgileReference(this), null);
+                ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
+
+                global::System.Threading.Interlocked.CompareExchange(ref @this.__agileReference, new AgileReference(@this), null);
             }
         }
 
@@ -805,16 +817,32 @@ namespace WinRT
             // of ConcurrentDictionary<,> and transitively dependent types for every vtable type T, since it's not
             // something we actually need. Because the cache is private and we're the only ones using it, we can
             // just store the per-context agile references as IObjectReference values, and then cast them on return.
-            IObjectReference objectReference = CachedContext.GetOrAdd(currentContext, CreateForCurrentContext);
+#if NET
+            IObjectReference objectReference = CachedContext.GetOrAdd(currentContext, ContextCallbackHolder.Value, this);
+#else
+            IObjectReference objectReference = CachedContext.GetOrAdd(currentContext, ptr => ContextCallbackHolder.Value(ptr, this));
+#endif
 
             return Unsafe.As<ObjectReference<T>>(objectReference);
+        }
+
+        private static class ContextCallbackHolder
+        {
+            // We have a single lambda expression in this type, so we can manually rewrite it to a 'static readonly'
+            // field. This avoids the extra logic to lazily initialized it (it's already lazily initialized because
+            // it's in a 'beforefieldinit' type which is only used when the lambda is actually needed), and also it
+            // allows storing the entire delegate in the Frozen Object Heap (FOH) on modern runtimes.
+            public static readonly Func<IntPtr, IObjectReference, IObjectReference> Value = CreateForCurrentContext;
 
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2087", Justification = "The '_iid' field is only empty when using annotated APIs not trim-safe.")]
 #endif
-            IObjectReference CreateForCurrentContext(IntPtr _)
+            private static IObjectReference CreateForCurrentContext(IntPtr _, IObjectReference state)
             {
-                var agileReference = AgileReference;
+                ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
+
+                var agileReference = @this.AgileReference;
+
                 // We may fail to switch context and thereby not get an agile reference.
                 // In these cases, fallback to using the current context.
                 if (agileReference == null)
@@ -829,17 +857,17 @@ namespace WinRT
                     // going through a trim-unsafe constructor, which is explicitly not supported in this configuration.
                     if (!RuntimeFeature.IsDynamicCodeCompiled)
                     {
-                        return agileReference.Get<T>(_iid);
+                        return agileReference.Get<T>(@this._iid);
                     }
 #endif
 
-                    if (_iid == Guid.Empty)
+                    if (@this._iid == Guid.Empty)
                     {
                         return agileReference.Get<T>(GuidGenerator.GetIID(typeof(T)));
                     }
                     else
                     {
-                        return agileReference.Get<T>(_iid);
+                        return agileReference.Get<T>(@this._iid);
                     }
                 }
                 catch (Exception)
@@ -858,8 +886,42 @@ namespace WinRT
                 CachedContext.Clear();
             }
 
-            Context.CallInContext(_contextCallbackPtr, _contextToken, base.Release, ReleaseWithoutContext);
+            Context.CallInContext(
+                _contextCallbackPtr,
+                _contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+                &Release,
+                &ReleaseWithoutContext,
+#else
+                Release,
+                ReleaseWithoutContext,
+#endif
+                this);
+
             Context.DisposeContextCallback(_contextCallbackPtr);
+
+            static void Release(object state)
+            {
+                ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
+
+                @this.ReleaseFromBase();
+            }
+
+            static void ReleaseWithoutContext(object state)
+            {
+                ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
+
+                @this.ReleaseWithoutContext();
+            }
+        }
+
+        // Helper stub to invoke 'base.Release()' on a given 'ObjectReferenceWithContext<T>' input parameter.
+        // We can't just do 'param.base.Release()' (or something like that), so the only way to specifically
+        // invoke the base implementation of an overridden method on that object is to go through a helper
+        // instance method invoked on it that just calls the base implementation of the method we want.
+        private void ReleaseFromBase()
+        {
+            base.Release();
         }
 
         public override ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -730,6 +730,11 @@ namespace WinRT
         internal ObjectReferenceWithContext(IntPtr thisPtr, IntPtr contextCallbackPtr, IntPtr contextToken, Guid iid)
             : this(thisPtr, contextCallbackPtr, contextToken)
         {
+            if (iid == default)
+            {
+                ObjectReferenceWithContextHelper.ThrowArgumentExceptionForEmptyIid();
+            }
+
             _iid = iid;
         }
 
@@ -749,6 +754,11 @@ namespace WinRT
         internal ObjectReferenceWithContext(IntPtr thisPtr, T vftblT, IntPtr contextCallbackPtr, IntPtr contextToken, Guid iid)
             : this(thisPtr, vftblT, contextCallbackPtr, contextToken)
         {
+            if (iid == default)
+            {
+                ObjectReferenceWithContextHelper.ThrowArgumentExceptionForEmptyIid();
+            }
+
             _iid = iid;
         }
 
@@ -879,6 +889,14 @@ namespace WinRT
             }
 
             return hr;
+        }
+    }
+
+    internal static class ObjectReferenceWithContextHelper
+    {
+        public static void ThrowArgumentExceptionForEmptyIid()
+        {
+            throw new ArgumentException("The input argument 'iid' cannot be empty and must be set to a valid IID.");
         }
     }
 

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -158,7 +158,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             return 0;
         }
 
-        internal static ObjectReference<IUnknownVftbl> FromAbi(IntPtr thisPtr) => ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<IUnknownVftbl> FromAbi(IntPtr thisPtr) => ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
 
         unsafe bool global::Microsoft.UI.Xaml.Interop.IBindableIterator.MoveNext()
         {
@@ -297,7 +297,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             return 0;
         }
 
-        internal static ObjectReference<IUnknownVftbl> FromAbi(IntPtr thisPtr) => ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<IUnknownVftbl> FromAbi(IntPtr thisPtr) => ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IUnknown);
 
         private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<IWinRTObject, ABI.System.Collections.IEnumerable.FromAbiHelper> _helperTable = new();
 
@@ -573,7 +573,7 @@ namespace ABI.System.Collections
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         private static FromAbiHelper _AbiHelper(IWinRTObject _this)
@@ -1281,7 +1281,7 @@ namespace ABI.System.Collections
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         internal static FromAbiHelper _VectorToList(IWinRTObject _this)

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -36,7 +36,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             private void* _CreateInstance_0;
             public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int> CreateInstance_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>)_CreateInstance_0;
         }
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_DataErrorsChangedEventArgsRuntimeClassFactory);
 
         public static implicit operator WinRTDataErrorsChangedEventArgsRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTDataErrorsChangedEventArgsRuntimeClassFactory(obj) : null;
         public static implicit operator WinRTDataErrorsChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTDataErrorsChangedEventArgsRuntimeClassFactory(obj) : null;
@@ -57,7 +57,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 fixed (void* ___name = __name)
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(ref __name), &__retval));
-                    return ObjectReference<IUnknownVftbl>.Attach(ref __retval);
+                    return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
                 }
             }
             finally

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -200,7 +200,7 @@ namespace ABI.System.Windows.Input
                 }
             }
         }
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_ICommand);
 
         private static global::ABI.WinRT.Interop.EventHandlerEventSource _CanExecuteChanged(IWinRTObject _this)
         {

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -1307,7 +1307,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = IDictionaryMethods<K,V>.PIID;

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -422,7 +422,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = ABI.System.Collections.Generic.IEnumerableMethods<T>.PIID;
@@ -812,7 +812,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return new FromAbiEnumerator<T>(ObjectReference<IUnknownVftbl>.FromAbi(abi));
+            return new FromAbiEnumerator<T>(ObjectReference<IUnknownVftbl>.FromAbi(abi, IID.IID_IUnknown));
         }
 
         public static void DisposeAbi(IntPtr abi) => MarshalInterfaceHelper<global::Windows.Foundation.Collections.IIterator<T>>.DisposeAbi(abi);
@@ -1135,7 +1135,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
         public static Guid PIID = IEnumeratorMethods<T>.PIID;
 

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -1412,7 +1412,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = IListMethods<T>.PIID;

--- a/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyCollectionChanged.net5.cs
@@ -121,7 +121,7 @@ namespace ABI.System.Collections.Specialized
                 }
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_INotifyCollectionChanged);
 
         private static global::ABI.WinRT.Interop.EventSource<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler> _CollectionChanged(IWinRTObject _this)
         {

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -205,7 +205,7 @@ namespace ABI.System.ComponentModel
                 }
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_INotifyDataErrorInfo);
 
         private static EventHandlerEventSource<global::System.ComponentModel.DataErrorsChangedEventArgs> _ErrorsChanged(IWinRTObject _this)
         {

--- a/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyPropertyChanged.net5.cs
@@ -119,7 +119,7 @@ namespace ABI.System.ComponentModel
                 }
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_INotifyPropertyChanged);
 
         private static global::ABI.WinRT.Interop.EventSource<global::System.ComponentModel.PropertyChangedEventHandler> _PropertyChanged(IWinRTObject _this)
         {

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -1138,7 +1138,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = IReadOnlyDictionaryMethods<K, V>.PIID;

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -691,7 +691,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = IReadOnlyListMethods<T>.PIID;

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -105,7 +105,7 @@ namespace ABI.Windows.Foundation
                 return null;
             }
 
-            var wrapper = new IReferenceArray<T>(ObjectReference<IUnknownVftbl>.FromAbi(ptr));
+            var wrapper = new IReferenceArray<T>(ObjectReference<IUnknownVftbl>.FromAbi(ptr, IID.IID_IUnknown));
             return wrapper.Value;
         }
 

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -440,7 +440,7 @@ namespace ABI.System.Collections.Generic
             {
                 return null;
             }
-            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr);
+            return ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
         }
 
         public static Guid PIID = KeyValuePairMethods<K, V>.IID;

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -90,7 +90,7 @@ namespace ABI.System.Collections.Specialized
             try
             {
                 _value = CreateMarshaler2(value);
-                return ObjectReference<IUnknownVftbl>.FromAbi(_value.GetAbi());
+                return ObjectReference<IUnknownVftbl>.FromAbi(_value.GetAbi(), IID.IID_IUnknown);
             }
             finally
             {

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -261,7 +261,7 @@ namespace ABI.System
                 return null;
             }
             var vftblT = new Vftbl(ptr);
-            var wrapper = new Nullable<T>(ObjectReference<Vftbl>.FromAbi(ptr, vftblT));
+            var wrapper = new Nullable<T>(ObjectReference<Vftbl>.FromAbi(ptr, vftblT, PIID));
             return wrapper.Value;
         }
 

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -32,7 +32,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             private void* _CreateInstance_0;
             public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int> CreateInstance_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr, IntPtr*, IntPtr*, int>)_CreateInstance_0;
         }
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_PropertyChangedEventArgsRuntimeClassFactory);
 
         public static implicit operator WinRTPropertyChangedEventArgsRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTPropertyChangedEventArgsRuntimeClassFactory(obj) : null;
         public static implicit operator WinRTPropertyChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTPropertyChangedEventArgsRuntimeClassFactory(obj) : null;
@@ -56,8 +56,8 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 {
                     __baseInterface = MarshalInspectable<object>.CreateMarshaler(baseInterface);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(ref __name), MarshalInspectable<object>.GetAbi(__baseInterface), &__innerInterface, &__retval));
-                    innerInterface = ObjectReference<IUnknownVftbl>.FromAbi(__innerInterface);
-                    return ObjectReference<IUnknownVftbl>.Attach(ref __retval);
+                    innerInterface = ObjectReference<IUnknownVftbl>.FromAbi(__innerInterface, IID.IID_IUnknown);
+                    return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
                 }
             }
             finally

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -51,7 +51,7 @@ namespace ABI.System
             public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int> CreateUri_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>)_CreateUri_0;
             public IntPtr _CreateWithRelativeUri;
         }
-        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_UriRuntimeClassFactory);
 
         public static implicit operator WinRTUriRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
         public static implicit operator WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
@@ -70,7 +70,7 @@ namespace ABI.System
             fixed (void* ___uri = __uri)
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, MarshalString.GetAbi(ref __uri), &__retval));
-                return ObjectReference<IUnknownVftbl>.Attach(ref __retval);
+                return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
             }
         }
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9971,13 +9971,13 @@ public static IntPtr Make()
 static readonly % _factory = new %();
 public static ObjectReference<I> ActivateInstance<
 #if NET5_0_OR_GREATER
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
     I>()
 {
     IntPtr instance = _factory.ActivateInstance();
 
-    return ObjectReference<IInspectable.Vftbl>.Attach(ref instance).As<I>();
+    return ObjectReference<IInspectable.Vftbl>.Attach(ref instance, global::WinRT.Interop.IID.IID_IInspectable).As<I>();
 }
 
 public IntPtr ActivateInstance()

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
@@ -196,7 +196,7 @@ namespace ABI.Com
                 return 0;
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IMarshal);
 
         public static implicit operator IMarshal(IObjectReference obj) => (obj != null) ? new IMarshal(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;


### PR DESCRIPTION
Discovered while testing #1573. This PR fixes:

> ILC : Trim analysis warning IL2087: WinRT.ObjectReferenceWithContext`1.<GetCurrentContext>g__CreateForCurrentContext|19_0(IntPtr): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'WinRT.GuidGenerator.GetIID(Type)'. The generic parameter 'T' of 'WinRT.ObjectReferenceWithContext`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. 

Related to: https://github.com/dotnet/runtime/issues/101203.

This PR includes two changes:
- Add the right annotations to `ObjectReferenceWithContext<T>`.
- Pass an IID explicitly wherever possible.