### PR TITLE
Fix incorrect AOT runtime feature check

### DIFF
--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -465,7 +465,7 @@ namespace ABI.System
             }
 
 #if NET
-            if (RuntimeFeature.IsDynamicCodeSupported)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
 #endif
             {
                 var __params = new object[] { thisPtr, null };


### PR DESCRIPTION
This was accidentally using `IsDynamicCodeSupported` rather than `Compild` like all other checks.