### PR TITLE
Support for exception handling from unmanaged caller

### DIFF
--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -116,9 +116,14 @@ namespace WinRT
 
         public static bool TryHandleWinRTServerException(object sender, Exception ex)
         {
-            UnhandledWinRTServerExceptionEventArgs args = new UnhandledWinRTServerExceptionEventArgs(ex);
-            UnhandledWinRTServerException?.Invoke(sender, args);
-            return args.Handled;
+            if (UnhandledWinRTServerException != null)
+            {
+                UnhandledWinRTServerExceptionEventArgs args = new UnhandledWinRTServerExceptionEventArgs(ex);
+                UnhandledWinRTServerException.Invoke(sender, args);
+                return args.Handled;
+            }
+
+            return false;
         }
 
         public static void ThrowExceptionForHR(int hr)

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -98,6 +98,29 @@ namespace WinRT
             return true;
         }
 
+        /// <summary>
+        /// Unhandled WinRT server exception event.
+        /// </summary>
+        public static event EventHandler<UnhandledWinRTServerExceptionEventArgs> UnhandledWinRTServerException;
+
+        public class UnhandledWinRTServerExceptionEventArgs : EventArgs
+        {
+            public Exception Exception { get; }
+            public bool Handled { get; set; }
+
+            public UnhandledWinRTServerExceptionEventArgs(Exception exception)
+            {
+                Exception = exception;
+            }
+        }
+
+        public static bool TryHandleWinRTServerException(object sender, Exception ex)
+        {
+            UnhandledWinRTServerExceptionEventArgs args = new UnhandledWinRTServerExceptionEventArgs(ex);
+            UnhandledWinRTServerException?.Invoke(sender, args);
+            return args.Handled;
+        }
+
         public static void ThrowExceptionForHR(int hr)
         {
             if (hr < 0)

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -114,17 +114,29 @@ namespace WinRT
             }
         }
 
-        public static bool TryHandleWinRTServerException(object sender, Exception ex)
+        public static int HandleWinRTServerException(object sender, Exception ex, bool dispatchExceptionToUnmanagedCode)
         {
             EventHandler<UnhandledWinRTServerExceptionEventArgs> handler = UnhandledWinRTServerException;
+
             if (handler != null)
             {
-                UnhandledWinRTServerExceptionEventArgs args = new UnhandledWinRTServerExceptionEventArgs(ex);
+                UnhandledWinRTServerExceptionEventArgs args = new(ex);
                 handler.Invoke(sender, args);
-                return args.Handled;
+                if (args.Handled)
+                {
+                    return 0;
+                }
             }
 
-            return false;
+            if (dispatchExceptionToUnmanagedCode)
+            {
+                SetErrorInfo(ex);
+                return GetHRForException(ex);
+            }
+            else
+            {
+                return ex.HResult;
+            }
         }
 
         public static void ThrowExceptionForHR(int hr)

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -116,10 +116,11 @@ namespace WinRT
 
         public static bool TryHandleWinRTServerException(object sender, Exception ex)
         {
-            if (UnhandledWinRTServerException != null)
+            EventHandler<UnhandledWinRTServerExceptionEventArgs> handler = UnhandledWinRTServerException;
+            if (handler != null)
             {
                 UnhandledWinRTServerExceptionEventArgs args = new UnhandledWinRTServerExceptionEventArgs(ex);
-                UnhandledWinRTServerException.Invoke(sender, args);
+                handler.Invoke(sender, args);
                 return args.Handled;
             }
 

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,5 @@
+MembersMustExist : Member 'public void WinRT.ExceptionHelpers.add_UnhandledWinRTServerException(System.EventHandler<WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public void WinRT.ExceptionHelpers.remove_UnhandledWinRTServerException(System.EventHandler<WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean WinRT.ExceptionHelpers.TryHandleWinRTServerException(System.Object, System.Exception)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 4

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -1,5 +1,5 @@
 MembersMustExist : Member 'public void WinRT.ExceptionHelpers.add_UnhandledWinRTServerException(System.EventHandler<WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ExceptionHelpers.remove_UnhandledWinRTServerException(System.EventHandler<WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.ExceptionHelpers.UnhandledWinRTServerExceptionEventArgs' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'public System.Boolean WinRT.ExceptionHelpers.TryHandleWinRTServerException(System.Object, System.Exception)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Int32 WinRT.ExceptionHelpers.HandleWinRTServerException(System.Object, System.Exception, System.Boolean)' does not exist in the reference but it does exist in the implementation.
 Total Issues: 4

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5263,12 +5263,7 @@ try
 }
 catch (Exception __exception__)
 {
-if (global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this__, __exception__))
-{
-return 0;
-}
-global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
-return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
+return global::WinRT.ExceptionHelpers.HandleWinRTServerException(__this__, __exception__, true);
 }
 return 0;)",
             [&](writer& w) {
@@ -5478,11 +5473,7 @@ return 0;
 }
 catch (Exception __ex)
 {
-if (global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this, __ex))
-{
-return 0;
-}
-return __ex.HResult;
+return global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this, __ex, false);
 }
 })",
             !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",
@@ -5515,11 +5506,7 @@ return 0;
 }
 catch (Exception __ex)
 {
-if (global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this, __ex))
-{
-return 0;
-}
-return __ex.HResult;
+return global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this, __ex, false);
 }
 })",
             !settings.netstandard_compat && !generic_type ? "[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]" : "",


### PR DESCRIPTION
Closes #1571

Codegen example:

```cs
[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
private static unsafe int Do_Abi_GetPoint_2(IntPtr thisPtr, global::Windows.Foundation.Point* __return_value__)
{
    global::AuthoringTest.BasicClass __this__ = default;
    global::Windows.Foundation.Point ____return_value__ = default;
    *__return_value__ = default;
    try
    {
        ____return_value__ = (__this__ = global::WinRT.ComWrappersSupport.FindObject<global::AuthoringTest.BasicClass>(thisPtr)).GetPoint();
        *__return_value__ = ____return_value__;

    }
    catch (Exception __exception__)
    {
        if (global::WinRT.ExceptionHelpers.TryHandleWinRTServerException(__this__, __exception__))
        {
            return 0;
        }
        global::WinRT.ExceptionHelpers.SetErrorInfo(__exception__);
        return global::WinRT.ExceptionHelpers.GetHRForException(__exception__);
    }
    return 0;
}
```