### PR TITLE
Add GC.KeepAlive when doing ABI call

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -126,6 +126,16 @@ stages:
           set CIBuildReason=CI
           set cswinrt_label=functionaltest
           build.cmd $(BuildPlatform) $(BuildConfiguration) $(VersionNumber) $(Build.BuildNumber) $(WinRT.Runtime.AssemblyVersion) 
+
+# Disable GC stress
+    - task: PowerShell@2
+      displayName: Disable GC Stress
+      condition: and(succeeded(), eq(variables['_RunGCStress'], 'true'))
+      inputs:
+        targetType: inline
+        script: |
+          Write-Host "##vso[task.setvariable variable=DOTNET_GCStress;]0x0"
+
     templateContext:
       outputs:
       - output: pipelineArtifact

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage.yml
@@ -43,6 +43,15 @@ stages:
           Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$env:LOCALAPPDATA\Microsoft\dotnet\"
           Write-Host "##vso[task.setvariable variable=DOTNET_ROOT(x86);]$env:LOCALAPPDATA\Microsoft\dotnet\x86\"
 
+# Enable GC stress
+    - task: PowerShell@2
+      displayName: Enable GC Stress
+      condition: and(succeeded(), eq(variables['_RunGCStress'], 'true'))
+      inputs:
+        targetType: inline
+        script: |
+          Write-Host "##vso[task.setvariable variable=DOTNET_GCStress;]0xC"
+
 # Run Unit Tests
     - task: DotNetCoreCLI@2
       displayName: Run Unit Tests

--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -24,6 +24,8 @@ variables:
   value: $[coalesce(variables.IsRelease, '')]
 - name: _RunBenchmarks
   value: $[coalesce(variables.RunBenchmarks, 'false')]
+- name: _RunGCStress
+  value: $[coalesce(variables.RunGCStress, 'false')]
 - name: _DotNetRuntimeVersion
   value: $[coalesce(variables.DotNetRuntimeVersion, '6.0.32')]  
 - name: _WindowsSdkVersionSuffix

--- a/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
+++ b/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
@@ -1029,6 +1029,7 @@ namespace Generator
                          IntPtr abiSender = MarshalInspectable<object>.GetAbi(__sender);
                          {{GeneratorHelper.GetCreateMarshaler(genericType, abiType, typeKind, "args")}}
                          global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, {{abiType}}, int>**)ThisPtr)[3](ThisPtr, abiSender, {{GeneratorHelper.GetAbiFromMarshaler(genericType, abiType, typeKind, "args")}}));
+                         global::System.GC.KeepAlive(objRef);
                      }
                      finally
                      {
@@ -1086,6 +1087,7 @@ namespace Generator
                          {{GeneratorHelper.GetCreateMarshaler(genericParameters[0], "sender")}}
                          {{GeneratorHelper.GetCreateMarshaler(genericParameters[1], "args")}}
                          global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, {{genericParameters[0].AbiType}}, {{genericParameters[1].AbiType}}, int>**)ThisPtr)[3](ThisPtr, {{GeneratorHelper.GetAbiFromMarshaler(genericParameters[0], "sender")}}, {{GeneratorHelper.GetAbiFromMarshaler(genericParameters[1], "args")}}));
+                         global::System.GC.KeepAlive(objRef);
                      }
                      finally
                      {
@@ -1218,6 +1220,7 @@ namespace Generator
                          IntPtr abiAsyncInfo = MarshalInspectable<object>.GetAbi(__asyncInfo);
                          {{GeneratorHelper.GetCreateMarshaler(progressParameter.ProjectedType, progressParameter.AbiType, progressParameter.TypeKind, "progressInfo")}}
                          global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, {{progressParameter.AbiType}}, int>**)ThisPtr)[3](ThisPtr, abiAsyncInfo, {{GeneratorHelper.GetAbiFromMarshaler(progressParameter.ProjectedType, progressParameter.AbiType, progressParameter.TypeKind, "progressInfo")}}));
+                         global::System.GC.KeepAlive(objRef);
                      }
                      finally
                      {

--- a/src/Tests/OOPExe/Program.cs
+++ b/src/Tests/OOPExe/Program.cs
@@ -24,7 +24,7 @@ namespace OOPExe
             var asyncAction = MarshalInterface<IAsyncAction>.FromAbi(Marshal.GetIUnknownForObject(obj));
             asyncAction.Completed = Completed;
 
-            done.WaitOne(8000);
+            done.WaitOne(15000);
 
             GC.KeepAlive(asyncAction);
         }

--- a/src/Tests/OOPExe/Program.cs
+++ b/src/Tests/OOPExe/Program.cs
@@ -24,7 +24,7 @@ namespace OOPExe
             var asyncAction = MarshalInterface<IAsyncAction>.FromAbi(Marshal.GetIUnknownForObject(obj));
             asyncAction.Completed = Completed;
 
-            done.WaitOne(5000);
+            done.WaitOne(8000);
 
             GC.KeepAlive(asyncAction);
         }

--- a/src/Tests/OOPExe/Program.cs
+++ b/src/Tests/OOPExe/Program.cs
@@ -24,7 +24,7 @@ namespace OOPExe
             var asyncAction = MarshalInterface<IAsyncAction>.FromAbi(Marshal.GetIUnknownForObject(obj));
             asyncAction.Completed = Completed;
 
-            done.WaitOne(15000);
+            done.WaitOne(30000);
 
             GC.KeepAlive(asyncAction);
         }

--- a/src/Tests/OOPExe/Program.cs
+++ b/src/Tests/OOPExe/Program.cs
@@ -25,6 +25,8 @@ namespace OOPExe
             asyncAction.Completed = Completed;
 
             done.WaitOne(5000);
+
+            GC.KeepAlive(asyncAction);
         }
 
         public static void Completed(IAsyncAction asyncInfo, AsyncStatus asyncStatus)

--- a/src/Tests/OOPExe/Program.cs
+++ b/src/Tests/OOPExe/Program.cs
@@ -24,9 +24,11 @@ namespace OOPExe
             var asyncAction = MarshalInterface<IAsyncAction>.FromAbi(Marshal.GetIUnknownForObject(obj));
             asyncAction.Completed = Completed;
 
-            done.WaitOne(30000);
-
-            GC.KeepAlive(asyncAction);
+            if (done.WaitOne(20000))
+            {
+                // Allow Completed handler to finish.
+                Thread.Sleep(5000);
+            }
         }
 
         public static void Completed(IAsyncAction asyncInfo, AsyncStatus asyncStatus)

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2043,7 +2043,7 @@ namespace UnitTest
             var task = InvokeAddAsync(42, 8);
             Assert.False(task.Wait(25));
             TestObject.CompleteAsync();
-            Assert.True(task.Wait(5000) || task.Status == TaskStatus.RanToCompletion);
+            Assert.True(task.Wait(10000));
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
             Assert.Equal(50, task.Result);
 
@@ -3262,7 +3262,7 @@ namespace UnitTest
             var launchExePath = $"{currentExecutingDir}\\OOPExe.dll";
             var proc = Process.Start("dotnet.exe", launchExePath);
 #endif
-            Thread.Sleep(3000);
+            Thread.Sleep(5000);
             obj.Close();
             Assert.True(obj.delegateCalled);
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2043,7 +2043,7 @@ namespace UnitTest
             var task = InvokeAddAsync(42, 8);
             Assert.False(task.Wait(25));
             TestObject.CompleteAsync();
