### PR TITLE
Trim 'ABI.System.EventHandler' when not needed

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -233,7 +233,7 @@ namespace WinRT
             else if (type == typeof(global::System.EventHandler))
             {
                 hasWinrtExposedClassAttribute = true;
-                entries.AddRange(ABI.System.EventHandler.GetExposedInterfaces());
+                entries.AddRange(Projections.GetAbiEventHandlerExposedInterfaces());
             }
             else if (ComInterfaceEntriesForType.TryGetValue(type, out var registeredEntries))
             {

--- a/src/WinRT.Runtime/Projections.CustomTypeMappings.EventHandler.cs
+++ b/src/WinRT.Runtime/Projections.CustomTypeMappings.EventHandler.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if NET
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Threading;
+using System.Windows.Input;
+using Microsoft.UI.Xaml.Interop;
+using Windows.Foundation.Collections;
+using static System.Runtime.InteropServices.ComWrappers;
+
+#nullable enable
+
+namespace WinRT
+{
+    /// <inheritdoc cref="Projections"/>
+    partial class Projections
+    {
+        private static int _EventHandler;
+
+        /// <summary>
+        /// ABI interfaces for <see cref="EventHandler"/>, conditionally set from <see cref="RegisterEventHandlerMapping"/>
+        /// to avoid rooting <see cref="ABI.System.EventHandler"/> when the type mapping for this type isn't needed.
+        /// </summary>
+        private static ComInterfaceEntry[]? _AbiEventHandlerExposedInterfaces;
+
+        /// <summary>Registers the custom ABI type mapping for the <see cref="EventHandler"/> type.</summary>
+        public static void RegisterEventHandlerMapping()
+        {
+            if (FeatureSwitches.EnableDefaultCustomTypeMappings)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _EventHandler, 1, 0) == 1)
+            {
+                return;
+            }
+
+            RegisterCustomAbiTypeMapping(
+                typeof(EventHandler),
+                typeof(ABI.System.EventHandler));
+
+            _AbiEventHandlerExposedInterfaces = ABI.System.EventHandler.GetExposedInterfaces();
+        }
+
+        /// <summary>
+        /// Gets the ABI interfaces for <see cref="EventHandler"/>.
+        /// </summary>
+        /// <returns>The ABI interfaces for <see cref="EventHandler"/>.</returns>
+        /// <exception cref="NotSupportedException">Thrown if the type mapping is disabled.</exception>
+        internal static ComInterfaceEntry[] GetAbiEventHandlerExposedInterfaces()
+        {
+            if (FeatureSwitches.EnableDefaultCustomTypeMappings)
+            {
+                return ABI.System.EventHandler.GetExposedInterfaces();
+            }
+
+            ComInterfaceEntry[]? interfaces = _AbiEventHandlerExposedInterfaces;
+
+            if (interfaces is null)
+            {
+                throw new NotSupportedException(
+                    "Support for type mapping for the 'EventHandler' type is currently disabled. " +
+                    "To enable it, either make sure to not set the 'CsWinRTEnableCustomTypeMappings' property to 'false', " +
+                    "or manually enable support for this specific type by calling 'Projections.RegisterEventHandlerMapping()'.");
+            }
+
+            return interfaces;
+        }
+    }
+}
+
+#endif

--- a/src/WinRT.Runtime/Projections.CustomTypeMappings.g.cs
+++ b/src/WinRT.Runtime/Projections.CustomTypeMappings.g.cs
@@ -69,7 +69,6 @@ namespace WinRT
         private static int _Vector2;
         private static int _Vector3;
         private static int _Vector4;
-        private static int _EventHandler;
         private static int _IMap___;
         private static int _IVector__;
         private static int _IMapView___;
@@ -1077,24 +1076,6 @@ namespace WinRT
                 typeof(ABI.System.Numerics.Vector4),
                 "Windows.Foundation.Numerics.Vector4",
                 isRuntimeClass: false);
-        }
-
-        /// <summary>Registers the custom ABI type mapping for the <see cref="EventHandler"/> type.</summary>
-        public static void RegisterEventHandlerMapping()
-        {
-            if (FeatureSwitches.EnableDefaultCustomTypeMappings)
-            {
-                return;
-            }
-
-            if (Interlocked.CompareExchange(ref _EventHandler, 1, 0) == 1)
-            {
-                return;
-            }
-
-            RegisterCustomAbiTypeMapping(
-                typeof(EventHandler),
-                typeof(ABI.System.EventHandler));
         }
 
         /// <summary>Registers the custom ABI type mapping for the <see cref="IMap{K, V}"/> type.</summary>

--- a/src/WinRT.Runtime/Projections.CustomTypeMappings.tt
+++ b/src/WinRT.Runtime/Projections.CustomTypeMappings.tt
@@ -111,7 +111,6 @@ var registerCustomAbiTypeMappings = new (string Public, string Abi, string Name,
     ("Vector2", "ABI.System.Numerics.Vector2", "Windows.Foundation.Numerics.Vector2", null, false),
     ("Vector3", "ABI.System.Numerics.Vector3", "Windows.Foundation.Numerics.Vector3", null, false),
     ("Vector4", "ABI.System.Numerics.Vector4", "Windows.Foundation.Numerics.Vector4", null, false),
-    ("EventHandler", "ABI.System.EventHandler", null, null, false)
 };
 
 // Types for 'RegisterCustomTypeToHelperTypeMapping'


### PR DESCRIPTION
This PR enables fully trimming `ABI.System.EventHandler` when not needed, making it fully pay-for-play.