### PR TITLE
Minor improvements to 'ExceptionHelpers.SetErrorInfo'

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -159,6 +159,11 @@ namespace WinRT
             return ComWrappers.GetOrRegisterObjectForComInstance(thisPtr, CreateObjectFlags.TrackerObject, obj);
         }
 
+        internal static IntPtr CreateCCWForObjectUnsafe(object obj)
+        {
+            return ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.TrackerSupport);
+        }
+
         public static IObjectReference CreateCCWForObject(object obj)
         {
             IntPtr ccw = ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.TrackerSupport);

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -388,8 +388,21 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                             hstring = IntPtr.Zero;
                         }
 
+#if NET
+                        IntPtr managedExceptionWrapper = ComWrappersSupport.CreateCCWForObjectUnsafe(ex);
+
+                        try
+                        {
+                            roOriginateLanguageException(GetHRForException(ex), hstring, managedExceptionWrapper);
+                        }
+                        finally
+                        {
+                            Marshal.Release(managedExceptionWrapper);
+                        }
+#else
                         using var managedExceptionWrapper = ComWrappersSupport.CreateCCWForObject(ex);
                         roOriginateLanguageException(GetHRForException(ex), hstring, managedExceptionWrapper.ThisPtr);
+#endif
                     }
                 }
             }

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -374,15 +374,15 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                         message = ex.GetType().FullName;
                     }
 
-                    IntPtr hstringHeader = IntPtr.Zero;
-                    IntPtr hstring = IntPtr.Zero;
+                    MarshalString.HSTRING_HEADER header = default;
+                    IntPtr hstring = default;
 
                     fixed (char* lpMessage = message)
                     {
                         if (Platform.WindowsCreateStringReference(
                             sourceString: (ushort*)lpMessage,
                             length: message.Length,
-                            hstring_header: &hstringHeader,
+                            hstring_header: (IntPtr*)&header,
                             hstring: &hstring) != 0)
                         {
                             hstring = IntPtr.Zero;

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -374,18 +374,23 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                         message = ex.GetType().FullName;
                     }
 
-                    IntPtr hstring;
+                    IntPtr hstringHeader = IntPtr.Zero;
+                    IntPtr hstring = IntPtr.Zero;
 
                     fixed (char* lpMessage = message)
                     {
-                        if (Platform.WindowsCreateString((ushort*)lpMessage, message.Length, &hstring) != 0)
+                        if (Platform.WindowsCreateStringReference(
+                            sourceString: (ushort*)lpMessage,
+                            length: message.Length,
+                            hstring_header: &hstringHeader,
+                            hstring: &hstring) != 0)
                         {
                             hstring = IntPtr.Zero;
                         }
-                    }
 
-                    using var managedExceptionWrapper = ComWrappersSupport.CreateCCWForObject(ex);
-                    roOriginateLanguageException(GetHRForException(ex), hstring, managedExceptionWrapper.ThisPtr);
+                        using var managedExceptionWrapper = ComWrappersSupport.CreateCCWForObject(ex);
+                        roOriginateLanguageException(GetHRForException(ex), hstring, managedExceptionWrapper.ThisPtr);
+                    }
                 }
             }
             else


### PR DESCRIPTION
This PR includes just a couple of tweaks to `ExceptionHelpers.SetErrorInfo`:
- Use `WindowsCreateStringReference`, since we can just pin the source text.
- Avoid allocating a temporary `IObjectReference` object.