-            Assert.True(task.Wait(5000), task.Status + " -  " + task.Exception);
+            Assert.True(task.Wait(5000) || task.Status == TaskStatus.RanToCompletion);
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
             Assert.Equal(50, task.Result);
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2043,7 +2043,7 @@ namespace UnitTest
             var task = InvokeAddAsync(42, 8);
             Assert.False(task.Wait(25));
             TestObject.CompleteAsync();
-            Assert.True(task.Wait(5000));
+            Assert.True(task.Wait(5000), task.Status + " -  " + task.Exception);
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
             Assert.Equal(50, task.Result);
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3262,7 +3262,7 @@ namespace UnitTest
             var launchExePath = $"{currentExecutingDir}\\OOPExe.dll";
             var proc = Process.Start("dotnet.exe", launchExePath);
 #endif
-            Thread.Sleep(1000);
+            Thread.Sleep(3000);
             obj.Close();
             Assert.True(obj.delegateCalled);
 

--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -159,6 +159,7 @@ namespace WinRT
             {
                 IntPtr thisPtr = ThisPtr;
                 var hr = ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)(*(void***)thisPtr)[4])(thisPtr, &__retval);
+                GC.KeepAlive(_obj);
                 if (hr != 0)
                 {
                     if (noThrow)

--- a/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
@@ -120,6 +120,7 @@ namespace ABI.WinRT.Interop
 #else
                         ExceptionHelpers.ThrowExceptionForHR(_addHandler(_objectReference.ThisPtr, nativeDelegate, out token));
 #endif
+                        global::System.GC.KeepAlive(_objectReference);
                         state.token = token;
                     }
                     finally
@@ -157,6 +158,7 @@ namespace ABI.WinRT.Interop
         private void UnsubscribeFromNative(EventSourceState<TDelegate> state)
         {
             ExceptionHelpers.ThrowExceptionForHR(_removeHandler(_objectReference.ThisPtr, state.token));
+            global::System.GC.KeepAlive(_objectReference);
             state.Dispose();
             _state = null;
         }

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -42,6 +42,7 @@ namespace ABI.WinRT.Interop
             IntPtr ptr = IntPtr.Zero;
             ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
                 ThisPtr, &riid, &ptr));
+            global::System.GC.KeepAlive(_obj);
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(ptr, riid, requireQI: false);
@@ -60,6 +61,7 @@ namespace ABI.WinRT.Interop
             IntPtr ptr = IntPtr.Zero;
             ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
                 ThisPtr, &riid, &ptr));
+            global::System.GC.KeepAlive(_obj);
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr, riid, requireQI: false);
@@ -139,6 +141,7 @@ namespace ABI.WinRT.Interop
             IntPtr thisPtr = ThisPtr;
             IntPtr cookie;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr*, int>)(*(void***)thisPtr)[3])(thisPtr, ptr, &riid, &cookie));
+            global::System.GC.KeepAlive(_obj);
             return cookie;
 
         }
@@ -147,6 +150,7 @@ namespace ABI.WinRT.Interop
         {
             IntPtr thisPtr = ThisPtr;
             int hresult = ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)(*(void***)thisPtr)[4])(thisPtr, cookie);
+            global::System.GC.KeepAlive(_obj);
 
             if (hresult == ExceptionHelpers.E_INVALIDARG)
             {
@@ -164,6 +168,8 @@ namespace ABI.WinRT.Interop
             IntPtr thisPtr = ThisPtr;
             IntPtr ptr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr*, int>)(*(void***)thisPtr)[5])(thisPtr, cookie, &riid, &ptr));
+            global::System.GC.KeepAlive(_obj);
+
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(ptr, riid, requireQI: false);

--- a/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.netstandard2.0.cs
@@ -51,6 +51,8 @@ namespace ABI.WinRT.Interop
             IntPtr ptr = IntPtr.Zero;
             ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
                 ThisPtr, &riid, &ptr));
+            global::System.GC.KeepAlive(_obj);
+
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(ptr, riid, requireQI: false);
@@ -69,6 +71,8 @@ namespace ABI.WinRT.Interop
             IntPtr ptr = IntPtr.Zero;
             ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](
                 ThisPtr, &riid, &ptr));
+            global::System.GC.KeepAlive(_obj);
+
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface<T>(ptr, riid, requireQI: false);
@@ -231,6 +235,7 @@ namespace ABI.WinRT.Interop
         public IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid)
         {
             ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RegisterInterfaceInGlobal(ThisPtr, ptr, ref riid, out IntPtr cookie));
+            global::System.GC.KeepAlive(_obj);
             return cookie;
 
         }
@@ -238,11 +243,13 @@ namespace ABI.WinRT.Interop
         public void RevokeInterfaceFromGlobal(IntPtr cookie)
         {
             ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RevokeInterfaceFromGlobal(ThisPtr, cookie));
+            global::System.GC.KeepAlive(_obj);
         }
 
         public IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid)
         {
             ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInterfaceFromGlobal(ThisPtr, cookie, ref riid, out IntPtr ptr));
+            global::System.GC.KeepAlive(_obj);
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(ptr, riid, requireQI: false);

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -123,6 +123,7 @@ namespace ABI.WinRT.Interop
         {
             var callback = Marshal.GetFunctionPointerForDelegate(pfnCallback);
             var result = _obj.Vftbl.ContextCallback_4(ThisPtr, callback, pParam, &riid, iMethod, IntPtr.Zero);
+            GC.KeepAlive(_obj);
             GC.KeepAlive(pfnCallback);
             Marshal.ThrowExceptionForHR(result);
         }

--- a/src/WinRT.Runtime/Interop/IMarshal.net5.cs
+++ b/src/WinRT.Runtime/Interop/IMarshal.net5.cs
@@ -216,36 +216,42 @@ namespace ABI.WinRT.Interop
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr, MSHCTX, IntPtr, MSHLFLAGS, Guid*, int>)(*(void***)thisPtr)[3])(thisPtr, riid, pv, dwDestContext, pvDestContext, mshlFlags, pCid));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void GetMarshalSizeMax(Guid* riid, IntPtr pv, MSHCTX dwDestContext, IntPtr pvDestContext, MSHLFLAGS mshlflags, uint* pSize)
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr, MSHCTX, IntPtr, MSHLFLAGS, uint*, int>)(*(void***)thisPtr)[4])(thisPtr, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void MarshalInterface(IntPtr pStm, Guid* riid, IntPtr pv, MSHCTX dwDestContext, IntPtr pvDestContext, MSHLFLAGS mshlflags)
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr, MSHCTX, IntPtr, MSHLFLAGS, int>)(*(void***)thisPtr)[5])(thisPtr, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void UnmarshalInterface(IntPtr pStm, Guid* riid, IntPtr* ppv)
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr*, int>)(*(void***)thisPtr)[6])(thisPtr, pStm, riid, ppv));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void ReleaseMarshalData(IntPtr pStm)
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)(*(void***)thisPtr)[7])(thisPtr, pStm));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void DisconnectObject(uint dwReserved)
         {
             IntPtr thisPtr = ThisPtr;
             Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, uint, int>)(*(void***)thisPtr)[8])(thisPtr, dwReserved));
+            GC.KeepAlive(_obj);
         }
     }
 }

