### PR TITLE
Rename BindableCustomProperty attribute to include Generated prefix

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -249,7 +249,7 @@ namespace Generator
         private static BindableCustomProperties GetBindableCustomProperties(GeneratorSyntaxContext context)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol((ClassDeclarationSyntax)context.Node)!;
-            INamedTypeSymbol bindableCustomPropertyAttributeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName("WinRT.BindableCustomPropertyAttribute")!;
+            INamedTypeSymbol bindableCustomPropertyAttributeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute")!;
 
             if (bindableCustomPropertyAttributeSymbol is null ||
                 !symbol.TryGetAttributeWithType(bindableCustomPropertyAttributeSymbol, out AttributeData? attributeData))

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -464,7 +464,7 @@ namespace Generator
         {
             return node.AttributeLists.SelectMany(list => list.Attributes).Any(IsBindableCustomPropertyAttribute);
 
-            // Check based on identifier name if this is the BindableCustomProperty attribute.
+            // Check based on identifier name if this is the GeneratedBindableCustomProperty attribute.
             // Technically this can be a different namespace, but we will confirm later once
             // we have access to the semantic model.
             static bool IsBindableCustomPropertyAttribute(AttributeSyntax attribute)
@@ -477,7 +477,8 @@ namespace Generator
                 }
 
                 return nameSyntax is IdentifierNameSyntax name &&
-                       name.Identifier.ValueText == "BindableCustomProperty";
+                       (name.Identifier.ValueText == "GeneratedBindableCustomProperty" ||
+                        name.Identifier.ValueText == "GeneratedBindableCustomPropertyAttribute");
             }
         }
 

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -199,7 +199,7 @@ namespace AuthoringTest
         public string Value => "CsWinRT";
     }
 
-    [BindableCustomProperty]
+    [GeneratedBindableCustomProperty]
     public sealed partial class CustomProperty
     {
         public int Number { get; } = 4;

--- a/src/Tests/FunctionalTests/CCW/Program.cs
+++ b/src/Tests/FunctionalTests/CCW/Program.cs
@@ -637,7 +637,7 @@ sealed partial class CustomCommand : ICommand
     }
 }
 
-[BindableCustomProperty([nameof(Name), nameof(Value)], [typeof(int)])]
+[GeneratedBindableCustomProperty([nameof(Name), nameof(Value)], [typeof(int)])]
 partial class Language
 {
     private readonly string[] _values = new string[4];
@@ -651,19 +651,19 @@ partial class Language
     }
 }
 
-[global::WinRT.BindableCustomProperty([nameof(Name), nameof(Derived)], [typeof(int)])]
+[global::WinRT.GeneratedBindableCustomProperty([nameof(Name), nameof(Derived)], [typeof(int)])]
 partial class LanguageDervied : Language
 {
     public int Derived { get; } = 4;
 }
 
-[WinRT.BindableCustomProperty]
+[WinRT.GeneratedBindableCustomProperty]
 partial class LanguageDervied2 : Language
 {
     public int Derived { get; set; }
 }
 
-[BindableCustomProperty]
+[GeneratedBindableCustomPropertyAttribute]
 sealed partial class Language2
 {
     public string Name { get; } = "Language2";
@@ -680,14 +680,14 @@ sealed partial class Language2
     public static double StaticDouble { get; set; } = 4.0;
 }
 
-[BindableCustomProperty]
+[GeneratedBindableCustomProperty]
 sealed partial class Language4
 {
     internal string Name { get; }
     private int Number { get; set; }
 }
 
