### PR TITLE
Fix GetEnumerator when C# enumerator gets passed to native and back

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -5,7 +5,7 @@ variables:
 - name: MinorVersion
   value: 1
 - name: PatchVersion
-  value: 1
+  value: 2
 - name: WinRT.Runtime.AssemblyVersion
   value: '2.1.0.0'
 - name: Net5.SDK.Feed

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.Designer.cs
@@ -223,7 +223,7 @@ namespace WinRT.SourceGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Class &apos;{0}&apos; implements WinRT interfaces but isn&apos;t marked partial.  Type should be marked partial for trimming and AOT compatibility if passed across the ABI..
+        ///   Looks up a localized string similar to Class &apos;{0}&apos; implements WinRT interfaces but isn&apos;t marked partial.  Type should be marked partial for trimming and AOT compatibility if passed across the WinRT ABI..
         /// </summary>
         internal static string ClassNotMarkedPartial_Text {
             get {
@@ -268,7 +268,7 @@ namespace WinRT.SourceGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the ABI. Project needs to be updated with &apos;&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;&apos;..
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the WinRT ABI. Project needs to be updated with &apos;&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;&apos;..
         /// </summary>
         internal static string EnableUnsafe_Text {
             get {

--- a/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
+++ b/src/Authoring/WinRT.SourceGenerator/CsWinRTDiagnosticStrings.resx
@@ -113,7 +113,7 @@
     <value>Class is not marked partial</value>
   </data>
   <data name="ClassNotMarkedPartial_Text" xml:space="preserve">
-    <value>Class '{0}' implements WinRT interfaces but isn't marked partial.  Type should be marked partial for trimming and AOT compatibility if passed across the ABI.</value>
+    <value>Class '{0}' implements WinRT interfaces but isn't marked partial.  Type should be marked partial for trimming and AOT compatibility if passed across the WinRT ABI.</value>
   </data>
   <data name="DisjointNamespaceRule_Brief" xml:space="preserve">
     <value>Namespace is disjoint from main (winmd) namespace</value>
@@ -130,7 +130,7 @@
     <value>Project does not enable unsafe blocks</value>
   </data>
   <data name="EnableUnsafe_Text" xml:space="preserve">
-    <value>Type '{0}' implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the ABI. Project needs to be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
+    <value>Type '{0}' implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the WinRT ABI. Project needs to be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
   </data>
   <data name="GenericTypeRule_Brief" xml:space="preserve">
     <value>Class (or interface) is generic</value>

--- a/src/Tests/FunctionalTests/CCW/Program.cs
+++ b/src/Tests/FunctionalTests/CCW/Program.cs
@@ -642,7 +642,7 @@ partial class Language
 {
     private readonly string[] _values = new string[4];
 
-    public string Name { get; } = "Language";
+    public string Name { get; init; } = "Language";
     public int Value { get; set; }
     public string this[int i]
     {

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -218,6 +218,25 @@ if (sum != 12)
     return 101;
 }
 
+CustomIteratorTest iterator = new CustomIteratorTest();
+iterator.MoveNext();
+if (iterator.Current != 2)
+{
+    return 101;
+}
+
+sum = 0;
+
+var customIterableTest3 = CustomIterableTest.CreateWithCustomIterator();
+foreach (var i in customIterableTest3)
+{
+    sum += i;
+}
+
+if (sum != 6)
+{
+    return 101;
+}
 
 return 100;
 

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -199,7 +199,7 @@ foreach (var i in customIterableTest)
     sum += i;
 }
 
-if (sum != 6)
+if (sum != 7)
 {
     return 101;
 }
@@ -233,7 +233,7 @@ foreach (var i in customIterableTest3)
     sum += i;
 }
 
-if (sum != 6)
+if (sum != 7)
 {
     return 101;
 }

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -179,6 +179,46 @@ if (count != 2)
     return 101;
 }
 
+int sum = 0;
+var enumerator = instance.GetIteratorForCollection(expected);
+while (enumerator.MoveNext())
+{
+    sum += enumerator.Current;
+}
+
+if (sum != 3)
+{
+    return 101;
+}
+
+sum = 0;
+
+CustomIterableTest customIterableTest = new CustomIterableTest();
+foreach (var i in customIterableTest)
+{
+    sum += i;
+}
+
+if (sum != 6)
+{
+    return 101;
+}
+
+sum = 0;
+
+var arr = new int[] { 2, 4, 6 };
+CustomIterableTest customIterableTest2 = new CustomIterableTest(arr);
+foreach (var i in customIterableTest2)
+{
+    sum += i;
+}
+
+if (sum != 12)
+{
+    return 101;
+}
+
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1503,6 +1503,11 @@ namespace winrt::TestComponentCSharp::implementation
         return winrt::single_threaded_vector(std::vector{ first, second });
     }
 
+    IIterator<int32_t> Class::GetIteratorForCollection(IIterable<int32_t> iterable)
+	{
+		return iterable.First();
+	}
+
     IBindableIterable Class::BindableIterableProperty()
     {
         return _bindableIterable;

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1504,9 +1504,9 @@ namespace winrt::TestComponentCSharp::implementation
     }
 
     IIterator<int32_t> Class::GetIteratorForCollection(IIterable<int32_t> iterable)
-	{
-		return iterable.First();
-	}
+    {
+        return iterable.First();
+    }
 
     IBindableIterable Class::BindableIterableProperty()
     {

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -302,6 +302,8 @@ namespace winrt::TestComponentCSharp::implementation
         Windows::Foundation::Collections::IIterable<TestComponentCSharp::EnumValue> GetEnumIterable();
         Windows::Foundation::Collections::IIterable<TestComponentCSharp::CustomDisposableTest> GetClassIterable();
 
+        Windows::Foundation::Collections::IIterator<int32_t> GetIteratorForCollection(Windows::Foundation::Collections::IIterable<int32_t> iterable);
+
         Microsoft::UI::Xaml::Interop::IBindableIterable BindableIterableProperty();
         void BindableIterableProperty(Microsoft::UI::Xaml::Interop::IBindableIterable const& value);
         void RaiseBindableIterableChanged();

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
@@ -11,7 +11,7 @@ namespace winrt::TestComponentCSharp::implementation
 
     CustomIterableTest::CustomIterableTest(winrt::Windows::Foundation::Collections::IIterable<int32_t> const& iterable)
     {
-		_iterable = iterable;
+        _iterable = iterable;
     }
 
     winrt::Windows::Foundation::Collections::IIterator<int32_t> CustomIterableTest::First()

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
@@ -6,7 +6,7 @@ namespace winrt::TestComponentCSharp::implementation
 {
     CustomIterableTest::CustomIterableTest()
     {
-        _iterable = winrt::single_threaded_vector(std::vector{ 0, 2, 4 });
+        _iterable = winrt::single_threaded_vector(std::vector{ 1, 2, 4 });
     }
 
     CustomIterableTest::CustomIterableTest(winrt::Windows::Foundation::Collections::IIterable<int32_t> const& iterable)

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
@@ -14,8 +14,26 @@ namespace winrt::TestComponentCSharp::implementation
         _iterable = iterable;
     }
 
+    CustomIterableTest::CustomIterableTest(bool useCustomIterator)
+        :CustomIterableTest()
+    {
+        _useCustomIterator = useCustomIterator;
+    }
+
+    winrt::TestComponentCSharp::CustomIterableTest CustomIterableTest::CreateWithCustomIterator()
+    {
+        return winrt::make<CustomIterableTest>(true);
+    }
+
     winrt::Windows::Foundation::Collections::IIterator<int32_t> CustomIterableTest::First()
     {
-        return _iterable.First();
+        if (_useCustomIterator)
+        {
+            return winrt::TestComponentCSharp::CustomIteratorTest(_iterable.First());
+        }
+        else
+        {
+            return _iterable.First();
+        }
     }
 }

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.cpp
@@ -1,0 +1,21 @@
+#include "pch.h"
+#include "CustomIterableTest.h"
+#include "CustomIterableTest.g.cpp"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    CustomIterableTest::CustomIterableTest()
+    {
+        _iterable = winrt::single_threaded_vector(std::vector{ 0, 2, 4 });
+    }
+
+    CustomIterableTest::CustomIterableTest(winrt::Windows::Foundation::Collections::IIterable<int32_t> const& iterable)
+    {
+		_iterable = iterable;
+    }
+
+    winrt::Windows::Foundation::Collections::IIterator<int32_t> CustomIterableTest::First()
+    {
+        return _iterable.First();
+    }
+}

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.h
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.h
@@ -7,10 +7,13 @@ namespace winrt::TestComponentCSharp::implementation
     {
         CustomIterableTest();
         CustomIterableTest(winrt::Windows::Foundation::Collections::IIterable<int32_t> const& iterable);
+        CustomIterableTest(bool useCustomIterator);
 
+        static winrt::TestComponentCSharp::CustomIterableTest CreateWithCustomIterator();
         winrt::Windows::Foundation::Collections::IIterator<int32_t> First();
 
         winrt::Windows::Foundation::Collections::IIterable<int32_t> _iterable;
+        bool _useCustomIterator = false;
     };
 }
 

