### PR TITLE
Add some more missing 'readonly' modifiers

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -41,7 +41,7 @@ namespace WinRT
         internal static Type CreateRCWType;
 
         private static ComWrappers _comWrappers;
-        private static object _comWrappersLock = new object();
+        private static readonly object _comWrappersLock = new object();
         private static ComWrappers ComWrappers
         {
             get

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -79,8 +79,8 @@ namespace WinRT
 
         public ref struct Pinnable
         {
-            private HSTRING_HEADER _header;
-            private string _value;
+            private readonly HSTRING_HEADER _header;
+            private readonly string _value;
 #if DEBUG
             private bool _pinned;
 #endif
@@ -116,7 +116,7 @@ namespace WinRT
                 Marshal.ThrowExceptionForHR(Platform.WindowsCreateStringReference(
                     (ushort*)Unsafe.AsPointer(ref Unsafe.AsRef(in GetPinnableReference())),
                     _value.Length,
-                    (IntPtr*)Unsafe.AsPointer(ref _header),
+                    (IntPtr*)Unsafe.AsPointer(ref Unsafe.AsRef(in _header)),
                     &hstring));
                 return hstring;
             }

--- a/src/WinRT.Runtime/MonoSupport.cs
+++ b/src/WinRT.Runtime/MonoSupport.cs
@@ -13,7 +13,7 @@ namespace WinRT
 {
     internal static class Mono
     {
-        static unsafe Lazy<bool> _usingMono = new Lazy<bool>(() =>
+        static readonly unsafe Lazy<bool> _usingMono = new Lazy<bool>(() =>
         {
             IntPtr modulePtr = Platform.LoadLibraryExW("mono-2.0-bdwgc.dll", IntPtr.Zero, 0);
             if (modulePtr == IntPtr.Zero) return false;
@@ -75,7 +75,7 @@ namespace WinRT
 
         public sealed class ThreadContext : IDisposable
         {
-            static Lazy<HashSet<IntPtr>> _foreignThreads = new Lazy<HashSet<IntPtr>>();
+            static readonly Lazy<HashSet<IntPtr>> _foreignThreads = new Lazy<HashSet<IntPtr>>();
 
             readonly IntPtr _threadPtr = IntPtr.Zero;
 

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -873,7 +873,7 @@ namespace ABI.System.Collections
         public sealed class ToAbiHelper : IBindableVector
 #pragma warning restore CA2257
         {
-            private global::System.Collections.IList _list;
+            private readonly global::System.Collections.IList _list;
 
             public ToAbiHelper(global::System.Collections.IList list) => _list = list;
 


### PR DESCRIPTION
This PR sprinkles a few more `readonly` modifiers that were accidentally missing. Only did this for .NET 6+ code.