### PR TITLE
Remove leftover implicit operators on .NET target

### DIFF
--- a/src/Projections/Test/TestHost.ProbeByHost.cs
+++ b/src/Projections/Test/TestHost.ProbeByHost.cs
@@ -70,7 +70,6 @@ namespace ABI.Windows.Foundation
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IActivationFactory);
 
-        public static implicit operator IActivationFactory(IObjectReference obj) => (obj != null) ? new IActivationFactory(obj) : null;
         protected readonly ObjectReference<Vftbl> _obj;
         public IObjectReference ObjRef { get => _obj; }
         public IntPtr ThisPtr => _obj.ThisPtr;

--- a/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
+++ b/src/Projections/TestHost.ProbeByClass/TestHost.ProbeByClass.cs
@@ -70,7 +70,6 @@ namespace ABI.Windows.Foundation
         }
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IActivationFactory);
 
-        public static implicit operator IActivationFactory(IObjectReference obj) => (obj != null) ? new IActivationFactory(obj) : null;
         protected readonly ObjectReference<Vftbl> _obj;
         public IObjectReference ObjRef { get => _obj; }
         public IntPtr ThisPtr => _obj.ThisPtr;

--- a/src/WinRT.Runtime/ApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.txt
@@ -37,4 +37,10 @@ MembersMustExist : Member 'public WinRT.ObjectReference<I> ABI.System.Collection
 MembersMustExist : Member 'public A ABI.WinRT.Interop.IActivationFactory.As<A>()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public WinRT.ObjectReference<I> ABI.WinRT.Interop.IActivationFactory.AsInterface<I>()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected WinRT.ObjectReference<ABI.WinRT.Interop.IActivationFactory.Vftbl> WinRT.ObjectReference<ABI.WinRT.Interop.IActivationFactory.Vftbl> ABI.WinRT.Interop.IActivationFactory._obj' does not exist in the implementation but it does exist in the contract.
-Total Issues: 38
+MembersMustExist : Member 'public ABI.System.Nullable<T> ABI.System.Nullable<T>.op_Implicit(WinRT.IObjectReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public ABI.System.Nullable<T> ABI.System.Nullable<T>.op_Implicit(WinRT.ObjectReference<ABI.System.Nullable<T>.Vftbl>)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public ABI.System.Collections.Generic.KeyValuePair<K, V> ABI.System.Collections.Generic.KeyValuePair<K, V>.op_Implicit(WinRT.IObjectReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public ABI.WinRT.Interop.IActivationFactory ABI.WinRT.Interop.IActivationFactory.op_Implicit(WinRT.IObjectReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public WinRT.IInspectable WinRT.IInspectable.op_Implicit(WinRT.IObjectReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public WinRT.IInspectable WinRT.IInspectable.op_Implicit(WinRT.ObjectReference<WinRT.IInspectable.Vftbl>)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 44

--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -126,8 +126,10 @@ namespace WinRT
 
         private readonly ObjectReference<IUnknownVftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
+#if !NET
         public static implicit operator IInspectable(IObjectReference obj) => obj.As<Vftbl>(IID.IID_IInspectable);
         public static implicit operator IInspectable(ObjectReference<Vftbl> obj) => new IInspectable(obj);
+#endif
 
 #if NET
         [RequiresUnreferencedCode(AttributeMessages.GenericRequiresUnreferencedCodeMessage)]

--- a/src/WinRT.Runtime/Interop/IActivationFactory.cs
+++ b/src/WinRT.Runtime/Interop/IActivationFactory.cs
@@ -143,7 +143,9 @@ namespace ABI.WinRT.Interop
             }
         }
 
+#if !NET
         public static implicit operator IActivationFactory(IObjectReference obj) => (obj != null) ? new IActivationFactory(obj) : null;
+#endif
 #if NET
         protected readonly ObjectReference<IUnknownVftbl> _obj;
 #else

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -38,8 +38,6 @@ namespace ABI.Microsoft.UI.Xaml.Data
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_DataErrorsChangedEventArgsRuntimeClassFactory);
 
-        public static implicit operator WinRTDataErrorsChangedEventArgsRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTDataErrorsChangedEventArgsRuntimeClassFactory(obj) : null;
-        public static implicit operator WinRTDataErrorsChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTDataErrorsChangedEventArgsRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
         public WinRTDataErrorsChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_DataErrorsChangedEventArgsRuntimeClassFactory)) { }