--- a/src/WinRT.Runtime/Interop/IMarshal.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IMarshal.netstandard2.0.cs
@@ -283,31 +283,37 @@ namespace ABI.WinRT.Interop
         public unsafe void GetUnmarshalClass(Guid* riid, IntPtr pv, global::WinRT.Interop.MSHCTX dwDestContext, IntPtr pvDestContext, global::WinRT.Interop.MSHLFLAGS mshlFlags, Guid* pCid)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.GetUnmarshalClass_0(ThisPtr, riid, pv, dwDestContext, pvDestContext, mshlFlags, pCid));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void GetMarshalSizeMax(Guid* riid, IntPtr pv, global::WinRT.Interop.MSHCTX dwDestContext, IntPtr pvDestContext, global::WinRT.Interop.MSHLFLAGS mshlflags, uint* pSize)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.GetMarshalSizeMax_1(ThisPtr, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void MarshalInterface(IntPtr pStm, Guid* riid, IntPtr pv, global::WinRT.Interop.MSHCTX dwDestContext, IntPtr pvDestContext, global::WinRT.Interop.MSHLFLAGS mshlflags)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.MarshalInterface_2(ThisPtr, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void UnmarshalInterface(IntPtr pStm, Guid* riid, IntPtr* ppv)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.UnmarshalInterface_3(ThisPtr, pStm, riid, ppv));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void ReleaseMarshalData(IntPtr pStm)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.ReleaseMarshalData_4(ThisPtr, pStm));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void DisconnectObject(uint dwReserved)
         {
             Marshal.ThrowExceptionForHR(_obj.Vftbl.DisconnectObject_5(ThisPtr, dwReserved));
+            GC.KeepAlive(_obj);
         }
     }
 

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -97,6 +97,7 @@ namespace ABI.WinRT.Interop
             try
             {
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[3](ThisPtr, &objRef));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::WinRT.Interop.IWeakReference>.FromAbi(objRef);
             }
             finally
@@ -185,6 +186,7 @@ namespace ABI.WinRT.Interop
 
             IntPtr objRef;
             ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>**)ThisPtr)[3](ThisPtr, &riid, &objRef));
+            GC.KeepAlive(_obj);
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(objRef, riid, requireQI: false);

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.netstandard2.0.cs
@@ -121,6 +121,7 @@ namespace ABI.WinRT.Interop
             try
             {
                 ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetWeakReference(ThisPtr, out objRef));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<WinRT.Interop.IWeakReference>.FromAbi(objRef);
             }
             finally
@@ -193,6 +194,7 @@ namespace ABI.WinRT.Interop
         public IObjectReference Resolve(Guid riid)
         {
             ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Resolve(ThisPtr, ref riid, out IntPtr objRef));
+            GC.KeepAlive(_obj);
             try
             {
                 return ComWrappersSupport.GetObjectReferenceForInterface(objRef, riid, requireQI: false);

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -166,6 +166,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             var ThisPtr = _obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[8](ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval != 0;
         }
 
@@ -185,6 +186,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, &__retval));
+                    GC.KeepAlive(_obj);
                     return MarshalInspectable<object>.FromAbi(__retval);
                 }
                 finally
@@ -202,6 +204,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 var ThisPtr = _obj.ThisPtr;
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }
@@ -307,6 +310,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr*, int>**)ThisPtr)[6](ThisPtr, index, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
@@ -330,6 +334,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                     MarshalInspectable<object>.GetAbi(__value),
                     &__index,
                     &__retval));
+                GC.KeepAlive(_obj);
                 index = __index;
                 return __retval != 0;
             }
@@ -347,6 +352,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 var ThisPtr = _obj.ThisPtr;
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }
@@ -588,6 +594,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Microsoft.UI.Xaml.Interop.IBindableIterator>.FromAbi(__retval);
             }
             finally
@@ -1296,6 +1303,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr*, int>**)ThisPtr)[6](ThisPtr, index, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
@@ -1312,6 +1320,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[8](ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>.FromAbi(__retval);
             }
             finally
@@ -1331,6 +1340,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, uint*, byte*, int>**)ThisPtr)[9](ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
+                GC.KeepAlive(_obj);
                 index = __index;
                 return __retval != 0;
             }
@@ -1349,6 +1359,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr, int>**)ThisPtr)[10](ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1365,6 +1376,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr, int>**)ThisPtr)[11](ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1377,6 +1389,7 @@ namespace ABI.System.Collections
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
             var ThisPtr = _obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, int>**)ThisPtr)[12](ThisPtr, index));
+            GC.KeepAlive(_obj);
         }
 
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.Append(object value)
@@ -1388,6 +1401,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)ThisPtr)[13](ThisPtr, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1400,6 +1414,7 @@ namespace ABI.System.Collections
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
             var ThisPtr = _obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[14](ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.Clear()
@@ -1407,6 +1422,7 @@ namespace ABI.System.Collections
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
             var ThisPtr = _obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[15](ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         unsafe uint global::Microsoft.UI.Xaml.Interop.IBindableVector.Size
@@ -1417,6 +1433,7 @@ namespace ABI.System.Collections
                 var ThisPtr = _obj.ThisPtr;
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.netstandard2.0.cs
@@ -189,6 +189,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
         {
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.MoveNext_2(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval != 0;
         }
 
@@ -200,6 +201,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Current_0(ThisPtr, &__retval));
+                    GC.KeepAlive(_obj);
                     return MarshalInspectable<object>.FromAbi(__retval);
                 }
                 finally
@@ -215,6 +217,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             {
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_HasCurrent_1(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }
@@ -355,6 +358,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
@@ -372,6 +376,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_2(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
+                GC.KeepAlive(_obj);
                 index = __index;
                 return __retval != 0;
             }
@@ -387,6 +392,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }
@@ -545,6 +551,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.First_0(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Microsoft.UI.Xaml.Interop.IBindableIterator>.FromAbi(__retval);
             }
             finally
@@ -1256,6 +1263,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetAt_0(ThisPtr, index, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally
@@ -1270,6 +1278,7 @@ namespace ABI.System.Collections
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetView_2(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Microsoft.UI.Xaml.Interop.IBindableVectorView>.FromAbi(__retval);
             }
             finally
@@ -1287,6 +1296,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.IndexOf_3(ThisPtr, MarshalInspectable<object>.GetAbi(__value), &__index, &__retval));
+                GC.KeepAlive(_obj);
                 index = __index;
                 return __retval != 0;
             }
@@ -1303,6 +1313,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.SetAt_4(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1317,6 +1328,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.InsertAt_5(ThisPtr, index, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1327,6 +1339,7 @@ namespace ABI.System.Collections
         public unsafe void RemoveAt(uint index)
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RemoveAt_6(ThisPtr, index));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void Append(object value)
@@ -1336,6 +1349,7 @@ namespace ABI.System.Collections
             {
                 __value = MarshalInspectable<object>.CreateMarshaler2(value);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Append_7(ThisPtr, MarshalInspectable<object>.GetAbi(__value)));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -1346,11 +1360,13 @@ namespace ABI.System.Collections
         public unsafe void RemoveAtEnd()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RemoveAtEnd_8(ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void _Clear()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Clear_9(ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe uint Size
@@ -1359,6 +1375,7 @@ namespace ABI.System.Collections
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -55,6 +55,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 fixed (void* ___name = __name)
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(ref __name), &__retval));
+                    GC.KeepAlive(_obj);
                     return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
                 }
             }
