### PR TITLE
Remove more closures in lambda expressions

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -526,7 +526,12 @@ namespace WinRT
             };
         }
 
-        internal static Func<IInspectable, object> CreateTypedRcwFactory(Type implementationType, string runtimeClassName = null)
+        internal static Func<IInspectable, object> CreateTypedRcwFactory(Type implementationType)
+        {
+            return CreateTypedRcwFactory(implementationType, null);
+        }
+
+        internal static Func<IInspectable, object> CreateTypedRcwFactory(Type implementationType, string runtimeClassName)
         {
             // If runtime class name is empty or "Object", then just use IInspectable.
             if (implementationType == null || implementationType == typeof(object))

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -198,7 +198,7 @@ namespace WinRT
             ComWrappers = wrappers;
         }
 
-        internal static Func<IInspectable, object> GetTypedRcwFactory(Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, classType => CreateTypedRcwFactory(classType));
+        internal static Func<IInspectable, object> GetTypedRcwFactory(Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, CreateTypedRcwFactory);
 
         public static bool RegisterTypedRcwFactory(Type implementationType, Func<IInspectable, object> rcwFactory) => TypedObjectFactoryCacheForType.TryAdd(implementationType, rcwFactory);
 

--- a/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.netstandard2.0.cs
@@ -32,7 +32,7 @@ namespace WinRT
             return CreateRcwForComObject<T>(ptr, true);
         }
 
-        internal static Func<IInspectable, object> GetTypedRcwFactory(Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, classType => CreateTypedRcwFactory(classType));
+        internal static Func<IInspectable, object> GetTypedRcwFactory(Type implementationType) => TypedObjectFactoryCacheForType.GetOrAdd(implementationType, CreateTypedRcwFactory);
 
         private static T CreateRcwForComObject<T>(IntPtr ptr, bool tryUseCache)
         {
@@ -63,7 +63,7 @@ namespace WinRT
                     else
                     {
                         Type runtimeClassType = GetRuntimeClassForTypeCreation(inspectable, typeof(T));
-                        runtimeWrapper = runtimeClassType == null ? inspectable : TypedObjectFactoryCacheForType.GetOrAdd(runtimeClassType, classType => CreateTypedRcwFactory(classType))(inspectable);
+                        runtimeWrapper = runtimeClassType == null ? inspectable : TypedObjectFactoryCacheForType.GetOrAdd(runtimeClassType, CreateTypedRcwFactory)(inspectable);
                     }
                 }
                 else if (identity.TryAs<ABI.WinRT.Interop.IWeakReference.Vftbl>(out var weakRef) == 0)
@@ -132,7 +132,7 @@ namespace WinRT
                 return TryUnwrapObject(del.Target, out objRef);
             }
 
