### PR TITLE
Optimize 'IGlobalInterfaceTable' on .NET

### DIFF
--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -39,7 +39,7 @@ namespace WinRT
         private const int E_POINTER = unchecked((int)0x80004003);
         private const int E_NOTIMPL = unchecked((int)0x80004001);
         private const int E_ACCESSDENIED = unchecked((int)0x80070005);
-        private const int E_INVALIDARG = unchecked((int)0x80070057);
+        internal const int E_INVALIDARG = unchecked((int)0x80070057);
         private const int E_NOINTERFACE = unchecked((int)0x80004002);
         private const int E_OUTOFMEMORY = unchecked((int)0x8007000e);
         private const int ERROR_ARITHMETIC_OVERFLOW = unchecked((int)0x80070216);


### PR DESCRIPTION
This PR includes a couple of small optimizations for `IGlobalInterfaceTable`:
- Remove the interface, just use the class directly
- Remove the `try/catch`, just don't throw for `E_INVALIDARG`