--- a/src/Tests/TestComponentCSharp/CustomIterableTest.h
+++ b/src/Tests/TestComponentCSharp/CustomIterableTest.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "CustomIterableTest.g.h"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    struct CustomIterableTest : CustomIterableTestT<CustomIterableTest>
+    {
+        CustomIterableTest();
+        CustomIterableTest(winrt::Windows::Foundation::Collections::IIterable<int32_t> const& iterable);
+
+        winrt::Windows::Foundation::Collections::IIterator<int32_t> First();
+
+        winrt::Windows::Foundation::Collections::IIterable<int32_t> _iterable;
+    };
+}
+
+namespace winrt::TestComponentCSharp::factory_implementation
+{
+    struct CustomIterableTest : CustomIterableTestT<CustomIterableTest, implementation::CustomIterableTest>
+    {
+    };
+}

--- a/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.cpp
+++ b/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.cpp
@@ -124,20 +124,44 @@ namespace winrt::TestComponentCSharp::implementation
     {
     }
 
+    CustomIteratorTest::CustomIteratorTest(winrt::Windows::Foundation::Collections::IIterator<int> iterator)
+    {
+        _iterator = iterator;
+    }
     int32_t CustomIteratorTest::Current()
     {
+        if (_iterator)
+        {
+            return _iterator.Current();
+        }
+
         return 2;
     }
     bool CustomIteratorTest::HasCurrent()
     {
+        if (_iterator)
+        {
+            return _iterator.HasCurrent();
+        }
+
         return true;
     }
     bool CustomIteratorTest::MoveNext()
     {
+        if (_iterator)
+        {
+            return _iterator.MoveNext();
+        }
+
         return true;
     }
     uint32_t CustomIteratorTest::GetMany(array_view<int32_t> items)
     {
+        if (_iterator)
+        {
+            return _iterator.GetMany(items);
+        }
+
         throw hresult_not_implemented();
     }
 }