-            var objRefFunc = TypeObjectRefFuncCache.GetOrAdd(o.GetType(), (type) =>
+            var objRefFunc = TypeObjectRefFuncCache.GetOrAdd(o.GetType(), static (type) =>
             {
                 ObjectReferenceWrapperAttribute objRefWrapper = type.GetCustomAttribute<ObjectReferenceWrapperAttribute>();
                 if (objRefWrapper is object)

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -318,9 +319,16 @@ namespace WinRT
 
         ConcurrentDictionary<RuntimeTypeHandle, object> AdditionalTypeData { get; }
 
+        [Obsolete("Use the 'Func<RuntimeTypeHandle, IWinRTObject, object>' overload.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         object GetOrCreateTypeHelperData(RuntimeTypeHandle type, Func<object> helperDataFactory)
         {
-            return AdditionalTypeData.GetOrAdd(type, (type) => helperDataFactory());
+            throw new NotSupportedException("'GetOrCreateTypeHelperData(RuntimeTypeHandle, Func<object>)' is not supported, use the 'Func<RuntimeTypeHandle, IWinRTObject, object>' overload.");
+        }
+
+        object GetOrCreateTypeHelperData(RuntimeTypeHandle type, Func<RuntimeTypeHandle, IWinRTObject, object> helperDataFactory, IWinRTObject state)
+        {
+            return AdditionalTypeData.GetOrAdd(type, helperDataFactory, state);
         }
     }
 }

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -319,16 +319,11 @@ namespace WinRT
 
         ConcurrentDictionary<RuntimeTypeHandle, object> AdditionalTypeData { get; }
 
-        [Obsolete("Use the 'Func<RuntimeTypeHandle, IWinRTObject, object>' overload.")]
+        [Obsolete("Use the 'AdditionalTypeData' property instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         object GetOrCreateTypeHelperData(RuntimeTypeHandle type, Func<object> helperDataFactory)
         {
-            throw new NotSupportedException("'GetOrCreateTypeHelperData(RuntimeTypeHandle, Func<object>)' is not supported, use the 'Func<RuntimeTypeHandle, IWinRTObject, object>' overload.");
-        }
-
-        object GetOrCreateTypeHelperData(RuntimeTypeHandle type, Func<RuntimeTypeHandle, IWinRTObject, object> helperDataFactory, IWinRTObject state)
-        {
-            return AdditionalTypeData.GetOrAdd(type, helperDataFactory, state);
+            throw new NotSupportedException("'GetOrCreateTypeHelperData(RuntimeTypeHandle, Func<object>)' is not supported, use 'AdditionalTypeData' instead.");
         }
     }
 }

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -237,6 +237,4 @@ MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterTypeRunt
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.Projections.FindCustomHelperTypeMapping(System.Type, System.Boolean)' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
-InterfacesShouldHaveSameMembers : Default interface member 'public System.Object WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.RuntimeTypeHandle, WinRT.IWinRTObject, System.Object>, WinRT.IWinRTObject)' is present in the implementation but not in the reference.
-MembersMustExist : Member 'public System.Object WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.RuntimeTypeHandle, WinRT.IWinRTObject, System.Object>, WinRT.IWinRTObject)' does not exist in the reference but it does exist in the implementation.
-Total Issues: 241
+Total Issues: 239

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -235,4 +235,8 @@ CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.Unconditional
 TypesMustExist : Type 'WinRT.WinRTRuntimeClassNameAttribute' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void WinRT.ComWrappersSupport.RegisterTypeRuntimeClassNameLookup(System.Func<System.Type, System.String>)' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute' exists on 'WinRT.Projections.FindCustomHelperTypeMapping(System.Type, System.Boolean)' in the implementation but not the reference.
-Total Issues: 237
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.Object>)' in the implementation but not the reference.
+InterfacesShouldHaveSameMembers : Default interface member 'public System.Object WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.RuntimeTypeHandle, WinRT.IWinRTObject, System.Object>, WinRT.IWinRTObject)' is present in the implementation but not in the reference.
+MembersMustExist : Member 'public System.Object WinRT.IWinRTObject.GetOrCreateTypeHelperData(System.RuntimeTypeHandle, System.Func<System.RuntimeTypeHandle, WinRT.IWinRTObject, System.Object>, WinRT.IWinRTObject)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 241

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -578,7 +578,7 @@ namespace ABI.System.Collections
 
         private static FromAbiHelper _AbiHelper(IWinRTObject _this)
         {
-            return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.IEnumerable).TypeHandle,
+            return (FromAbiHelper)_this.AdditionalTypeData.GetOrAdd(typeof(global::System.Collections.IEnumerable).TypeHandle,
                 static (_, _this) => new FromAbiHelper((global::System.Collections.IEnumerable)_this), _this);
         }
 
@@ -1286,7 +1286,7 @@ namespace ABI.System.Collections
 
         internal static FromAbiHelper _VectorToList(IWinRTObject _this)
         {
-            return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.IList).TypeHandle,
+            return (FromAbiHelper)_this.AdditionalTypeData.GetOrAdd(typeof(global::System.Collections.IList).TypeHandle,
                 static (_, _this) => new FromAbiHelper((global::Microsoft.UI.Xaml.Interop.IBindableVector)_this), _this);
         }
 

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -579,7 +579,7 @@ namespace ABI.System.Collections
         private static FromAbiHelper _AbiHelper(IWinRTObject _this)
         {
             return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.IEnumerable).TypeHandle,
-                () => new FromAbiHelper((global::System.Collections.IEnumerable)_this));
+                static (_, _this) => new FromAbiHelper((global::System.Collections.IEnumerable)_this), _this);
         }
 
         unsafe global::Microsoft.UI.Xaml.Interop.IBindableIterator global::Microsoft.UI.Xaml.Interop.IBindableIterable.First()
@@ -1287,7 +1287,7 @@ namespace ABI.System.Collections
         internal static FromAbiHelper _VectorToList(IWinRTObject _this)
         {
             return (FromAbiHelper)_this.GetOrCreateTypeHelperData(typeof(global::System.Collections.IList).TypeHandle,
-                () => new FromAbiHelper((global::Microsoft.UI.Xaml.Interop.IBindableVector)_this));
+                static (_, _this) => new FromAbiHelper((global::Microsoft.UI.Xaml.Interop.IBindableVector)_this), _this);
         }
 
         unsafe object global::Microsoft.UI.Xaml.Interop.IBindableVector.GetAt(uint index)

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -16,7 +16,7 @@ namespace ABI.System.Collections.Generic
     [DynamicInterfaceCastableImplementation]
     interface IReadOnlyCollection<T> : global::System.Collections.Generic.IReadOnlyCollection<T>
     {
-        private static global::System.Collections.Generic.IReadOnlyCollection<T> CreateHelper(IWinRTObject _this)
+        private static global::System.Collections.Generic.IReadOnlyCollection<T> CreateHelper(RuntimeTypeHandle type, IWinRTObject _this)
         {
             var genericType = typeof(T);
             if (genericType.IsGenericType && genericType.GetGenericTypeDefinition() == typeof(global::System.Collections.Generic.KeyValuePair<,>))
@@ -53,7 +53,7 @@ namespace ABI.System.Collections.Generic
         {
             return (global::System.Collections.Generic.IReadOnlyCollection<T>)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.Generic.IReadOnlyCollection<T>).TypeHandle,
-                static (_, _this) => CreateHelper(_this), _this);
+                CreateHelper, _this);
         }
 
         int global::System.Collections.Generic.IReadOnlyCollection<T>.Count
