### PR TITLE
Fix edge cases with .NET Standard embedded support

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -65,6 +65,8 @@
     <file src="..\src\WinRT.Runtime\Projections\*net5*.cs" target="embedded\net6.0\" />
     <file src="..\src\WinRT.Runtime\Projections\*netstandard2.0*.cs" target="embedded\netstandard2.0\" />
 
+    <file src="..\src\WinRT.Runtime\Configuration\*.cs" exclude="..\src\WinRT.Runtime\Configuration\*.net*.cs"  target="embedded\any\" />
+
     <file src="$guid_patch$" target ="build\tools\IIDOptimizer"/>
   </files>
 </package>

--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -20,14 +20,14 @@ namespace WinRT
 #if NET
         private static volatile ABI.WinRT.Interop.IGlobalInterfaceTable _git;
 #else
-        private static volatile IGlobalInterfaceTable _git;
+        private static volatile global::WinRT.Interop.IGlobalInterfaceTable _git;
 #endif
 
         // Simple singleton lazy-initialization scheme (and saving the Lazy<T> size)
 #if NET
         internal static ABI.WinRT.Interop.IGlobalInterfaceTable Git
 #else
-        internal static IGlobalInterfaceTable Git
+        internal static global::WinRT.Interop.IGlobalInterfaceTable Git
 #endif
         {
             get
@@ -38,7 +38,7 @@ namespace WinRT
 #if NET
                 static ABI.WinRT.Interop.IGlobalInterfaceTable Git_Slow()
 #else
-                static IGlobalInterfaceTable Git_Slow()
+                static global::WinRT.Interop.IGlobalInterfaceTable Git_Slow()
 #endif
                 {
                     lock (_lock)
@@ -87,7 +87,7 @@ namespace WinRT
             }
             finally
             {
-                MarshalInterface<IAgileReference>.DisposeAbi(agileReference);
+                MarshalInterface<global::WinRT.Interop.IAgileReference>.DisposeAbi(agileReference);
             }
         }
 
@@ -122,7 +122,7 @@ namespace WinRT
 #if NET
         private static unsafe ABI.WinRT.Interop.IGlobalInterfaceTable GetGitTable()
 #else