@@ -71,6 +72,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             fixed (void* ___name = __name)
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateInstance_0(ThisPtr, MarshalString.GetAbi(ref __name), &__retval));
+                GC.KeepAlive(_obj);
                 return new ObjectReferenceValue(__retval);
             }
         }

--- a/src/WinRT.Runtime/Projections/EventHandler.cs
+++ b/src/WinRT.Runtime/Projections/EventHandler.cs
@@ -253,6 +253,8 @@ namespace ABI.System
                         __args = Marshaler<T>.CreateMarshaler2(args);
                         __params[2] = Marshaler<T>.GetAbi(__args);
                         abiInvoke.DynamicInvokeAbi(__params);
+                        GC.KeepAlive(_nativeDelegate);
+                        GC.KeepAlive(__params);
                     }
                     finally
                     {
@@ -422,6 +424,7 @@ namespace ABI.System
                         ThisPtr,
                         MarshalInspectable<object>.GetAbi(__sender),
                         MarshalInspectable<EventArgs>.GetAbi(__args)));
+                    GC.KeepAlive(_nativeDelegate);
                 }
                 finally
                 {

--- a/src/WinRT.Runtime/Projections/ICommand.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.net5.cs
@@ -30,6 +30,7 @@ namespace ABI.System.Windows.Input
             {
                 __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, byte*, int>**)ThisPtr)[8](ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), &__retval));
+                GC.KeepAlive(obj);
                 return __retval != 0;
             }
             finally
@@ -46,6 +47,7 @@ namespace ABI.System.Windows.Input
             {
                 __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)ThisPtr)[9](ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
+                GC.KeepAlive(obj);
             }
             finally
             {

--- a/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/ICommand.netstandard2.0.cs
@@ -162,6 +162,7 @@ namespace ABI.System.Windows.Input
             {
                 __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CanExecute_2(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter), out __retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
             finally
@@ -177,6 +178,7 @@ namespace ABI.System.Windows.Input
             {
                 __parameter = MarshalInspectable<object>.CreateMarshaler2(parameter);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Execute_3(ThisPtr, MarshalInspectable<object>.GetAbi(__parameter)));
+                GC.KeepAlive(_obj);
             }
             finally
             {

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -198,6 +198,7 @@ namespace ABI.Windows.Foundation.Collections
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[9](ThisPtr, &__retval));
+                    GC.KeepAlive(obj);
                     return MarshalInterface<global::System.Collections.Generic.IReadOnlyDictionary<K, V>>.FromAbi(__retval);
                 }
                 finally
@@ -226,6 +227,7 @@ namespace ABI.Windows.Foundation.Collections
         {
             var ThisPtr = obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[12](ThisPtr));
+            GC.KeepAlive(obj);
         }
 
         public static unsafe uint get_Size(IObjectReference obj)
@@ -233,6 +235,7 @@ namespace ABI.Windows.Foundation.Collections
             var ThisPtr = obj.ThisPtr;
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval;
         }
     }
@@ -764,6 +767,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 DelegateHelper.Get(obj).Lookup.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 return Marshaler<V>.FromAbi(valueAbi);
             }
             finally
@@ -787,6 +792,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 DelegateHelper.Get(obj).HasKey.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 return found != 0;
             }
             finally
@@ -812,6 +819,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<V>.CreateMarshaler2(value);
                 __params[2] = Marshaler<V>.GetAbi(__value);
                 DelegateHelper.Get(obj).Insert.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 return replaced != 0;
             }
             finally
@@ -834,6 +843,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 DelegateHelper.Get(obj).Remove.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
             }
             finally
             {

--- a/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.netstandard2.0.cs
@@ -736,6 +736,7 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return Marshaler<V>.FromAbi(__params[2]);
             }
             finally
@@ -754,6 +755,7 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return (byte)__params[2] != 0;
             }
             finally
@@ -768,6 +770,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetView_3(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__retval);
             }
             finally
@@ -788,6 +791,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<V>.CreateMarshaler2(value);
                 __params[2] = Marshaler<V>.GetAbi(__value);
                 _obj.Vftbl.Insert_4.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
+                GC.KeepAlive(__params);
                 return (byte)__params[3] != 0;
             }
             finally
@@ -806,6 +811,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Remove_5.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -816,6 +823,7 @@ namespace ABI.System.Collections.Generic
         public unsafe void Clear()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Clear_6(ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe uint Size
@@ -824,6 +832,7 @@ namespace ABI.System.Collections.Generic
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/IDisposable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDisposable.net5.cs
@@ -24,6 +24,7 @@ namespace ABI.System
         {
             var ThisPtr = obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[6](ThisPtr));
+            GC.KeepAlive(obj);
         }
     }
 

--- a/src/WinRT.Runtime/Projections/IDisposable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IDisposable.netstandard2.0.cs
@@ -80,6 +80,7 @@ namespace ABI.System
         public unsafe void Dispose()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Close_0(ThisPtr));
+            GC.KeepAlive(_obj);
         }
     }
 }

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -64,6 +64,7 @@ namespace ABI.Windows.Foundation.Collections
                 {
                     var ThisPtr = obj.ThisPtr;
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, &__retval));
+                    GC.KeepAlive(obj);
                     return ABI.System.Collections.Generic.FromAbiEnumerator<T>.FromAbi(__retval);
                 }
                 finally
@@ -474,6 +475,7 @@ namespace ABI.System.Collections.Generic
             var ThisPtr = obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[8](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval != 0;
         }
 
@@ -503,6 +505,7 @@ namespace ABI.System.Collections.Generic
                     __items = Marshaler<T>.CreateMarshalerArray(items);
                     (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, uint*, int>**)ThisPtr)[9](ThisPtr, __items_length, __items_data, &__retval));
+                    GC.KeepAlive(obj);
                     items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                     return __retval;
                 }
@@ -523,6 +526,7 @@ namespace ABI.System.Collections.Generic
             var ThisPtr = obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval != 0;
         }
     }
@@ -661,6 +665,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)ThisPtr)[6](ThisPtr, &result));
+                GC.KeepAlive(obj);
                 return Marshaler<T>.FromAbi(result);
             }
             finally

--- a/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.netstandard2.0.cs
@@ -186,6 +186,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.First_0(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return ABI.System.Collections.Generic.IEnumerator<T>.FromAbi(__retval);
             }
             finally
@@ -609,6 +610,7 @@ namespace ABI.System.Collections.Generic
         {
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.MoveNext_2(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval != 0;
         }
 
@@ -623,6 +625,7 @@ namespace ABI.System.Collections.Generic
                 __items = Marshaler<T>.CreateMarshalerArray(items);
                 (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetMany_3(ThisPtr, __items_length, __items_data, out __retval));
+                GC.KeepAlive(_obj);
                 items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                 return __retval;
             }
@@ -640,6 +643,7 @@ namespace ABI.System.Collections.Generic
                 try
                 {
                     _obj.Vftbl.get_Current_0.DynamicInvokeAbi(__params);
+                    GC.KeepAlive(_obj);
                     return Marshaler<T>.FromAbi(__params[1]);
                 }
                 finally
