### PR TITLE
Add ObsoleteAttribute projection.

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -11068,4 +11068,15 @@ return true;
 //------------------------------------------------------------------------------
 )", VERSION_STRING);
     }
+
+    void write_deprecated_attribute(writer& w, CustomAttribute const& deprecatedAttribute)
+    {
+        std::string_view message = std::get<std::string_view>(std::get<ElemSig>(deprecatedAttribute.Value().FixedArgs()[0].value).value);
+        ElemSig::EnumValue deprecationType = std::get<ElemSig::EnumValue>(std::get<ElemSig>(deprecatedAttribute.Value().FixedArgs()[1].value).value);
+        bool shouldError = deprecationType.equals_enumerator("Remove");
+        w.write(R"([System.Obsolete("%", %)])",
+			message,
+			shouldError ? "true" : "false");
+        w.write('\n');
+    }
 }

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -217,6 +217,16 @@ Where <spec> is one or more of:
                             auto guard1{ helperWriter.push_generic_params(type.GenericParam()) };
 
                             bool type_requires_abi = true;
+
+                            for (auto&& attribute : type.CustomAttribute())
+                            {
+                                auto attribute_name = attribute.TypeNamespaceAndName();
+                                if (attribute_name.first == "Windows.Foundation.Metadata" && attribute_name.second == "DeprecatedAttribute")
+                                {
+                                    write_deprecated_attribute(w, attribute);
+                                    break;
+                                }
+                            }
                             switch (get_category(type))
                             {
                             case category::class_type:
@@ -292,35 +302,68 @@ Where <spec> is one or more of:
                                     if (is_attribute_type(type)) { continue; }
                                     auto guard{ w.push_generic_params(type.GenericParam()) };
 
+                                    bool is_deprecated = false;
+                                    CustomAttribute deprecatedAttribute;
+
+                                    for (auto&& attribute : type.CustomAttribute())
+                                    {
+                                        auto attribute_name = attribute.TypeNamespaceAndName();
+                                        if (attribute_name.first == "Windows.Foundation.Metadata" && attribute_name.second == "DeprecatedAttribute")
+                                        {
+                                            is_deprecated = true;
+                                            deprecatedAttribute = attribute;
+                                            break;
+                                        }
+                                    }
                                     switch (get_category(type))
                                     {
                                     case category::class_type:
+                                        if (is_deprecated)
+                                            write_deprecated_attribute(w, deprecatedAttribute);
                                         write_abi_class(w, type);
                                         if (settings.component && componentActivatableClasses.count(type) == 1)
                                         {
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_winrt_exposed_type_class(w, type, true);
                                         }
+                                        if (is_deprecated)
+                                            write_deprecated_attribute(w, deprecatedAttribute);
                                         write_winrt_implementation_type_rcw_factory_attribute_type(w, type);
                                         break;
                                     case category::delegate_type:
+                                        if (is_deprecated)
+                                            write_deprecated_attribute(w, deprecatedAttribute);
                                         write_abi_delegate(w, type);
+                                        if (is_deprecated)
+                                            write_deprecated_attribute(w, deprecatedAttribute);
                                         write_winrt_exposed_type_class(w, type, false);
                                         break;
                                     case category::interface_type:
                                         if (settings.netstandard_compat)
                                         {
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_static_abi_classes(w, type);
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_abi_interface_netstandard(w, type);
                                         }
                                         else
                                         {
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_static_abi_classes(w, type);
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_abi_interface(w, type);
                                         }
                                         break;
                                     case category::struct_type:
                                         if (!is_type_blittable(type))
                                         {
+                                            if (is_deprecated)
+                                                write_deprecated_attribute(w, deprecatedAttribute);
                                             write_abi_struct(w, type);
                                         }
                                         break;


### PR DESCRIPTION
If the WinMD specifies `DeprecationType.Removal`, we still project, but set `ObsoleteAttribute` to error instead of warning. Information relating to version, contract and platform are irrelevant here since `ObsoleteAttribute` doesn't request them.

Fixes #1323.