-        private static unsafe IGlobalInterfaceTable GetGitTable()
+        private static unsafe global::WinRT.Interop.IGlobalInterfaceTable GetGitTable()
 #endif
         {
             Guid gitClsid = CLSID_StdGlobalInterfaceTable;

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -4,172 +4,173 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace WinRT;
-
-/// <summary>
-/// A container for all shared <see cref="AppContext"/> configuration switches for CsWinRT.
-/// </summary>
-/// <remarks>
-/// <para>
-/// This type uses a very specific setup for configuration switches to ensure ILLink can work the best.
-/// This mirrors the architecture of feature switches in the runtime as well, and it's needed so that
-/// no static constructor is generated for the type.
-/// </para>
-/// <para>
-/// For more info, see <see href="https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md#adding-new-feature-switch"/>.
-/// </para>
-/// </remarks>
-internal static class FeatureSwitches
+namespace WinRT
 {
     /// <summary>
-    /// The configuration property name for <see cref="EnableDynamicObjectsSupport"/>.
+    /// A container for all shared <see cref="AppContext"/> configuration switches for CsWinRT.
     /// </summary>
-    private const string EnablesDynamicObjectsSupportPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
-
-    /// <summary>
-    /// The configuration property name for <see cref="UseExceptionResourceKeys"/>.
-    /// </summary>
-    private const string UseExceptionResourceKeysPropertyName = "CSWINRT_USE_EXCEPTION_RESOURCE_KEYS";
-
-    /// <summary>
-    /// The configuration property name for <see cref="EnableDefaultCustomTypeMappings"/>.
-    /// </summary>
-    private const string EnableDefaultCustomTypeMappingsPropertyName = "CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS";
-
-    /// <summary>
-    /// The configuration property name for <see cref="EnableICustomPropertyProviderSupport"/>.
-    /// </summary>
-    private const string EnableICustomPropertyProviderSupportPropertyName = "CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT";
-
-    /// <summary>
-    /// The configuration property name for <see cref="EnableIReferenceSupport"/>.
-    /// </summary>
-    private const string EnableIReferenceSupportPropertyName = "CSWINRT_ENABLE_IREFERENCE_SUPPORT";
-
-    /// <summary>
-    /// The configuration property name for <see cref="EnableIDynamicInterfaceCastableSupport"/>.
-    /// </summary>
-    private const string EnableIDynamicInterfaceCastableSupportPropertyName = "CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE";
-
-    /// <summary>
-    /// The backing field for <see cref="EnableDynamicObjectsSupport"/>.
-    /// </summary>
-    private static int _enableDynamicObjectsSupportEnabled;
-
-    /// <summary>
-    /// The backing field for <see cref="UseExceptionResourceKeys"/>.
-    /// </summary>
-    private static int _useExceptionResourceKeys;
-
-    /// <summary>
-    /// The backing field for <see cref="EnableDefaultCustomTypeMappings"/>.
-    /// </summary>
-    private static int _enableDefaultCustomTypeMappings;
-
-    /// <summary>
-    /// The backing field for <see cref="EnableICustomPropertyProviderSupport"/>.
-    /// </summary>
-    private static int _enableICustomPropertyProviderSupport;
-
-    /// <summary>
-    /// The backing field for <see cref="EnableIReferenceSupport"/>.
-    /// </summary>
-    private static int _enableIReferenceSupport;
-
-    /// <summary>
-    /// The backing field for <see cref="EnableIDynamicInterfaceCastableSupport"/>.
-    /// </summary>
-    private static int _enableIDynamicInterfaceCastableSupport;
-
-    /// <summary>
-    /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
-    /// </summary>
-    public static bool EnableDynamicObjectsSupport
+    /// <remarks>
+    /// <para>
+    /// This type uses a very specific setup for configuration switches to ensure ILLink can work the best.
+    /// This mirrors the architecture of feature switches in the runtime as well, and it's needed so that
+    /// no static constructor is generated for the type.
+    /// </para>
+    /// <para>
+    /// For more info, see <see href="https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md#adding-new-feature-switch"/>.
+    /// </para>
+    /// </remarks>
+    internal static class FeatureSwitches
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnablesDynamicObjectsSupportPropertyName, ref _enableDynamicObjectsSupportEnabled, true);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="EnableDynamicObjectsSupport"/>.
+        /// </summary>
+        private const string EnablesDynamicObjectsSupportPropertyName = "CSWINRT_ENABLE_DYNAMIC_OBJECTS_SUPPORT";
 
-    /// <summary>
-    /// Gets a value indicating whether or not exceptions should use resource keys rather than localized messages (defaults to <see langword="false"/>).
-    /// </summary>
-    public static bool UseExceptionResourceKeys
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(UseExceptionResourceKeysPropertyName, ref _useExceptionResourceKeys, false);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="UseExceptionResourceKeys"/>.
+        /// </summary>
+        private const string UseExceptionResourceKeysPropertyName = "CSWINRT_USE_EXCEPTION_RESOURCE_KEYS";
 
-    /// <summary>
-    /// Gets a value indicating whether or not <see cref="Projections"/> should initialize all default type mappings automatically (defaults to <see langword="true"/>).
-    /// </summary>
-    public static bool EnableDefaultCustomTypeMappings
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnableDefaultCustomTypeMappingsPropertyName, ref _enableDefaultCustomTypeMappings, true);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="EnableDefaultCustomTypeMappings"/>.
+        /// </summary>
+        private const string EnableDefaultCustomTypeMappingsPropertyName = "CSWINRT_ENABLE_DEFAULT_CUSTOM_TYPE_MAPPINGS";
 
-    /// <summary>
-    /// Gets a value indicating whether or not <see cref="ABI.Microsoft.UI.Xaml.Data.ManagedCustomPropertyProviderVftbl"/> should be enabled (defaults to <see langword="true"/>).
-    /// </summary>
-    public static bool EnableICustomPropertyProviderSupport
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnableICustomPropertyProviderSupportPropertyName, ref _enableICustomPropertyProviderSupport, true);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="EnableICustomPropertyProviderSupport"/>.
+        /// </summary>
+        private const string EnableICustomPropertyProviderSupportPropertyName = "CSWINRT_ENABLE_ICUSTOMPROPERTYPROVIDER_SUPPORT";
 