@@ -655,6 +659,7 @@ namespace ABI.System.Collections.Generic
             {
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_HasCurrent_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -510,6 +510,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, void*, int>**)ThisPtr)[6](ThisPtr, index, &result));
+                GC.KeepAlive(obj);
                 return Marshaler<T>.FromAbi(result);
             }
             finally
@@ -533,6 +534,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 DelegateHelper.Get(obj).IndexOf.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 index = _index;
                 return found != 0;
             }
@@ -555,6 +558,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 DelegateHelper.Get(obj).SetAt.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -575,6 +580,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 DelegateHelper.Get(obj).InsertAt.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -595,6 +602,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 DelegateHelper.Get(obj).Append.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -993,6 +1002,7 @@ namespace ABI.System.Collections.Generic
             IntPtr ThisPtr = obj.ThisPtr;
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval;
         }
 
@@ -1021,6 +1031,7 @@ namespace ABI.System.Collections.Generic
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)ThisPtr)[8](ThisPtr, &__retval));
+                    GC.KeepAlive(obj);
                     return MarshalInterface<global::System.Collections.Generic.IReadOnlyList<T>>.FromAbi(__retval);
                 }
                 finally
@@ -1049,6 +1060,7 @@ namespace ABI.System.Collections.Generic
         {
             var ThisPtr = obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, int>**)ThisPtr)[12](ThisPtr, index));
+            GC.KeepAlive(obj);
         }
 
         public static unsafe void Append(IObjectReference obj, T value)
@@ -1060,12 +1072,14 @@ namespace ABI.System.Collections.Generic
         {
             var ThisPtr = obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[14](ThisPtr));
+            GC.KeepAlive(obj);
         }
 
         public static unsafe void Clear(IObjectReference obj)
         {
             var ThisPtr = obj.ThisPtr;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)ThisPtr)[15](ThisPtr));
+            GC.KeepAlive(obj);
         }
 
         public static unsafe uint GetMany(IObjectReference obj, uint startIndex, ref T[] items)
@@ -1093,6 +1107,7 @@ namespace ABI.System.Collections.Generic
                     __items = Marshaler<T>.CreateMarshalerArray(items);
                     (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, int, IntPtr, uint*, int>**)ThisPtr)[16](ThisPtr, startIndex, __items_length, __items_data, &__retval));
+                    GC.KeepAlive(obj);
                     items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                     return __retval;
                 }
@@ -1129,6 +1144,7 @@ namespace ABI.System.Collections.Generic
                     __items = Marshaler<T>.CreateMarshalerArray(items);
                     (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int, IntPtr, int>**)ThisPtr)[17](ThisPtr, __items_length, __items_data));
+                    GC.KeepAlive(obj);
                 }
                 finally
                 {

--- a/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IList.netstandard2.0.cs
@@ -770,6 +770,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 _obj.Vftbl.GetAt_0.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return Marshaler<T>.FromAbi(__params[2]);
             }
             finally
@@ -784,6 +785,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetView_2(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return MarshalInterface<global::Windows.Foundation.Collections.IVectorView<T>>.FromAbi(__retval);
             }
             finally
@@ -801,6 +803,7 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_3.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 index = (uint)__params[2];
                 return (byte)__params[3] != 0;
             }
@@ -819,6 +822,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.SetAt_4.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -835,6 +840,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[2] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.InsertAt_5.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -845,6 +852,7 @@ namespace ABI.System.Collections.Generic
         public unsafe void RemoveAt(uint index)
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RemoveAt_6(ThisPtr, index));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void Append(T value)
@@ -856,6 +864,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.Append_7.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
+                GC.KeepAlive(__params);
             }
             finally
             {
@@ -866,11 +876,13 @@ namespace ABI.System.Collections.Generic
         public unsafe void RemoveAtEnd()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.RemoveAtEnd_8(ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void _Clear()
         {
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Clear_9(ThisPtr));
+            GC.KeepAlive(_obj);
         }
 
         public unsafe uint GetMany(uint startIndex, ref T[] items)
@@ -884,6 +896,7 @@ namespace ABI.System.Collections.Generic
                 __items = Marshaler<T>.CreateMarshalerArray(items);
                 (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetMany_10(ThisPtr, startIndex, __items_length, __items_data, out __retval));
+                GC.KeepAlive(_obj);
                 items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                 return __retval;
             }
@@ -903,6 +916,7 @@ namespace ABI.System.Collections.Generic
                 __items = Marshaler<T>.CreateMarshalerArray(items);
                 (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.ReplaceAll_11(ThisPtr, __items_length, __items_data));
+                GC.KeepAlive(_obj);
             }
             finally
             {
@@ -916,6 +930,7 @@ namespace ABI.System.Collections.Generic
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.net5.cs
@@ -28,6 +28,7 @@ namespace ABI.System.ComponentModel
             var ThisPtr = obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, byte*, int>**)ThisPtr)[6](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval != 0;
         }
 
@@ -51,6 +52,7 @@ namespace ABI.System.ComponentModel
                         ThisPtr,
                         MarshalString.GetAbi(ref __propertyName),
                         &__retval));
+                    GC.KeepAlive(obj);
                     return (global::ABI.System.Collections.Generic.IEnumerable<object>)(object)IInspectable.FromAbi(__retval);
                 }
             }

--- a/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/INotifyDataErrorInfo.netstandard2.0.cs
@@ -187,6 +187,7 @@ namespace ABI.System.ComponentModel
                 fixed (void* ___propertyName = __propertyName)
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetErrors_3(ThisPtr, MarshalString.GetAbi(ref __propertyName), &__retval));
+                    GC.KeepAlive(_obj);
                     return (global::ABI.System.Collections.Generic.IEnumerable<object>)(object)IInspectable.FromAbi(__retval);
                 }
             }
