### PR TITLE
Add WUX 'DispatcherQueueSynchronizationContext' type

### DIFF
--- a/src/Projections/Windows.UI.Xaml/ABI.Windows.System/DispatcherQueueProxyHandler.cs
+++ b/src/Projections/Windows.UI.Xaml/ABI.Windows.System/DispatcherQueueProxyHandler.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using WinRT;
+using WinRT.Interop;
+
+#nullable enable
+
+namespace ABI.Windows.System;
+
+/// <summary>
+/// A custom <c>IDispatcherQueueHandler</c> object, that internally stores a captured <see cref="SendOrPostCallback"/> instance and the
+/// input captured state. This allows consumers to enqueue a state and a cached stateless delegate without any managed allocations.
+/// </summary>
+internal unsafe struct DispatcherQueueProxyHandler
+{
+    /// <summary>
+    /// The shared vtable pointer for <see cref="DispatcherQueueProxyHandler"/> instances.
+    /// </summary>
+    private static readonly void** Vtbl = InitVtbl();
+
+    /// <summary>
+    /// Setups the vtable pointer for <see cref="DispatcherQueueProxyHandler"/>.
+    /// </summary>
+    /// <returns>The initialized vtable pointer for <see cref="DispatcherQueueProxyHandler"/>.</returns>
+    /// <remarks>
+    /// The vtable itself is allocated with <see cref="RuntimeHelpers.AllocateTypeAssociatedMemory(Type, int)"/>,
+    /// which allocates memory in the high frequency heap associated with the input runtime type. This will be
+    /// automatically cleaned up when the type is unloaded, so there is no need to ever manually free this memory.
+    /// </remarks>
+    private static void** InitVtbl()
+    {
+        void** vtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DispatcherQueueProxyHandler), sizeof(void*) * 4);
+
+        vtbl[0] = (delegate* unmanaged<DispatcherQueueProxyHandler*, Guid*, void**, int>)&Impl.QueryInterface;
+        vtbl[1] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.AddRef;
+        vtbl[2] = (delegate* unmanaged<DispatcherQueueProxyHandler*, uint>)&Impl.Release;
+        vtbl[3] = (delegate* unmanaged<DispatcherQueueProxyHandler*, int>)&Impl.Invoke;
+
+        return vtbl;
+    }
+
+    /// <summary>
+    /// The vtable pointer for the current instance.
+    /// </summary>
+    private void** vtbl;
+
+    /// <summary>
+    /// The <see cref="GCHandle"/> to the captured <see cref="SendOrPostCallback"/>.
+    /// </summary>
+    private GCHandle callbackHandle;
+
+    /// <summary>
+    /// The <see cref="GCHandle"/> to the captured state (if present, or a <see langword="null"/> handle otherwise).
+    /// </summary>
+    private GCHandle stateHandle;
+
+    /// <summary>
+    /// The current reference count for the object (from <c>IUnknown</c>).
+    /// </summary>
+    private volatile uint referenceCount;
+
+    /// <summary>
+    /// Creates a new <see cref="DispatcherQueueProxyHandler"/> instance for the input callback and state.
+    /// </summary>
+    /// <param name="handler">The input <see cref="SendOrPostCallback"/> callback to enqueue.</param>
+    /// <param name="state">The input state to capture and pass to the callback.</param>
+    /// <returns>A pointer to the newly initialized <see cref="DispatcherQueueProxyHandler"/> instance.</returns>
+    public static DispatcherQueueProxyHandler* Create(SendOrPostCallback handler, object? state)
+    {
+        DispatcherQueueProxyHandler* @this = (DispatcherQueueProxyHandler*)NativeMemory.Alloc((nuint)sizeof(DispatcherQueueProxyHandler));
+
+        @this->vtbl = Vtbl;
+        @this->callbackHandle = GCHandle.Alloc(handler);
+        @this->stateHandle = state is not null ? GCHandle.Alloc(state) : default;
+        @this->referenceCount = 1;
+
+        return @this;
+    }
+
+    /// <summary>
+    /// Devirtualized API for <c>IUnknown.Release()</c>.
+    /// </summary>
+    /// <returns>The updated reference count for the current instance.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public uint Release()
+    {
+        uint referenceCount = Interlocked.Decrement(ref this.referenceCount);
+
+        if (referenceCount == 0)
+        {
+            callbackHandle.Free();
+
+            if (stateHandle.IsAllocated)
+            {
+                stateHandle.Free();
+            }
+
+            NativeMemory.Free(Unsafe.AsPointer(ref this));
+        }
+
+        return referenceCount;
+    }
+
+    /// <summary>
+    /// A private type with the implementation of the unmanaged methods for <see cref="DispatcherQueueProxyHandler"/>.
+    /// These methods will be set into the shared vtable and invoked by WinRT from the object passed to it as an interface.
+    /// </summary>
+    private static class Impl
+    {
+        /// <summary>
+        /// The HRESULT for a successful operation.
+        /// </summary>
+        private const int S_OK = 0;
+
+        /// <summary>
+        /// The HRESULT for an invalid cast from <c>IUnknown.QueryInterface</c>.
+        /// </summary>
+        private const int E_NOINTERFACE = unchecked((int)0x80004002);
+
+        /// <summary>The IID for <c>IDispatcherQueueHandler</c> (2E0872A9-4E29-5F14-B688-FB96D5F9D5F8).</summary>
+        private static ref readonly Guid IID_IDispatcherQueueHandler
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                ReadOnlySpan<byte> data =
+                [
+                    0xA9, 0x72, 0x08, 0x2E,
+                    0x29, 0x4E,
+                    0x14, 0x5F,
+                    0xB6,
+                    0x88,
+                    0xFB,
+                    0x96,
+                    0xD5,
+                    0xF9,
+                    0xD5,
+                    0xF8
+                ];
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
+        /// <summary>
+        /// Implements <c>IUnknown.QueryInterface(REFIID, void**)</c>.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static int QueryInterface(DispatcherQueueProxyHandler* @this, Guid* riid, void** ppvObject)
+        {
+            if (riid->Equals(IID.IID_IUnknown) ||
+                riid->Equals(IID.IID_IAgileObject) ||
+                riid->Equals(IID_IDispatcherQueueHandler))
+            {
+                Interlocked.Increment(ref @this->referenceCount);
+
+                *ppvObject = @this;
+
+                return S_OK;
+            }
+
+            return E_NOINTERFACE;
+        }
+
+        /// <summary>
+        /// Implements <c>IUnknown.AddRef()</c>.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static uint AddRef(DispatcherQueueProxyHandler* @this)
+        {
+            return Interlocked.Increment(ref @this->referenceCount);
+        }
+
+        /// <summary>
+        /// Implements <c>IUnknown.Release()</c>.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static uint Release(DispatcherQueueProxyHandler* @this)
+        {
+            uint referenceCount = Interlocked.Decrement(ref @this->referenceCount);
+
+            if (referenceCount == 0)
+            {
+                @this->callbackHandle.Free();
+
+                if (@this->stateHandle.IsAllocated)
+                {
+                    @this->stateHandle.Free();
+                }
+
+                NativeMemory.Free(@this);
+            }
+
+            return referenceCount;
+        }
+
+        /// <summary>
+        /// Implements <c>IDispatcherQueueHandler.Invoke()</c>.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static int Invoke(DispatcherQueueProxyHandler* @this)
+        {
+            object callback = @this->callbackHandle.Target!;
+            object? state = @this->stateHandle.IsAllocated ? @this->stateHandle.Target! : null;
+
+            try
+            {
+                Unsafe.As<SendOrPostCallback>(callback)(state);
+            }
+            catch (Exception e)
+            {
+                // Register the exception with the global error handler. The failfast behavior
+                // is governed by the state of the 'UnhandledExceptionEventArgs.Handled' property.
+                // If 'Handled' is true the app continues running, else it failfasts.
+                ExceptionHelpers.ReportUnhandledError(e);
+            }
+
+            return S_OK;
+        }
+    }
+}

