### PR TITLE
Improve performance of source generator

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -53,7 +53,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTCcwLookupTableGeneratorEnabled" />
     <CompilerVisibleProperty Include="CsWinRTMergeReferencedActivationFactories" />
     <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
-    <CompilerVisibleProperty Include="CsWinRTEmbedded" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Embedded.targets" Condition="'$(CsWinRTEmbedded)' == 'true'"/>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -53,6 +53,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTCcwLookupTableGeneratorEnabled" />
     <CompilerVisibleProperty Include="CsWinRTMergeReferencedActivationFactories" />
     <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
+    <CompilerVisibleProperty Include="CsWinRTEmbedded" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Embedded.targets" Condition="'$(CsWinRTEmbedded)' == 'true'"/>

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -19,14 +19,28 @@ namespace Generator
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            var analyzerConfigProperties = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => 
-                    (provider.IsCsWinRTAotOptimizerEnabled(), provider.IsCsWinRTComponent(), provider.IsCsWinRTCcwLookupTableGeneratorEnabled(), provider.IsCsWinRTAotOptimizerEnabledForBuiltInInterfaces()));
+            var analyzerConfigProperties = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => (
+                    provider.IsCsWinRTAotOptimizerEnabled(),
+                    provider.IsCsWinRTComponent(),
+                    provider.IsCsWinRTCcwLookupTableGeneratorEnabled(),
+                    provider.IsCsWinRTAotOptimizerEnabledForBuiltInInterfaces(),
+                    provider.IsCsWinRTEmbeddedSupport())
+                );
 
-            var hasWinRTRuntimeReference = context.CompilationProvider.Select(static (compilation, ct) => GeneratorHelper.HasWinRTRuntimeReference(compilation, ct));
-
-            var properties = analyzerConfigProperties.Combine(hasWinRTRuntimeReference).Select(
-                static (((bool isCsWinRTAotOptimizerEnabled, bool, bool, bool isCsWinRTAotOptimizerEnabledForBuiltInInterfaces) properties, bool hasWinRTRuntimeReference) value, CancellationToken _) =>
-                (value.properties.isCsWinRTAotOptimizerEnabled && (value.hasWinRTRuntimeReference || value.properties.isCsWinRTAotOptimizerEnabledForBuiltInInterfaces), value.properties.Item2, value.properties.Item3));
+            var properties = context.CompilationProvider.Combine(analyzerConfigProperties).
+                    Select(static ((Compilation compilation, (bool isCsWinRTAotOptimizerEnabled, bool isCsWinRTComponent, bool, bool isCsWinRTAotOptimizerEnabledForBuiltInInterfaces, bool isCsWinRTEmbeddedSupport) properties) value, CancellationToken ct) =>
+                    // Enable the optimizer if the optimizer property is set and we would have a WinRT.Runtime reference.
+                    // There are a couple scenarios where we might not detect a WinRT.Runtime reference which we explicitly
+                    // check for such as component support where the generator introduces the reference and embedded support.
+                    // We will allow for an override for this by detecting whether CsWinRTAotWarningLevel is set to 2 which
+                    // indicates the component cares about optimization for built-in interfaces.
+                    (value.properties.isCsWinRTAotOptimizerEnabled && 
+                     (value.properties.isCsWinRTComponent ||
+                      value.properties.isCsWinRTAotOptimizerEnabledForBuiltInInterfaces ||
+                      value.properties.isCsWinRTEmbeddedSupport ||
+                      GeneratorHelper.HasWinRTRuntimeReference(value.compilation, ct)), 
+                     value.properties.isCsWinRTComponent,
+                     value.properties.Item3));
 
             var assemblyName = context.CompilationProvider.Select(static (compilation, _) => GeneratorHelper.EscapeTypeNameForIdentifier(compilation.AssemblyName));
 

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -19,28 +19,11 @@ namespace Generator
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            var analyzerConfigProperties = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => (
+            var properties = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => (
                     provider.IsCsWinRTAotOptimizerEnabled(),
                     provider.IsCsWinRTComponent(),
-                    provider.IsCsWinRTCcwLookupTableGeneratorEnabled(),
-                    provider.IsCsWinRTAotOptimizerEnabledForBuiltInInterfaces(),
-                    provider.IsCsWinRTEmbeddedSupport())
+                    provider.IsCsWinRTCcwLookupTableGeneratorEnabled())
                 );