@@ -202,6 +203,7 @@ namespace ABI.System.ComponentModel
             {
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_HasErrors_0(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }

--- a/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.net5.cs
@@ -1370,6 +1370,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt8_2(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1379,6 +1380,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             short __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt16_3(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1388,6 +1390,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             ushort __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt16_4(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1397,6 +1400,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             int __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt32_5(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1406,6 +1410,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt32_6(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1415,6 +1420,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             long __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt64_7(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1424,6 +1430,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             ulong __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt64_8(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1433,6 +1440,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             float __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSingle_9(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1442,6 +1450,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             double __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDouble_10(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1451,6 +1460,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             ushort __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetChar16_11(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return (char)__retval;
         }
 
@@ -1460,6 +1470,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetBoolean_12(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval != 0;
         }
 
@@ -1471,6 +1482,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetString_13(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalString.FromAbi(__retval);
             }
             finally
@@ -1485,6 +1497,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             Guid __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetGuid_14(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1496,6 +1509,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDateTime_15(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return global::ABI.System.DateTimeOffset.FromAbi(__retval);
             }
             finally
@@ -1512,6 +1526,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetTimeSpan_16(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return global::ABI.System.TimeSpan.FromAbi(__retval);
             }
             finally
@@ -1526,6 +1541,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             global::Windows.Foundation.Point __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetPoint_17(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1535,6 +1551,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             global::Windows.Foundation.Size __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSize_18(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1544,6 +1561,7 @@ namespace ABI.Windows.Foundation
             var ThisPtr = _obj.ThisPtr;
             global::Windows.Foundation.Rect __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetRect_19(ThisPtr, &__retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1556,6 +1574,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt8Array_20(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<byte>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1573,6 +1592,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt16Array_21(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<short>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1590,6 +1610,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt16Array_22(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<ushort>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1607,6 +1628,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt32Array_23(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<int>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1624,6 +1646,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt32Array_24(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<uint>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1641,6 +1664,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt64Array_25(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<long>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1658,6 +1682,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt64Array_26(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<ulong>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1675,6 +1700,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSingleArray_27(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<float>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1692,6 +1718,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDoubleArray_28(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<double>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1709,6 +1736,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetChar16Array_29(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<char>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1726,6 +1754,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetBooleanArray_30(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<bool>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1743,6 +1772,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetStringArray_31(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalString.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1760,6 +1790,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInspectableArray_32(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalInspectable<object>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1777,6 +1808,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetGuidArray_33(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<Guid>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1794,6 +1826,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDateTimeArray_34(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<global::System.DateTimeOffset>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1811,6 +1844,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetTimeSpanArray_35(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<global::System.TimeSpan>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1828,6 +1862,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetPointArray_36(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Point>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1845,6 +1880,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSizeArray_37(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Size>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1862,6 +1898,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetRectArray_38(ThisPtr, &__value_length, &__value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Rect>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1878,6 +1915,7 @@ namespace ABI.Windows.Foundation
                 var ThisPtr = _obj.ThisPtr;
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_IsNumericScalar_1(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }
@@ -1890,6 +1928,7 @@ namespace ABI.Windows.Foundation
                 var ThisPtr = _obj.ThisPtr;
                 global::Windows.Foundation.PropertyType __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Type_0(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IPropertyValue.netstandard2.0.cs
@@ -1318,6 +1318,7 @@ namespace ABI.Windows.Foundation
         {
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt8_2(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1325,6 +1326,7 @@ namespace ABI.Windows.Foundation
         {
             short __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt16_3(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1332,6 +1334,7 @@ namespace ABI.Windows.Foundation
         {
             ushort __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt16_4(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1339,6 +1342,7 @@ namespace ABI.Windows.Foundation
         {
             int __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt32_5(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1346,6 +1350,7 @@ namespace ABI.Windows.Foundation
         {
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt32_6(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1353,6 +1358,7 @@ namespace ABI.Windows.Foundation
         {
             long __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt64_7(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1360,6 +1366,7 @@ namespace ABI.Windows.Foundation
         {
             ulong __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt64_8(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1367,6 +1374,7 @@ namespace ABI.Windows.Foundation
         {
             float __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSingle_9(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1374,6 +1382,7 @@ namespace ABI.Windows.Foundation
         {
             double __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDouble_10(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1381,6 +1390,7 @@ namespace ABI.Windows.Foundation
         {
             ushort __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetChar16_11(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return (char)__retval;
         }
 
@@ -1388,6 +1398,7 @@ namespace ABI.Windows.Foundation
         {
             byte __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetBoolean_12(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval != 0;
         }
 
@@ -1397,6 +1408,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetString_13(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return MarshalString.FromAbi(__retval);
             }
             finally
@@ -1409,6 +1421,7 @@ namespace ABI.Windows.Foundation
         {
             Guid __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetGuid_14(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1418,6 +1431,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDateTime_15(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return global::ABI.System.DateTimeOffset.FromAbi(__retval);
             }
             finally
@@ -1432,6 +1446,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetTimeSpan_16(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return global::ABI.System.TimeSpan.FromAbi(__retval);
             }
             finally
@@ -1444,6 +1459,7 @@ namespace ABI.Windows.Foundation
         {
             global::Windows.Foundation.Point __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetPoint_17(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1451,6 +1467,7 @@ namespace ABI.Windows.Foundation
         {
             global::Windows.Foundation.Size __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSize_18(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1458,6 +1475,7 @@ namespace ABI.Windows.Foundation
         {
             global::Windows.Foundation.Rect __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetRect_19(ThisPtr, out __retval));
+            GC.KeepAlive(_obj);
             return __retval;
         }
 
@@ -1468,6 +1486,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt8Array_20(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<byte>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1483,6 +1502,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt16Array_21(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<short>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1498,6 +1518,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt16Array_22(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<ushort>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1513,6 +1534,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt32Array_23(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<int>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1528,6 +1550,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt32Array_24(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<uint>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1543,6 +1566,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInt64Array_25(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<long>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1558,6 +1582,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetUInt64Array_26(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<ulong>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1573,6 +1598,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSingleArray_27(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<float>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1588,6 +1614,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDoubleArray_28(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<double>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1603,6 +1630,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetChar16Array_29(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<char>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1618,6 +1646,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetBooleanArray_30(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<bool>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1633,6 +1662,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetStringArray_31(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalString.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1648,6 +1678,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetInspectableArray_32(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalInspectable<object>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1663,6 +1694,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetGuidArray_33(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<Guid>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1678,6 +1710,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetDateTimeArray_34(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<global::System.DateTimeOffset>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1693,6 +1726,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetTimeSpanArray_35(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalNonBlittable<global::System.TimeSpan>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1708,6 +1742,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetPointArray_36(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Point>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1723,6 +1758,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetSizeArray_37(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Size>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1738,6 +1774,7 @@ namespace ABI.Windows.Foundation
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetRectArray_38(ThisPtr, out __value_length, out __value_data));
+                GC.KeepAlive(_obj);
                 value = MarshalBlittable<global::Windows.Foundation.Rect>.FromAbiArray((__value_length, __value_data));
             }
             finally
@@ -1752,6 +1789,7 @@ namespace ABI.Windows.Foundation
             {
                 byte __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_IsNumericScalar_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval != 0;
             }
         }
@@ -1762,6 +1800,7 @@ namespace ABI.Windows.Foundation
             {
                 global::Windows.Foundation.PropertyType __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Type_0(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -148,6 +148,7 @@ namespace ABI.Windows.Foundation.Collections
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, IntPtr*, int>**)ThisPtr)[9](ThisPtr, &__first, &__second));
+                    GC.KeepAlive(obj);
                     first = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__first);
                     second = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__second);
                 }
@@ -165,6 +166,7 @@ namespace ABI.Windows.Foundation.Collections
 
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval;   
         }
     }
@@ -504,6 +506,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 DelegateHelper.Get(obj).Lookup.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 return Marshaler<V>.FromAbi(valueAbi);
             }
             finally
@@ -527,6 +531,8 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 DelegateHelper.Get(obj).HasKey.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 return found != 0;
             }
             finally

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.netstandard2.0.cs
@@ -673,6 +673,7 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.Lookup_0.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return Marshaler<V>.FromAbi(__params[2]);
             }
             finally
@@ -691,6 +692,7 @@ namespace ABI.System.Collections.Generic
                 __key = Marshaler<K>.CreateMarshaler2(key);
                 __params[1] = Marshaler<K>.GetAbi(__key);
                 _obj.Vftbl.HasKey_2.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return (byte)__params[2] != 0;
             }
             finally
@@ -706,6 +708,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.Split_3(ThisPtr, out __first, out __second));
+                GC.KeepAlive(_obj);
                 first = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__first);
                 second = MarshalInterface<global::Windows.Foundation.Collections.IMapView<K, V>>.FromAbi(__second);
             }
@@ -722,6 +725,7 @@ namespace ABI.System.Collections.Generic
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -145,6 +145,7 @@ namespace ABI.Windows.Foundation.Collections
 
             uint __retval = default;
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint*, int>**)ThisPtr)[7](ThisPtr, &__retval));
+            GC.KeepAlive(obj);
             return __retval;
         }
 
@@ -180,6 +181,7 @@ namespace ABI.Windows.Foundation.Collections
                     __items = Marshaler<T>.CreateMarshalerArray(items);
                     (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, int, IntPtr, uint*, int>**)ThisPtr)[9](ThisPtr, startIndex, __items_length, __items_data, &__retval));
+                    GC.KeepAlive(obj);
                     items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                     return __retval;
                 }
@@ -316,6 +318,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, uint, void*, int>**)ThisPtr)[6](ThisPtr, index, &result));
+                GC.KeepAlive(obj);
                 return Marshaler<T>.FromAbi(result);
             }
             finally
@@ -339,6 +342,8 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 DelegateHelper.Get(obj).IndexOf.DynamicInvokeAbi(__params);
+                GC.KeepAlive(obj);
+                GC.KeepAlive(__params);
                 index = _index;
                 return found != 0;
             }

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.netstandard2.0.cs
@@ -380,6 +380,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 _obj.Vftbl.GetAt_0.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 return Marshaler<T>.FromAbi(__params[2]);
             }
             finally
@@ -397,6 +398,7 @@ namespace ABI.System.Collections.Generic
                 __value = Marshaler<T>.CreateMarshaler2(value);
                 __params[1] = Marshaler<T>.GetAbi(__value);
                 _obj.Vftbl.IndexOf_2.DynamicInvokeAbi(__params);
+                GC.KeepAlive(_obj);
                 index = (uint)__params[2];
                 return (byte)__params[3] != 0;
             }
@@ -417,6 +419,7 @@ namespace ABI.System.Collections.Generic
                 __items = Marshaler<T>.CreateMarshalerArray(items);
                 (__items_length, __items_data) = Marshaler<T>.GetAbiArray(__items);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetMany_3(ThisPtr, startIndex, __items_length, __items_data, out __retval));
+                GC.KeepAlive(_obj);
                 items = Marshaler<T>.FromAbiArray((__items_length, __items_data));
                 return __retval;
             }
@@ -432,6 +435,7 @@ namespace ABI.System.Collections.Generic
             {
                 uint __retval = default;
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Size_1(ThisPtr, out __retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -95,6 +95,7 @@ namespace ABI.Windows.Foundation
                     Marshal.QueryInterface(inspectable.ThisPtr, ref Unsafe.AsRef(in PIID), out referenceArrayPtr)
 #endif
                     );
+                GC.KeepAlive(inspectable);
                 ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, IntPtr*, int>**)referenceArrayPtr)[6](referenceArrayPtr, &__retval_length, &__retval_data));
                 return Marshaler<T>.FromAbiArray((__retval_length, __retval_data));
             }
@@ -143,6 +144,7 @@ namespace ABI.Windows.Foundation
                 try
                 {
                     ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int*, IntPtr*, int>**)ThisPtr)[6](ThisPtr, &__retval_length, &__retval_data));
+                    GC.KeepAlive(_obj);
                     return Marshaler<T>.FromAbiArray((__retval_length, __retval_data));
                 }
                 finally

--- a/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.netstandard2.0.cs
@@ -154,6 +154,7 @@ namespace ABI.Windows.Foundation
                 try
                 {
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.get_Value_0(ThisPtr, out __retval_length, out __retval_data));
+                    GC.KeepAlive(_obj);
                     return Marshaler<T>.FromAbiArray((__retval_length, __retval_data));
                 }
                 finally

--- a/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/IServiceProvider.net5.cs
@@ -31,6 +31,7 @@ namespace ABI.System
                     ThisPtr,
                     global::ABI.System.Type.GetAbi(__type),
                     &__retval));
+                GC.KeepAlive(obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally

--- a/src/WinRT.Runtime/Projections/IServiceProvider.netstandard2.0.cs
+++ b/src/WinRT.Runtime/Projections/IServiceProvider.netstandard2.0.cs
@@ -79,6 +79,7 @@ namespace ABI.System
             {
                 __type = global::ABI.System.Type.CreateMarshaler(type);
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.GetService_0(ThisPtr, global::ABI.System.Type.GetAbi(__type), &__retval));
+                GC.KeepAlive(_obj);
                 return MarshalInspectable<object>.FromAbi(__retval);
             }
             finally

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -159,6 +159,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)ThisPtr)[6](ThisPtr, &keyAbi));
+                GC.KeepAlive(obj);
                 return Marshaler<K>.FromAbi(keyAbi);
             }
             finally
@@ -174,6 +175,7 @@ namespace ABI.System.Collections.Generic
             try
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, void*, int>**)ThisPtr)[7](ThisPtr, &valueAbi));
+                GC.KeepAlive(obj);
                 return Marshaler<V>.FromAbi(valueAbi);
             }
             finally

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -58,6 +58,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
                     IntPtr.Zero,
                     &__innerInterface,
                     &__retval));
+                GC.KeepAlive(_obj);
                 return new ObjectReferenceValue(__retval);
             }
             finally

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventHandler.cs
@@ -118,6 +118,7 @@ namespace ABI.System.Collections.Specialized
                     __sender = MarshalInspectable<object>.CreateMarshaler2(sender);
                     __e = global::ABI.System.Collections.Specialized.NotifyCollectionChangedEventArgs.CreateMarshaler2(e);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable<object>.GetAbi(__sender), MarshalInspectable<object>.GetAbi(__e)));
+                    GC.KeepAlive(_nativeDelegate);
                 }
                 finally
                 {

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -43,6 +43,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                             MarshalInspectable<object>.GetAbi(__baseInterface),
                             &__innerInterface,
                             &__retval));
+                    global::System.GC.KeepAlive(_obj);
                     innerInterface = ObjectReference<IUnknownVftbl>.FromAbi(__innerInterface, IID.IID_IUnknown);
                     return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
                 }
@@ -72,6 +73,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
                             IntPtr.Zero,
                             &__innerInterface,
                             &__retval));
+                    global::System.GC.KeepAlive(_obj);
                     return new ObjectReferenceValue(__retval);
                 }
             }

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventHandler.cs
@@ -117,6 +117,7 @@ namespace ABI.System.ComponentModel
                     __sender = MarshalInspectable<object>.CreateMarshaler2(sender);
                     __e = global::ABI.System.ComponentModel.PropertyChangedEventArgs.CreateMarshaler2(e);
                     global::WinRT.ExceptionHelpers.ThrowExceptionForHR(abiInvoke(ThisPtr, MarshalInspectable<object>.GetAbi(__sender), MarshalInspectable<object>.GetAbi(__e)));
+                    global::System.GC.KeepAlive(_nativeDelegate);
                 }
                 finally
                 {

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -68,6 +68,7 @@ namespace ABI.System
             fixed (void* ___uri = __uri)
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, MarshalString.GetAbi(ref __uri), &__retval));
+                GC.KeepAlive(_obj);
                 return ObjectReference<IUnknownVftbl>.Attach(ref __retval, IID.IID_IUnknown);
             }
         }
@@ -79,6 +80,7 @@ namespace ABI.System
             fixed (void* ___uri = __uri)
             {
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, IntPtr*, int>**)ThisPtr)[6](ThisPtr, MarshalString.GetAbi(ref __uri), &__retval));
+                GC.KeepAlive(_obj);
                 return new ObjectReferenceValue(__retval);
             }
         }

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -4648,7 +4648,7 @@ event % %;)",
         return marshalers;
     }
 
-    void write_abi_method_call_marshalers(writer& w, std::string_view invoke_target, std::optional<std::string_view> invoke_objref,  bool is_generic, std::vector<abi_marshaler> const& marshalers, bool has_noexcept_attr = false)
+    void write_abi_method_call_marshalers(writer& w, std::string_view invoke_target, std::string_view invoke_objref,  bool is_generic, std::vector<abi_marshaler> const& marshalers, bool has_noexcept_attr = false)
     {
         auto write_abi_invoke = [&](writer& w)
         {
@@ -4685,11 +4685,8 @@ event % %;)",
             if (is_generic)
             {
                 w.write("global::System.Runtime.InteropServices.Marshal.ThrowExceptionForHR((int)%.DynamicInvoke(__params));\n", invoke_target);
-                if (invoke_objref)
-                {
-                    w.write("global::System.GC.KeepAlive(__params);\n");
-                    w.write("global::System.GC.KeepAlive(%);\n", invoke_objref.value());
-                }
+                w.write("global::System.GC.KeepAlive(__params);\n");
+                w.write("global::System.GC.KeepAlive(%);\n", invoke_objref);
             }
             else if (!has_noexcept_attr)
             {
@@ -4700,11 +4697,7 @@ event % %;)",
                         w.write(", ");
                         m.write_marshal_to_abi(w);
                     }, marshalers));
-
-                if (invoke_objref)
-                {
-                    w.write("global::System.GC.KeepAlive(%);\n", invoke_objref.value());
-                }
+                w.write("global::System.GC.KeepAlive(%);\n", invoke_objref);
             }
             else {
                 w.write("%(ThisPtr%);\n",
@@ -4714,11 +4707,7 @@ event % %;)",
                             w.write(", ");
                             m.write_marshal_to_abi(w);
                         }, marshalers));
-
-                if (invoke_objref)
-                {
-                    w.write("global::System.GC.KeepAlive(%);\n", invoke_objref.value());
-                }
+                w.write("global::System.GC.KeepAlive(%);\n", invoke_objref);
             }
             for (auto&& m : marshalers)
             {
@@ -4778,7 +4767,7 @@ finally
         );
     }
 