@@ -69,7 +69,7 @@ namespace ABI.System.Collections.Generic
     [DynamicInterfaceCastableImplementation]
     interface ICollection<T> : global::System.Collections.Generic.ICollection<T>
     {
-        private static global::System.Collections.Generic.ICollection<T> CreateHelper(IWinRTObject _this)
+        private static global::System.Collections.Generic.ICollection<T> CreateHelper(RuntimeTypeHandle type, IWinRTObject _this)
         {
             var genericType = typeof(T);
             if (genericType.IsGenericType && genericType.GetGenericTypeDefinition() == typeof(global::System.Collections.Generic.KeyValuePair<,>))
@@ -106,7 +106,7 @@ namespace ABI.System.Collections.Generic
         {
             return (global::System.Collections.Generic.ICollection<T>)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.Generic.ICollection<T>).TypeHandle,
-                static (_, _this) => CreateHelper(_this), _this);
+                CreateHelper, _this);
         }
 
         int global::System.Collections.Generic.ICollection<T>.Count
@@ -143,7 +143,7 @@ namespace ABI.System.Collections
     [DynamicInterfaceCastableImplementation]
     interface ICollection : global::System.Collections.ICollection
     {
-        private static global::System.Collections.ICollection CreateHelper(IWinRTObject _this)
+        private static global::System.Collections.ICollection CreateHelper(RuntimeTypeHandle type, IWinRTObject _this)
         {
             var iList = typeof(global::System.Collections.IList);
             if (_this.IsInterfaceImplemented(iList.TypeHandle, false))
@@ -158,7 +158,7 @@ namespace ABI.System.Collections
         {
             return (global::System.Collections.ICollection)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.ICollection).TypeHandle,
-                static (_, _this) => CreateHelper(_this), _this);
+                CreateHelper, _this);
         }
 
         int global::System.Collections.ICollection.Count

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -51,7 +51,7 @@ namespace ABI.System.Collections.Generic
 
         private static global::System.Collections.Generic.IReadOnlyCollection<T> GetHelper(IWinRTObject _this)
         {
-            return (global::System.Collections.Generic.IReadOnlyCollection<T>)_this.GetOrCreateTypeHelperData(
+            return (global::System.Collections.Generic.IReadOnlyCollection<T>)_this.AdditionalTypeData.GetOrAdd(
                 typeof(global::System.Collections.Generic.IReadOnlyCollection<T>).TypeHandle,
                 CreateHelper, _this);
         }
@@ -104,7 +104,7 @@ namespace ABI.System.Collections.Generic
 
         private static global::System.Collections.Generic.ICollection<T> GetHelper(IWinRTObject _this)
         {
-            return (global::System.Collections.Generic.ICollection<T>)_this.GetOrCreateTypeHelperData(
+            return (global::System.Collections.Generic.ICollection<T>)_this.AdditionalTypeData.GetOrAdd(
                 typeof(global::System.Collections.Generic.ICollection<T>).TypeHandle,
                 CreateHelper, _this);
         }
@@ -156,7 +156,7 @@ namespace ABI.System.Collections
 
         private static global::System.Collections.ICollection GetHelper(IWinRTObject _this)
         {
-            return (global::System.Collections.ICollection)_this.GetOrCreateTypeHelperData(
+            return (global::System.Collections.ICollection)_this.AdditionalTypeData.GetOrAdd(
                 typeof(global::System.Collections.ICollection).TypeHandle,
                 CreateHelper, _this);
         }

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -53,7 +53,7 @@ namespace ABI.System.Collections.Generic
         {
             return (global::System.Collections.Generic.IReadOnlyCollection<T>)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.Generic.IReadOnlyCollection<T>).TypeHandle,
-                () => CreateHelper(_this));
+                static (_, _this) => CreateHelper(_this), _this);
         }
 
         int global::System.Collections.Generic.IReadOnlyCollection<T>.Count
@@ -106,7 +106,7 @@ namespace ABI.System.Collections.Generic
         {
             return (global::System.Collections.Generic.ICollection<T>)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.Generic.ICollection<T>).TypeHandle,
-                () => CreateHelper(_this));
+                static (_, _this) => CreateHelper(_this), _this);
         }
 
         int global::System.Collections.Generic.ICollection<T>.Count
@@ -158,7 +158,7 @@ namespace ABI.System.Collections
         {
             return (global::System.Collections.ICollection)_this.GetOrCreateTypeHelperData(
                 typeof(global::System.Collections.ICollection).TypeHandle,
-                () => CreateHelper(_this));
+                static (_, _this) => CreateHelper(_this), _this);
         }
 
         int global::System.Collections.ICollection.Count


### PR DESCRIPTION
This PR includes some more changes to remove unnecessary closures, and improve delegate caching.