### PR TITLE
Skip closure allocation in ObjectReferenceWithContext<T>

### DIFF
--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -94,7 +94,7 @@ namespace WinRT
                     {
                         Git.RevokeInterfaceFromGlobal(_cookie);
                     }
-                    catch(ArgumentException)
+                    catch (ArgumentException)
                     {
                         // Revoking cookie from GIT table may fail if apartment is gone.
                     }

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -52,7 +52,7 @@ namespace WinRT
                     return 0;
                 }, &data, IID.IID_ICallbackWithNoReentrancyToApplicationSTA, 5);
             } 
-            catch(Exception)
+            catch (Exception)
             {
                 onFailCallback?.Invoke();
             }

--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -29,17 +29,31 @@ namespace WinRT
         // On any exception, calls onFail callback if any set.
         // If not set, exception is handled due to today we don't
         // have any scenario to propagate it from here.
-        public unsafe static void CallInContext(IntPtr contextCallbackPtr, IntPtr contextToken, Action callback, Action onFailCallback)
+        //
+        // On modern .NET, we can use function pointers to avoid the
+        // small binary size increase from all generated fields and
+        // logic to cache delegates, since we don't need any of that.
+        public unsafe static void CallInContext(
+            IntPtr contextCallbackPtr,
+            IntPtr contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+            delegate*<object, void> callback,
+            delegate*<object, void> onFailCallback,
+#else
+            Action<object> callback,
+            Action<object> onFailCallback,
+#endif
+            object state)
         {
             // Check if we are already on the same context, if so we do not need to switch.
             if(contextCallbackPtr == IntPtr.Zero || GetContextToken() == contextToken)
             {
-                callback();
+                callback(state);
                 return;
             }
 
 #if NET && CsWinRT_LANG_11_FEATURES
-            IContextCallbackVftbl.ContextCallback(contextCallbackPtr, callback, onFailCallback);
+            IContextCallbackVftbl.ContextCallback(contextCallbackPtr, callback, onFailCallback, state);
 #else
             ComCallData data = default;
             var contextCallback = new ABI.WinRT.Interop.IContextCallback(ObjectReference<ABI.WinRT.Interop.IContextCallback.Vftbl>.FromAbi(contextCallbackPtr));
@@ -48,13 +62,13 @@ namespace WinRT
             {
                 contextCallback.ContextCallback(_ =>
                 {
-                    callback();
+                    callback(state);
                     return 0;
                 }, &data, IID.IID_ICallbackWithNoReentrancyToApplicationSTA, 5);
             } 
             catch (Exception)
             {
-                onFailCallback?.Invoke();
+                onFailCallback?.Invoke(state);
             }
 #endif
         }

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -18,6 +18,14 @@ namespace ABI.WinRT.Interop
     }
 
 #if NET && CsWinRT_LANG_11_FEATURES
+    internal unsafe struct CallbackData
+    {
+        public delegate*<object, void> Callback;
+        public object State;
+    }
+#endif
+
+#if NET && CsWinRT_LANG_11_FEATURES
     internal unsafe struct IContextCallbackVftbl
     {
 #pragma warning disable CS0649 // Native layout
@@ -25,34 +33,31 @@ namespace ABI.WinRT.Interop
         private delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4;
 #pragma warning restore CS0649
 
-        public static void ContextCallback(IntPtr contextCallbackPtr, Action callback, Action onFailCallback)
+        public static void ContextCallback(IntPtr contextCallbackPtr, delegate*<object, void> callback, delegate*<object, void> onFailCallback, object state)
         {
             ComCallData comCallData;
             comCallData.dwDispid = 0;
             comCallData.dwReserved = 0;
 
-            // Copy the callback into a local to make sure it really is a local that
-            // gets marked as address taken, rather than something that could potentially
-            // be inlined into the caller into some state machine or anything else not safe.
-            Action callbackAddressTaken = callback;
+            CallbackData callbackData;
+            callbackData.Callback = callback;
+            callbackData.State = state;
 
             // We can just store a pointer to the callback to invoke in the context,
             // so we don't need to allocate another closure or anything. The callback
             // will be kept alive automatically, because 'comCallData' is address exposed.
             // We only do this if we can use C# 11, and if we're on modern .NET, to be safe.
             // In the callback below, we can then just retrieve the Action again to invoke it.
-            comCallData.pUserDefined = (IntPtr)(void*)&callbackAddressTaken;
+            comCallData.pUserDefined = (IntPtr)(void*)&callbackData;
             
             [UnmanagedCallersOnly]
             static int InvokeCallback(ComCallData* comCallData)
             {
                 try
                 {
-                    // Dereference the pointer to Action and invoke it (see notes above).
-                    // Once again, the pointer is not to the Action object, but just to the
-                    // local *reference* to the object, which is pinned (as it's a local).
-                    // That means that there's no pinning to worry about either.
-                    ((Action*)comCallData->pUserDefined)->Invoke();
+                    CallbackData* callbackData = (CallbackData*)comCallData->pUserDefined;
+
+                    callbackData->Callback(callbackData->State);
 
                     return 0; // S_OK
                 }
@@ -74,7 +79,10 @@ namespace ABI.WinRT.Interop
 
             if (hresult < 0)
             {
-                onFailCallback?.Invoke();
+                if (onFailCallback is not null)
+                {
+                    onFailCallback(state);
+                }
             }
         }
     }


### PR DESCRIPTION
Small optimization to `ObjectReferenceWithContext<T>` on modern .NET, we can skip a closure.