-    void write_abi_method_call(writer& w, method_signature signature, std::string_view invoke_target, std::optional<std::string_view> invoke_objref, bool is_generic, bool raw_return_type = false, bool has_noexcept_attr = false, bool is_generic_instantiation_class = false)
+    void write_abi_method_call(writer& w, method_signature signature, std::string_view invoke_target, std::string_view invoke_objref, bool is_generic, bool raw_return_type = false, bool has_noexcept_attr = false, bool is_generic_instantiation_class = false)
     {
         write_abi_method_call_marshalers(w, invoke_target, invoke_objref, is_generic, get_abi_marshalers(w, signature, is_generic, "", raw_return_type, is_generic_instantiation_class), has_noexcept_attr);
     }

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -532,6 +532,7 @@ namespace Windows.ApplicationModel.DataTransfer
                 // IDataTransferManagerInterop inherits IUnknown (3 functions) and provides GetForWindow giving a total of 5 functions
                 fixed(Guid* _riid = &riid)
                 global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, global::System.Guid*, global::System.IntPtr*, int>**)thisPtr)[3](thisPtr, appWindow, _riid, &ptr));
+                GC.KeepAlive(_obj);
                 return global::WinRT.MarshalInspectable<global::Windows.ApplicationModel.DataTransfer.DataTransferManager>.FromAbi(ptr);
             }
             finally
