### PR TITLE
Fix get type for nullable enums and fix WUX projections

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -720,4 +720,6 @@ TEST(AuthoringTest, XamlMetadataProvider)
     CustomXamlMetadataProvider provider;
     EXPECT_NE(provider.GetXamlType(winrt::xaml_typename<Windows::Foundation::IReference<double>>()), nullptr);
     EXPECT_NE(provider.GetXamlType(winrt::xaml_typename<Windows::Foundation::IReference<Windows::Foundation::TimeSpan>>()), nullptr);
+    EXPECT_NE(provider.GetXamlType(winrt::xaml_typename<Windows::Foundation::IReference<BasicEnum>>()), nullptr);
+    EXPECT_NE(provider.GetXamlType(winrt::xaml_typename<Windows::Foundation::IReference<FlagsEnum>>()), nullptr);
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1112,7 +1112,9 @@ namespace AuthoringTest
         public IXamlType GetXamlType(Type type)
         {
             if (type == typeof(Nullable<double>) ||
-                type == typeof(TimeSpan?))
+                type == typeof(TimeSpan?) ||
+                type == typeof(BasicEnum?) ||
+                type == typeof(FlagsEnum?))
             {
                 return new XamlType(type);
             }

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.txt
@@ -272,4 +272,5 @@ TypesMustExist : Type 'Microsoft.UI.Xaml.Data.BindableCustomProperty' does not e
 TypesMustExist : Type 'WinRT.GeneratedBindableCustomPropertyAttribute' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'Microsoft.UI.Xaml.Data.IBindableCustomPropertyImplementation' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void ABI.System.Uri.DisposeAbiArray(System.Object)' does not exist in the reference but it does exist in the implementation.
-Total Issues: 273
+TypesMustExist : Type 'WinRT.EnumTypeDetails<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 274

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2285,7 +2285,32 @@ namespace ABI.System
             if (type == typeof(global::System.Numerics.Vector2)) return typeof(global::System.Nullable<global::System.Numerics.Vector2>);
             if (type == typeof(global::System.Numerics.Vector3)) return typeof(global::System.Nullable<global::System.Numerics.Vector3>);
             if (type == typeof(global::System.Numerics.Vector4)) return typeof(global::System.Nullable<global::System.Numerics.Vector4>);
- 
+
+#if NET
+            var winrtExposedClassAttribute = type.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+            if (winrtExposedClassAttribute == null)
+            {
+                var authoringMetadaType = type.GetAuthoringMetadataType();
+                if (authoringMetadaType != null)
+                {
+                    winrtExposedClassAttribute = authoringMetadaType.GetCustomAttribute<WinRTExposedTypeAttribute>(false);
+                }
+            }
+
+            if (winrtExposedClassAttribute != null && winrtExposedClassAttribute.WinRTExposedTypeDetails != null)
+            {
+                if (Activator.CreateInstance(winrtExposedClassAttribute.WinRTExposedTypeDetails) is IWinRTNullableTypeDetails nullableTypeDetails)
+                {
+                    return nullableTypeDetails.GetNullableType();
+                }
+            }
+
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                throw new NotSupportedException($"Failed to construct nullable with type '{type}'.");
+            }
+#endif
+
             return null;
         }
     }
@@ -2311,6 +2336,7 @@ namespace ABI.System
     internal interface IWinRTNullableTypeDetails
     {
         object GetNullableValue(IInspectable inspectable);
+        Type GetNullableType();
     }
 
     public sealed class StructTypeDetails<T, TAbi> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T: struct where TAbi : unmanaged
@@ -2364,6 +2390,8 @@ namespace ABI.System
                 Marshal.Release(nullablePtr);
             }
         }
+
+        Type IWinRTNullableTypeDetails.GetNullableType() => typeof(global::System.Nullable<T>);
     }
 
     public abstract class DelegateTypeDetails<T> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T : global::System.Delegate
@@ -2418,6 +2446,53 @@ namespace ABI.System
                 Marshal.Release(nullablePtr);
             }
         }
