### PR TITLE
Fix scenario where generic implementation type doesn't have type factory intialized

### DIFF
--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -146,6 +146,32 @@ if (dateTimeOffsetList != instance.BindableIterableProperty)
     return 101;
 }
 
+// Test sccenarios where the actual implementation type of the result or its RCW factory
+// hasn't been initialized and the statically declared type is a derived generic interface.
+var enums = instance.GetEnumIterable();
+int count = 0;
+foreach (var curEnum in enums)
+{
+    count++;
+}
+
+if (count != 2)
+{
+    return 101;
+}
+
+count = 0;
+var disposableClasses = instance.GetClassIterable();
+foreach (var curr in disposableClasses)
+{
+    count++;
+}
+
+if (count != 2)
+{
+    return 101;
+}
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1491,6 +1491,18 @@ namespace winrt::TestComponentCSharp::implementation
         _charColl = value;
     }
 
+    IIterable<EnumValue> Class::GetEnumIterable()
+    {
+        return winrt::single_threaded_vector(std::vector{ EnumValue::One, EnumValue::Two });
+    }
+
+    IIterable<TestComponentCSharp::CustomDisposableTest> Class::GetClassIterable()
+    {
+        TestComponentCSharp::CustomDisposableTest first;
+        TestComponentCSharp::CustomDisposableTest second;
+        return winrt::single_threaded_vector(std::vector{ first, second });
+    }
+
     IBindableIterable Class::BindableIterableProperty()
     {
         return _bindableIterable;

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -299,6 +299,8 @@ namespace winrt::TestComponentCSharp::implementation
         Windows::Foundation::Collections::IIterable<int32_t> GetIntIterable();
         void SetIntIterable(Windows::Foundation::Collections::IIterable<int32_t> const& value);
         void SetCharIterable(Windows::Foundation::Collections::IIterable<char16_t> const& value);
+        Windows::Foundation::Collections::IIterable<TestComponentCSharp::EnumValue> GetEnumIterable();
+        Windows::Foundation::Collections::IIterable<TestComponentCSharp::CustomDisposableTest> GetClassIterable();
 
         Microsoft::UI::Xaml::Interop::IBindableIterable BindableIterableProperty();
         void BindableIterableProperty(Microsoft::UI::Xaml::Interop::IBindableIterable const& value);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -346,6 +346,8 @@ namespace TestComponentCSharp
         Windows.Foundation.Collections.IIterable<Int32> GetIntIterable();
         void SetIntIterable(Windows.Foundation.Collections.IIterable<Int32> value);
         void SetCharIterable(Windows.Foundation.Collections.IIterable<Char> value);
+        Windows.Foundation.Collections.IIterable<EnumValue> GetEnumIterable();
+        Windows.Foundation.Collections.IIterable<CustomDisposableTest> GetClassIterable();
 
         // Bindable
         Microsoft.UI.Xaml.Interop.IBindableIterable BindableIterableProperty;


### PR DESCRIPTION
Fixing the scenario where the implementation type of an RCW we are creating is not the same as the statically declared type and it is a generic type whose RCW factory hasn't been initialized by the projection for another scenario.

For instance, lets say we are returning a list<object> in the implementation but we declared on the API surface as an `IEnumerable<object>`.  In this case, runtime class name would report it is a `IList<object>` but the RCW factory for it would not have been registered by the projection given it only knows `IEnumerable<object>` and registered that one.  We now detect such scenarios and fallback best effort to the statically known type's RCW factory which should be initialized.  If a user wants to cast after to the actual implementation type, they can still manually register the RCW factory to get it properly constructed.

Fixes the issue referenced in this comment: https://github.com/microsoft/CsWinRT/issues/1623#issuecomment-2181803648