-
-            var properties = context.CompilationProvider.Combine(analyzerConfigProperties).
-                    Select(static ((Compilation compilation, (bool isCsWinRTAotOptimizerEnabled, bool isCsWinRTComponent, bool, bool isCsWinRTAotOptimizerEnabledForBuiltInInterfaces, bool isCsWinRTEmbeddedSupport) properties) value, CancellationToken ct) =>
-                    // Enable the optimizer if the optimizer property is set and we would have a WinRT.Runtime reference.
-                    // There are a couple scenarios where we might not detect a WinRT.Runtime reference which we explicitly
-                    // check for such as component support where the generator introduces the reference and embedded support.
-                    // We will allow for an override for this by detecting whether CsWinRTAotWarningLevel is set to 2 which
-                    // indicates the component cares about optimization for built-in interfaces.
-                    (value.properties.isCsWinRTAotOptimizerEnabled && 
-                     (value.properties.isCsWinRTComponent ||
-                      value.properties.isCsWinRTAotOptimizerEnabledForBuiltInInterfaces ||
-                      value.properties.isCsWinRTEmbeddedSupport ||
-                      GeneratorHelper.HasWinRTRuntimeReference(value.compilation, ct)), 
-                     value.properties.isCsWinRTComponent,
-                     value.properties.Item3));
 
             var assemblyName = context.CompilationProvider.Select(static (compilation, _) => GeneratorHelper.EscapeTypeNameForIdentifier(compilation.AssemblyName));
 

--- a/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
+++ b/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
@@ -4,7 +4,6 @@
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection.Metadata;
 using WinRT.SourceGenerator;
 
 namespace Generator
@@ -183,7 +182,7 @@ namespace Generator
             // Splitting on the dots and the generic specifier (`) will get us the class name
             // in the 2nd last element.
             var interfaceName = genericInterface.Split('.', '`')[^2];
-            var genericParametersStr = string.Join("_", genericParameters.Select(genericParameter => GeneratorHelper.EscapeTypeNameForIdentifier(genericParameter.ProjectedType)));
+            var genericParametersStr = string.Join("_", genericParameters.Select(static genericParameter => GeneratorHelper.EscapeTypeNameForIdentifier(genericParameter.ProjectedType)));
             return $$"""        _ = global::WinRT.{{escapedAssemblyName}}GenericHelpers.{{interfaceName}}_{{genericParametersStr}}.Initialized;""";
         }
 

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -104,16 +104,6 @@ namespace Generator
             return false;
         }
 
-        public static bool IsCsWinRTEmbeddedSupport(this AnalyzerConfigOptionsProvider provider)
-        {
-            if (provider.GlobalOptions.TryGetValue("build_property.CsWinRTEmbedded", out var isCsWinRTEmbeddedStr))
-            {
-                return bool.TryParse(isCsWinRTEmbeddedStr, out var isCsWinRTEmbedded) && isCsWinRTEmbedded;
-            }
-
-            return false;
-        }
-
         public static bool IsCsWinRTAotOptimizerEnabled(this AnalyzerConfigOptionsProvider provider)
         {
             if (provider.GlobalOptions.TryGetValue("build_property.CsWinRTAotOptimizerEnabled", out var isCsWinRTAotOptimizerEnabledStr))
@@ -183,11 +173,6 @@ namespace Generator
             }
 
             return 0;
