### PR TITLE
Add .NET 9 target for WinRT.Runtime.dll

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
@@ -44,6 +44,21 @@ steps:
      
      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET8_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
 
+# Install .NET 9 SDK 
+- task: PowerShell@2
+  displayName: Install .NET 9 SDK
+  inputs:
+    targetType: inline
+    failOnStderr: true
+    script: |
+     Write-Host ##vso[task.setvariable variable=PATH;]${env:LocalAppData}\Microsoft\dotnet;${env:PATH}; 
+     
+     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 
+     
+     dotnet new globaljson --sdk-version "$($env:NET9_SDK_VERSION)" 
+     
+     &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET9_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
+
 # Verify .NET SDK
 - task: CmdLine@2
   displayName: Verify .NET SDK

--- a/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Benchmarks-Steps.yml
@@ -40,8 +40,6 @@ steps:
      
      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 
      
-     dotnet new globaljson --sdk-version "$($env:NET8_SDK_VERSION)" 
-     
      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET8_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
 
 # Install .NET 9 SDK 

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -62,8 +62,6 @@ steps:
      
      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 
      
-     dotnet new globaljson --sdk-version "$($env:NET8_SDK_VERSION)" 
-     
      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET8_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
 
 # Install .NET 9 SDK 

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -66,6 +66,21 @@ steps:
      
      &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET8_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
 
+# Install .NET 9 SDK 
+- task: PowerShell@2
+  displayName: Install .NET 9 SDK
+  inputs:
+    targetType: inline
+    failOnStderr: true
+    script: |
+     Write-Host ##vso[task.setvariable variable=PATH;]${env:LocalAppData}\Microsoft\dotnet;${env:PATH}; 
+     
+     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 
+     
+     dotnet new globaljson --sdk-version "$($env:NET9_SDK_VERSION)" 
+     
+     &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Version "$($env:NET9_SDK_VERSION)" -Architecture "x64" -AzureFeed "$($env:NET5_SDK_FEED)"
+
 # Verify .NET SDK
 - task: CmdLine@2
   displayName: Verify .NET SDK
@@ -297,6 +312,17 @@ steps:
       WinRT.Runtime.dll
       WinRT.Runtime.pdb
     TargetFolder: $(Build.ArtifactStagingDirectory)\release_net8.0
+
+# Stage Net9.0
+- task: CopyFiles@2
+  displayName: Stage Net9.0
+  condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+  inputs:
+    SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Runtime\bin\$(BuildConfiguration)\net9.0
+    Contents: |
+      WinRT.Runtime.dll
+      WinRT.Runtime.pdb
+    TargetFolder: $(Build.ArtifactStagingDirectory)\release_net9.0
 
 # Stage WinRT.Host.Shim
 - task: CopyFiles@2 

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -188,6 +188,11 @@ stages:
         condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
         targetPath: $(Build.ArtifactStagingDirectory)\release_net8.0
         artifactName: net8.0
+      - output: pipelineArtifact
+        displayName: 'Publish Net9.0'
+        condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+        targetPath: $(Build.ArtifactStagingDirectory)\release_net9.0
+        artifactName: net9.0
 
   - job: Benchmarks
     displayName: Run Benchmarks

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
@@ -65,7 +65,7 @@ stages:
         itemPattern: ''
         targetPath: $(Build.SourcesDirectory)\net8.0
 
-# Download Net8.0
+# Download Net9.0
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Net9.0'
       inputs:

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuget-Stage.yml
@@ -65,6 +65,14 @@ stages:
         itemPattern: ''
         targetPath: $(Build.SourcesDirectory)\net8.0
 
+# Download Net8.0
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Net9.0'
+      inputs:
+        artifactName: net9.0
+        itemPattern: ''
+        targetPath: $(Build.SourcesDirectory)\net9.0
+
 # Stage Binaries
     - task: CmdLine@2
       displayName: Stage Binaries
@@ -94,6 +102,7 @@ stages:
           netstandard2.0\roslyn4120\WinRT.SourceGenerator.dll
           net8.0\WinRT.Host.Shim.dll
           net8.0\WinRT.Runtime.dll
+          net9.0\WinRT.Runtime.dll
           release_x64\WinRT.Host.dll
           release_x64\WinRT.Host.dll.mui
           release_x86\WinRT.Host.dll
