### PR TITLE
Fix types in attributes being projected as System.Type in WinMD.

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1294,7 +1294,7 @@ namespace Generator
 
                     break;
                 case TypedConstantKind.Type:
-                    encoder.Scalar().SystemType(constant.Type.ToString());
+                    encoder.Scalar().SystemType(constant.Value.ToString());
                     break;
                 case TypedConstantKind.Array:
                     {


### PR DESCRIPTION
Fixes #1570.

It looks like `Type` is used here as a mistake? Looking at the log, `Type` is always `System.Type`, whereas `Value` is the name of the actual type passed into the argument.

```
attribute: Windows.Foundation.Metadata.ExclusiveToAttribute(typeof(TestWinMD.DesktopActions))
attribute type: Windows.Foundation.Metadata.ExclusiveToAttribute
attribute constructor: Windows.Foundation.Metadata.ExclusiveToAttribute.ExclusiveToAttribute(System.Type)
atttribute # constructor arguments: 1
atttribute # named arguments: 0
add type: Windows.Foundation.Metadata.ExclusiveToAttribute
adding method reference: .ctor
custom mapping System.Type to System.Type from mscorlib
found # constructors: 1
typed constant kind: Type
typed constant type: System.Type
typed constant value: TestWinMD.DesktopActions
```