### PR TITLE
Fix regression in IBindableIterator

### DIFF
--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -917,11 +917,20 @@ namespace ABI.System.Collections.Generic
         {
             return new ComWrappers.ComInterfaceEntry[]
             {
-                    new ComWrappers.ComInterfaceEntry
-                    {
-                        IID = typeof(ABI.Microsoft.UI.Xaml.Interop.IBindableIterator).GUID,
-                        Vtable = ABI.Microsoft.UI.Xaml.Interop.IBindableIterator.AbiToProjectionVftablePtr
-                    }
+                new ComWrappers.ComInterfaceEntry
+                {
+                    IID = typeof(ABI.Microsoft.UI.Xaml.Interop.IBindableIterator).GUID,
+                    Vtable = ABI.Microsoft.UI.Xaml.Interop.IBindableIterator.AbiToProjectionVftablePtr
+                },
+                new ComWrappers.ComInterfaceEntry
+                {
+                    // IBindableIterator is intentionally used here as the vtable because
+                    // we provide the same functions on the vtable as IIterator<object>
+                    // and this allows to avoid introducing another class to initialize the
+                    // IIterator<object> vtable.
+                    IID = ABI.System.Collections.Generic.IEnumeratorMethods<object>.IID,
+                    Vtable = ABI.Microsoft.UI.Xaml.Interop.IBindableIterator.AbiToProjectionVftablePtr
+                }
             };
         }
     }
@@ -970,9 +979,9 @@ namespace ABI.System.Collections.Generic
 
         public static string GetGuidSignature() => GuidGenerator.GetSignature(typeof(IEnumerator<T>));
 
-        // Limiting projected surface to IBindableIterator as we only create a CCW for it during those scenarios.
-        // In IEnumerator<> scenarios, we use this as a helper for the implementation and don't actually use it to
-        // create a CCW.
+        // Limiting projected surface to IBindableIterator and IIterator<object> as we only create a CCW for it during the IEnumerator scenario.
+        // In IEnumerator<T> scenarios, we use this as a helper for the implementation and don't actually use it to create a CCW.
+        // We include IIterator<object> in IEnumerator scenarios due to compat reasons with how WinUI uses it where it treats both as the same.
         [global::WinRT.WinRTExposedType(typeof(IBindableIteratorTypeDetails))]
 #pragma warning disable CA2257 // This member is a type (so it cannot be invoked)
         public sealed class ToAbiHelper : global::Windows.Foundation.Collections.IIterator<T>, global::Microsoft.UI.Xaml.Interop.IBindableIterator


### PR DESCRIPTION
WinUI happens to treat `IBindableIterator` (`IEnumerable`) and `IIterator<object>` (`IEnumerable<object>`) as the same and we maintain that for compat reasons.  But CsWinRT itself doesn't assume that and does do a QI for `IIterator<object>` as needed which means we need to make sure that interface is also on the vtable when `IBindableIterator` is used.  This was the case with JIT as both interfaces were implemented, but the WinRT exposed attribute we put didn't and this regressed.

Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/9855