### PR TITLE
Fix exception when using funcs and take another approach to escape assembly name

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -25,7 +25,7 @@ namespace Generator
                     provider.IsCsWinRTCcwLookupTableGeneratorEnabled())
                 );
 
-            var assemblyName = context.CompilationProvider.Select(static (compilation, _) => GeneratorHelper.EscapeTypeNameForIdentifier(compilation.AssemblyName));
+            var assemblyName = context.CompilationProvider.Select(static (compilation, _) => GeneratorHelper.EscapeAssemblyNameForIdentifier(compilation.AssemblyName));
 
             var propertiesAndAssemblyName = properties.Combine(assemblyName);
 
@@ -1107,7 +1107,7 @@ namespace Generator
 
             if (context.Node is InvocationExpressionSyntax invocation)
             {
-                var invocationSymbol = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol;
+                var invocationSymbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
                 if (invocationSymbol is IMethodSymbol methodSymbol &&
                     // Filter checks for boxing and casts to ones calling CsWinRT projected functions and
                     // functions within same assembly.  Functions within same assembly can take a boxed value

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -1060,6 +1060,11 @@ namespace Generator
             throw new ArgumentException();
         }
 
+        public static string EscapeAssemblyNameForIdentifier(string typeName)
+        {
+            return Regex.Replace(typeName, """[^a-zA-Z0-9_]""", "_");
+        }
+
         public static string EscapeTypeNameForIdentifier(string typeName)
         {
             return Regex.Replace(typeName, """[(\ |:<>,\.\-@;+'^!`)]""", "_");

--- a/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTAotCodeFixer.cs
@@ -136,7 +136,7 @@ namespace WinRT.SourceGenerator
 
                         if (context.Node is InvocationExpressionSyntax invocation)
                         {
-                            var invocationSymbol = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol;
+                            var invocationSymbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol;
                             if (invocationSymbol is IMethodSymbol methodSymbol)
                             {
                                 var taskAdapter = GeneratorHelper.GetTaskAdapterIfAsyncMethod(methodSymbol);

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -264,11 +264,22 @@ if (sum != 3)
     return 101;
 }
 
+// Testing to ensure no exceptions from any of the analyzers while building.
+Action<int, int> s = (a, b) => { _ = a + b; };
+ActionToFunction(s)(2, 3);
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));
 
 static bool AllEqual<T>(T[] x, params T[][] list) => list.All((y) => x.SequenceEqual(y));
+
+static Func<TA1, TA2, TA1> ActionToFunction<TA1, TA2>(Action<TA1, TA2> action) =>
+    (a1, a2) =>
+    {
+        action(a1, a2);
+        return a1;
+    };
 
 sealed partial class CustomClass : INotifyPropertyChanged
 {


### PR DESCRIPTION
- We were previously checking the nested expression to get the parameters.  This typically worked before unless it is a func and there was a nested invocation.  Fixed to not use the nested ones to get parameters.
- We previously tried to escape any invalid characters from the assembly name.  Given that seems to actually be trickier, change the approach to escape anything not on our valid list.