+
+        // Delegates are handled separately.
+        Type IWinRTNullableTypeDetails.GetNullableType() => throw new NotImplementedException();
+    }
+
+    public sealed class EnumTypeDetails<T> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T : struct, Enum
+    {
+        [SkipLocalsInit]
+        public ComWrappers.ComInterfaceEntry[] GetExposedInterfaces()
+        {
+            Span<ComWrappers.ComInterfaceEntry> entries = stackalloc ComWrappers.ComInterfaceEntry[2];
+            int count = 0;
+
+            if (FeatureSwitches.EnableIReferenceSupport)
+            {
+                entries[count++] = new ComWrappers.ComInterfaceEntry
+                {
+                    IID = global::WinRT.Interop.IID.IID_IPropertyValue,
+                    Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
+                };
+
+                var type = typeof(T);
+                if (type.IsDefined(typeof(FlagsAttribute)))
+                {
+                    entries[count++] = new ComWrappers.ComInterfaceEntry
+                    {
+                        IID = ABI.System.Nullable_FlagsEnum.GetIID(type),
+                        Vtable = ABI.System.Nullable_FlagsEnum.AbiToProjectionVftablePtr
+                    };
+                }
+                else
+                {
+                    entries[count++] = new ComWrappers.ComInterfaceEntry
+                    {
+                        IID = ABI.System.Nullable_IntEnum.GetIID(type),
+                        Vtable = ABI.System.Nullable_IntEnum.AbiToProjectionVftablePtr
+                    };
+                }
+            }
+
+            return entries.Slice(0, count).ToArray();
+        }
+
+        Type IWinRTNullableTypeDetails.GetNullableType() => typeof(global::System.Nullable<T>);
+
+        // Unboxing enums are handled separately.
+        object IWinRTNullableTypeDetails.GetNullableValue(IInspectable inspectable) => throw new NotImplementedException();
     }
 }
 #endif

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -2451,7 +2451,7 @@ namespace ABI.System
         Type IWinRTNullableTypeDetails.GetNullableType() => throw new NotImplementedException();
     }
 
-    public sealed class EnumTypeDetails<T> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T : struct, Enum
+    public sealed class EnumTypeDetails<T> : IWinRTExposedTypeDetails, IWinRTNullableTypeDetails where T : unmanaged, Enum
     {
         [SkipLocalsInit]
         public ComWrappers.ComInterfaceEntry[] GetExposedInterfaces()
@@ -2467,12 +2467,11 @@ namespace ABI.System
                     Vtable = ABI.Windows.Foundation.ManagedIPropertyValueImpl.AbiToProjectionVftablePtr
                 };
 
-                var type = typeof(T);
-                if (type.IsDefined(typeof(FlagsAttribute)))
+                if (typeof(T).IsDefined(typeof(FlagsAttribute)))
                 {
                     entries[count++] = new ComWrappers.ComInterfaceEntry
                     {
-                        IID = ABI.System.Nullable_FlagsEnum.GetIID(type),
+                        IID = ABI.System.Nullable_FlagsEnum.GetIID(typeof(T)),
                         Vtable = ABI.System.Nullable_FlagsEnum.AbiToProjectionVftablePtr
                     };
                 }
@@ -2480,7 +2479,7 @@ namespace ABI.System
                 {
                     entries[count++] = new ComWrappers.ComInterfaceEntry
                     {
-                        IID = ABI.System.Nullable_IntEnum.GetIID(type),
+                        IID = ABI.System.Nullable_IntEnum.GetIID(typeof(T)),
                         Vtable = ABI.System.Nullable_IntEnum.AbiToProjectionVftablePtr
                     };
                 }

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -267,7 +267,7 @@ namespace WinRT
                     {
                         if (type.IsValueType)
                         {
-                            throw new NotSupportedException($"Cannot provide generic type from '{runtimeClassName}'.");
+                            return null;
                         }
                     }
                 }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -3606,6 +3606,7 @@ private % AsInternal(InterfaceTag<%> _) => % ?? Make_%();
 
         return isFactory || 
             get_category(type) == category::struct_type ||
+            get_category(type) == category::enum_type ||
             (get_category(type) == category::delegate_type && distance(type.GenericParam()) == 0);
     }
 
@@ -3618,6 +3619,11 @@ private % AsInternal(InterfaceTag<%> _) => % ?? Make_%();
                 w.write(R"([global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<%, %>))])",
                     bind<write_type_name>(type, typedef_name_type::Projected, false),
                     bind<write_type_name>(type, is_type_blittable(type) ? typedef_name_type::Projected : typedef_name_type::ABI, false));
