### PR TITLE
Fix property initializers and derived ObservableCollection

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1091,13 +1091,13 @@ namespace Generator
             else if (context.Node is VariableDeclarationSyntax variableDeclaration)
             {
                 var leftSymbol = context.SemanticModel.GetSymbolInfo(variableDeclaration.Type).Symbol;
-                foreach (var variable in variableDeclaration.Variables)
+                if (leftSymbol is INamedTypeSymbol namedType)
                 {
-                    if (variable.Initializer != null)
+                    foreach (var variable in variableDeclaration.Variables)
                     {
-                        var instantiatedType = context.SemanticModel.GetTypeInfo(variable.Initializer.Value);
-                        if (leftSymbol is INamedTypeSymbol namedType)
+                        if (variable.Initializer != null)
                         {
+                            var instantiatedType = context.SemanticModel.GetTypeInfo(variable.Initializer.Value);
                             AddVtableAttributesForType(instantiatedType, namedType);
                         }
                     }
@@ -1106,12 +1106,12 @@ namespace Generator
             // Detect scenarios where the property declaration has an initializer and is to a boxed or cast type during initialization.
             else if (context.Node is PropertyDeclarationSyntax propertyDeclaration)
             {
-                var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
                 if (propertyDeclaration.Initializer != null)
                 {
-                    var instantiatedType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Initializer.Value);
+                    var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
                     if (leftSymbol is INamedTypeSymbol namedType)
                     {
+                        var instantiatedType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Initializer.Value);
                         AddVtableAttributesForType(instantiatedType, namedType);
                     }
                 }

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1279,7 +1279,7 @@ namespace Generator
                 }
             }
 
-            if (classType is INamedTypeSymbol namedType && namedType.MetadataName == "ObservableCollection`1")
+            if (classType is INamedTypeSymbol namedType && IsDerivedFromOrIsObservableCollection(namedType))
             {
                 // ObservableCollection make use of an internal built-in type as part of its
                 // implementation for INotifyPropertyChanged.  Handling that manually here.
@@ -1312,6 +1312,12 @@ namespace Generator
                         vtableAttributes.Add(vtableAttribute);
                     }
                 }
+            }
+
+            bool IsDerivedFromOrIsObservableCollection(INamedTypeSymbol namedType)
+            {
+                return namedType.MetadataName == "ObservableCollection`1" || 
+                    (namedType.BaseType is not null && IsDerivedFromOrIsObservableCollection(namedType.BaseType));
             }
         }
 

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1013,7 +1013,8 @@ namespace Generator
         {
             return (node is InvocationExpressionSyntax invocation && invocation.ArgumentList.Arguments.Count != 0) ||
                     node is AssignmentExpressionSyntax ||
-                    node is VariableDeclarationSyntax || 
+                    node is VariableDeclarationSyntax ||
+                    node is PropertyDeclarationSyntax ||
                     node is ReturnStatementSyntax;
         }
 
@@ -1099,6 +1100,19 @@ namespace Generator
                         {
                             AddVtableAttributesForType(instantiatedType, namedType);
                         }
+                    }
+                }
+            }
+            // Detect scenarios where the property declaration has an initializer and is to a boxed or cast type during initialization.
+            else if (context.Node is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
+                if (propertyDeclaration.Initializer != null)
+                {
+                    var instantiatedType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Initializer.Value);
+                    if (leftSymbol is INamedTypeSymbol namedType)
+                    {
+                        AddVtableAttributesForType(instantiatedType, namedType);
                     }
                 }
             }

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -106,6 +106,14 @@ if (CustomClass.Instances != instance.BindableIterableProperty)
     return 101;
 }
 
+var customObservableCollection = new CustomObservableCollection();
+instance.BindableIterableProperty = customObservableCollection;
+if (customObservableCollection != instance.BindableIterableProperty)
+{
+    return 101;
+}
+
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));
@@ -117,4 +125,9 @@ sealed partial class CustomClass : INotifyPropertyChanged
     public event PropertyChangedEventHandler PropertyChanged;
 
     public static IReadOnlyList<CustomClass> Instances { get; } = new CustomClass[] { };
+}
+
+sealed partial class CustomObservableCollection : System.Collections.ObjectModel.ObservableCollection<CustomClass>
+{
+    public int CustomCount => Items.Count;
 }

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using test_component_derived.Nested;
@@ -99,8 +100,21 @@ if (names?.Count > 0)
     networkNames.AddRange(names);
 }
 
+instance.BindableIterableProperty = CustomClass.Instances;
+if (CustomClass.Instances != instance.BindableIterableProperty)
+{
+    return 101;
+}
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));
 
 static bool AllEqual<T>(T[] x, params T[][] list) => list.All((y) => x.SequenceEqual(y));
+
+sealed partial class CustomClass : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public static IReadOnlyList<CustomClass> Instances { get; } = new CustomClass[] { };
+}


### PR DESCRIPTION
The source generator was not detecting property initializers during lookup table generation.  It was also not detecting scenarios where classes extended ObservableCollection.  Both of those are now addressed.

Fixes #1685 
Fixes #1663 