-    /// <summary>
-    /// Gets a value indicating whether or not <c>IReference&lt;T&gt;</c>, <c>IReferenceArray&lt;T&gt;</c> and <c>IPropertyValue</c> CCW implementations should be supported (defaults to <see langword="true"/>).
-    /// </summary>
-    public static bool EnableIReferenceSupport
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnableIReferenceSupportPropertyName, ref _enableIReferenceSupport, true);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="EnableIReferenceSupport"/>.
+        /// </summary>
+        private const string EnableIReferenceSupportPropertyName = "CSWINRT_ENABLE_IREFERENCE_SUPPORT";
 
-    /// <summary>
-    /// Gets a value indicating whether or not <see cref="System.Runtime.InteropServices.IDynamicInterfaceCastable"/> should be supported by RCW types (defaults to <see langword="true"/>).
-    /// </summary>
-    public static bool EnableIDynamicInterfaceCastableSupport
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(EnableIDynamicInterfaceCastableSupportPropertyName, ref _enableIDynamicInterfaceCastableSupport, true);
-    }
+        /// <summary>
+        /// The configuration property name for <see cref="EnableIDynamicInterfaceCastableSupport"/>.
+        /// </summary>
+        private const string EnableIDynamicInterfaceCastableSupportPropertyName = "CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE";
 
-    /// <summary>
-    /// Gets a configuration value for a specified property.
-    /// </summary>
-    /// <param name="propertyName">The property name to retrieve the value for.</param>
-    /// <param name="cachedResult">The cached result for the target configuration value.</param>
-    /// <returns>The value of the specified configuration setting.</returns>
-    private static bool GetConfigurationValue(string propertyName, ref int cachedResult, bool defaultValue)
-    {
-        // The cached switch value has 3 states:
-        //   0: unknown.
-        //   1: true
-        //   -1: false
-        //
-        // This method doesn't need to worry about concurrent accesses to the cached result,
-        // as even if the configuration value is retrieved twice, that'll always be the same.
-        if (cachedResult < 0)
+        /// <summary>
+        /// The backing field for <see cref="EnableDynamicObjectsSupport"/>.
+        /// </summary>
+        private static int _enableDynamicObjectsSupportEnabled;
+
+        /// <summary>
+        /// The backing field for <see cref="UseExceptionResourceKeys"/>.
+        /// </summary>
+        private static int _useExceptionResourceKeys;
+
+        /// <summary>
+        /// The backing field for <see cref="EnableDefaultCustomTypeMappings"/>.
+        /// </summary>
+        private static int _enableDefaultCustomTypeMappings;
+
+        /// <summary>
+        /// The backing field for <see cref="EnableICustomPropertyProviderSupport"/>.
+        /// </summary>
+        private static int _enableICustomPropertyProviderSupport;
+
+        /// <summary>
+        /// The backing field for <see cref="EnableIReferenceSupport"/>.
+        /// </summary>
+        private static int _enableIReferenceSupport;
+
+        /// <summary>
+        /// The backing field for <see cref="EnableIDynamicInterfaceCastableSupport"/>.
+        /// </summary>
+        private static int _enableIDynamicInterfaceCastableSupport;
+
+        /// <summary>
+        /// Gets a value indicating whether or not projections support for dynamic objects is enabled (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableDynamicObjectsSupport
         {
-            return false;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnablesDynamicObjectsSupportPropertyName, ref _enableDynamicObjectsSupportEnabled, true);
         }
 
-        if (cachedResult > 0)
+        /// <summary>
+        /// Gets a value indicating whether or not exceptions should use resource keys rather than localized messages (defaults to <see langword="false"/>).
+        /// </summary>
+        public static bool UseExceptionResourceKeys
         {
-            return true;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(UseExceptionResourceKeysPropertyName, ref _useExceptionResourceKeys, false);
         }
 
-        // Get the configuration switch value, or its default.
-        // All feature switches have a default set in the .targets file.
-        if (!AppContext.TryGetSwitch(propertyName, out bool isEnabled))
+        /// <summary>
+        /// Gets a value indicating whether or not <see cref="Projections"/> should initialize all default type mappings automatically (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableDefaultCustomTypeMappings
         {
-            isEnabled = defaultValue;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnableDefaultCustomTypeMappingsPropertyName, ref _enableDefaultCustomTypeMappings, true);
         }
 
-        // Update the cached result
-        cachedResult = isEnabled ? 1 : -1;
+        /// <summary>
+        /// Gets a value indicating whether or not <see cref="ABI.Microsoft.UI.Xaml.Data.ManagedCustomPropertyProviderVftbl"/> should be enabled (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableICustomPropertyProviderSupport
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnableICustomPropertyProviderSupportPropertyName, ref _enableICustomPropertyProviderSupport, true);
+        }
 