+            }
+            else if (get_category(type) == category::enum_type)
+            {
+                w.write(R"([global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<%>))])",
+                    bind<write_type_name>(type, typedef_name_type::Projected, false));
             }
             else
             {
@@ -9606,10 +9612,11 @@ return true;
 
         auto enum_underlying_type = is_flags_enum(type) ? "uint" : "int";
 
-        w.write(R"(%%% enum % : %
+        w.write(R"(%%%% enum % : %
 {
 )", 
         bind<write_winrt_attribute>(type),
+        bind<write_winrt_exposed_type_attribute>(type, false),
         bind<write_type_custom_attributes>(type, true),
         (settings.internal || settings.embedded) ? (settings.public_enums ? "public" : "internal") : "public",
         bind<write_type_name>(type, typedef_name_type::Projected, false), enum_underlying_type);

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.cs
@@ -82,6 +82,9 @@ namespace Microsoft.UI.Xaml.Media.Animation
     }
 
     [global::WinRT.WindowsRuntimeType("Microsoft.UI")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<RepeatBehaviorType>))]
+#endif
 #if EMBED
     internal
 #else

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.cs
@@ -155,6 +155,9 @@ namespace Microsoft.UI.Xaml
     }
 
     [global::WinRT.WindowsRuntimeType("Microsoft.UI")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<GridUnitType>))]
+#endif
 #if EMBED
     internal
 #else
@@ -406,6 +409,9 @@ namespace Microsoft.UI.Xaml
     }
 
     [global::WinRT.WindowsRuntimeType("Microsoft.UI")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<DurationType>))]
+#endif
 #if EMBED
     internal
 #else

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Controls/Windows.UI.Xaml.Controls.Primitives.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Controls/Windows.UI.Xaml.Controls.Primitives.cs
@@ -5,6 +5,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Controls.Primitives.GeneratorPosition))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<GeneratorPosition, GeneratorPosition>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.cs
@@ -5,6 +5,9 @@ namespace Windows.UI.Xaml.Media.Animation
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Media.Animation.KeyTime))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<KeyTime, KeyTime>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal
@@ -79,6 +82,9 @@ namespace Windows.UI.Xaml.Media.Animation
     }
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<RepeatBehaviorType>))]
+#endif
 #if EMBED
     internal
 #else
@@ -93,6 +99,9 @@ namespace Windows.UI.Xaml.Media.Animation
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Media.Animation.RepeatBehavior))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<RepeatBehavior, RepeatBehavior>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.cs
@@ -5,6 +5,9 @@ namespace Windows.UI.Xaml.Media.Media3D
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Media.Media3D.Matrix3D))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<Matrix3D, Matrix3D>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media/Windows.UI.Xaml.Media.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media/Windows.UI.Xaml.Media.cs
@@ -5,6 +5,9 @@ namespace Windows.UI.Xaml.Media
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Media.Matrix))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<Matrix, Matrix>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.cs
@@ -5,6 +5,9 @@ namespace Windows.UI.Xaml
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.CornerRadius))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<CornerRadius, CornerRadius>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal
@@ -152,6 +155,9 @@ namespace Windows.UI.Xaml
     }
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<GridUnitType>))]
+#endif
 #if EMBED
     internal
 #else
@@ -166,6 +172,9 @@ namespace Windows.UI.Xaml
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.GridLength))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<GridLength, GridLength>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal
@@ -284,6 +293,9 @@ namespace Windows.UI.Xaml
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Thickness))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<Thickness, Thickness>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal
@@ -397,6 +409,9 @@ namespace Windows.UI.Xaml
     }
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.EnumTypeDetails<DurationType>))]
+#endif
 #if EMBED
     internal
 #else
@@ -411,6 +426,9 @@ namespace Windows.UI.Xaml
 
     [global::WinRT.WindowsRuntimeType("Windows.UI.Xaml")]
     [global::WinRT.WindowsRuntimeHelperType(typeof(global::ABI.Windows.UI.Xaml.Duration))]
+#if NET
+    [global::WinRT.WinRTExposedType(typeof(global::WinRT.StructTypeDetails<Duration, Duration>))]
+#endif
     [StructLayout(LayoutKind.Sequential)]
 #if EMBED
     internal


### PR DESCRIPTION
- In the previous PR for nullable, we fixed the scenario where WinUI asks for the type of the nullable version of built-in types.  But it looks common for WinUI to do the same for nullable enums too.  This expands the approach we take with `WinRTExposedType` to enums and addresses this issue via an interface that it internally implements to get the nullable version of the enum.
- Also removing the throw we had in `ResolveGenericType` as we always catch that exception later and return null.  It was there primarily as a hint, but given we now properly support nullable in this scenario and we have fallbacks for the other scenarios such as during RCW creation, removing it.
- Noticed that the custom mapped WUX projections were missing the AOT attributes for `WinRTExposedType`, so adding them there.

Fixes #1697 