### PR TITLE
Allow projecting `Windows.UI.ColorHelper` type

### DIFF
--- a/src/Projections/Windows/Windows.csproj
+++ b/src/Projections/Windows/Windows.csproj
@@ -24,6 +24,10 @@
 -exclude Windows.UI.IColors
 -exclude Windows.UI.ColorHelper
 -exclude Windows.UI.IColorHelper
+-exclude Windows.UI.ColorHelper
+-exclude Windows.UI.IColorHelper
+-exclude Windows.UI.IColorHelperStatics
+-exclude Windows.UI.IColorHelperStatics2
 #-exclude Windows.UI.Text (must include Windows.UI.Text to work around WinUI nuget issues)
 -exclude Windows.UI.Xaml
 -exclude Windows.ApplicationModel.Store.Preview

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -811,10 +811,6 @@ namespace cswinrt
             { "Windows.UI",
                 {
                     { "Color", "Windows.UI", "Color" },
-                    { "ColorHelper" },
-                    { "IColorHelper" },
-                    { "IColorHelperStatics" },
-                    { "IColorHelperStatics2" },
                 }
             },
             { "Windows.UI.Xaml",


### PR DESCRIPTION
This PR removes `ColorHelper` from the set of projected types, as it's needed in `Microsoft.Windows.UI.Xaml.dll`. WinUI 3 has its own `Microsoft.UI.ColorHelper` type, but the WUX one is already filtered out in the Windows SDK projections, so that's fine.