### PR TITLE
Fix merged component support in non-WinRT component projects

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -232,6 +232,16 @@ namespace Generator
             }
             return Path.Combine(context.GetGeneratedFilesDir(), fileName + ".winmd");
         }
+
+        public static bool GetCsWinRTMergeReferencedActivationFactories(this GeneratorExecutionContext context)
+        {
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.CsWinRTMergeReferencedActivationFactories", out var csWinRTMergeReferencedActivationFactories))
+            {
+                return bool.TryParse(csWinRTMergeReferencedActivationFactories, out var isCsWinRTMergeReferencedActivationFactories) && isCsWinRTMergeReferencedActivationFactories;
+            }
+
+            return false;
+        }
     }
 
     static class GeneratorHelper


### PR DESCRIPTION
This PR adds support for generating WinRT exports to chain referenced components, from non-component projects.