### PR TITLE
Support explicitly implementing 'ICustomPropertyProvider'

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -98,5 +98,9 @@
        name="AuthoringTest.TypeOnlyActivatableViaItsOwnFactory"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.CustomPropertyProviderWithExplicitImplementation"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/pch.h
+++ b/src/Tests/AuthoringConsumptionTest/pch.h
@@ -17,6 +17,7 @@
 #pragma pop_macro("X86")
 
 #include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Data.h>
 #include <winrt/Microsoft.UI.Xaml.Input.h>
 #include <winrt/Microsoft.UI.Xaml.Interop.h>
 #include <winrt/Microsoft.UI.Xaml.Markup.h>

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -746,3 +746,29 @@ TEST(AuthoringTest, TypeOnlyActivatableViaItsOwnFactory)
 {
     EXPECT_EQ(TypeOnlyActivatableViaItsOwnFactory::Create().GetText(), L"Hello!");
 }
+
+TEST(AuthoringTest, ExplicitlyImplementedICustomPropertyProvider)
+{
+    CustomPropertyProviderWithExplicitImplementation userObject;
+
+    // We should be able to cast to 'ICustomPropertyProvider'
+    auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
+
+    auto providerType = propertyProvider.Type();
+    EXPECT_EQ(providerType.Kind, Windows::UI::Xaml::Interop::TypeKind::Metadata);
+    EXPECT_EQ(providerType.Name, L"AuthoringTest.CustomPropertyProviderWithExplicitImplementation");
+
+    auto customProperty = propertyProvider.GetCustomProperty(L"TestCustomProperty");
+    
+    EXPECT_NE(customProperty, nullptr);
+    EXPECT_TRUE(customProperty.CanRead());
+    EXPECT_FALSE(customProperty.CanWrite());
+    EXPECT_EQ(customProperty.Name(), L"TestCustomProperty");
+
+    auto propertyType = customProperty.Type();
+    EXPECT_EQ(propertyType.Kind, Windows::UI::Xaml::Interop::TypeKind::Metadata);
+    EXPECT_EQ(propertyType.Name, L"AuthoringTest.CustomPropertyWithExplicitImplementation");
+
+    auto propertyValue = customProperty.GetValue(nullptr);
+    EXPECT_EQ(propertyValue, L"TestPropertyValue");
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -770,5 +770,5 @@ TEST(AuthoringTest, ExplicitlyImplementedICustomPropertyProvider)
     EXPECT_EQ(propertyType.Name, L"AuthoringTest.CustomPropertyWithExplicitImplementation");
 
     auto propertyValue = customProperty.GetValue(nullptr);
-    EXPECT_EQ(propertyValue, L"TestPropertyValue");
+    EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"TestPropertyValue");
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Markup;
 using System;
 using System.Collections;
@@ -204,6 +205,70 @@ namespace AuthoringTest
     {
         public int Number { get; } = 4;
         public string Value => "CsWinRT";
+    }
+
+    public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider
+    {
+        public Type Type => typeof(CustomPropertyProviderWithExplicitImplementation);
+
+        public ICustomProperty GetCustomProperty(string name)
+        {
+            if (name == "TestCustomProperty")
+            {
+                return new CustomPropertyWithExplicitImplementation();
+            }
+
+            return null;
+        }
+
+        public ICustomProperty GetIndexedProperty(string name, Type type)
+        {
+            return null;
+        }
+
+        public string GetStringRepresentation()
+        {
+            return string.Empty;
+        }
+    }
+
+    public sealed partial class CustomPropertyWithExplicitImplementation : ICustomProperty
+    {
+        internal CustomPropertyWithExplicitImplementation()
+        {
+        }
+
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public string Name => "TestCustomProperty";
+
+        public Type Type => typeof(CustomPropertyWithExplicitImplementation);
+
+        /// <inheritdoc />
+        public object GetIndexedValue(object target, object index)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public object GetValue(object target)
+        {
+            return "TestPropertyValue";
+        }
+
+        /// <inheritdoc />
+        public void SetIndexedValue(object target, object value, object index)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public void SetValue(object target, object value)
+        {
+            throw new NotSupportedException();
+        }
     }
 
     [Version(3u)]


### PR DESCRIPTION
This PR ensures that types explicitly implementing `ICustomPropertyProvider` work as expected:
- The user defined implementation is guaranteed to be picked
- No duplicated vtable entry is added

Also added some tests for this scenario.