### PR TITLE
Fix GetGuidSignature for event args

### DIFF
--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -208,7 +208,7 @@ namespace ABI.System.Collections.Specialized
             {
                 return "rc(Windows.UI.Xaml.Interop.NotifyCollectionChangedEventArgs;{4cf68d33-e3f2-4964-b85e-945b4f7e2f21})";
             }
-            return "rc(Microsoft.UI.Xaml.Interop.NotifyCollectionChangedEventArgs;{4cf68d33-e3f2-4964-b85e-945b4f7e2f21})";
+            return "rc(Microsoft.UI.Xaml.Interop.NotifyCollectionChangedEventArgs;{da049ff2-d2e0-5fe8-8c7b-f87f26060b6f})";
         }
     }
 }

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -168,10 +168,10 @@ namespace ABI.System.ComponentModel
         {
             if (FeatureSwitches.UseWindowsUIXamlProjections)
             {
-                return "rc(Windows.UI.Xaml.Data.NotifyPropertyChangedEventArgs;{4f33a9a0-5cf4-47a4-b16f-d7faaf17457e})";
+                return "rc(Windows.UI.Xaml.Data.PropertyChangedEventArgs;{4f33a9a0-5cf4-47a4-b16f-d7faaf17457e})";
             }
 
-            return "rc(Microsoft.UI.Xaml.Data.NotifyPropertyChangedEventArgs;{4f33a9a0-5cf4-47a4-b16f-d7faaf17457e})";
+            return "rc(Microsoft.UI.Xaml.Data.PropertyChangedEventArgs;{63d0c952-396b-54f4-af8c-ba8724a427bf})";
         }
     }
 }


### PR DESCRIPTION
Fixing IID in GetGuidSignature to reflect MUX versions.  Addressing comments from https://github.com/microsoft/CsWinRT/pull/1421#discussion_r1651683184