### PR TITLE
Detect when property expressions are used

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1136,6 +1136,15 @@ namespace Generator
                         AddVtableAttributesForType(instantiatedType, namedType);
                     }
                 }
+                else if (propertyDeclaration.ExpressionBody != null)
+                {
+                    var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
+                    if (leftSymbol is INamedTypeSymbol namedType)
+                    {
+                        var instantiatedType = context.SemanticModel.GetTypeInfo(propertyDeclaration.ExpressionBody.Expression);
+                        AddVtableAttributesForType(instantiatedType, namedType);
+                    }
+                }
             }
             // Detect scenarios where the method or property being returned from is doing a box or cast of the type
             // in the return statement.

--- a/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
@@ -232,6 +232,19 @@ namespace WinRT.SourceGenerator
                                     }
                                 }
                             }
+                            else if (propertyDeclaration.ExpressionBody != null)
+                            {
+                                var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
+                                if (leftSymbol is INamedTypeSymbol namedType)
+                                {
+                                    var instantiatedType = context.SemanticModel.GetTypeInfo(propertyDeclaration.ExpressionBody.Expression);
+                                    if (IsTypeOnLookupTable(instantiatedType, namedType, out var implementsOnlyCustomMappedInterface))
+                                    {
+                                        ReportEnableUnsafeDiagnostic(context.ReportDiagnostic, instantiatedType.Type, propertyDeclaration.GetLocation(), !implementsOnlyCustomMappedInterface);
+                                        return;
+                                    }
+                                }
+                            }
                         }
                         // Detect scenarios where the method or property being returned from is doing a box or cast of the type
                         // in the return statement.

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -125,6 +125,9 @@ if (CustomClass.Instances != instance.BindableIterableProperty)
     return 101;
 }
 
+instance.BindableIterableProperty = CustomClass.DictionaryInstance;
+instance.BindableIterableProperty = CustomClass.DictionaryInstance2;
+
 var customObservableCollection = new CustomObservableCollection();
 instance.BindableIterableProperty = customObservableCollection;
 if (customObservableCollection != instance.BindableIterableProperty)
@@ -190,6 +193,16 @@ sealed partial class CustomClass : INotifyPropertyChanged
     public event PropertyChangedEventHandler PropertyChanged;
 
     public static IReadOnlyList<CustomClass> Instances { get; } = new CustomClass[] { };
+
+    public static IReadOnlyDictionary<string, CustomClass> DictionaryInstance => new Dictionary<string, CustomClass>();
+
+    public static IReadOnlyDictionary<int, CustomClass> DictionaryInstance2
+    {
+        get
+        {
+            return new Dictionary<int, CustomClass>();
+        }
+    }
 }
 
 sealed partial class CustomObservableCollection : System.Collections.ObjectModel.ObservableCollection<CustomClass>


### PR DESCRIPTION
Our analyzer didn't detect when property expressions were used.  This adds logic to detect that similar to property initializers.

Fixes #1726 