### PR TITLE
Remove even more closure allocations in ObjectReferenceWithContext<T>

### DIFF
--- a/src/WinRT.Runtime/Context.cs
+++ b/src/WinRT.Runtime/Context.cs
@@ -29,7 +29,21 @@ namespace WinRT
         // On any exception, calls onFail callback if any set.
         // If not set, exception is handled due to today we don't
         // have any scenario to propagate it from here.
-        public unsafe static void CallInContext(IntPtr contextCallbackPtr, IntPtr contextToken, Action<object> callback, Action<object> onFailCallback, object state)
+        //
+        // On modern .NET, we can use function pointers to avoid the
+        // small binary size increase from all generated fields and
+        // logic to cache delegates, since we don't need any of that.
+        public unsafe static void CallInContext(
+            IntPtr contextCallbackPtr,
+            IntPtr contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+            delegate*<object, void> callback,
+            delegate*<object, void> onFailCallback,
+#else
+            Action<object> callback,
+            Action<object> onFailCallback,
+#endif
+            object state)
         {
             // Check if we are already on the same context, if so we do not need to switch.
             if(contextCallbackPtr == IntPtr.Zero || GetContextToken() == contextToken)

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -18,9 +18,9 @@ namespace ABI.WinRT.Interop
     }
 
 #if NET && CsWinRT_LANG_11_FEATURES
-    internal struct CallbackData
+    internal unsafe struct CallbackData
     {
-        public Action<object> Callback;
+        public delegate*<object, void> Callback;
         public object State;
     }
 #endif
@@ -33,7 +33,7 @@ namespace ABI.WinRT.Interop
         private delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4;
 #pragma warning restore CS0649
 
-        public static void ContextCallback(IntPtr contextCallbackPtr, Action<object> callback, Action<object> onFailCallback, object state)
+        public static void ContextCallback(IntPtr contextCallbackPtr, delegate*<object, void> callback, delegate*<object, void> onFailCallback, object state)
         {
             ComCallData comCallData;
             comCallData.dwDispid = 0;
@@ -79,7 +79,10 @@ namespace ABI.WinRT.Interop
 
             if (hresult < 0)
             {
-                onFailCallback?.Invoke(state);
+                if (onFailCallback is not null)
+                {
+                    onFailCallback(state);
+                }
             }
         }
     }

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -18,6 +18,14 @@ namespace ABI.WinRT.Interop
     }
 
 #if NET && CsWinRT_LANG_11_FEATURES
+    internal struct CallbackData
+    {
+        public Action<object> Callback;
+        public object State;
+    }
+#endif
+
+#if NET && CsWinRT_LANG_11_FEATURES
     internal unsafe struct IContextCallbackVftbl
     {
 #pragma warning disable CS0649 // Native layout
@@ -25,34 +33,31 @@ namespace ABI.WinRT.Interop
         private delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4;
 #pragma warning restore CS0649
 
-        public static void ContextCallback(IntPtr contextCallbackPtr, Action callback, Action onFailCallback)
+        public static void ContextCallback(IntPtr contextCallbackPtr, Action<object> callback, Action<object> onFailCallback, object state)
         {
             ComCallData comCallData;
             comCallData.dwDispid = 0;
             comCallData.dwReserved = 0;
 
-            // Copy the callback into a local to make sure it really is a local that
-            // gets marked as address taken, rather than something that could potentially
-            // be inlined into the caller into some state machine or anything else not safe.
-            Action callbackAddressTaken = callback;
+            CallbackData callbackData;
+            callbackData.Callback = callback;
+            callbackData.State = state;
 
             // We can just store a pointer to the callback to invoke in the context,
             // so we don't need to allocate another closure or anything. The callback
             // will be kept alive automatically, because 'comCallData' is address exposed.
             // We only do this if we can use C# 11, and if we're on modern .NET, to be safe.
             // In the callback below, we can then just retrieve the Action again to invoke it.
-            comCallData.pUserDefined = (IntPtr)(void*)&callbackAddressTaken;
+            comCallData.pUserDefined = (IntPtr)(void*)&callbackData;
             
             [UnmanagedCallersOnly]
             static int InvokeCallback(ComCallData* comCallData)
             {
                 try
                 {
-                    // Dereference the pointer to Action and invoke it (see notes above).
-                    // Once again, the pointer is not to the Action object, but just to the
-                    // local *reference* to the object, which is pinned (as it's a local).
-                    // That means that there's no pinning to worry about either.
-                    ((Action*)comCallData->pUserDefined)->Invoke();
+                    CallbackData* callbackData = (CallbackData*)comCallData->pUserDefined;
+
+                    callbackData->Callback(callbackData->State);
 
                     return 0; // S_OK
                 }
@@ -74,7 +79,7 @@ namespace ABI.WinRT.Interop
 
             if (hresult < 0)
             {
-                onFailCallback?.Invoke();
+                onFailCallback?.Invoke(state);
             }
         }
     }

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -698,9 +698,18 @@ namespace WinRT
         private volatile bool _isAgileReferenceSet;
         private volatile AgileReference __agileReference;
         private AgileReference AgileReference => _isAgileReferenceSet ? __agileReference : Make_AgileReference();
-        private AgileReference Make_AgileReference()
+        private unsafe AgileReference Make_AgileReference()
         {
-            Context.CallInContext(_contextCallbackPtr, _contextToken, InitAgileReference, null, this);
+            Context.CallInContext(
+                _contextCallbackPtr,
+                _contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+                &InitAgileReference,
+#else
+                InitAgileReference,
+#endif
+                null,
+                this);
 
             // Set after CallInContext callback given callback can fail to occur.
             _isAgileReferenceSet = true;
@@ -866,7 +875,18 @@ namespace WinRT
                 CachedContext.Clear();
             }
 
-            Context.CallInContext(_contextCallbackPtr, _contextToken, Release, ReleaseWithoutContext, this);
+            Context.CallInContext(
+                _contextCallbackPtr,
+                _contextToken,
+#if NET && CsWinRT_LANG_11_FEATURES
+                &Release,
+                &ReleaseWithoutContext,
+#else
+                Release,
+                ReleaseWithoutContext,
+#endif
+                this);
+
             Context.DisposeContextCallback(_contextCallbackPtr);
 
             static void Release(object state)


### PR DESCRIPTION
Builds on top of #1587 and further improves things. This drops all closures for `Context` callback invocations.