@@ -222,7 +231,7 @@ stages:
         command: pack
         searchPatternPack: nuget/Microsoft.Windows.CsWinRT.nuspec
         configurationToPack: Release
-        buildProperties: cswinrt_nuget_version=$(NugetVersion);cswinrt_exe=$(Build.SourcesDirectory)\cswinrt.exe;interop_winmd=$(Build.SourcesDirectory)\WinRT.Interop.winmd;netstandard2_runtime=$(Build.SourcesDirectory)\netstandard2.0\WinRT.Runtime.dll;net8_runtime=$(Build.SourcesDirectory)\net8.0\WinRT.Runtime.dll;source_generator_roslyn4080=$(Build.SourcesDirectory)\netstandard2.0\roslyn4080\WinRT.SourceGenerator.dll;source_generator_roslyn4120=$(Build.SourcesDirectory)\netstandard2.0\roslyn4120\WinRT.SourceGenerator.dll;winrt_shim=$(Build.SourcesDirectory)\net8.0\WinRT.Host.Shim.dll;winrt_host_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll;winrt_host_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll;winrt_host_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll;winrt_host_resource_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll.mui;winrt_host_resource_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll.mui;winrt_host_resource_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll.mui;guid_patch=$(Build.SourcesDirectory)\net8.0\IIDOptimizer\*.*
+        buildProperties: cswinrt_nuget_version=$(NugetVersion);cswinrt_exe=$(Build.SourcesDirectory)\cswinrt.exe;interop_winmd=$(Build.SourcesDirectory)\WinRT.Interop.winmd;netstandard2_runtime=$(Build.SourcesDirectory)\netstandard2.0\WinRT.Runtime.dll;net8_runtime=$(Build.SourcesDirectory)\net8.0\WinRT.Runtime.dll;net9_runtime=$(Build.SourcesDirectory)\net9.0\WinRT.Runtime.dll;source_generator_roslyn4080=$(Build.SourcesDirectory)\netstandard2.0\roslyn4080\WinRT.SourceGenerator.dll;source_generator_roslyn4120=$(Build.SourcesDirectory)\netstandard2.0\roslyn4120\WinRT.SourceGenerator.dll;winrt_shim=$(Build.SourcesDirectory)\net8.0\WinRT.Host.Shim.dll;winrt_host_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll;winrt_host_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll;winrt_host_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll;winrt_host_resource_x86=$(Build.SourcesDirectory)\release_x86\WinRT.Host.dll.mui;winrt_host_resource_x64=$(Build.SourcesDirectory)\release_x64\WinRT.Host.dll.mui;winrt_host_resource_arm64=$(Build.SourcesDirectory)\release_arm64\WinRT.Host.dll.mui;guid_patch=$(Build.SourcesDirectory)\net8.0\IIDOptimizer\*.*
 
     - task: NuGetCommand@2
       displayName: NuGet pack

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -13,7 +13,8 @@ variables:
 - name: Net8.SDK.Version
   value: '8.0.303'
 - name: Net9.SDK.Version
-  value: '9.0.100'
+  value: '9.0.201'
+
 - name: NoSamples
   value: 'false'
   
@@ -29,7 +30,8 @@ variables:
 - name: _DotNetRuntimeVersion
   value: $[coalesce(variables.DotNetRuntimeVersion, '8.0.303')]  
 - name: _DotNet9RuntimeVersion
-  value: $[coalesce(variables.DotNet9RuntimeVersion, '9.0.100')]  
+  value: $[coalesce(variables.DotNet9RuntimeVersion, '9.0.201')]  
+
 - name: _WindowsSdkVersionSuffix
   value: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '25')]  
 - name: _PublishCsWinMD

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -12,6 +12,8 @@ variables:
   value: 'https://dotnetcli.blob.core.windows.net/dotnet'
 - name: Net8.SDK.Version
   value: '8.0.303'
+- name: Net9.SDK.Version
+  value: '9.0.100'
 - name: NoSamples
   value: 'false'
   
@@ -26,6 +28,8 @@ variables:
   value: $[coalesce(variables.RunGCStress, 'false')]
 - name: _DotNetRuntimeVersion
   value: $[coalesce(variables.DotNetRuntimeVersion, '8.0.303')]  
