### PR TITLE
Add 'WindowsUIXamlProjectionsAnalyzer' to error on invalid configs

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CsWinRT1028 | Usage | Info | Class should be marked partial
+CsWinRT1029 | Usage | Error | Missing 'UseUwp' property when referencing Windows.UI.Xaml projections
+CsWinRT1030 | Usage | Error | Using 'UseUwp' when referencing WinAppSDK
+CsWinRT1031 | Usage | Error | Using 'UseWinUI' when referencing Windows.UI.Xaml projections
+CsWinRT1032 | Usage | Error | Using 'UseUwp' and 'UseWinUI' together 

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
@@ -277,6 +277,24 @@ namespace WinRT.SourceGenerator {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing &apos;UseUwp&apos; property.
+        /// </summary>
+        internal static string MissingUseUwpWhenUsingWindowsUIXamlProjections_Brief {
+            get {
+                return ResourceManager.GetString("MissingUseUwpWhenUsingWindowsUIXamlProjections_Brief", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project is referencing the Windows.UI.Xaml projections, but it is not setting the required &apos;UseUwp&apos; property (set &apos;UseUwp&apos; to &apos;true&apos; to fix the error).
+        /// </summary>
+        internal static string MissingUseUwpWhenUsingWindowsUIXamlProjections_Text {
+            get {
+                return ResourceManager.GetString("MissingUseUwpWhenUsingWindowsUIXamlProjections_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Array signature found with multi-dimensional array, which is not a valid Windows Runtime type.
         /// </summary>
         internal static string MultiDimensionalArrayRule_Brief {
@@ -678,6 +696,60 @@ namespace WinRT.SourceGenerator {
         internal static string UnsupportedTypeRule_Text4 {
             get {
                 return ResourceManager.GetString("UnsupportedTypeRule_Text4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;UseUwp&apos; and &apos;UseWinUI&apos; set in the same project.
+        /// </summary>
+        internal static string UsingUseUwpAndUseWinUITogether_Brief {
+            get {
+                return ResourceManager.GetString("UsingUseUwpAndUseWinUITogether_Brief", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project is setting both the &apos;UseUwp&apos; and &apos;UseWinUI&apos; properties, but those cannot be used at the same time (set either of them to &apos;false&apos; to fix the error).
+        /// </summary>
+        internal static string UsingUseUwpAndUseWinUITogether_Text {
+            get {
+                return ResourceManager.GetString("UsingUseUwpAndUseWinUITogether_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;UseUwp&apos; property set when using WinAppSDK.
+        /// </summary>
+        internal static string UsingUseUwpWhenUsingWinAppSDK_Brief {
+            get {
+                return ResourceManager.GetString("UsingUseUwpWhenUsingWinAppSDK_Brief", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project is referencing WindowsAppSDK while also setting the &apos;UseUwp&apos; property, which can only be used with Windows.UI.Xaml projections (either remove the WindowsAppSDK dependency, or set &apos;UseUwp&apos; to &apos;false&apos; to fix the error).
+        /// </summary>
+        internal static string UsingUseUwpWhenUsingWinAppSDK_Text {
+            get {
+                return ResourceManager.GetString("UsingUseUwpWhenUsingWinAppSDK_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;UseWinUI&apos; property set when using Windows.UI.Xaml projections.
+        /// </summary>
+        internal static string UsingUseWinUIWhenUsingWindowsUIXamlProjections_Brief {
+            get {
+                return ResourceManager.GetString("UsingUseWinUIWhenUsingWindowsUIXamlProjections_Brief", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project is referencing the Windows.UI.Xaml projections while also setting the &apos;UseWinUI&apos; property, which can only be used with WindowsAppSDK and Microsoft.UI.Xaml projections (either remove the Windows.UI.Xaml projections dependency, or set &apos;UseWinUI&apos; to &apos;false&apos; to fix the error).
+        /// </summary>
+        internal static string UsingUseWinUIWhenUsingWindowsUIXamlProjections_Text {
+            get {
+                return ResourceManager.GetString("UsingUseWinUIWhenUsingWindowsUIXamlProjections_Text", resourceCulture);
             }
         }
     }

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
@@ -133,6 +133,12 @@
   <data name="JaggedArrayRule_Text" xml:space="preserve">
     <value>Method {0} has a nested array of type {1} in its signature; arrays in Windows Runtime method signature cannot be nested</value>
   </data>
+  <data name="MissingUseUwpWhenUsingWindowsUIXamlProjections_Brief" xml:space="preserve">
+    <value>Missing 'UseUwp' property</value>
+  </data>
+  <data name="MissingUseUwpWhenUsingWindowsUIXamlProjections_Text" xml:space="preserve">
+    <value>The project is referencing the Windows.UI.Xaml projections, but it is not setting the required 'UseUwp' property (set 'UseUwp' to 'true' to fix the error)</value>
+  </data>
   <data name="MultiDimensionalArrayRule_Brief" xml:space="preserve">
     <value>Array signature found with multi-dimensional array, which is not a valid Windows Runtime type</value>
   </data>
@@ -273,5 +279,23 @@
   <data name="UnsupportedTypeRule_Text4" xml:space="preserve">
     <value>Consider changing the type '{1} in the member signature to one of the following types from System.Collections.Generic: {2}.</value>
     <comment>{1} and {2} will be keywords (types) from DotNet</comment>
+  </data>
+  <data name="UsingUseUwpAndUseWinUITogether_Brief" xml:space="preserve">
+    <value>'UseUwp' and 'UseWinUI' set in the same project</value>
+  </data>
+  <data name="UsingUseUwpAndUseWinUITogether_Text" xml:space="preserve">
+    <value>The project is setting both the 'UseUwp' and 'UseWinUI' properties, but those cannot be used at the same time (set either of them to 'false' to fix the error)</value>
+  </data>
+  <data name="UsingUseUwpWhenUsingWinAppSDK_Brief" xml:space="preserve">
+    <value>'UseUwp' property set when using WinAppSDK</value>
+  </data>
+  <data name="UsingUseUwpWhenUsingWinAppSDK_Text" xml:space="preserve">
+    <value>The project is referencing WindowsAppSDK while also setting the 'UseUwp' property, which can only be used with Windows.UI.Xaml projections (either remove the WindowsAppSDK dependency, or set 'UseUwp' to 'false' to fix the error)</value>
+  </data>
+  <data name="UsingUseWinUIWhenUsingWindowsUIXamlProjections_Brief" xml:space="preserve">
+    <value>'UseWinUI' property set when using Windows.UI.Xaml projections</value>
+  </data>
+  <data name="UsingUseWinUIWhenUsingWindowsUIXamlProjections_Text" xml:space="preserve">
+    <value>The project is referencing the Windows.UI.Xaml projections while also setting the 'UseWinUI' property, which can only be used with WindowsAppSDK and Microsoft.UI.Xaml projections (either remove the Windows.UI.Xaml projections dependency, or set 'UseWinUI' to 'false' to fix the error)</value>
   </data>
 </root>

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -164,6 +164,26 @@ namespace Generator
             return 0;
         }
 
+        public static bool GetUseUwp(this AnalyzerConfigOptionsProvider provider)
+        {
+            if (provider.GlobalOptions.TryGetValue("build_property.UseUwp", out var useUwp))
+            {
+                return bool.TryParse(useUwp, out var useUwpValue) && useUwpValue;
+            }
+
+            return false;
+        }
+
+        public static bool GetUseWinUI(this AnalyzerConfigOptionsProvider provider)
+        {
+            if (provider.GlobalOptions.TryGetValue("build_property.UseWinUI", out var useWinUI))
+            {
+                return bool.TryParse(useWinUI, out var useWinUIValue) && useWinUIValue;
+            }
+
+            return false;
+        }
+
         public static bool ShouldGenerateWinMDOnly(this GeneratorExecutionContext context)
         {
             if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.CsWinRTGenerateWinMDOnly", out var CsWinRTGenerateWinMDOnlyStr))

--- a/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
@@ -192,5 +192,25 @@ namespace WinRT.SourceGenerator
             CsWinRTDiagnosticStrings.ClassNotMarkedPartial_Brief,
             CsWinRTDiagnosticStrings.ClassNotMarkedPartial_Text,
             false);
+
+        public static DiagnosticDescriptor MissingUseUwpWhenUsingWindowsUIXamlProjections = MakeRule(
+            "CsWinRT1029",
+            CsWinRTDiagnosticStrings.MissingUseUwpWhenUsingWindowsUIXamlProjections_Brief,
+            CsWinRTDiagnosticStrings.MissingUseUwpWhenUsingWindowsUIXamlProjections_Text);
+
+        public static DiagnosticDescriptor UsingUseUwpWhenUsingWinAppSDK = MakeRule(
+            "CsWinRT1030",
+            CsWinRTDiagnosticStrings.UsingUseUwpWhenUsingWinAppSDK_Brief,
+            CsWinRTDiagnosticStrings.UsingUseUwpWhenUsingWinAppSDK_Text);
+
+        public static DiagnosticDescriptor UsingUseWinUIWhenUsingWindowsUIXamlProjections = MakeRule(
+            "CsWinRT1031",
+            CsWinRTDiagnosticStrings.UsingUseWinUIWhenUsingWindowsUIXamlProjections_Brief,
+            CsWinRTDiagnosticStrings.UsingUseWinUIWhenUsingWindowsUIXamlProjections_Text);
+
+        public static DiagnosticDescriptor UsingUseUwpAndUseWinUITogether = MakeRule(
+            "CsWinRT1032",
+            CsWinRTDiagnosticStrings.UsingUseUwpAndUseWinUITogether_Brief,
+            CsWinRTDiagnosticStrings.UsingUseUwpAndUseWinUITogether_Text);
     }
 } 

--- a/src/Authoring/WinRT.SourceGenerator/WindowsUIXamlProjectionsAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WindowsUIXamlProjectionsAnalyzer.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using Generator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#nullable enable
+
+namespace WinRT.SourceGenerator;
+
+/// <summary>
+/// A diagnostic analyzer that emits errors when 'UseUwp' and 'UseWinUI' are used incorrectly.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp), Shared]
+public sealed class WindowsUIXamlProjectionsAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        WinRTRules.MissingUseUwpWhenUsingWindowsUIXamlProjections,
+        WinRTRules.UsingUseUwpWhenUsingWinAppSDK,
+        WinRTRules.UsingUseWinUIWhenUsingWindowsUIXamlProjections,
+        WinRTRules.UsingUseUwpAndUseWinUITogether);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(static context =>
+        {
+            // Are we referencing the Windows.UI.Xaml projections?
+            bool isWindowsUIXamlProjectionsAssemblyReferenced = IsAssemblyReferenced(
+                context.Compilation,
+                "Microsoft.Windows.UI.Xaml",
+                context.CancellationToken);
+
+            // Are we referencing WindowsAppSDK?
+            bool isWindowsAppSDKReferenced = IsAssemblyReferenced(
+                context.Compilation,
+                "Microsoft.Windows.ApplicationModel.WindowsAppRuntime.Projection",
+                context.CancellationToken);
+
+            // Check the MSBuild properties
+            bool useUwp = context.Options.AnalyzerConfigOptionsProvider.GetUseUwp();
+            bool useWinUI = context.Options.AnalyzerConfigOptionsProvider.GetUseWinUI();
+
+            // Error #1: missing 'UseUwp' when using Windows.UI.Xaml projections
+            if (!useUwp && isWindowsUIXamlProjectionsAssemblyReferenced)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(WinRTRules.MissingUseUwpWhenUsingWindowsUIXamlProjections, location: null));
+            }
+
+            // Error #2: using 'UseUwp' when referencing WindowsAppSDK
+            if (useUwp && isWindowsAppSDKReferenced)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(WinRTRules.UsingUseUwpWhenUsingWinAppSDK, location: null));
+            }
+
+            // Error #3: using 'UseWinUI' when referencing Windows.UI.Xaml projections
+            if (useUwp && isWindowsAppSDKReferenced)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(WinRTRules.UsingUseWinUIWhenUsingWindowsUIXamlProjections, location: null));
+            }
+
+            // Error #4: using 'UseUwp' and 'UseWinUI' together
+            if (useUwp && isWindowsAppSDKReferenced)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(WinRTRules.UsingUseUwpAndUseWinUITogether, location: null));
+            }
+        });
+    }
+
+    /// <summary>
+    /// Checks whether a given assembly is referenced.
+    /// </summary>
+    /// <param name="compilation">The input <see cref="Compilation"/> to check.</param>
+    /// <param name="assemblyName">The name of the assembly to check.</param>
+    /// <param name="token">The cancellation token for the operation.</param>
+    /// <returns>Whether <paramref name="compilation"/> references an assembly with a given name.</returns>
+    private static bool IsAssemblyReferenced(
+        Compilation compilation,
+        string assemblyName,
+        CancellationToken token)
+    {
+        foreach (MetadataReference metadataReference in compilation.References)
+        {
+            token.ThrowIfCancellationRequested();
+
+            // We're only looking for PE files, not project references
+            if (metadataReference is not PortableExecutableReference)
+            {
+                continue;
+            }
+
+            // If we can't resolve the assembly symbol, ignore the reference
+            if (compilation.GetAssemblyOrModuleSymbol(metadataReference) is not IAssemblySymbol assemblySymbol)
+            {
+                continue;
+            }
+
+            // If we found the target assembly (including in transitive dependencies), we can stop
+            if (string.Equals(assemblySymbol.Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
+++ b/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
@@ -11,6 +11,11 @@
     <!-- <CsWinRTEnableLogging>true</CsWinRTEnableLogging> -->
     <!--<CsWinRTKeepGeneratedSources>true</CsWinRTKeepGeneratedSources>--> 
   </PropertyGroup>
+
+  <!-- Workaround: this should eventually be moved in the .targets in the .NET SDK -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="UseUwp" />
+  </ItemGroup>
   
   <ItemGroup>    
     <ProjectReference Include="..\..\Projections\Windows\Windows.csproj" />    

--- a/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
+++ b/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
@@ -5,6 +5,7 @@
     <Platforms>x64;x86</Platforms>
     <CsWinRTComponent>true</CsWinRTComponent>
     <IsTrimmable>true</IsTrimmable>
+    <UseUwp>true</UseUwp>
     <CsWinRTUIXamlProjections>WindowsUIXaml</CsWinRTUIXamlProjections>
     <!-- CsWinRTEnableLogging helps to diagnose generation issues -->
     <!-- <CsWinRTEnableLogging>true</CsWinRTEnableLogging> -->


### PR DESCRIPTION
Implements an analyzer to emit errors when the WUX/MUX configuration is invalid.