### PR TITLE
Add 'CsWinRTUseUtcDateTimeOffsetMarshalling' switch

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -251,6 +251,7 @@ $(CsWinRTInternalProjection)
   <PropertyGroup>
     <CsWinRTEnableDynamicObjectsSupport Condition="'$(CsWinRTEnableDynamicObjectsSupport)' == ''">true</CsWinRTEnableDynamicObjectsSupport>
     <CsWinRTUseExceptionResourceKeys Condition="'$(CsWinRTUseExceptionResourceKeys)' == ''">false</CsWinRTUseExceptionResourceKeys>
+    <CsWinRTUseUtcDateTimeOffsetMarshalling Condition="'$(CsWinRTUseUtcDateTimeOffsetMarshalling)' == ''">false</CsWinRTUseUtcDateTimeOffsetMarshalling>
     <CsWinRTEnableDefaultCustomTypeMappings Condition="'$(CsWinRTEnableDefaultCustomTypeMappings)' == ''">true</CsWinRTEnableDefaultCustomTypeMappings>
     <CsWinRTEnableICustomPropertyProviderSupport Condition="'$(CsWinRTEnableICustomPropertyProviderSupport)' == ''">true</CsWinRTEnableICustomPropertyProviderSupport>
     <CsWinRTEnableIReferenceSupport Condition="'$(CsWinRTEnableIReferenceSupport)' == ''">true</CsWinRTEnableIReferenceSupport>
@@ -271,6 +272,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_USE_EXCEPTION_RESOURCE_KEYS switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_USE_EXCEPTION_RESOURCE_KEYS"
                                     Value="$(CsWinRTUseExceptionResourceKeys)"
+                                    Trim="true" />
+
+    <!-- CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING"
+                                    Value="$(CsWinRTUseUtcDateTimeOffsetMarshalling)"
                                     Trim="true" />
                                   
     <!-- CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS switch -->

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -24,12 +24,17 @@ internal static class FeatureSwitches
     /// <summary>
     /// The configuration property name for <see cref="EnableDynamicObjectsSupport"/>.
     /// </summary>
-    private const string EnablesDynamicObjectsSupportPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
+    private const string EnableDynamicObjectsSupportPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
+
+    /// <summary>
+    /// The configuration property name for <see cref="UseUtcDateTimeOffsetMarshalling"/>.
+    /// </summary>
+    private const string UseExceptionResourceKeysPropertyName = "CSWINRT_USE_EXCEPTION_RESOURCE_KEYS";
 
     /// <summary>
     /// The configuration property name for <see cref="UseExceptionResourceKeys"/>.
     /// </summary>
-    private const string UseExceptionResourceKeysPropertyName = "CSWINRT_USE_EXCEPTION_RESOURCE_KEYS";
+    private const string UseUtcDateTimeOffsetMarshallingPropertyName = "CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING";
 
     /// <summary>
     /// The configuration property name for <see cref="EnableDefaultCustomTypeMappings"/>.
@@ -62,6 +67,11 @@ internal static class FeatureSwitches
     private static int _useExceptionResourceKeys;
 
     /// <summary>
+    /// The backing field for <see cref="UseUtcDateTimeOffsetMarshalling"/>.
+    /// </summary>
+    private static int _useUtcDateTimeOffsetMarshalling;
+
+    /// <summary>
     /// The backing field for <see cref="EnableDefaultCustomTypeMappings"/>.
     /// </summary>
     private static int _enableDefaultCustomTypeMappings;
@@ -87,7 +97,7 @@ internal static class FeatureSwitches
     public static bool EnableDynamicObjectsSupport
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnablesDynamicObjectsSupportPropertyName, ref _enableDynamicObjectsSupportEnabled, true);
+        get => GetConfigurationValue(EnableDynamicObjectsSupportPropertyName, ref _enableDynamicObjectsSupportEnabled, true);
     }
 
     /// <summary>
@@ -97,6 +107,15 @@ internal static class FeatureSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetConfigurationValue(UseExceptionResourceKeysPropertyName, ref _useExceptionResourceKeys, false);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not <see cref="DateTimeOffset"/> values should be marshalled as UTC (defaults to <see langword="false"/>).
+    /// </summary>
+    public static bool UseUtcDateTimeOffsetMarshalling
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetConfigurationValue(UseUtcDateTimeOffsetMarshallingPropertyName, ref _useUtcDateTimeOffsetMarshalling, false);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -10,6 +10,10 @@
       <method signature="System.Boolean get_UseExceptionResourceKeys()" body="stub" value="false" feature="CSWINRT_USE_EXCEPTION_RESOURCE_KEYS" featurevalue="false"/>
       <method signature="System.Boolean get_UseExceptionResourceKeys()" body="stub" value="true" feature="CSWINRT_USE_EXCEPTION_RESOURCE_KEYS" featurevalue="true"/>
         
+      <!-- CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING switch -->
+      <method signature="System.Boolean get_UseUtcDateTimeOffsetMarshalling()" body="stub" value="false" feature="CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING" featurevalue="false"/>
+      <method signature="System.Boolean get_UseUtcDateTimeOffsetMarshalling()" body="stub" value="true" feature="CSWINRT_USE_UTC_DATETIMEOFFSET_MARSHALLING" featurevalue="true"/>
+        
       <!-- CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS switch -->
       <method signature="System.Boolean get_EnableDefaultCustomTypeMappings()" body="stub" value="false" feature="CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS" featurevalue="false"/>
       <method signature="System.Boolean get_EnableDefaultCustomTypeMappings()" body="stub" value="true" feature="CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS" featurevalue="true"/>


### PR DESCRIPTION
This PR adds the 'CsWinRTUseUtcDateTimeOffsetMarshalling' switch to opt-in into standard UTC `DateTimeOffset` marshalling.