-        return isEnabled;
+        /// <summary>
+        /// Gets a value indicating whether or not <c>IReference&lt;T&gt;</c>, <c>IReferenceArray&lt;T&gt;</c> and <c>IPropertyValue</c> CCW implementations should be supported (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableIReferenceSupport
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnableIReferenceSupportPropertyName, ref _enableIReferenceSupport, true);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not <see cref="System.Runtime.InteropServices.IDynamicInterfaceCastable"/> should be supported by RCW types (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableIDynamicInterfaceCastableSupport
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnableIDynamicInterfaceCastableSupportPropertyName, ref _enableIDynamicInterfaceCastableSupport, true);
+        }
+
+        /// <summary>
+        /// Gets a configuration value for a specified property.
+        /// </summary>
+        /// <param name="propertyName">The property name to retrieve the value for.</param>
+        /// <param name="cachedResult">The cached result for the target configuration value.</param>
+        /// <returns>The value of the specified configuration setting.</returns>
+        private static bool GetConfigurationValue(string propertyName, ref int cachedResult, bool defaultValue)
+        {
+            // The cached switch value has 3 states:
+            //   0: unknown.
+            //   1: true
+            //   -1: false
+            //
+            // This method doesn't need to worry about concurrent accesses to the cached result,
+            // as even if the configuration value is retrieved twice, that'll always be the same.
+            if (cachedResult < 0)
+            {
+                return false;
+            }
+
+            if (cachedResult > 0)
+            {
+                return true;
+            }
+
+            // Get the configuration switch value, or its default.
+            // All feature switches have a default set in the .targets file.
+            if (!AppContext.TryGetSwitch(propertyName, out bool isEnabled))
+            {
+                isEnabled = defaultValue;
+            }
+
+            // Update the cached result
+            cachedResult = isEnabled ? 1 : -1;
+
+            return isEnabled;
+        }
     }
 }

--- a/src/WinRT.Runtime/EventRegistrationTokenTable{T}.cs
+++ b/src/WinRT.Runtime/EventRegistrationTokenTable{T}.cs
@@ -196,3 +196,6 @@ namespace WinRT
         }
     }
 }
+
+// Restore in case this file is merged with others.
+#nullable restore

--- a/src/WinRT.Runtime/Interop/EventSourceState{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSourceState{TDelegate}.cs
@@ -162,3 +162,6 @@ namespace ABI.WinRT.Interop
         }
     }
 }
+
+// Restore in case this file is merged with others.
+#nullable restore

--- a/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
@@ -184,3 +184,6 @@ namespace ABI.WinRT.Interop
         }
     }
 }
+
+// Restore in case this file is merged with others.
+#nullable restore

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -64,7 +64,7 @@ namespace ABI.Windows.Foundation
             }
         }
 