+- name: _DotNet9RuntimeVersion
+  value: $[coalesce(variables.DotNet9RuntimeVersion, '9.0.100')]  
 - name: _WindowsSdkVersionSuffix
   value: $[coalesce(variables.WindowsSdkPackageVersionSuffix, '25')]  
 - name: _PublishCsWinMD

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -15,6 +15,7 @@
     <projectUrl>https://github.com/microsoft/cswinrt</projectUrl>
     <dependencies>
       <group targetFramework=".NET8.0" />
+      <group targetFramework=".NET9.0" />
     </dependencies>
   </metadata>
   <files>
@@ -31,12 +32,14 @@
     <file src="$interop_winmd$" target="metadata"/>
     <file src="readme.txt"/>
     <file src="$net8_runtime$" target="lib\net8.0\"/>
+    <file src="$net9_runtime$" target="lib\net9.0\"/>
     <file src="$source_generator_roslyn4080$" target="analyzers\dotnet\cs\roslyn4.8"/>
     <file src="$source_generator_roslyn4120$" target="analyzers\dotnet\cs\roslyn4.12"/>
     <file src="$winrt_host_x64$" target ="hosting\x64\native"/>
     <file src="$winrt_host_x86$" target ="hosting\x86\native"/>
     <file src="$winrt_host_arm64$" target ="hosting\arm64\native"/>
     <file src="$winrt_shim$" target ="lib\net8.0\"/>
+    <file src="$winrt_shim$" target ="lib\net9.0\"/>
 
     <!-- Localized resources for error strings 
          The paths here leads to a folder of folders, 
@@ -45,12 +48,13 @@
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\x64\native"/>
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\x86\native"/>
     <file src="..\src\Authoring\WinRT.Host\MUI\**" target ="hosting\arm64\native"/>
-    <file src="$winrt_host_resource_x64$" target ="hosting\x64\native\en-US"/>
-    <file src="$winrt_host_resource_x86$" target ="hosting\x86\native\en-US"/>
+    <file src="$winrt_host_resource_x64$"   target ="hosting\x64\native\en-US"/>
+    <file src="$winrt_host_resource_x86$"   target ="hosting\x86\native\en-US"/>
     <file src="$winrt_host_resource_arm64$" target ="hosting\arm64\native\en-US"/>
 
     <!-- Pack the .resx files for WinRT.Runtime for those using the embedded support -->
     <file src="..\src\WinRT.Runtime\ResX\**" target ="lib\net8.0\"/>
+    <file src="..\src\WinRT.Runtime\ResX\**" target ="lib\net9.0\"/>
 
     <!-- Add the WinRT.Runtime sources to the pkg for embedded scenarios -->
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,9 +28,9 @@
     <IsTargetFrameworkNet8OrGreater Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">true</IsTargetFrameworkNet8OrGreater>
     <AppBuildTFMs>netcoreapp3.1;net8.0</AppBuildTFMs>
     <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netcoreapp3.1;net8.0</AppBuildTFMs>
-    <LibBuildTFMs>netstandard2.0;net8.0</LibBuildTFMs>
+    <LibBuildTFMs>netstandard2.0;net8.0;net9.0</LibBuildTFMs>
     <LibBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netstandard2.0;net8.0</LibBuildTFMs>
-    <LibBuildTFMsNoNetStandard>net8.0</LibBuildTFMsNoNetStandard>
+    <LibBuildTFMsNoNetStandard>net8.0;net9.0</LibBuildTFMsNoNetStandard>
     <LibBuildTFMsNoNetStandard Condition="'$(CIBuildReason)' == 'CI'">net8.0</LibBuildTFMsNoNetStandard>
     <TestsBuildTFMs>net8.0-windows10.0.19041.0</TestsBuildTFMs>
     <TestsBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">net8.0-windows10.0.19041.0</TestsBuildTFMs>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,9 +29,9 @@
     <AppBuildTFMs>netcoreapp3.1;net8.0</AppBuildTFMs>
     <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netcoreapp3.1;net8.0</AppBuildTFMs>
     <LibBuildTFMs>netstandard2.0;net8.0;net9.0</LibBuildTFMs>
-    <LibBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netstandard2.0;net8.0</LibBuildTFMs>
+    <LibBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netstandard2.0;net8.0;net9.0</LibBuildTFMs>
     <LibBuildTFMsNoNetStandard>net8.0;net9.0</LibBuildTFMsNoNetStandard>
