### PR TITLE
Pass IID for 'IBufferByteAccess.FromAbi'

### DIFF
--- a/src/WinRT.Runtime/Interop/IID.g.cs
+++ b/src/WinRT.Runtime/Interop/IID.g.cs
@@ -240,6 +240,56 @@ namespace WinRT.Interop
             }
         }
 
+        /// <summary>The IID for <c>IBuffer</c> (905A0FE0-BC53-11DF-8C49-001E4FC686DA).</summary>
+        public static ref readonly Guid IID_IBuffer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0xE0, 0x0F, 0x5A, 0x90,
+                    0x53, 0xBC,
+                    0xDF, 0x11,
+                    0x8C,
+                    0x49,
+                    0x00,
+                    0x1E,
+                    0x4F,
+                    0xC6,
+                    0x86,
+                    0xDA
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>The IID for <c>IBufferByteAccess</c> (905A0FEF-BC53-11DF-8C49-001E4FC686DA).</summary>
+        public static ref readonly Guid IID_IBufferByteAccess
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0xEF, 0x0F, 0x5A, 0x90,
+                    0x53, 0xBC,
+                    0xDF, 0x11,
+                    0x8C,
+                    0x49,
+                    0x00,
+                    0x1E,
+                    0x4F,
+                    0xC6,
+                    0x86,
+                    0xDA
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
         /// <summary>The IID for <c>IContextCallback</c> (000001DA-0000-0000-C000-000000000046).</summary>
         internal static ref readonly Guid IID_IContextCallback
         {

--- a/src/WinRT.Runtime/Interop/IID.tt
+++ b/src/WinRT.Runtime/Interop/IID.tt
@@ -31,6 +31,8 @@ var entries = new (string Name, string IID, bool IsPublic)[]
     ("IActivationFactory", "00000035-0000-0000-C000-000000000046", true),
     ("IAgileObject", "94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90", false),
     ("IMarshal", "00000003-0000-0000-C000-000000000046", true),
+    ("IBuffer", "905A0FE0-BC53-11DF-8C49-001E4FC686DA", true),
+    ("IBufferByteAccess", "905A0FEF-BC53-11DF-8C49-001E4FC686DA", true),
     ("IContextCallback", "000001DA-0000-0000-C000-000000000046", false),
     ("ICallbackWithNoReentrancyToApplicationSTA", "0A299774-3E4E-FC42-1D9D-72CEE105CA57", false),
     ("IErrorInfo", "1CF2B120-547D-101B-8E65-08002B2BD119", false),

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
@@ -124,7 +124,7 @@ namespace ABI.Windows.Storage.Streams
                 return 0;
             }
         }
-        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+        internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IBufferByteAccess);
 
         IntPtr global::Windows.Storage.Streams.IBufferByteAccess.Buffer
         {

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBuffer.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBuffer.cs
@@ -324,17 +324,17 @@ namespace ABI.System.Runtime.InteropServices.WindowsRuntime
             {
                 new ComWrappers.ComInterfaceEntry
                 {
-                    IID = typeof(global::Windows.Storage.Streams.IBuffer).GUID,
+                    IID = global::WinRT.Interop.IID.IID_IBuffer,
                     Vtable = global::ABI.Windows.Storage.Streams.IBuffer.AbiToProjectionVftablePtr
                 },
                 new ComWrappers.ComInterfaceEntry
                 {
-                    IID = typeof(global::Windows.Storage.Streams.IBufferByteAccess).GUID,
+                    IID = global::WinRT.Interop.IID.IID_IBufferByteAccess,
                     Vtable = global::ABI.Windows.Storage.Streams.IBufferByteAccess.Vftbl.AbiToProjectionVftablePtr
                 },
                 new ComWrappers.ComInterfaceEntry
                 {
-                    IID = typeof(global::Com.IMarshal).GUID,
+                    IID = global::WinRT.Interop.IID.IID_IMarshal,
                     Vtable = global::ABI.Com.IMarshal.Vftbl.AbiToProjectionVftablePtr
                 }
             };


### PR DESCRIPTION
This PR fixes the generated `IBufferByteAccess` addition to pass the IID to `FromAbi`. It also exposes the `IBuffer` and `IBufferByteAccess` IIDs as constant RVA fields, both so they can be used here, and in the generated vtable info attribute.