### PR TITLE
Make generator compatible with older version of projections

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -5,7 +5,7 @@ variables:
 - name: MinorVersion
   value: 1
 - name: PatchVersion
-  value: 0
+  value: 1
 - name: WinRT.Runtime.AssemblyVersion
   value: '2.1.0.0'
 - name: Net5.SDK.Feed

--- a/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -33,3 +33,11 @@ CsWinRT1024 | Usage | Error | Array parameter marked `out` should not be declare
 CsWinRT1025 | Usage | Error | Array parameter should be marked either `ReadOnlyArrayAttribute` or `WriteOnlyArrayAttribute`
 CsWinRT1026 | Usage | Error | Non-array parameter should not be marked `ReadOnlyArrayAttribute` or `WriteOnlyArrayAttribute`
 CsWinRT1027 | Usage | Error | Class incorrectly implements an interface
+
+## Release 2.1.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+CsWinRT1028 | Usage | Warning | Class should be marked partial
+CsWinRT1029 | Usage | Warning | Class implements WinRT interfaces generated using an older version of CsWinRT.

--- a/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -4,4 +4,3 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-CsWinRT1028 | Usage | Info | Class should be marked partial

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -523,6 +523,17 @@ namespace Generator
             {
                 if (isWinRTType(iface, mapper))
                 {
+                    // If the interface projection was generated using an older CsWinRT version,
+                    // it won't have the necessary properties to generate the AOT compatible code
+                    // and we don't want to result in compiler errors.
+                    // We exclude generic types as they are either defined in WinRT.Runtime or the
+                    // Windows SDK projection, so we don't need to check them.
+                    if (!iface.IsGenericType && 
+                        GeneratorHelper.IsOldProjectionAssembly(iface.ContainingAssembly))
+                    {
+                        return default;
+                    }
+
                     interfacesToAddToVtable.Add(ToFullyQualifiedString(iface));
                     AddGenericInterfaceInstantiation(iface);
                     CheckForInterfaceToUseForRuntimeClassName(iface);

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
@@ -196,6 +196,24 @@ namespace WinRT.SourceGenerator {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Class not trimming / AOT compatible.
+        /// </summary>
+        internal static string ClassImplementsOldProjection_Brief {
+            get {
+                return ResourceManager.GetString("ClassImplementsOldProjection_Brief", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Class &apos;{0}&apos; implements WinRT interface(s) {1} generated using an older version of CsWinRT.  Update to a projection generated using CsWinRT 2.1.0 or later for trimming and AOT compatibility..
+        /// </summary>
+        internal static string ClassImplementsOldProjection_Text {
+            get {
+                return ResourceManager.GetString("ClassImplementsOldProjection_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Class is not marked partial.
         /// </summary>
         internal static string ClassNotMarkedPartial_Brief {

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
@@ -103,6 +103,12 @@
   <data name="ClassConstructorRule_Text" xml:space="preserve">
     <value>Classes cannot have multiple constructors of the same arity in the Windows Runtime, class {0} has multiple {1}-arity constructors</value>
   </data>
+  <data name="ClassImplementsOldProjection_Brief" xml:space="preserve">
+    <value>Class not trimming / AOT compatible</value>
+  </data>
+  <data name="ClassImplementsOldProjection_Text" xml:space="preserve">
+    <value>Class '{0}' implements WinRT interface(s) {1} generated using an older version of CsWinRT.  Update to a projection generated using CsWinRT 2.1.0 or later for trimming and AOT compatibility.</value>
+  </data>
   <data name="ClassNotMarkedPartial_Brief" xml:space="preserve">
     <value>Class is not marked partial</value>
   </data>

--- a/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTRules.cs
@@ -192,5 +192,17 @@ namespace WinRT.SourceGenerator
             CsWinRTDiagnosticStrings.ClassNotMarkedPartial_Brief,
             CsWinRTDiagnosticStrings.ClassNotMarkedPartial_Text,
             false);
+
+        public static DiagnosticDescriptor ClassNotAotCompatibleOldProjectionWarning = MakeRule(
+            "CsWinRT1029",
+            CsWinRTDiagnosticStrings.ClassImplementsOldProjection_Brief,
+            CsWinRTDiagnosticStrings.ClassImplementsOldProjection_Text,
+            true);
+
+        public static DiagnosticDescriptor ClassNotAotCompatibleOldProjectionInfo = MakeRule(
+            "CsWinRT1029",
+            CsWinRTDiagnosticStrings.ClassImplementsOldProjection_Brief,
+            CsWinRTDiagnosticStrings.ClassImplementsOldProjection_Text,
+            false);
     }
 } 


### PR DESCRIPTION
If the AOT generator is used in apps that have references to older CsWinRT projections, it shouldn't result in compiler errors.  Instead, we should produce warnings that indicate so.  Also, special casing 3 types in the `RcwReflectionFallbackGenerator` as those types moved projections and due to that it can run into reference issues when used with older version of projections.