### PR TITLE
Don't emit default ctor for non activatable types

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -94,5 +94,9 @@
        name="AuthoringTest.NonActivatableFactory"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.TypeOnlyActivatableViaItsOwnFactory"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -82,8 +82,12 @@
        name="AuthoringTest.CustomXamlMetadataProvider"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
-     <activatableClass
+    <activatableClass
        name="AuthoringTest.CustomInterfaceGuidClass"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.NonActivatableType"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -90,5 +90,9 @@
        name="AuthoringTest.NonActivatableType"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.NonActivatableFactory"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -736,3 +736,21 @@ TEST(AuthoringTest, CustomInterfaceGuid)
 
     EXPECT_EQ(customInterface.HelloWorld(), L"Hello World!");
 }
+
+TEST(AuthoringTest, NonActivatableType)
+{
+    bool hasFailed = false;
+
+    try
+    {
+        NonActivatableType nonActivatableType;
+
+        nonActivatableType.Dummy();
+    }
+    catch (...)
+    {
+        hasFailed = true;
+    }
+
+    ASSERT_TRUE(hasFailed);
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -737,24 +737,6 @@ TEST(AuthoringTest, CustomInterfaceGuid)
     EXPECT_EQ(customInterface.HelloWorld(), L"Hello World!");
 }
 
-TEST(AuthoringTest, NonActivatableType)
-{
-    bool hasFailed = false;
-
-    try
-    {
-        NonActivatableType nonActivatableType;
-
-        nonActivatableType.GetText();
-    }
-    catch (...)
-    {
-        hasFailed = true;
-    }
-
-    ASSERT_TRUE(hasFailed);
-}
-
 TEST(AuthoringTest, NonActivatableFactory)
 {
     EXPECT_EQ(NonActivatableFactory::Create().GetText(), L"Test123");

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -741,3 +741,8 @@ TEST(AuthoringTest, NonActivatableFactory)
 {
     EXPECT_EQ(NonActivatableFactory::Create().GetText(), L"Test123");
 }
+
+TEST(AuthoringTest, TypeOnlyActivatableViaItsOwnFactory)
+{
+    EXPECT_EQ(TypeOnlyActivatableViaItsOwnFactory::Create().GetText(), L"Hello!");
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -745,7 +745,7 @@ TEST(AuthoringTest, NonActivatableType)
     {
         NonActivatableType nonActivatableType;
 
-        nonActivatableType.Dummy();
+        nonActivatableType.GetText();
     }
     catch (...)
     {
@@ -753,4 +753,9 @@ TEST(AuthoringTest, NonActivatableType)
     }
 
     ASSERT_TRUE(hasFailed);
+}
+
+TEST(AuthoringTest, NonActivatableFactory)
+{
+    EXPECT_EQ(NonActivatableFactory::Create().GetText(), L"Test123");
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1889,6 +1889,26 @@ namespace AuthoringTest
             return new("Test123");
         }
     }
+
+    public sealed class TypeOnlyActivatableViaItsOwnFactory
+    {
+        private readonly string _text;
+
+        private TypeOnlyActivatableViaItsOwnFactory(string text)
+        {
+            _text = text;
+        }
+
+        public static TypeOnlyActivatableViaItsOwnFactory Create()
+        {
+            return new("Hello!");
+        }
+
+        public string GetText()
+        {
+            return _text;
+        }
+    }
 }
 
 namespace ABI.AuthoringTest

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1865,6 +1865,18 @@ namespace AuthoringTest
     {
         public string HelloWorld() => "Hello World!";
     }
+
+    public sealed class NonActivatableType
+    {
+        // This should not be referenced by the generated activation factory
+        internal NonActivatableType(string dummyParameter)
+        {
+        }
+
+        public void Dummy()
+        {
+        }
+    }
 }
 
 namespace ABI.AuthoringTest

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1868,13 +1868,25 @@ namespace AuthoringTest
 
     public sealed class NonActivatableType
     {
+        private readonly string _text;
+
         // This should not be referenced by the generated activation factory
-        internal NonActivatableType(string dummyParameter)
+        internal NonActivatableType(string text)
         {
+            _text = text;
         }
 
-        public void Dummy()
+        public string GetText()
         {
+            return _text;
+        }
+    }
+
+    public static class NonActivatableFactory
+    {
+        public static NonActivatableType Create()
+        {
+            return new("Test123");
         }
     }
 }


### PR DESCRIPTION
This PR fixes the .winmd generation logic to avoid the default constructor for types that do have some non public constructor that takes any parameters. This bug is blocking the migration of one of our WinRT component projects in the Microsoft Store.