--- a/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.h
+++ b/src/Tests/TestComponentCSharp/ManualProjectionTestClasses.h
@@ -59,11 +59,14 @@ namespace winrt::TestComponentCSharp::implementation
 	struct CustomIteratorTest : CustomIteratorTestT<CustomIteratorTest>
 	{
 		CustomIteratorTest() = default;
+		CustomIteratorTest(winrt::Windows::Foundation::Collections::IIterator<int> iterator);
 
 		int32_t Current();
 		bool HasCurrent();
 		bool MoveNext();
 		uint32_t GetMany(array_view<int32_t> items);
+
+		winrt::Windows::Foundation::Collections::IIterator<int> _iterator;
 	};
 }
 

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -523,7 +523,7 @@ namespace TestComponentCSharp
     [default_interface]
     runtimeclass CustomIterableTest : Windows.Foundation.Collections.IIterable<Int32>
     {
-		CustomIterableTest();
+        CustomIterableTest();
         CustomIterableTest(Windows.Foundation.Collections.IIterable<Int32> iterable);
     }
 

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -518,6 +518,7 @@ namespace TestComponentCSharp
     runtimeclass CustomIteratorTest : Windows.Foundation.Collections.IIterator<Int32>
     {
         CustomIteratorTest();
+        CustomIteratorTest(Windows.Foundation.Collections.IIterator<Int32> iterator);
     }
 
     [default_interface]
@@ -525,6 +526,8 @@ namespace TestComponentCSharp
     {
         CustomIterableTest();
         CustomIterableTest(Windows.Foundation.Collections.IIterable<Int32> iterable);
+
+        static CustomIterableTest CreateWithCustomIterator();
     }
 
     // SupportedOSPlatform warning tests

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -349,6 +349,8 @@ namespace TestComponentCSharp
         Windows.Foundation.Collections.IIterable<EnumValue> GetEnumIterable();
         Windows.Foundation.Collections.IIterable<CustomDisposableTest> GetClassIterable();
 