-        private static unsafe int Do_Abi_get_Value_0_DateTimeOffset(void* thisPtr, DateTimeOffset* result)
+        private static unsafe int Do_Abi_get_Value_0_DateTimeOffset(void* thisPtr, global::ABI.System.DateTimeOffset* result)
         {
             if (result is null)
             {
@@ -75,7 +75,7 @@ namespace ABI.Windows.Foundation
             {
                 T unboxedValue = (T)global::WinRT.ComWrappersSupport.FindObject<object>(new IntPtr(thisPtr));
 
-                Unsafe.WriteUnaligned(result, DateTimeOffset.FromManaged(Unsafe.As<T, global::System.DateTimeOffset>(ref unboxedValue)));
+                Unsafe.WriteUnaligned(result, global::ABI.System.DateTimeOffset.FromManaged(Unsafe.As<T, global::System.DateTimeOffset>(ref unboxedValue)));
 
                 return 0;
             }
@@ -136,7 +136,7 @@ namespace ABI.Windows.Foundation
                 (typeof(T).IsEnum && Enum.GetUnderlyingType(typeof(T)) == typeof(int)) ||
                 (typeof(T).IsEnum && Enum.GetUnderlyingType(typeof(T)) == typeof(uint)))
             {
-                Nullable_Delegates.GetValueDelegateAbi stub = new(Do_Abi_get_Value_0_Blittable);
+                global::ABI.System.Nullable_Delegates.GetValueDelegateAbi stub = new(Do_Abi_get_Value_0_Blittable);
 
                 nativePtr = Marshal.GetFunctionPointerForDelegate(stub);
 
@@ -145,7 +145,7 @@ namespace ABI.Windows.Foundation
 
             if (typeof(T) == typeof(global::System.DateTimeOffset))
             {
-                Nullable_Delegates.GetValueDelegateAbiDateTimeOffset stub = new(Do_Abi_get_Value_0_DateTimeOffset);
+                global::ABI.System.Nullable_Delegates.GetValueDelegateAbiDateTimeOffset stub = new(Do_Abi_get_Value_0_DateTimeOffset);
 
                 nativePtr = Marshal.GetFunctionPointerForDelegate(stub);
 
@@ -159,10 +159,10 @@ namespace ABI.Windows.Foundation
 #endif
             {
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                Nullable<T>.Vftbl.get_Value_0_Type ??= Projections.GetAbiDelegateType(typeof(void*), Marshaler<T>.AbiType.MakeByRefType(), typeof(int));
+                global::ABI.System.Nullable<T>.Vftbl.get_Value_0_Type ??= Projections.GetAbiDelegateType(typeof(void*), Marshaler<T>.AbiType.MakeByRefType(), typeof(int));
 
                 Delegate stub = Delegate.CreateDelegate(
-                    Nullable<T>.Vftbl.get_Value_0_Type,
+                    global::ABI.System.Nullable<T>.Vftbl.get_Value_0_Type,
                     typeof(BoxedValueIReferenceImpl<T>).GetMethod(nameof(Do_Abi_get_Value_0), BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(Marshaler<T>.AbiType));
 
                 nativePtr = Marshal.GetFunctionPointerForDelegate(stub);
@@ -178,7 +178,7 @@ namespace ABI.Windows.Foundation
     internal static class BoxedValueIReferenceImpl<T, TAbi> where TAbi : unmanaged
     {
         public static IntPtr AbiToProjectionVftablePtr;
-        private readonly static Nullable_Delegates.GetValueDelegateAbi GetValue;
+        private readonly static global::ABI.System.Nullable_Delegates.GetValueDelegateAbi GetValue;
 
         static unsafe BoxedValueIReferenceImpl()
         {

--- a/src/WinRT.Runtime/WeakReference.netstandard2.0.cs
+++ b/src/WinRT.Runtime/WeakReference.netstandard2.0.cs
@@ -19,13 +19,13 @@ namespace WinRT
         where T : class
     {
         private System.WeakReference<T> _managedWeakReference;
-        private IWeakReference _nativeWeakReference;
+        private global::WinRT.Interop.IWeakReference _nativeWeakReference;
         public WeakReference(T target)
         {
             _managedWeakReference = new System.WeakReference<T>(target);
-            if (target is object && ComWrappersSupport.TryUnwrapObject(target, out var objRef))
+            if (target is object && ComWrappersSupport.TryUnwrapObject(target, out var _))
             {
-                _nativeWeakReference = target.As<IWeakReferenceSource>().GetWeakReference();
+                _nativeWeakReference = target.As<global::WinRT.Interop.IWeakReferenceSource>().GetWeakReference();
             }
         }
 
@@ -36,7 +36,7 @@ namespace WinRT
                 _managedWeakReference.SetTarget(target);
                 if (target is object && ComWrappersSupport.TryUnwrapObject(target, out _))
                 {
-                    _nativeWeakReference = target.As<IWeakReferenceSource>().GetWeakReference();
+                    _nativeWeakReference = target.As<global::WinRT.Interop.IWeakReferenceSource>().GetWeakReference();
                 }
             }
         }
@@ -58,7 +58,7 @@ namespace WinRT
             }
         }
 
-        private static object ResolveNativeWeakReference(IWeakReference reference)
+        private static object ResolveNativeWeakReference(global::WinRT.Interop.IWeakReference reference)
         {
             if (reference is null)
             {

--- a/src/WinRT.Runtime/WinRTRuntimeErrorStrings.Designer.cs
+++ b/src/WinRT.Runtime/WinRTRuntimeErrorStrings.Designer.cs
@@ -78,3 +78,6 @@ namespace WinRT
         }
     }
 }
+
+// Restore in case this file is merged with others.
+#nullable restore


### PR DESCRIPTION
Fixing some edge cases with .NET Standard embedded support impacting one of our users of it.  The changes are mainly using explicit namespaces, removing file namespace scope, and adding the configuration file missed in embedded support.