-    <LibBuildTFMsNoNetStandard Condition="'$(CIBuildReason)' == 'CI'">net8.0</LibBuildTFMsNoNetStandard>
+    <LibBuildTFMsNoNetStandard Condition="'$(CIBuildReason)' == 'CI'">net8.0;net9.0</LibBuildTFMsNoNetStandard>
     <TestsBuildTFMs>net8.0-windows10.0.19041.0</TestsBuildTFMs>
     <TestsBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">net8.0-windows10.0.19041.0</TestsBuildTFMs>
     <FunctionalTestsBuildTFMs>net8.0</FunctionalTestsBuildTFMs>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,6 +17,8 @@
 	
   <ItemGroup>
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
+    <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Windows" />
+    <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Xaml" />
   </ItemGroup>
 
   <Import Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(SimulateCsWinRTNugetReference)' == 'true'" Project="..\nuget\Microsoft.Windows.CsWinRT.targets" />

--- a/src/Samples/TestEmbedded/NetFrameworkApp/NetFrameworkApp.csproj
+++ b/src/Samples/TestEmbedded/NetFrameworkApp/NetFrameworkApp.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net47</TargetFramework>
     <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
@@ -36,6 +36,8 @@
     </ItemGroup>
     <ItemGroup>
         <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
+        <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Windows" />
+        <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Xaml" />
         <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
     </ItemGroup>
     <ItemGroup>

--- a/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
@@ -1,2 +1,0 @@
-Compat issues with assembly WinRT.Runtime:
-Total Issues: 0

--- a/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
@@ -3,4 +3,6 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.Gen
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.WinRTExposedTypeAttribute' in the contract but not the implementation.
 ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
 ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String, System.Guid)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
-Total Issues: 4
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.EventRegistrationTokenTable<T>' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.EventRegistrationTokenTable<T>' in the contract but not the implementation.
+Total Issues: 6

--- a/src/WinRT.Runtime/EventRegistrationTokenTable{T}.cs
+++ b/src/WinRT.Runtime/EventRegistrationTokenTable{T}.cs
@@ -65,10 +65,10 @@ namespace WinRT
         /// <param name="handler">The handler to add to the table.</param>
         /// <returns>The <see cref="EventRegistrationToken"/> value for the new handler.</returns>
         /// <remarks>
-        /// Handler can be registered multiple times, and they will use a different token each time.
-        /// If the input handler is <see langword="null"/>, the resulting token will be 0.
+        /// <para>Handler can be registered multiple times, and they will use a different token each time.</para>
+        /// <para>If the input handler is <see langword="null"/>, the resulting token will be 0.</para>
         /// </remarks>
