### PR TITLE
Add null checks to some 'Marshal.Release' calls

### DIFF
--- a/src/WinRT.Runtime/AgileReference.cs
+++ b/src/WinRT.Runtime/AgileReference.cs
@@ -146,7 +146,7 @@ namespace WinRT
             }
             finally
             {
-                Marshal.Release(gitPtr);
+                MarshalExtensions.ReleaseIfNotNull(gitPtr);
             }
         }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -647,10 +647,7 @@ namespace WinRT
             }
             finally
             {
-                if (ptr != IntPtr.Zero)
-                {
-                    Marshal.Release(ptr);
-                }
+                MarshalExtensions.ReleaseIfNotNull(ptr);
             }
         }
 

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -16,6 +16,21 @@ namespace WinRT
 {
     internal static class MarshalExtensions
     {
+        /// <summary>
+        /// Releases a COM object, if not <see langword="null"/>.
+        /// </summary>
+        /// <param name="pUnk">The input COM object to release.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void ReleaseIfNotNull(IntPtr pUnk)
+        {
+            if ((void*)pUnk == null)
+            {
+                return;
+            }
+
+            _ = ((delegate* unmanaged[Stdcall]<IntPtr, int>)(*(*(void***)pUnk + 2 /* IUnknown.Release slot */)))(pUnk);
+        }
+
         public static void Dispose(this GCHandle handle)
         {
             if (handle.IsAllocated)

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -101,7 +101,7 @@ namespace ABI.Windows.Foundation
             finally
             {
                 Marshaler<T>.DisposeAbiArray((__retval_length, __retval_data));
-                Marshal.Release(referenceArrayPtr);
+                MarshalExtensions.ReleaseIfNotNull(referenceArrayPtr);
             }
         }
 

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -157,7 +157,7 @@ namespace ABI.System.Collections.Specialized
             {
                 MarshalInterface<global::System.Collections.IList>.DisposeAbi(newItems);
                 MarshalInterface<global::System.Collections.IList>.DisposeAbi(oldItems);
-                Marshal.Release(thisPtr);
+                MarshalExtensions.ReleaseIfNotNull(thisPtr);
             }
         }
 

--- a/src/WinRT.Runtime/Projections/Nullable.cs
+++ b/src/WinRT.Runtime/Projections/Nullable.cs
@@ -417,7 +417,7 @@ namespace ABI.System
             }
             finally
             {
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
 
@@ -630,7 +630,7 @@ namespace ABI.System
             finally
             {
                 MarshalString.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1427,7 +1427,7 @@ namespace ABI.System
             finally
             {
                 DateTimeOffset.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1504,7 +1504,7 @@ namespace ABI.System
             finally
             {
                 TimeSpan.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1641,7 +1641,7 @@ namespace ABI.System
             finally
             {
                 Type.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1724,7 +1724,7 @@ namespace ABI.System
             finally
             {
                 Exception.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1784,7 +1784,7 @@ namespace ABI.System
             finally
             {
                 EventHandler.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1849,7 +1849,7 @@ namespace ABI.System
             finally
             {
                 global::ABI.System.ComponentModel.PropertyChangedEventHandler.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1914,7 +1914,7 @@ namespace ABI.System
             finally
             {
                 global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventHandler.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -1977,7 +1977,7 @@ namespace ABI.System
             finally
             {
                 Marshaler<T>.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -2039,7 +2039,7 @@ namespace ABI.System
             }
             finally
             {
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -2101,7 +2101,7 @@ namespace ABI.System
             }
             finally
             {
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -2129,7 +2129,7 @@ namespace ABI.System
             }
             finally
             {
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
     }
@@ -2387,7 +2387,7 @@ namespace ABI.System
             finally
             {
                 Marshaler<T>.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
 
@@ -2443,7 +2443,7 @@ namespace ABI.System
             finally
             {
                 Marshaler<T>.DisposeAbi(__retval);
-                Marshal.Release(nullablePtr);
+                MarshalExtensions.ReleaseIfNotNull(nullablePtr);
             }
         }
 


### PR DESCRIPTION
This PR adds some null checks to fix some incorrect COM releases that'd alter the correct exception and stack trace.