### PR TITLE
Small optimization in 'GetAuthoringMetadataType'

### DIFF
--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -302,10 +302,14 @@ namespace WinRT
             return AuthoringMetadataTypeCache.GetOrAdd(type,
                 (type) =>
                 {
-                    var lookupFunc = AuthoringMetadaTypeLookup.Find(lookupFunc => lookupFunc(type) != null);
-                    if (lookupFunc != null)
+                    foreach (Func<Type, Type> func in AuthoringMetadaTypeLookup)
                     {
-                        return lookupFunc(type);
+                        Type metadataType = func(type);
+
+                        if (metadataType is not null)
+                        {
+                            return metadataType;
+                        }
                     }
 
 #if NET


### PR DESCRIPTION
This PR includes a small optimization to 'GetAuthoringMetadataType':
- Remove unnecessary duplicate lookup
- Remove lambda and closure allocation