@@ -546,6 +547,7 @@ namespace Windows.ApplicationModel.DataTransfer
 
             // IDataTransferManagerInterop inherits IUnknown (3 functions) and provides ShowShareUIForWindow giving a total of 5 functions
             global::WinRT.ExceptionHelpers.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<global::System.IntPtr, global::System.IntPtr, int>**)thisPtr)[4](thisPtr, appWindow));
+            GC.KeepAlive(_obj);
         }
     }
 }

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
@@ -82,6 +82,7 @@ namespace ABI.Windows.Storage.Streams
             {
                 IntPtr __retval = default;
                 Marshal.ThrowExceptionForHR(_obj.Vftbl.get_Buffer_0(ThisPtr, &__retval));
+                GC.KeepAlive(_obj);
                 return __retval;
             }
         }
@@ -134,6 +135,7 @@ namespace ABI.Windows.Storage.Streams
                 var ThisPtr = _obj.ThisPtr;
                 IntPtr buffer = default;
                 Marshal.ThrowExceptionForHR(((delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)(*(void***)ThisPtr)[3])(ThisPtr, &buffer));
+                GC.KeepAlive(_obj);
                 return buffer;
             }
         }

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
@@ -230,6 +230,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.GetUnmarshalClass_0(ThisPtr, riid, pv, dwDestContext, pvDestContext, mshlFlags, pCid));
 #endif
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void GetMarshalSizeMax(Guid* riid, IntPtr pv, global::Com.MSHCTX dwDestContext, IntPtr pvDestContext, global::Com.MSHLFLAGS mshlflags, uint* pSize)
@@ -240,6 +241,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.GetMarshalSizeMax_1(ThisPtr, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize));
 #endif
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void MarshalInterface(IntPtr pStm, Guid* riid, IntPtr pv, global::Com.MSHCTX dwDestContext, IntPtr pvDestContext, global::Com.MSHLFLAGS mshlflags)
@@ -250,6 +252,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.MarshalInterface_2(ThisPtr, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags));
 #endif
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void UnmarshalInterface(IntPtr pStm, Guid* riid, IntPtr* ppv)
@@ -260,6 +263,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.UnmarshalInterface_3(ThisPtr, pStm, riid, ppv));
 #endif
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void ReleaseMarshalData(IntPtr pStm)
@@ -270,6 +274,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.ReleaseMarshalData_4(ThisPtr, pStm));
 #endif
+            GC.KeepAlive(_obj);
         }
 
         public unsafe void DisconnectObject(uint dwReserved)
@@ -280,6 +285,7 @@ namespace ABI.Com
 #else
             Marshal.ThrowExceptionForHR(_obj.Vftbl.DisconnectObject_5(ThisPtr, dwReserved));
 #endif
+            GC.KeepAlive(_obj);
         }
     }
 

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/StreamTaskAdaptersImplementation.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/StreamTaskAdaptersImplementation.cs
@@ -257,6 +257,7 @@ namespace Windows.Storage.Streams
                         ThisPtr,
                         abiAsyncInfo,
                         progressInfo));
+                    GC.KeepAlive(objRef);
                 }
                 finally
                 {
@@ -462,6 +463,7 @@ namespace Windows.Storage.Streams
                         ThisPtr,
                         abiAsyncInfo,
                         progressInfo));
+                    GC.KeepAlive(objRef);
                 }
                 finally
                 {


### PR DESCRIPTION
Looking at some recent crash dumps, it looked like the object / RCW was going away while the function call was happening.  This then lead to an AV.  Adding GC.KeepAlive throughout to try to avoid this.  Also added capability to run tests with GC stress.

Fixes #1022