### PR TITLE
Add missing check for 'IReference<T>' support

### DIFF
--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2049,6 +2049,11 @@ namespace ABI.System
 
         public static Func<IInspectable, object> GetValueFactory(global::System.Type type)
         {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                throw new NotSupportedException("Support for 'IReference<T>' is not enabled.");
+            }
+
             return ComWrappersSupport.CreateReferenceCachingFactory(GetValueFactoryInternal(type));
         }
 


### PR DESCRIPTION
Leftover from #1575 that was causing a bunch more stuff to be rooted.