--- a/src/Projections/Windows.UI.Xaml/DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Windows.UI.Xaml/DispatcherQueueSynchronizationContext.cs
@@ -4,7 +4,7 @@ using WinRT;
 
 #nullable enable
 
-namespace Microsoft.Windows.System;
+namespace Windows.System;
 
 /// <summary>
 /// The <see cref="DispatcherQueueSynchronizationContext"/> type allows developers to await calls and get back onto

--- a/src/Projections/Windows.UI.Xaml/DispatcherQueueSynchronizationContext.cs
+++ b/src/Projections/Windows.UI.Xaml/DispatcherQueueSynchronizationContext.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading;
+using WinRT;
+
+#nullable enable
+
+namespace Microsoft.Windows.System;
+
+/// <summary>
+/// The <see cref="DispatcherQueueSynchronizationContext"/> type allows developers to await calls and get back onto
+/// the UI thread. Needs to be installed on the UI thread through <see cref="SynchronizationContext.SetSynchronizationContext"/>.
+/// </summary>
+public sealed partial class DispatcherQueueSynchronizationContext : SynchronizationContext
+{
+    /// <summary>
+    /// The <see cref="IObjectReference"/> instance for the target dispatcher queue.
+    /// </summary>
+    private readonly IObjectReference _objectReference;
+
+    /// <summary>
+    /// Creates a new <see cref="DispatcherQueueSynchronizationContext"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="dispatcherQueue">The target <see cref="global::Windows.System.DispatcherQueue"/> instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcherQueue"/> is <see langword="null"/>.</exception>
+    public DispatcherQueueSynchronizationContext(global::Windows.System.DispatcherQueue dispatcherQueue)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcherQueue);
+
+        _objectReference = ((IWinRTObject)dispatcherQueue).NativeObject;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="DispatcherQueueSynchronizationContext"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="objectReference">The <see cref="IObjectReference"/> instance for the target dispatcher queue.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="objectReference"/> is <see langword="null"/>.</exception>
+    private DispatcherQueueSynchronizationContext(IObjectReference objectReference)
+    {
+        ArgumentNullException.ThrowIfNull(objectReference);
+
+        _objectReference = objectReference;
+    }
+
+    /// <inheritdoc/>
+    public override unsafe void Post(SendOrPostCallback d, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(d);
+
+        global::ABI.Windows.System.DispatcherQueueProxyHandler* dispatcherQueueProxyHandler = global::ABI.Windows.System.DispatcherQueueProxyHandler.Create(d, state);
+        int hresult;
+
+        try
+        {
+            void* thisPtr = (void*)_objectReference.ThisPtr;
+            bool success;
+
+            // Note: we're intentionally ignoring the retval for 'DispatcherQueue::TryEnqueue'.
+            // This matches the behavior for the equivalent type on WinUI 3 as well.
+            hresult = ((delegate* unmanaged<void*, void*, byte*, int>)(*(void***)thisPtr)[7])(thisPtr, dispatcherQueueProxyHandler, (byte*)&success);
+
+            GC.KeepAlive(_objectReference);
+        }
+        finally
+        {
+            dispatcherQueueProxyHandler->Release();
+        }
+
+        ExceptionHelpers.ThrowExceptionForHR(hresult);
+    }
+
+    /// <inheritdoc/>
+    public override void Send(SendOrPostCallback d, object? state)
+    {
+        throw new NotSupportedException("'SynchronizationContext.Send' is not supported.");
+    }
+
+    /// <inheritdoc/>
+    public override SynchronizationContext CreateCopy()
+    {
+        return new DispatcherQueueSynchronizationContext(_objectReference);
+    }
+}

