### PR TITLE
Don't cache 'RegisterTypeComInterfaceEntriesLookup'

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1130,7 +1130,7 @@ namespace Generator
                                             [System.Runtime.CompilerServices.ModuleInitializer]
                                             internal static void InitializeGlobalVtableLookup()
                                             {
-                                                ComWrappersSupport.RegisterTypeComInterfaceEntriesLookup(LookupVtableEntries);
+                                                ComWrappersSupport.RegisterTypeComInterfaceEntriesLookup(new Func<Type, ComWrappers.ComInterfaceEntry[]>(LookupVtableEntries));
                                                 {{(hasRuntimeClasNameEntries ? "ComWrappersSupport.RegisterTypeRuntimeClassNameLookup(new Func<Type, string>(LookupRuntimeClassName));" : "")}}
                                             }
 


### PR DESCRIPTION
Minimal size optimization, same as in #1470 and #1586.