### PR TITLE
Remove redundant items in .targets

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -33,7 +33,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTWindowsMetadata" />
     <CompilerVisibleProperty Include="CsWinRTGenerateProjection" />
     <CompilerVisibleProperty Include="CsWinRTAuthoringInputs" />
-    <CompilerVisibleProperty Include="CsWinRTUseWindowsUIXamlProjections" />
   </ItemGroup>
 
   <!-- Note this runs before the msbuild editor config file is generated because that is what is used to pass properties to the source generator. -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -328,7 +328,11 @@ $(CsWinRTInternalProjection)
     <CsWinRTEnableICustomPropertyProviderSupport Condition="'$(CsWinRTEnableICustomPropertyProviderSupport)' == ''">true</CsWinRTEnableICustomPropertyProviderSupport>
     <CsWinRTEnableIReferenceSupport Condition="'$(CsWinRTEnableIReferenceSupport)' == ''">true</CsWinRTEnableIReferenceSupport>
     <CsWinRTEnableIDynamicInterfaceCastableSupport Condition="'$(CsWinRTEnableIDynamicInterfaceCastableSupport)' == ''">true</CsWinRTEnableIDynamicInterfaceCastableSupport>
-    <CsWinRTUseWindowsUIXamlProjections Condition="'$(CsWinRTUseWindowsUIXamlProjections)' == ''">false</CsWinRTUseWindowsUIXamlProjections>
+
+    <!--
+      Note: the 'CsWinRTUseWindowsUIXamlProjections' property and associated 'CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS' feature
+      switch are set by the .NET SDK, so that the right projection mode is enabled even when CsWinRT is not directly referenced.
+    -->
   </PropertyGroup>
 
   <!-- Default values for all other CsWinRT properties (without feature switches) -->
@@ -370,11 +374,6 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE"
                                     Value="$(CsWinRTEnableIDynamicInterfaceCastableSupport)"
-                                    Trim="true" />
-
-    <!-- CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS switch -->
-    <RuntimeHostConfigurationOption Include="CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS"
-                                    Value="$(CsWinRTUseWindowsUIXamlProjections)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -309,13 +309,6 @@ $(CsWinRTInternalProjection)
     </ItemGroup>
   </Target>
 
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="CsWinRT.UiXamlMode" Condition="'$(CsWinRTUiXamlMode)' != ''">
-      <Value>$(CsWinRTUiXamlMode)</Value>
-      <Trim>true</Trim>
-    </RuntimeHostConfigurationOption>
-  </ItemGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets')"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>

--- a/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
+++ b/src/Tests/AuthoringWuxTest/AuthoringWuxTest.csproj
@@ -11,6 +11,14 @@
     <!-- <CsWinRTEnableLogging>true</CsWinRTEnableLogging> -->
     <!--<CsWinRTKeepGeneratedSources>true</CsWinRTKeepGeneratedSources>--> 
   </PropertyGroup>
+
+  <!-- Temporary workaround, remove when https://github.com/dotnet/sdk/pull/41936 is available in the .NET SDK -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="CsWinRTUseWindowsUIXamlProjections" />
+    <RuntimeHostConfigurationOption Include="CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS"
+                                    Value="$(CsWinRTUseWindowsUIXamlProjections)"
+                                    Trim="true" />
+  </ItemGroup>
   
   <ItemGroup>    
     <ProjectReference Include="..\..\Projections\Windows\Windows.csproj" />    


### PR DESCRIPTION
This PR removes the Windows.UI.Xaml switch from the .targets here, as it's being added to the .NET SDK directly.
See: https://github.com/dotnet/sdk/pull/41936.