### PR TITLE
ToArray fails when buffer capacity is larger than its length.

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -470,6 +470,23 @@ namespace UnitTest
             Assert.True(newArr.Length == 3);
         }
 
+        [Fact]
+        public void TestBufferCopyToBufferCapacityLargerThanLength()
+        {
+            var buffer = new Windows.Storage.Streams.Buffer(100);
+            byte[] arr = new byte[] { 0x01, 0x02, 0x03 };
+            arr.CopyTo(0, buffer, 0, 3);
+
+            var buffer2 = new Windows.Storage.Streams.Buffer(50);
+            byte[] arr2 = new byte[] { 0x01, 0x02 };
+            arr2.CopyTo(0, buffer2, 0, 2);
+
+            Assert.True(buffer2.Length == 2);
+
+            buffer.CopyTo(buffer2);
+            Assert.True(buffer2.Length == 3);
+        }
+
 #if NET
         [Fact]
         public void TestTryGetDataUnsafe()

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -459,6 +459,17 @@ namespace UnitTest
             Assert.True(array.Length == 0);
         }
 
+        [Fact]
+        public void TestBufferToArrayCapacityLargerThanLength()
+        {
+            var buffer = new Windows.Storage.Streams.Buffer(100);
+            byte[] arr = new byte[] { 0x01, 0x02, 0x03 };
+            arr.CopyTo(0, buffer, 0, 3);
+
+            byte[] newArr = buffer.ToArray();
+            Assert.True(newArr.Length == 3);
+        }
+
 #if NET
         [Fact]
         public void TestTryGetDataUnsafe()

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/WindowsRuntimeBufferExtensions.cs
@@ -196,7 +196,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Debug.Assert(sourceIndex <= int.MaxValue);
 
-            Span<byte> srcSpan = source.TryGetUnderlyingData(out byte[] srcDataArr, out int srcOffset) ? srcDataArr.AsSpan(srcOffset + (int)sourceIndex, count) : source.GetSpanForCapacityUnsafe(sourceIndex);
+            Span<byte> srcSpan = source.TryGetUnderlyingData(out byte[] srcDataArr, out int srcOffset) ? srcDataArr.AsSpan(srcOffset + (int)sourceIndex, count) : source.GetSpanForCapacityUnsafe(sourceIndex).Slice(0, (int)count);
             srcSpan.CopyTo(destination);
 
             // Ensure source and destination stay alive for the copy operation
@@ -252,8 +252,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Debug.Assert(destinationIndex <= int.MaxValue);
 
             // If source are destination are backed by managed arrays, use the arrays instead of the pointers as it does not require pinning:
-            Span<byte> srcSpan = source.TryGetUnderlyingData(out byte[] srcDataArr, out int srcOffset) ? srcDataArr.AsSpan(srcOffset + (int)sourceIndex, (int)count) : source.GetSpanForCapacityUnsafe(sourceIndex);
-            Span<byte> destSpan = destination.TryGetUnderlyingData(out byte[] destDataArr, out int destOffset) ? destDataArr.AsSpan(destOffset + (int)destinationIndex) : destination.GetSpanForCapacityUnsafe(destinationIndex);
+            Span<byte> srcSpan = source.TryGetUnderlyingData(out byte[] srcDataArr, out int srcOffset) ? srcDataArr.AsSpan(srcOffset + (int)sourceIndex, (int)count) : source.GetSpanForCapacityUnsafe(sourceIndex).Slice(0, (int)count);
+            Span<byte> destSpan = destination.TryGetUnderlyingData(out byte[] destDataArr, out int destOffset) ? destDataArr.AsSpan(destOffset + (int)destinationIndex) : destination.GetSpanForCapacityUnsafe(destinationIndex).Slice(0, (int)count);
 
             srcSpan.CopyTo(destSpan);
 


### PR DESCRIPTION
Introduced in #1541

Workaround:

```
if (WindowsRuntimeMarshal.TryGetDataUnsafe(buffer, out var data))
{
    Span<byte> bufferAsSpan = new Span<byte>(data.ToPointer(), (int)buffer.Length);
    return bufferAsSpan.ToArray();
}
```