-        }
-
-        public static bool IsCsWinRTAotOptimizerEnabledForBuiltInInterfaces(this AnalyzerConfigOptionsProvider provider)
-        {
-            return GetCsWinRTAotWarningLevel(provider) == 2;
         }
 
         public static bool ShouldGenerateWinMDOnly(this GeneratorExecutionContext context)
@@ -1137,12 +1122,6 @@ namespace Generator
             }
 
             return null;
-        }
-
-        public static bool HasWinRTRuntimeReference(Compilation compilation, CancellationToken ct)
-        {
-            return compilation.GetUsedAssemblyReferences(ct).Any(reference => 
-                string.Equals(compilation.GetAssemblyOrModuleSymbol(reference)?.Name, "WinRT.Runtime", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -11,7 +11,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace Generator
 {

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -327,7 +327,7 @@ namespace Generator
         public static bool IsWinRTType(ISymbol type, Func<ISymbol, TypeMapper, bool> isAuthoringWinRTType, TypeMapper mapper)
         {
             bool isProjectedType = type.GetAttributes().
-                Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WindowsRuntimeTypeAttribute") == 0) ||
+                Any(static attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WindowsRuntimeTypeAttribute") == 0) ||
                 IsFundamentalType(type);
 
             if (!isProjectedType & type.ContainingNamespace != null)
@@ -493,7 +493,7 @@ namespace Generator
             for (ITypeSymbol parent = symbol; parent is not null; parent = parent.ContainingType)
             {
                 isPartial &= parent.DeclaringSyntaxReferences.Any(
-                    syntax => syntax.GetSyntax() is BaseTypeDeclarationSyntax declaration &&
+                    static syntax => syntax.GetSyntax() is BaseTypeDeclarationSyntax declaration &&
                     declaration.Modifiers.Any(SyntaxKind.PartialKeyword));
             }
             return isPartial;
@@ -513,13 +513,13 @@ namespace Generator
         {
             return symbol is INamedTypeSymbol namedType &&
                 (namedType.DeclaredAccessibility == Accessibility.Private ||
-                 namedType.TypeArguments.Any(argument => argument.DeclaredAccessibility == Accessibility.Private));
+                 namedType.TypeArguments.Any(static argument => argument.DeclaredAccessibility == Accessibility.Private));
         }
 
         public static bool HasWinRTExposedTypeAttribute(ISymbol type)
         {
             return type.GetAttributes().
-                Any(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTExposedTypeAttribute") == 0);
+                Any(static attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WinRTExposedTypeAttribute") == 0);
         }
 
         public static bool HasWinRTRuntimeClassNameAttribute(ISymbol type, Compilation compilation)
@@ -535,14 +535,14 @@ namespace Generator
 
         public static bool IsWinRTType(MemberDeclarationSyntax node)
         {
-            bool isProjectedType = node.AttributeLists.SelectMany(list => list.Attributes).
-                Any(attribute => string.CompareOrdinal(attribute.Name.NormalizeWhitespace().ToFullString(), "global::WinRT.WindowsRuntimeType") == 0);
+            bool isProjectedType = node.AttributeLists.SelectMany(static list => list.Attributes).
+                Any(static attribute => string.CompareOrdinal(attribute.Name.NormalizeWhitespace().ToFullString(), "global::WinRT.WindowsRuntimeType") == 0);
             return isProjectedType;
         }
 
         public static bool HasBindableCustomPropertyAttribute(MemberDeclarationSyntax node)
         {
-            return node.AttributeLists.SelectMany(list => list.Attributes).Any(IsBindableCustomPropertyAttribute);
+            return node.AttributeLists.SelectMany(static list => list.Attributes).Any(IsBindableCustomPropertyAttribute);
 
             // Check based on identifier name if this is the GeneratedBindableCustomProperty attribute.
             // Technically this can be a different namespace, but we will confirm later once
@@ -713,7 +713,7 @@ namespace Generator
                 if (!IsBlittableValueType(type, mapper))
                 {
                     var winrtHelperAttribute = type.GetAttributes().
-                        Where(attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WindowsRuntimeHelperTypeAttribute") == 0).
+                        Where(static attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WindowsRuntimeHelperTypeAttribute") == 0).
                         FirstOrDefault();
                     if (winrtHelperAttribute != null &&
                         winrtHelperAttribute.ConstructorArguments.Any())

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -104,6 +104,16 @@ namespace Generator
             return false;
         }
 
+        public static bool IsCsWinRTEmbeddedSupport(this AnalyzerConfigOptionsProvider provider)
+        {
+            if (provider.GlobalOptions.TryGetValue("build_property.CsWinRTEmbedded", out var isCsWinRTEmbeddedStr))
+            {
+                return bool.TryParse(isCsWinRTEmbeddedStr, out var isCsWinRTEmbedded) && isCsWinRTEmbedded;
+            }
+
+            return false;
+        }
+
         public static bool IsCsWinRTAotOptimizerEnabled(this AnalyzerConfigOptionsProvider provider)
         {
             if (provider.GlobalOptions.TryGetValue("build_property.CsWinRTAotOptimizerEnabled", out var isCsWinRTAotOptimizerEnabledStr))
@@ -1131,7 +1141,8 @@ namespace Generator
 
         public static bool HasWinRTRuntimeReference(Compilation compilation, CancellationToken ct)
         {
-            return compilation.GetUsedAssemblyReferences(ct).Any(reference => compilation.GetAssemblyOrModuleSymbol(reference).Name == "WinRT.Runtime");
+            return compilation.GetUsedAssemblyReferences(ct).Any(reference => 
+                string.Equals(compilation.GetAssemblyOrModuleSymbol(reference)?.Name, "WinRT.Runtime", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Generator
 {
@@ -172,6 +173,11 @@ namespace Generator
             }
 
             return 0;
+        }
+
+        public static bool IsCsWinRTAotOptimizerEnabledForBuiltInInterfaces(this AnalyzerConfigOptionsProvider provider)
+        {
+            return GetCsWinRTAotWarningLevel(provider) == 2;
         }
 
         public static bool ShouldGenerateWinMDOnly(this GeneratorExecutionContext context)
@@ -1121,6 +1127,11 @@ namespace Generator
             }
 
             return null;
+        }
+
+        public static bool HasWinRTRuntimeReference(Compilation compilation, CancellationToken ct)
+        {
+            return compilation.GetUsedAssemblyReferences(ct).Any(reference => compilation.GetAssemblyOrModuleSymbol(reference).Name == "WinRT.Runtime");
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
@@ -57,6 +57,7 @@ namespace WinRT.SourceGenerator
                 var typeMapper = new TypeMapper(context.Options.AnalyzerConfigOptionsProvider.GetCsWinRTUseWindowsUIXamlProjections());
                 var csWinRTAotWarningLevel = context.Options.AnalyzerConfigOptionsProvider.GetCsWinRTAotWarningLevel();
                 var allowUnsafe = GeneratorHelper.AllowUnsafe(context.Compilation);
+                var isCsWinRTCcwLookupTableGeneratorEnabled = context.Options.AnalyzerConfigOptionsProvider.IsCsWinRTCcwLookupTableGeneratorEnabled();
 
                 context.RegisterSymbolAction(context =>
                 {
@@ -127,7 +128,7 @@ namespace WinRT.SourceGenerator
                     }
                 }, SymbolKind.NamedType);
 
-                if (!allowUnsafe)
+                if (!allowUnsafe && isCsWinRTCcwLookupTableGeneratorEnabled)
                 {
                     context.RegisterSyntaxNodeAction(context =>
                     {


### PR DESCRIPTION
- Changed the ordering of the properties during the combine operations to allow us to know earlier whether authoring support is enabled.  This allows us to reduce how often we call `GetVtableAttributesToAddOnLookupTable` and thereby reducing calls to `GetSymbolInfo`.  This should reduce the number of calls by half and thereby improve performance.