@@ -90,7 +88,7 @@ namespace ABI.System.ComponentModel
 #endif
     unsafe struct DataErrorsChangedEventArgs
     {
-        private static ABI.Microsoft.UI.Xaml.Data.WinRTDataErrorsChangedEventArgsRuntimeClassFactory Instance = ActivationFactory.Get("Microsoft.UI.Xaml.Data.DataErrorsChangedEventArgs");
+        private static readonly ABI.Microsoft.UI.Xaml.Data.WinRTDataErrorsChangedEventArgsRuntimeClassFactory Instance = new(ActivationFactory.Get("Microsoft.UI.Xaml.Data.DataErrorsChangedEventArgs"));
 
         public static IObjectReference CreateMarshaler(global::System.ComponentModel.DataErrorsChangedEventArgs value)
         {

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -445,8 +445,10 @@ namespace ABI.System.Collections.Generic
 
         public static readonly Guid PIID = KeyValuePairMethods<K, V>.IID;
 
+#if !NET
         public static implicit operator KeyValuePair<K, V>(IObjectReference obj) => (obj != null) ? new KeyValuePair<K, V>(obj) : null;
         public static implicit operator KeyValuePair<K, V>(ObjectReference<IUnknownVftbl> obj) => (obj != null) ? new KeyValuePair<K, V>(obj) : null;
+#endif
         protected readonly ObjectReference<IUnknownVftbl> _obj;
         public IObjectReference ObjRef { get => _obj; }
 

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -388,8 +388,10 @@ namespace ABI.System
 
         public static readonly Guid PIID = NullableType.GetIID<T>();
 
+#if !NET
         public static implicit operator Nullable<T>(IObjectReference obj) => (obj != null) ? new Nullable<T>(obj) : null;
         public static implicit operator Nullable<T>(ObjectReference<Vftbl> obj) => (obj != null) ? new Nullable<T>(obj) : null;
+#endif
         protected readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
 

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -34,8 +34,6 @@ namespace ABI.Microsoft.UI.Xaml.Data
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_PropertyChangedEventArgsRuntimeClassFactory);
 
-        public static implicit operator WinRTPropertyChangedEventArgsRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTPropertyChangedEventArgsRuntimeClassFactory(obj) : null;
-        public static implicit operator WinRTPropertyChangedEventArgsRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTPropertyChangedEventArgsRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
         public WinRTPropertyChangedEventArgsRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_PropertyChangedEventArgsRuntimeClassFactory)) { }
@@ -101,7 +99,7 @@ namespace ABI.System.ComponentModel
 #endif
     unsafe struct PropertyChangedEventArgs
     {
-        private static ABI.Microsoft.UI.Xaml.Data.WinRTPropertyChangedEventArgsRuntimeClassFactory Instance = ActivationFactory.Get("Microsoft.UI.Xaml.Data.PropertyChangedEventArgs");
+        private static readonly ABI.Microsoft.UI.Xaml.Data.WinRTPropertyChangedEventArgsRuntimeClassFactory Instance = new(ActivationFactory.Get("Microsoft.UI.Xaml.Data.PropertyChangedEventArgs"));
 
         public static IObjectReference CreateMarshaler(global::System.ComponentModel.PropertyChangedEventArgs value)
         {

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -53,8 +53,6 @@ namespace ABI.System
         }
         public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, IID.IID_UriRuntimeClassFactory);
 
-        public static implicit operator WinRTUriRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
-        public static implicit operator WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
         private readonly ObjectReference<Vftbl> _obj;
         public IntPtr ThisPtr => _obj.ThisPtr;
         public WinRTUriRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>(IID.IID_UriRuntimeClassFactory)) { }
@@ -95,7 +93,7 @@ namespace ABI.System
 #endif
     unsafe struct Uri
     {
-        private static WinRTUriRuntimeClassFactory Instance = ActivationFactory.Get("Windows.Foundation.Uri");
+        private static readonly WinRTUriRuntimeClassFactory Instance = new(ActivationFactory.Get("Windows.Foundation.Uri"));
 
         public static IObjectReference CreateMarshaler(global::System.Uri value)
         {

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
@@ -201,7 +201,6 @@ namespace ABI.Com
 #else
         internal static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IMarshal);
 #endif
-        public static implicit operator IMarshal(IObjectReference obj) => (obj != null) ? new IMarshal(obj) : null;
 #if NET
         private readonly ObjectReference<global::WinRT.Interop.IUnknownVftbl> _obj;
 #else


### PR DESCRIPTION
Split off from #1597. Removes the leftover implicit operators from the .NET API surface.