--- a/src/Projections/Windows.UI.Xaml/Windows.UI.Xaml.csproj
+++ b/src/Projections/Windows.UI.Xaml/Windows.UI.Xaml.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\..\WinRT.Runtime\WinRT.Runtime.csproj" />
     <ProjectReference Include="..\..\cswinrt\cswinrt.vcxproj" />
     <InternalsVisibleTo Include="UnitTest" />
-    <ProjectReference Include="..\..\Authoring\WinRT.SourceGenerator\WinRT.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=x64"/>
+    <ProjectReference Include="..\..\Authoring\WinRT.SourceGenerator\WinRT.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=x64" />
     <ProjectReference Include="..\Windows\Windows.csproj" />
   </ItemGroup>
 

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -103,6 +104,7 @@ namespace WinRT
                 Throw(hr);
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             static void Throw(int hr)
             {
                 Exception ex = GetExceptionForHR(hr, useGlobalErrorState: true, out bool restoredExceptionFromGlobalState);

--- a/src/WinRT.Runtime/Interop/IID.g.cs
+++ b/src/WinRT.Runtime/Interop/IID.g.cs
@@ -191,7 +191,7 @@ namespace WinRT.Interop
         }
 
         /// <summary>The IID for <c>IAgileObject</c> (94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90).</summary>
-        internal static ref readonly Guid IID_IAgileObject
+        public static ref readonly Guid IID_IAgileObject
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]   
             get

--- a/src/WinRT.Runtime/Interop/IID.tt
+++ b/src/WinRT.Runtime/Interop/IID.tt
@@ -29,7 +29,7 @@ var entries = new (string Name, string IID, bool IsPublic)[]
     ("IReferenceTracker", "11D3B13A-180E-4789-A8BE-7712882893E6", false),
     ("IReferenceTrackerTarget", "64BD43F8-BFEE-4EC4-B7EB-2935158DAE21", false),
     ("IActivationFactory", "00000035-0000-0000-C000-000000000046", true),
-    ("IAgileObject", "94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90", false),
+    ("IAgileObject", "94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90", true),
     ("IMarshal", "00000003-0000-0000-C000-000000000046", true),
     ("IBuffer", "905A0FE0-BC53-11DF-8C49-001E4FC686DA", true),
     ("IBufferByteAccess", "905A0FEF-BC53-11DF-8C49-001E4FC686DA", true),


### PR DESCRIPTION
This PR adds a `DispatcherQueueSynchronizationContext` type to the WUX projections assembly, which implements a custom `SynchronizationContext` backed by [`Windows.System.DispatcherQueue`](https://learn.microsoft.com/en-us/uwp/api/windows.system.dispatcherqueue?view=winrt-22621), such that it can work on `CoreWindow`-based apps.