### PR TITLE
Fix issue in WPF scenarios where our source generator was getting ran twice

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -14,7 +14,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CsWinRTGenerateProjection Condition="!$(CsWinRTEnabled)">false</CsWinRTGenerateProjection>
     <CsWinRTGenerateProjection Condition="'$(CsWinRTGenerateProjection)' == ''">true</CsWinRTGenerateProjection>
     <AllowUnsafeBlocks Condition="$(CsWinRTEnabled)">true</AllowUnsafeBlocks>
-    <CoreCompileDependsOn>CsWinRTIncludeProjection;CsWinRTRemoveWinMDReferences;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+    <!-- Making sure ResolveAssemblyReferences runs before CoreCompile runs as we have seen it not run in WPF scenarios
+         causing for our targeting pack to not get included or conflicts to be resolved. -->
+    <CoreCompileDependsOn>CsWinRTIncludeProjection;CsWinRTRemoveWinMDReferences;$(CoreCompileDependsOn);ResolveAssemblyReferences</CoreCompileDependsOn>
     <TrackFileAccess Condition="'$(CsWinRTComponent)' != 'true'">false</TrackFileAccess>
     <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
     <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' != 'true'">false</CsWinRTAotOptimizerEnabled>


### PR DESCRIPTION
When the Windows SDK projection package and the CsWinRT package is referenced, the same source generator from both packages get included.  But .NET has logic as part of `ResolveAssemblyReferences` to determine the newer one and only use that.  But for some reason this logic wasn't getting triggered in WPF scenarios.  Given this issue only occurs when the CsWinRT package is referenced, making use of our targets to ensure `ResolveAssemblyReferences` has ran by the time `CoreCompile` runs to ensure the deduplication has happened.