### PR TITLE
Pass more explicit IIDs in more places

### DIFF
--- a/src/WinRT.Runtime/CastExtensions.cs
+++ b/src/WinRT.Runtime/CastExtensions.cs
@@ -91,12 +91,12 @@ namespace WinRT
         {
             if (ComWrappersSupport.TryUnwrapObject(value, out var objRef))
             {
-                reference = objRef.As<IUnknownVftbl>();
+                reference = objRef.As<IUnknownVftbl>(IID.IID_IUnknown);
                 return true;
             }
             else if (allowComposed && TryGetComposedRefForQI(value, out objRef))
             {
-                reference = objRef.As<IUnknownVftbl>();
+                reference = objRef.As<IUnknownVftbl>(IID.IID_IUnknown);
                 return true;
             }
             reference = null;

--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -126,7 +126,7 @@ namespace WinRT
 
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
-        public static implicit operator IInspectable(IObjectReference obj) => obj.As<Vftbl>();
+        public static implicit operator IInspectable(IObjectReference obj) => obj.As<Vftbl>(IID.IID_IInspectable);
         public static implicit operator IInspectable(ObjectReference<Vftbl> obj) => new IInspectable(obj);
 
 #if NET
@@ -136,7 +136,7 @@ namespace WinRT
 #endif
         public ObjectReference<I> As<I>() => _obj.As<I>();
         public IObjectReference ObjRef { get => _obj; }
-        public IInspectable(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IInspectable(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_IInspectable)) { }
         public IInspectable(ObjectReference<Vftbl> obj)
         {
             _obj = obj;

--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -161,7 +161,7 @@ namespace ABI.WinRT.Interop
         [EditorBrowsable(EditorBrowsableState.Never)]
 #endif
         public A As<A>() => _obj.AsType<A>();
-        public IActivationFactory(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IActivationFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_IActivationFactory)) { }
         internal IActivationFactory(ObjectReference<Vftbl> obj)
         {
             _obj = obj;

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -156,7 +156,7 @@ namespace ABI.WinRT.Interop
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
 
-        public IGlobalInterfaceTable(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public IGlobalInterfaceTable(IObjectReference obj) : this(obj.As<Vftbl>(global::WinRT.Interop.IID.IID_IGlobalInterfaceTable)) { }
         public IGlobalInterfaceTable(ObjectReference<Vftbl> obj)
         {
             _obj = obj;

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -42,7 +42,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
         public static implicit operator WinRTDataErrorsChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTDataErrorsChangedEventArgsRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
-        public WinRTDataErrorsChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public WinRTDataErrorsChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_DataErrorsChangedEventArgsRuntimeClassFactory)) { }
         public WinRTDataErrorsChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj)
         {
             _obj = obj;

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -38,7 +38,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
         public static implicit operator WinRTPropertyChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTPropertyChangedEventArgsRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
-        public WinRTPropertyChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public WinRTPropertyChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_PropertyChangedEventArgsRuntimeClassFactory)) { }
         public WinRTPropertyChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj)
         {
             _obj = obj;

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -57,7 +57,7 @@ namespace ABI.System
         public static implicit operator WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
-        public WinRTUriRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public WinRTUriRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_UriRuntimeClassFactory)) { }
         public WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj)
         {
             _obj = obj;


### PR DESCRIPTION
This PR passes more IIDs explicitly to `As<T>()` calls, which is faster and avoids `[DAM(PublicFields)]` on the `T`.