+        Windows.Foundation.Collections.IIterator<Int32> GetIteratorForCollection(Windows.Foundation.Collections.IIterable<Int32> iterable);
+
         // Bindable
         Microsoft.UI.Xaml.Interop.IBindableIterable BindableIterableProperty;
         void RaiseBindableIterableChanged();
@@ -516,6 +518,13 @@ namespace TestComponentCSharp
     runtimeclass CustomIteratorTest : Windows.Foundation.Collections.IIterator<Int32>
     {
         CustomIteratorTest();
+    }
+
+    [default_interface]
+    runtimeclass CustomIterableTest : Windows.Foundation.Collections.IIterable<Int32>
+    {
+		CustomIterableTest();
+        CustomIterableTest(Windows.Foundation.Collections.IIterable<Int32> iterable);
     }
 
     // SupportedOSPlatform warning tests

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -84,6 +84,7 @@
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
     <ClInclude Include="CustomExperimentClass.h" />
     <ClInclude Include="CustomEquals.h" />
+    <ClInclude Include="CustomIterableTest.h" />
     <ClInclude Include="ManualProjectionTestClasses.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Class.h">
@@ -105,6 +106,7 @@
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
     <ClCompile Include="CustomExperimentClass.cpp" />
     <ClCompile Include="CustomEquals.cpp" />
+    <ClCompile Include="CustomIterableTest.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -23,6 +23,8 @@
     <ClCompile Include="CustomExperimentClass.cpp" />
     <ClCompile Include="WinRT.Class.cpp" />
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
+    <ClCompile Include="NonUniqueClass.cpp" />
+    <ClCompile Include="CustomIterableTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -39,6 +41,8 @@
     <ClInclude Include="CustomExperimentClass.h" />
     <ClInclude Include="WinRT.Class.h" />
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
+    <ClInclude Include="NonUniqueClass.h" />
+    <ClInclude Include="CustomIterableTest.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -244,7 +244,7 @@ namespace ABI.System.Collections.Generic
                 return toAbiAdapter.m_enumerator;
             }
 
-            throw new InvalidOperationException("Unexpected type for enumerator");
+            return first;
         }
 
         private static IntPtr abiToProjectionVftablePtr;

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -243,8 +243,15 @@ namespace ABI.System.Collections.Generic
                 // Unwrap to get the C# enumerator if it was originally one.
                 return toAbiAdapter.m_enumerator;
             }
+            else if (first is IWinRTObject winrtObject)
+            {
+                // This is a projected RCW implementing IEnumerator<T>, but since it is being used
+                // as part of GetEnumerator, we need to remap the enumerator starting index.
+                // Due to that, we don't return the RCW itself.
+                return new global::ABI.System.Collections.Generic.FromAbiEnumerator<T>(winrtObject.NativeObject);
+            }
 
-            return first;
+            throw new InvalidOperationException("Unexpected type for enumerator");
         }
 
         private static IntPtr abiToProjectionVftablePtr;

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -238,6 +238,11 @@ namespace ABI.System.Collections.Generic
             {
                 return new global::ABI.System.Collections.Generic.FromAbiEnumerator<T>(ienumeratorImpl);
             }
+            else if (first is global::ABI.System.Collections.Generic.ToAbiEnumeratorAdapter<T> toAbiAdapter)
+            {
+                // Unwrap to get the C# enumerator if it was originally one.
+                return toAbiAdapter.m_enumerator;
+            }
 
             throw new InvalidOperationException("Unexpected type for enumerator");
         }
@@ -939,7 +944,7 @@ namespace ABI.System.Collections.Generic
     // we can't make them AOT friendly due to we can't reference them.
     public sealed class ToAbiEnumeratorAdapter<T> : global::System.Collections.Generic.IEnumerator<T>, global::System.Collections.IEnumerator
     {
-        private readonly global::System.Collections.Generic.IEnumerator<T> m_enumerator;
+        internal readonly global::System.Collections.Generic.IEnumerator<T> m_enumerator;
 
         internal ToAbiEnumeratorAdapter(global::System.Collections.Generic.IEnumerator<T> enumerator) => m_enumerator = enumerator;
 


### PR DESCRIPTION
We previously didn't handle the case where a C# enumerator gets passed to native and then gets passed back to C# as part of an IIterable implementation instead of just as an enumerator.  We now handle this by unwrapping our adapter type.

Added tests to validate a couple different variations of this, only one was failing before this change.

Also adjusting some strings from previous PR.

Fixes #1733