### PR TITLE
Minor changes to IIDOptimizer and AOTOptimizer

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -943,7 +943,9 @@ namespace Generator
                 // type need to be put on the CCW.
                 if (instantiatedType.Type is IArrayTypeSymbol arrayType)
                 {
-                    if (convertedToTypeSymbol is not IArrayTypeSymbol)
+                    if (convertedToTypeSymbol is not IArrayTypeSymbol &&
+                        // Make sure we aren't just assigning it to a value type such as ReadOnlySpan
+                        !convertedToTypeSymbol.IsValueType)
                     {
                         if (visitedTypes.Contains(arrayType))
                         {

--- a/src/Perf/IIDOptimizer/Program.cs
+++ b/src/Perf/IIDOptimizer/Program.cs
@@ -129,9 +129,15 @@ namespace GuidPatch
 
                 int numPatches = guidPatcher.ProcessAssembly(); 
 
-                guidPatcher.SaveAssembly(outputDirectory);
+                // Only write assembly if we actually patched anything.
+                // Otherwise we would just write a type we use as part of our implementation
+                // when it is actually not needed.
+                if (numPatches > 0)
+                {
+                    guidPatcher.SaveAssembly(outputDirectory);
+                    Console.WriteLine($"Saved patched .dll to {outputDirectory}");
+                }
 
-                Console.WriteLine($"Saved patched .dll to {outputDirectory}");
                 Console.WriteLine($"{numPatches} IID calculations/fetches patched"); 
                 return 0; 
             }

--- a/src/Perf/IIDOptimizer/Program.cs
+++ b/src/Perf/IIDOptimizer/Program.cs
@@ -121,13 +121,13 @@ namespace GuidPatch
                 var winRTRuntimeAssembly = ResolveWinRTRuntime(targetAssemblyDefinition, resolver);
                 if (winRTRuntimeAssembly is null)
                 {
-                    Console.WriteLine("Failed to resolve WinRT.Runtime.dll.");
                     return -1;
                 }
 
                 var guidPatcher = new GuidPatcher(winRTRuntimeAssembly, targetAssemblyDefinition);
 
-                int numPatches = guidPatcher.ProcessAssembly(); 
+                int numPatches = guidPatcher.ProcessAssembly();
+                Console.WriteLine($"{numPatches} IID calculations/fetches patched");
 
                 // Only write assembly if we actually patched anything.
                 // Otherwise we would just write a type we use as part of our implementation
@@ -136,10 +136,13 @@ namespace GuidPatch
                 {
                     guidPatcher.SaveAssembly(outputDirectory);
                     Console.WriteLine($"Saved patched .dll to {outputDirectory}");
+                    return 0;
                 }
-
-                Console.WriteLine($"{numPatches} IID calculations/fetches patched"); 
-                return 0; 
+                else
+                {
+                    // Exit code is checked by caller to copy patched file over.
+                    return -1;
+                }
             }
             catch (AssemblyResolutionException e)
             { 


### PR DESCRIPTION
- One of our recent changes to convert the IID properties in the methods class to the new format where it is a ref caused the AOT optimizer to detect it as a boxing scenario (going from byte[] to readonlyspan) when it isn't.  Adding logic to detect that.
- Removing misleading WinRT.Runtime message from IIDOptimizer which caused confusions to folks when they see it
- Fixing IIDOptimizer to only write DLL if it patched something as I have seen in updated projections that it doesn't patch anything anymore in most cases as expected given we use the IID instead, but it is still writing its internal implementation type when not needed.