### PR TITLE
Add 'CsWinRTDynamicallyInterfaceCastableExclusiveTo'

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -244,6 +244,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CsWinRTEmbeddedProjection Condition="'$(CsWinRTEmbedded)' == 'true'">-embedded</CsWinRTEmbeddedProjection>
       <CsWinRTEmbeddedEnums Condition="'$(CsWinRTEmbeddedPublicEnums)' == 'true'">-public_enums</CsWinRTEmbeddedEnums>
       <CsWinRTPublicExclusiveTo Condition="'$(CsWinRTPublicExclusiveToInterfaces)' == 'true'">-public_exclusiveto</CsWinRTPublicExclusiveTo>
+      <CsWinRTDynamicallyInterfaceCastableExclusiveTo Condition="'$(CsWinRTDynamicallyInterfaceCastableExclusiveTo)' == 'true'">-idic_exclusiveto</CsWinRTDynamicallyInterfaceCastableExclusiveTo>
 
       <CsWinRTParams Condition="'$(CsWinRTParams)' == ''">
 $(CsWinRTCommandVerbosity)

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -257,6 +257,7 @@ $(CsWinRTIncludeWinRTInterop)
 $(CsWinRTEmbeddedProjection)
 $(CsWinRTEmbeddedEnums)
 $(CsWinRTPublicExclusiveTo)
+$(CsWinRTDynamicallyInterfaceCastableExclusiveTo)
       </CsWinRTParams>
 
       <CsWinRTPrivateParams Condition="'$(CsWinRTPrivateParams)' == ''">

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8092,7 +8092,7 @@ internal unsafe interface % : %
 %%%%}
 )",
 // Interface abi implementation
-            is_exclusive_to(type) ? "" : "[DynamicInterfaceCastableImplementation]",
+            is_exclusive_to(type) && !settings.idic_exclusiveto ? "" : "[DynamicInterfaceCastableImplementation]",
             bind<write_guid_attribute>(type),
             type_name,
             bind<write_type_name>(type, typedef_name_type::CCW, false),
@@ -8223,7 +8223,7 @@ AbiToProjectionVftablePtr = ComWrappersSupport.AllocateVtableMemory(typeof(@), s
             bind<write_interface_members>(type),
             "",
             [&](writer& w) {
-                if (!is_exclusive_to(type))
+                if (!is_exclusive_to(type) || settings.idic_exclusiveto)
                 {
                     for (auto required_interface : required_interfaces)
                     {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8075,10 +8075,11 @@ NativeMemory.Free((void*)abiToProjectionVftablePtr);
                 if (settings.idic_exclusiveto)
                 {
                     shouldOmitCcwCodegen = true;
-                    break;
                 }
-
-                w.write(R"(%
+                else
+                {
+                    // Otherwise, just write the minimal non-IDIC interface
+                    w.write(R"(%
 internal interface % : %
 {
 }
@@ -8086,7 +8087,9 @@ internal interface % : %
                     bind<write_guid_attribute>(type),
                     type_name,
                     bind<write_type_name>(type, typedef_name_type::CCW, false));
-                return true;
+                    
+                    return true;
+                }
             }
         }
 

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -41,6 +41,7 @@ namespace cswinrt
         { "embedded", 0, 0, {}, "Generates an embedded projection."},
         { "public_enums", 0, 0, {}, "Used with embedded option to generate enums as public"},
         { "public_exclusiveto", 0, 0, {}, "Make exclusiveto interfaces public in the projection (default is internal)"},
+        { "idic_exclusiveto", 0, 0, {}, "Make exclusiveto interfaces support IDIC for RCW scenarios (default is false)"},
         { "help", 0, option::no_max, {}, "Show detailed help" },
         { "?", 0, option::no_max, {}, {} },
     };
@@ -104,6 +105,7 @@ Where <spec> is one or more of:
         settings.embedded = args.exists("embedded");
         settings.public_enums = args.exists("public_enums");
         settings.public_exclusiveto = args.exists("public_exclusiveto");
+        settings.idic_exclusiveto = args.exists("idic_exclusiveto");
         settings.input = args.files("input", database::is_database);
 
         for (auto && include : args.values("include"))

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -41,7 +41,7 @@ namespace cswinrt
         { "embedded", 0, 0, {}, "Generates an embedded projection."},
         { "public_enums", 0, 0, {}, "Used with embedded option to generate enums as public"},
         { "public_exclusiveto", 0, 0, {}, "Make exclusiveto interfaces public in the projection (default is internal)"},
-        { "idic_exclusiveto", 0, 0, {}, "Make exclusiveto interfaces support IDIC for RCW scenarios (default is false)"},
+        { "idic_exclusiveto", 0, 0, {}, "Make exclusiveto interfaces support IDynamicInterfaceCastable (IDIC) for RCW scenarios (default is false)"},
         { "help", 0, option::no_max, {}, "Show detailed help" },
         { "?", 0, option::no_max, {}, {} },
     };

--- a/src/cswinrt/settings.h
+++ b/src/cswinrt/settings.h
@@ -19,6 +19,7 @@ namespace cswinrt
         bool embedded{};
         bool public_enums{};
         bool public_exclusiveto{};
+        bool idic_exclusiveto{};
     };
 
     extern settings_type settings;


### PR DESCRIPTION
This PR adds the "CsWinRTDynamicallyInterfaceCastableExclusiveTo" option, which allows generating IDIC supporting code for `[exclusive_to]` WinRT interfaces. This enables casting existing projected types to them and using their APIs normally.