### PR TITLE
Fix enum attribute argument.

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1283,10 +1283,12 @@ namespace Generator
                     encoder.Scalar().Constant(constant.Value);
                     break;
                 case TypedConstantKind.Enum:
-                    encoder.TaggedScalar(
-                        type => type.Enum(constant.Type.ToString()),
-                        scalar => scalar.Constant(constant.Value)
-                    );
+                    encoder.Scalar().Constant(constant.Value);
+
+                    //encoder.TaggedScalar(
+                    //    type => type.Enum(constant.Type.ToString()),
+                    //    scalar => scalar.Constant(constant.Value)
+                    //);
                     break;
                 case TypedConstantKind.Type:
                     encoder.Scalar().SystemType(constant.Type.ToString());

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1285,10 +1285,13 @@ namespace Generator
                 case TypedConstantKind.Enum:
                     encoder.Scalar().Constant(constant.Value);
 
-                    //encoder.TaggedScalar(
-                    //    type => type.Enum(constant.Type.ToString()),
-                    //    scalar => scalar.Constant(constant.Value)
-                    //);
+                    // This looks more correct, but the code above matches what the C# compiler produces.
+                    // Eg. win32metadata does the same (see 'MetadataUtils.EncodeHelpers' in https://github.com/microsoft/win32metadata).
+                    // encoder.TaggedScalar(
+                    //     type => type.Enum(constant.Type.ToString()),
+                    //     scalar => scalar.Constant(constant.Value)
+                    // );
+
                     break;
                 case TypedConstantKind.Type:
                     encoder.Scalar().SystemType(constant.Type.ToString());


### PR DESCRIPTION
Fixes #1825.

Even though `TaggedScalar` would look more correct, it looks like the actual C# compiler use `Scalar` instead. This is mentioned on win32metadata: https://github.com/microsoft/win32metadata/blob/527806d20d83d3abd43d16cd3fa8795d8deba343/sources/MetadataUtils/EncodeHelpers.cs#L125-L129