### PR TITLE
Strip generated authoring metadata types

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8266,14 +8266,12 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
         auto type_name = write_type_name_temp(w, type, "%", typedef_name_type::CCW);
         auto wrapped_type_name = write_type_name_temp(w, type, "%", typedef_name_type::Projected);
         auto default_interface_name = get_default_interface_name(w, type, false, true);
-        auto base_semantics = get_type_semantics(type.Extends());
-        auto from_abi_new = !std::holds_alternative<object_type>(base_semantics) ? "new " : "";
 
         // This type can be empty, as it is only used for metadata lookup, but not as implementation
         w.write(R"(%%[global::WinRT.ProjectedRuntimeClass(typeof(%))]
 %internal % partial class %
 {
-public static %% FromAbi(IntPtr thisPtr)
+public static % FromAbi(IntPtr thisPtr)
 {
 if (thisPtr == IntPtr.Zero) return null;
 return MarshalInspectable<%>.FromAbi(thisPtr);
@@ -8286,7 +8284,6 @@ return MarshalInspectable<%>.FromAbi(thisPtr);
         bind<write_type_custom_attributes>(type, false),
         bind<write_class_modifiers>(type),
         type_name,
-        from_abi_new,
         wrapped_type_name,
         wrapped_type_name);
     }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8264,33 +8264,12 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
         }
 
         auto type_name = write_type_name_temp(w, type, "%", typedef_name_type::CCW);
-        auto wrapped_type_name = write_type_name_temp(w, type, "%", typedef_name_type::Projected);
         auto default_interface_name = get_default_interface_name(w, type, false, true);
-        auto base_semantics = get_type_semantics(type.Extends());
-        auto from_abi_new = !std::holds_alternative<object_type>(base_semantics) ? "new " : "";
 
+        // This type can be empty, as it is only used for metadata lookup, but not as implementation
         w.write(R"(%%[global::WinRT.ProjectedRuntimeClass(typeof(%))]
-%internal % partial class %%
+%internal % partial class %
 {
-public %(% comp)
-{
-_comp = comp;
-}
-public static implicit operator %(% comp)
-{
-return comp._comp;
-}
-public static implicit operator %(% comp)
-{
-return new %(comp);
-}
-public static %% FromAbi(IntPtr thisPtr)
-{
-if (thisPtr == IntPtr.Zero) return null;
-return MarshalInspectable<%>.FromAbi(thisPtr);
-}
-%
-private readonly % _comp;
 }
 )",
         bind<write_winrt_attribute>(type),
@@ -8298,20 +8277,7 @@ private readonly % _comp;
         default_interface_name,
         bind<write_type_custom_attributes>(type, false),
         bind<write_class_modifiers>(type),
-        type_name,
-        bind<write_type_inheritance>(type, base_semantics, false, true),
-        type_name,
-        wrapped_type_name,
-        wrapped_type_name,
-        type_name,
-        type_name,
-        wrapped_type_name,
-        type_name,
-        from_abi_new,
-        wrapped_type_name,
-        wrapped_type_name,
-        bind<write_class_members>(type, true, false),
-        wrapped_type_name);
+        type_name);
     }
 
     void write_class_netstandard(writer& w, TypeDef const& type)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8264,12 +8264,20 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
         }
 
         auto type_name = write_type_name_temp(w, type, "%", typedef_name_type::CCW);
+        auto wrapped_type_name = write_type_name_temp(w, type, "%", typedef_name_type::Projected);
         auto default_interface_name = get_default_interface_name(w, type, false, true);
+        auto base_semantics = get_type_semantics(type.Extends());
+        auto from_abi_new = !std::holds_alternative<object_type>(base_semantics) ? "new " : "";
 
         // This type can be empty, as it is only used for metadata lookup, but not as implementation
         w.write(R"(%%[global::WinRT.ProjectedRuntimeClass(typeof(%))]
 %internal % partial class %
 {
+public static %% FromAbi(IntPtr thisPtr)
+{
+if (thisPtr == IntPtr.Zero) return null;
+return MarshalInspectable<%>.FromAbi(thisPtr);
+}
 }
 )",
         bind<write_winrt_attribute>(type),
@@ -8277,7 +8285,10 @@ return global::System.Runtime.InteropServices.CustomQueryInterfaceResult.NotHand
         default_interface_name,
         bind<write_type_custom_attributes>(type, false),
         bind<write_class_modifiers>(type),
-        type_name);
+        type_name,
+        from_abi_new,
+        wrapped_type_name,
+        wrapped_type_name);
     }
 
     void write_class_netstandard(writer& w, TypeDef const& type)


### PR DESCRIPTION
This PR strips all generated code from the `ABI.Impl` types in authoring scenarios. The types are only used for metadata lookups, and they're never actually instantiated, so they don't actually need to contain any logic to execute at runtime.