### PR TITLE
Fix IDIC casts throwing exceptions for is operator checks

### DIFF
--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -90,6 +90,15 @@ if (observableCollection != instance.BindableIterableProperty)
     return 101;
 }
 
+var profile = Windows.Networking.Connectivity.NetworkInformation.GetInternetConnectionProfile();
+var names = profile.GetNetworkNames();
+
+List<string> networkNames = new();
+if (names?.Count > 0)
+{
+    networkNames.AddRange(names);
+}
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));

--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -39,7 +39,8 @@ namespace WinRT
         {
             if (!FeatureSwitches.EnableIDynamicInterfaceCastableSupport)
             {
-                throw new NotSupportedException($"Support for 'IDynamicInterfaceCastable' is disabled (make sure that the 'CsWinRTEnableIDynamicInterfaceCastableSupport' property is not set to 'false').");
+                return throwIfNotImplemented ? 
+                    throw new NotSupportedException($"Support for 'IDynamicInterfaceCastable' is disabled (make sure that the 'CsWinRTEnableIDynamicInterfaceCastableSupport' property is not set to 'false').") : false;
             }
 
             if (QueryInterfaceCache.ContainsKey(interfaceType))
@@ -67,7 +68,7 @@ namespace WinRT
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.");
+                    return throwIfNotImplemented ? throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.") : false;
                 }
 #endif
 
@@ -103,7 +104,7 @@ namespace WinRT
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.");
+                    return throwIfNotImplemented ? throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.") : false;
                 }
 #endif
 
@@ -204,7 +205,7 @@ namespace WinRT
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    throw new NotSupportedException($"Cannot construct an object reference for vtable type '{vftblType}'.");
+                    return throwIfNotImplemented ? throw new NotSupportedException($"Cannot construct an object reference for vtable type '{vftblType}'.") : false;
                 }
 #endif
 


### PR DESCRIPTION
Fix `is operator` checks such as in `AddRange` throwing exceptions when IDIC indicates it doesn't support that interface.  We will still throw if an explicit cast is done.  In this scenario IDIC was getting triggered as we had a `IReadOnlyList` and were trying to check if it implements `ICollection` which it actually doesn't as it implements `IReadOnlyCollection`.  So, in that scenario, we should indeed return false rather than throw an exception for the AOT check.

Fixes #1671 