-        public EventRegistrationToken AddEventHandler(T handler)
+        public EventRegistrationToken AddEventHandler(T? handler)
         {
             // Windows Runtime allows null handlers. Assign those the default token (token value 0) for simplicity
             if (handler is null)

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1092,7 +1092,7 @@ namespace WinRT
 
         public static new unsafe MarshalerArray CreateMarshalerArray(T[] array)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1108,7 +1108,12 @@ namespace WinRT
             {
                 int length = array.Length;
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var abi_element_size = Marshal.SizeOf(AbiType);
+                var abi_element_size =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                    Marshal.SizeOf(AbiType);
+#endif
 #pragma warning restore IL3050
                 var byte_length = length * abi_element_size;
                 m._array = Marshal.AllocCoTaskMem(byte_length);
@@ -1140,7 +1145,7 @@ namespace WinRT
 
         public static new unsafe T[] FromAbiArray(object box)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1158,10 +1163,20 @@ namespace WinRT
             var array = new T[abi.length];
             var data = (byte*)abi.data.ToPointer();
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            var abi_element_size = Marshal.SizeOf(AbiType);
+            var abi_element_size =
+#if NET9_0_OR_GREATER
+                RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                Marshal.SizeOf(AbiType);
+#endif
             for (int i = 0; i < abi.length; i++)
             {
-                var abi_element = Marshal.PtrToStructure((IntPtr)data, AbiType);
+                var abi_element =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.Box(ref *data, AbiType.TypeHandle);
+#else
+                    Marshal.PtrToStructure((IntPtr)data, AbiType);
+#endif
 #pragma warning restore IL3050
                 array[i] = Marshaler<T>.FromAbi(abi_element);
                 data += abi_element_size;
@@ -1171,7 +1186,7 @@ namespace WinRT
 
         public static unsafe void CopyAbiArray(T[] array, object box)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1184,10 +1199,20 @@ namespace WinRT
             }
             var data = (byte*)abi.data.ToPointer();
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            var abi_element_size = Marshal.SizeOf(AbiType);
+            var abi_element_size =
+#if NET9_0_OR_GREATER
+                RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                Marshal.SizeOf(AbiType);
+#endif
             for (int i = 0; i < abi.length; i++)
             {
-                var abi_element = Marshal.PtrToStructure((IntPtr)data, AbiType);
+                var abi_element =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.Box(ref *data, AbiType.TypeHandle);
+#else
+                    Marshal.PtrToStructure((IntPtr)data, AbiType);
+#endif
 #pragma warning restore IL3050
                 array[i] = Marshaler<T>.FromAbi(abi_element);
                 data += abi_element_size;
@@ -1196,7 +1221,7 @@ namespace WinRT
 
         public static new unsafe (int length, IntPtr data) FromManagedArray(T[] array)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1213,7 +1238,12 @@ namespace WinRT
             {
                 int length = array.Length;
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var abi_element_size = Marshal.SizeOf(AbiType);
+                var abi_element_size =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                    Marshal.SizeOf(AbiType);
+#endif
 #pragma warning restore IL3050
                 var byte_length = length * abi_element_size;
                 data = Marshal.AllocCoTaskMem(byte_length);
@@ -1237,7 +1267,7 @@ namespace WinRT
 
         public static unsafe void CopyManagedArray(T[] array, IntPtr data)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1254,7 +1284,12 @@ namespace WinRT
             {
                 int length = array.Length;
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-                var abi_element_size = Marshal.SizeOf(AbiType);
+                var abi_element_size =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                    Marshal.SizeOf(AbiType);
+#endif
 #pragma warning restore IL3050
                 var byte_length = length * abi_element_size;
                 var bytes = (byte*)data.ToPointer();
@@ -1278,7 +1313,7 @@ namespace WinRT
 
         public static unsafe void DisposeAbiArrayElements((int length, IntPtr data) abi)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1286,10 +1321,20 @@ namespace WinRT
 #endif
             var data = (byte*)abi.data.ToPointer();
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
-            var abi_element_size = Marshal.SizeOf(AbiType);
+            var abi_element_size =
+#if NET9_0_OR_GREATER
+                RuntimeHelpers.SizeOf(AbiType.TypeHandle);
+#else
+                Marshal.SizeOf(AbiType);
+#endif
             for (int i = 0; i < abi.length; i++)
             {
-                var abi_element = Marshal.PtrToStructure((IntPtr)data, AbiType);
+                var abi_element =
+#if NET9_0_OR_GREATER
+                    RuntimeHelpers.Box(ref *data, AbiType.TypeHandle);
+#else
+                    Marshal.PtrToStructure((IntPtr)data, AbiType);
+#endif
 #pragma warning restore IL3050
                 Marshaler<T>.DisposeAbi(abi_element);
                 data += abi_element_size;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
@@ -1,2 +1,0 @@
-Compat issues with assembly WinRT.Runtime:
-Total Issues: 0

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -6,4 +6,5 @@ TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory.ActivationHandler' in the implementation but not the reference.
-Total Issues: 7
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.EventRegistrationTokenTable<T>.AddEventHandler(T)' in the implementation but not the reference.
+Total Issues: 8

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -300,6 +300,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+            [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void InitRcwHelperFallbackIfNeeded()
@@ -1299,6 +1300,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -421,6 +421,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()
@@ -606,6 +607,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+            [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void InitRcwHelperFallbackIfNeeded()
@@ -1163,6 +1165,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -177,6 +177,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+            [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void InitRcwHelperFallbackIfNeeded()
@@ -1412,6 +1413,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -229,6 +229,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+            [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void InitRcwHelperFallbackIfNeeded()
@@ -1122,6 +1123,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -114,6 +114,7 @@ namespace ABI.Windows.Foundation.Collections
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitRcwHelperFallbackIfNeeded()
@@ -664,6 +665,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -80,6 +80,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+            [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void InitRcwHelperFallbackIfNeeded()
@@ -409,6 +410,7 @@ namespace ABI.System.Collections.Generic
 #endif
 #if NET
                 [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
+                [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = AttributeMessages.AbiTypesNeverHaveConstructors)]
 #endif
                 [MethodImpl(MethodImplOptions.NoInlining)]
                 static void InitFallbackCCWVTableIfNeeded()

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -60,9 +60,9 @@ namespace WinRT
                         int count = projectionTypeNameToBaseTypeNameMappings.Count;
                         for (int i = 0; i < count; i++)
                         {
-                            if (projectionTypeNameToBaseTypeNameMappings[i].ContainsKey(runtimeClassName))
+                            if (projectionTypeNameToBaseTypeNameMappings[i].TryGetValue(runtimeClassName, out string value))
                             {
-                                return FindRcwTypeByNameCached(projectionTypeNameToBaseTypeNameMappings[i][runtimeClassName]);
+                                return FindRcwTypeByNameCached(value);
                             }
                         }
 

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -26,6 +26,9 @@
     <!-- Set remote for source link. -->
     <AdoMirrorBuild Condition="'$(AdoMirrorBuild)' == ''">false</AdoMirrorBuild>
     <GitRepositoryRemoteName Condition="$(AdoMirrorBuild)">github</GitRepositoryRemoteName>
+
+    <!-- Suppress warnings for using 'ref' as 'in', to simplify multi-targeting -->
+    <NoWarn>$(NoWarn);CS9191</NoWarn>
   </PropertyGroup>
 	
   <!-- Configure the assembly version as needed -->

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -2,7 +2,7 @@
 if /i "%cswinrt_echo%" == "on" @echo on
 
 set CsWinRTBuildNetSDKVersion=8.0.303
-set CsWinRTBuildNet8SDKVersion=8.0.303
+set CsWinRTBuildNet9SDKVersion=9.0.100
 set this_dir=%~dp0
 
 :dotnet
@@ -23,16 +23,16 @@ powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
 -Version '%CsWinRTBuildNetSDKVersion%' -InstallDir '%DOTNET_ROOT(x86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
 -AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
-rem Install .NET 8 used to build projection
+rem Install .NET 9 used to build projection
 powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
--Version '%CsWinRTBuildNet8SDKVersion%' -InstallDir '%DOTNET_ROOT%' -Architecture 'x64' -DownloadTimeout %DownloadTimeout% ^
+-Version '%CsWinRTBuildNet9SDKVersion%' -InstallDir '%DOTNET_ROOT%' -Architecture 'x64' -DownloadTimeout %DownloadTimeout% ^
 -AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
 powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) ^
--Version '%CsWinRTBuildNet8SDKVersion%' -InstallDir '%DOTNET_ROOT(x86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
+-Version '%CsWinRTBuildNet9SDKVersion%' -InstallDir '%DOTNET_ROOT(x86)%' -Architecture 'x86' -DownloadTimeout %DownloadTimeout% ^
 -AzureFeed 'https://dotnetcli.blob.core.windows.net/dotnet'
 
 :globaljson
@@ -40,7 +40,7 @@ rem Create global.json for current .NET SDK, and with allowPrerelease=true
 set global_json=%this_dir%global.json
 echo { > %global_json%
 echo   "sdk": { >> %global_json%
-echo     "version": "%CsWinRTBuildNet8SDKVersion%", >> %global_json%
+echo     "version": "%CsWinRTBuildNet9SDKVersion%", >> %global_json%
 echo     "allowPrerelease": true >> %global_json%
 echo   } >> %global_json%
 echo } >> %global_json%
@@ -339,6 +339,7 @@ set cswinrt_exe=%cswinrt_bin_dir%cswinrt.exe
 set interop_winmd=%cswinrt_bin_dir%WinRT.Interop.winmd
 set netstandard2_runtime=%this_dir%WinRT.Runtime\bin\%cswinrt_configuration%\netstandard2.0\WinRT.Runtime.dll
 set net8_runtime=%this_dir%WinRT.Runtime\bin\%cswinrt_configuration%\net8.0\WinRT.Runtime.dll
+set net9_runtime=%this_dir%WinRT.Runtime\bin\%cswinrt_configuration%\net9.0\WinRT.Runtime.dll
 set source_generator_roslyn4080=%this_dir%Authoring\WinRT.SourceGenerator.Roslyn4080\bin\%cswinrt_configuration%\netstandard2.0\WinRT.SourceGenerator.dll
 set source_generator_roslyn4120=%this_dir%Authoring\WinRT.SourceGenerator.Roslyn4120\bin\%cswinrt_configuration%\netstandard2.0\WinRT.SourceGenerator.dll
 set winrt_host_%cswinrt_platform%=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Host\bin\WinRT.Host.dll
@@ -348,7 +349,7 @@ set guid_patch=%this_dir%Perf\IIDOptimizer\bin\%cswinrt_configuration%\net8.0\*.
 set cswinmd_outpath=%this_dir%Authoring\cswinmd\bin\%cswinrt_configuration%\net8.0
 rem Now call pack
 echo Creating nuget package
-call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinRT.nuspec -Properties cswinrt_exe=%cswinrt_exe%;interop_winmd=%interop_winmd%;netstandard2_runtime=%netstandard2_runtime%;net8_runtime=%net8_runtime%;source_generator_roslyn4080=%source_generator_roslyn4080%;source_generator_roslyn4120=%source_generator_roslyn4120%;cswinrt_nuget_version=%cswinrt_version_string%;winrt_host_x86=%winrt_host_x86%;winrt_host_x64=%winrt_host_x64%;winrt_host_arm=%winrt_host_arm%;winrt_host_arm64=%winrt_host_arm64%;winrt_host_resource_x86=%winrt_host_resource_x86%;winrt_host_resource_x64=%winrt_host_resource_x64%;winrt_host_resource_arm=%winrt_host_resource_arm%;winrt_host_resource_arm64=%winrt_host_resource_arm64%;winrt_shim=%winrt_shim%;guid_patch=%guid_patch% -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
+call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinRT.nuspec -Properties cswinrt_exe=%cswinrt_exe%;interop_winmd=%interop_winmd%;netstandard2_runtime=%netstandard2_runtime%;net8_runtime=%net8_runtime%;net9_runtime=%net9_runtime%;source_generator_roslyn4080=%source_generator_roslyn4080%;source_generator_roslyn4120=%source_generator_roslyn4120%;cswinrt_nuget_version=%cswinrt_version_string%;winrt_host_x86=%winrt_host_x86%;winrt_host_x64=%winrt_host_x64%;winrt_host_arm=%winrt_host_arm%;winrt_host_arm64=%winrt_host_arm64%;winrt_host_resource_x86=%winrt_host_resource_x86%;winrt_host_resource_x64=%winrt_host_resource_x64%;winrt_host_resource_arm=%winrt_host_resource_arm%;winrt_host_resource_arm64=%winrt_host_resource_arm64%;winrt_shim=%winrt_shim%;guid_patch=%guid_patch% -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
 call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinMD.nuspec -Properties cswinmd_outpath=%cswinmd_outpath%;source_generator_roslyn4080=%source_generator_roslyn4080%;cswinmd_nuget_version=%cswinrt_version_string%; -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
 goto :eof
 

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -2,7 +2,8 @@
 if /i "%cswinrt_echo%" == "on" @echo on
 
 set CsWinRTBuildNetSDKVersion=8.0.303
-set CsWinRTBuildNet9SDKVersion=9.0.100
+set CsWinRTBuildNet9SDKVersion=9.0.201
+
 set this_dir=%~dp0
 
 :dotnet

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -7699,6 +7699,7 @@ if (RuntimeFeature.IsDynamicCodeCompiled)
     [RequiresDynamicCode("Generic instantiations might not be available in AOT scenarios.")]
 #endif
     [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = "ABI types never have constructors.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = "ABI types never have constructors.")]
     [MethodImpl(MethodImplOptions.NoInlining)]
     static void @MethodsFallback()
     {
@@ -7908,6 +7909,9 @@ return true;
 
 private static global::System.Delegate[] DelegateCache;
 
+#if NET8_0_OR_GREATER
+[RequiresDynamicCode("The necessary marshalling code or generic instantiations might not be available.")]
+#endif
 internal static unsafe void InitFallbackCCWVtable()
 {
 %
@@ -8176,6 +8180,7 @@ if (RuntimeFeature.IsDynamicCodeCompiled)
     [RequiresDynamicCode("Generic instantiations might not be available in AOT scenarios.")]
 #endif
     [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = "ABI types never have constructors.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2081", Justification = "ABI types never have constructors.")]
     [MethodImpl(MethodImplOptions.NoInlining)]
     static void @Fallback()
     {


### PR DESCRIPTION
This PR includes the following changes:
- Enables building CsWinRT with .NET 9 locally
- Fixes some new trim warnings
- Makes `MarshalNonBlittable` work on AOT