-[BindableCustomProperty]
+[GeneratedBindableCustomProperty]
 sealed partial class Language5<T>
 {
     private readonly Dictionary<T, T> _values = new();
@@ -707,7 +707,7 @@ namespace Test
     {
         sealed partial class Nested
         {
-            [BindableCustomProperty([nameof(Value)], [])]
+            [GeneratedBindableCustomProperty([nameof(Value)], [])]
             sealed partial class Language3 : IProperties2
             {
                 private readonly string[] _values = new string[4];

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -240,12 +240,12 @@ namespace WinRT
 #else
     public
 #endif
-    sealed class BindableCustomPropertyAttribute : Attribute
+    sealed class GeneratedBindableCustomPropertyAttribute : Attribute
     {
         /// <summary>
         /// Marks all public properties as bindable.
         /// </summary>
-        public BindableCustomPropertyAttribute()
+        public GeneratedBindableCustomPropertyAttribute()
         {
         }
 
@@ -254,7 +254,7 @@ namespace WinRT
         /// </summary>
         /// <param name="propertyNames">The name of the non-indexer public properties to mark as bindable.</param>
         /// <param name="indexerPropertyTypes">The parameter type of the indexer public properties to mark as bindable.</param>
-        public BindableCustomPropertyAttribute(string[] propertyNames, Type[] indexerPropertyTypes)
+        public GeneratedBindableCustomPropertyAttribute(string[] propertyNames, Type[] indexerPropertyTypes)
         {
             PropertyNames = propertyNames;
             IndexerPropertyTypes = indexerPropertyTypes;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -269,7 +269,7 @@ MembersMustExist : Member 'public System.Guid ABI.System.Collections.Specialized
 MembersMustExist : Member 'public System.Guid ABI.System.ComponentModel.PropertyChangedEventHandler.IID.get()' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'WinRT.WinRTAssemblyExportsTypeAttribute' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'Microsoft.UI.Xaml.Data.BindableCustomProperty' does not exist in the reference but it does exist in the implementation.
-TypesMustExist : Type 'WinRT.BindableCustomPropertyAttribute' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'WinRT.GeneratedBindableCustomPropertyAttribute' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'Microsoft.UI.Xaml.Data.IBindableCustomPropertyImplementation' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void ABI.System.Uri.DisposeAbiArray(System.Object)' does not exist in the reference but it does exist in the implementation.
 Total Issues: 273

--- a/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
@@ -28,7 +28,7 @@ namespace Microsoft.UI.Xaml.Data
     }
 
     /// <summary>
-    /// An interface complementing <see cref="BindableCustomPropertyAttribute"/> providing the implementation to expose the specified properties.
+    /// An interface complementing <see cref="GeneratedBindableCustomPropertyAttribute"/> providing the implementation to expose the specified properties.
     /// </summary>
 #if EMBED
     internal
@@ -408,7 +408,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
                     throw new NotSupportedException(
-                        $"ICustomProperty support used by XAML binding for '{target.GetType()}' requires the type to marked with 'WinRT.BindableCustomPropertyAttribute'. " +
+                        $"ICustomProperty support used by XAML binding for '{target.GetType()}' requires the type to marked with 'WinRT.GeneratedBindableCustomPropertyAttribute'. " +
                         $"If this is a built-in type or a type that can't be marked, a wrapper type should be used around it that is marked to enable this support.");
                 }
 
@@ -461,7 +461,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
                     throw new NotSupportedException(
-                        $"ICustomProperty support used by XAML binding for '{target.GetType()}' requires the type to marked with 'WinRT.BindableCustomPropertyAttribute'. " +
+                        $"ICustomProperty support used by XAML binding for '{target.GetType()}' requires the type to marked with 'WinRT.GeneratedBindableCustomPropertyAttribute'. " +
                         $"If this is a built-in type or a type that can't be marked, a wrapper type should be used around it that is marked to enable this support.");
                 }
 


### PR DESCRIPTION
Initial feedback shows that it is easy to get confused between the `BindableCustomProperty` attribute in the WinRT namespace and the `BindableCustomProperty` class in the `Microsoft.UI.Xaml.Data` namespace.  In addition, it is convention that such attributes which generate stuff has a Generated prefix.  So renaming the attribute to have a Generated prefix.  Also fixing the attribute check to handle the Attribute suffix.