### PR TITLE
Reuse generated code when possible

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -882,7 +882,7 @@ namespace Generator
                         }
 
                         source.AppendLine($$"""
-                            [global::WinRT.WinRTExposedType(typeof(WinRT.{{escapedAssemblyName}}CCWClasses.{{ccwClassName}}WinRTTypeDetails))]
+                            [global::WinRT.WinRTExposedType(typeof(global::WinRT.{{escapedAssemblyName}}VtableClasses.{{ccwClassName}}WinRTTypeDetails))]
                             partial class {{vtableAttribute.ClassName}}
                             {
                             }
@@ -908,7 +908,7 @@ namespace Generator
                         }
 
                         source.AppendLine($$"""
-                            [global::WinRT.WinRTExposedType(typeof(WinRT.{{escapedAssemblyName}}CCWClasses.{{ccwClassName}}WinRTTypeDetails))]
+                            [global::WinRT.WinRTExposedType(typeof(global::WinRT.{{escapedAssemblyName}}VtableClasses.{{ccwClassName}}WinRTTypeDetails))]
                             partial {{classHierarchy[0].GetTypeKeyword()}} {{classHierarchy[0].QualifiedName}}
                             {
                             }
@@ -926,7 +926,7 @@ namespace Generator
                         if (firstCCWClass)
                         {
                             ccwClassesSource.AppendLine($$""" 
-                            namespace WinRT.{{escapedAssemblyName}}CCWClasses
+                            namespace WinRT.{{escapedAssemblyName}}VtableClasses
                             {
                             """);
                             firstCCWClass = false;


### PR DESCRIPTION
Made changes to both the vtable lookup table and for the attribute vtable classes to reuse the generated code when possible.  In the first one, the ifs are now grouped together.  In the second one, the classes with the same vtable use the same attribute class.