### PR TITLE
Avoid closure in 'CreateReferenceCachingFactory'

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -496,16 +496,11 @@ namespace WinRT
 
         // This is used to hold the reference to the native value type object (IReference) until the actual value in it (boxed as an object) gets cleaned up by GC
         // This is done to avoid pointer reuse until GC cleans up the boxed object
-        private static readonly ConditionalWeakTable<object, IInspectable> _boxedValueReferenceCache = new();
+        internal static readonly ConditionalWeakTable<object, IInspectable> BoxedValueReferenceCache = new();
 
         internal static Func<IInspectable, object> CreateReferenceCachingFactory(Func<IInspectable, object> internalFactory)
         {
-            return inspectable =>
-            {
-                object resultingObject = internalFactory(inspectable);
-                _boxedValueReferenceCache.Add(resultingObject, inspectable);
-                return resultingObject;
-            };
+            return internalFactory.InvokeWithBoxedValueReferenceCacheInsertion;
         }
 
         private static Func<IInspectable, object> CreateCustomTypeMappingFactory(

--- a/src/WinRT.Runtime/DelegateExtensions.cs
+++ b/src/WinRT.Runtime/DelegateExtensions.cs
@@ -95,5 +95,16 @@ namespace WinRT
         {
             action.Invoke(arg1, arg2);
         }
+
+        // This extension method allows us to create a new delegate directly pointing to this method, which
+        // also adds the resulting object to the conditional weak table before returning it to callers.
+        public static object InvokeWithBoxedValueReferenceCacheInsertion(this Func<IInspectable, object> factory, IInspectable inspectable)
+        {
+            object resultingObject = factory(inspectable);
+
+            ComWrappersSupport.BoxedValueReferenceCache.Add(resultingObject, inspectable);
+
+            return resultingObject;
+        }
     }
 }


### PR DESCRIPTION
Small trick to avoid a closure class, since this delegate is only capturing the original delegate itself.