### PR TITLE
Treat init-only properties as cannot write

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -346,7 +346,7 @@ namespace Generator
                         ToFullyQualifiedString(propertySymbol.Type),
                         // Make sure the property accessors are also public even if property itself is public.
                         propertySymbol.GetMethod != null && propertySymbol.GetMethod.DeclaredAccessibility == Accessibility.Public,
-                        propertySymbol.SetMethod != null && propertySymbol.SetMethod.DeclaredAccessibility == Accessibility.Public,
+                        propertySymbol.SetMethod != null && !propertySymbol.SetMethod.IsInitOnly && propertySymbol.SetMethod.DeclaredAccessibility == Accessibility.Public,
                         propertySymbol.IsIndexer,
                         propertySymbol.IsIndexer ? ToFullyQualifiedString(propertySymbol.Parameters[0].Type) : "",
                         propertySymbol.IsStatic


### PR DESCRIPTION
We cannot write to init-only properties after initialized, treat them as cannot write to avoid compilation error. 

Alternatives: generate an `UnsafeAccessor` to mutate the property.