### PR TITLE
Add 'TryGetDataUnsafe' overload for 'IMemoryBufferReference'

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -483,6 +483,26 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestTryGetDataUnsafe_MemoryBufferReference()
+        {
+            var buffer = new Windows.Foundation.MemoryBuffer(256);
+            var reference = buffer.CreateReference();
+
+            Assert.True(WindowsRuntimeMarshal.TryGetDataUnsafe(reference, out IntPtr dataPtr1, out uint capacity1));
+            Assert.True(dataPtr1 != IntPtr.Zero);
+            Assert.True(capacity1 == 256);
+
+            Assert.True(WindowsRuntimeMarshal.TryGetDataUnsafe(reference, out IntPtr dataPtr2, out uint capacity2));
+            Assert.True(dataPtr2 != IntPtr.Zero);
+            Assert.True(capacity2 == 256);
+
+            Assert.True(dataPtr1 == dataPtr2);
+
+            // Ensure the reference doesn't get collected while we use the data pointer
+            GC.KeepAlive(reference);
+        }
+
+        [Fact]
         public void TestBufferTryGetArray()
         {
             byte[] arr = new byte[] { 0x01, 0x02, 0x03 };

--- a/src/WinRT.Runtime/Interop/IID.g.cs
+++ b/src/WinRT.Runtime/Interop/IID.g.cs
@@ -290,6 +290,31 @@ namespace WinRT.Interop
             }
         }
 
+        /// <summary>The IID for <c>IMemoryBufferByteAccess</c> (5B0D3235-4DBA-4D44-865E-8F1D0E4FD04D).</summary>
+        public static ref readonly Guid IID_IMemoryBufferByteAccess
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]   
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[]
+                {
+                    0x35, 0x32, 0x0D, 0x5B,
+                    0xBA, 0x4D,
+                    0x44, 0x4D,
+                    0x86,
+                    0x5E,
+                    0x8F,
+                    0x1D,
+                    0x0E,
+                    0x4F,
+                    0xD0,
+                    0x4D
+                };
+
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+
         /// <summary>The IID for <c>IContextCallback</c> (000001DA-0000-0000-C000-000000000046).</summary>
         internal static ref readonly Guid IID_IContextCallback
         {
@@ -640,7 +665,7 @@ namespace WinRT.Interop
             }
         }
 
-        /// <summary>The IID for <c>WUX_MotifyCollectionChangedEventHandler</c> (8B0909DC-2005-5D93-BF8A-725F017BAA8D).</summary>
+        /// <summary>The IID for <c>MUX_NotifyCollectionChangedEventHandler</c> (8B0909DC-2005-5D93-BF8A-725F017BAA8D).</summary>
         internal static ref readonly Guid IID_MUX_NotifyCollectionChangedEventHandler
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]   

--- a/src/WinRT.Runtime/Interop/IID.tt
+++ b/src/WinRT.Runtime/Interop/IID.tt
@@ -33,6 +33,7 @@ var entries = new (string Name, string IID, bool IsPublic)[]
     ("IMarshal", "00000003-0000-0000-C000-000000000046", true),
     ("IBuffer", "905A0FE0-BC53-11DF-8C49-001E4FC686DA", true),
     ("IBufferByteAccess", "905A0FEF-BC53-11DF-8C49-001E4FC686DA", true),
+    ("IMemoryBufferByteAccess", "5B0D3235-4DBA-4D44-865E-8F1D0E4FD04D", true),
     ("IContextCallback", "000001DA-0000-0000-C000-000000000046", false),
     ("ICallbackWithNoReentrancyToApplicationSTA", "0A299774-3E4E-FC42-1D9D-72CEE105CA57", false),
     ("IErrorInfo", "1CF2B120-547D-101B-8E65-08002B2BD119", false),


### PR DESCRIPTION
### Contributes to #1672

Users shouldn't need manual interop (and defining an interface) to get data out of an `IMemoryBufferReference` object. This PR adds a new `WindowsRuntimeMarshal` interop API that does the same we're already doing for `IBuffer`.