### PR TITLE
Add new 'IObjectReference' tracking APIs

### DIFF
--- a/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
@@ -1,2 +1,0 @@
-Compat issues with assembly WinRT.Runtime:
-Total Issues: 0

--- a/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
@@ -3,4 +3,7 @@ CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.Gen
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.WinRTExposedTypeAttribute' in the contract but not the implementation.
 ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
 ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String, System.Guid)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
-Total Issues: 4
+MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'protected void WinRT.IObjectReference.AddRef(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'protected void WinRT.IObjectReference.ThrowIfDisposed()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 7

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -525,7 +525,7 @@ namespace WinRT
 
                     if (addRefFromTrackerSource)
                     {
-                        objRef.AddRefFromTrackerSource(); // ObjRef instance
+                        objRef.AddRefFromTrackerSourceUnsafe(); // ObjRef instance
                     }
                     else
                     {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -525,7 +525,7 @@ namespace WinRT
 
                     if (addRefFromTrackerSource)
                     {
-                        objRef.AddRefFromTrackerSourceUnsafe(); // ObjRef instance
+                        objRef.NativeAddRefFromTrackerSourceUnsafe(); // ObjRef instance
                     }
                     else
                     {

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -678,7 +678,7 @@ namespace WinRT
                 // Handle the scenario where the CLR has already done an AddRefFromTrackerSource on the instance
                 // stored by the RCW type.  We handle it by releasing the AddRef we did and not doing an release
                 // on destruction as the CLR would do it.
-                winrtObj.NativeObject.ReleaseFromTrackerSource();
+                winrtObj.NativeObject.ReleaseFromTrackerSourceUnsafe();
                 winrtObj.NativeObject.PreventReleaseFromTrackerSourceOnDispose = true;
             }
 

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -678,7 +678,7 @@ namespace WinRT
                 // Handle the scenario where the CLR has already done an AddRefFromTrackerSource on the instance
                 // stored by the RCW type.  We handle it by releasing the AddRef we did and not doing an release
                 // on destruction as the CLR would do it.
-                winrtObj.NativeObject.ReleaseFromTrackerSourceUnsafe();
+                winrtObj.NativeObject.NativeReleaseFromTrackerSourceUnsafe();
                 winrtObj.NativeObject.PreventReleaseFromTrackerSourceOnDispose = true;
             }
 

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
@@ -1,2 +1,0 @@
-Compat issues with assembly WinRT.Runtime:
-Total Issues: 0

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -6,4 +6,17 @@ TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory.ActivationHandler' in the implementation but not the reference.
-Total Issues: 7
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.ThisPtr' in the implementation but not the reference.
+MembersMustExist : Member 'public void WinRT.IObjectReference.AddRefUnsafe()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.GetRef()' in the implementation but not the reference.
+MembersMustExist : Member 'public System.IntPtr WinRT.IObjectReference.GetReferenceTrackerPtrUnsafe()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.IntPtr WinRT.IObjectReference.GetThisPtr()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.IntPtr WinRT.IObjectReference.GetThisPtrUnsafe()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.Release()' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.Release()' in the implementation but not the reference.
+MembersMustExist : Member 'public void WinRT.IObjectReference.ReleaseUnsafe()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'protected void WinRT.IObjectReference.ThrowIfDisposedUnsafe()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.TryAddRefUnsafe()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.VftblIUnknown' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.VftblIUnknown' in the implementation but not the reference.
+Total Issues: 20

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -15,8 +15,7 @@ MembersMustExist : Member 'public System.IntPtr WinRT.IObjectReference.GetThisPt
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.Release()' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.Release()' in the implementation but not the reference.
 MembersMustExist : Member 'public void WinRT.IObjectReference.ReleaseUnsafe()' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'protected void WinRT.IObjectReference.ThrowIfDisposedUnsafe()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.Boolean WinRT.IObjectReference.TryAddRefUnsafe()' does not exist in the reference but it does exist in the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.IObjectReference.VftblIUnknown' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'WinRT.IObjectReference.VftblIUnknown' in the implementation but not the reference.
-Total Issues: 20
+Total Issues: 19

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -41,7 +41,7 @@ namespace WinRT
         /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IntPtr GetThisRefUnsafe()
+        public IntPtr GetThisPtrUnsafe()
         {
             return GetThisPtrForCurrentContextUnsafe();
         }
@@ -60,9 +60,9 @@ namespace WinRT
         /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IntPtr GetReferenceTrackerRefUnsafe()
+        public IntPtr GetReferenceTrackerPtrUnsafe()
         {
-            return GetThisPtrForCurrentContextUnsafe();
+            return _referenceTrackerPtr;
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace WinRT
         /// </para>
         /// <para>
         /// This method exists mostly for backwards compatibility for older APIs. New code should always use <see cref="AddRefUnsafe"/>
-        /// and <see cref="ReleaseUnsafe"/>, and then <see cref="GetThisRefUnsafe"/> to access the native pointer to use for interop.
+        /// and <see cref="ReleaseUnsafe"/>, and then <see cref="GetThisPtrUnsafe"/> to access the native pointer to use for interop.
         /// </para>
         /// </remarks>
         /// <exception cref="ObjectDisposedException">Thrown if the current instance is disposed.</exception>

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -232,7 +232,7 @@ namespace WinRT
                 Release();
             }
 
-            DisposeTrackerSource();
+            DisposeTrackerSourceUnsafe();
 
             GC.RemoveMemoryPressure(ComWrappersSupport.GC_PRESSURE_BASE);
         }

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -69,9 +69,23 @@ namespace WinRT
         /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IntPtr GetThisPtrUnsafe()
+        public virtual IntPtr GetThisPtrUnsafe()
         {
-            return GetThisPtrForCurrentContextUnsafe();
+            return _thisPtr;
+        }
+
+        /// <summary>
+        /// Gets the underlying pointer owned by the current instance, with no context.
+        /// </summary>
+        /// <returns>The underlying pointer owned by the current instance.</returns>
+        /// <remarks>
+        /// This method does not check for disposal, nor does it increment the managed reference count of
+        /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private IntPtr GetThisPtrWithoutContextUnsafe()
+        {
+            return _thisPtr;
         }
 
         /// <summary>
@@ -350,7 +364,7 @@ namespace WinRT
         {
             NativeReleaseFromTrackerSourceUnsafe();
 
-            Marshal.Release(_thisPtr);
+            Marshal.Release(GetThisPtrWithoutContextUnsafe());
         }
 
         /// <summary>
@@ -360,7 +374,7 @@ namespace WinRT
         /// This method does not check for disposal before releasing the reference.
         /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
         /// </remarks>
-        internal unsafe void NativeReleaseFromTrackerSourceUnsafe()
+        internal void NativeReleaseFromTrackerSourceUnsafe()
         {
             IntPtr referenceTrackerPtr = GetReferenceTrackerPtrUnsafe();
 

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -5,10 +5,11 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using WinRT.Interop;
 
 namespace WinRT
 {
-    partial class IObjectReference
+    unsafe partial class IObjectReference
     {
         /// <summary>
         /// Finalizes the current object instance. If the underlying native
@@ -271,13 +272,30 @@ namespace WinRT
         /// This method does not check for disposal, nor does it increment the managed reference count of
         /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
         /// </remarks>
-        private protected void NativeAddRefUnsafe(bool addRefFromTrackerSource)
+        internal void NativeAddRefUnsafe(bool addRefFromTrackerSource)
         {
             Marshal.AddRef(GetThisPtrUnsafe());
 
             if (addRefFromTrackerSource)
             {
-                AddRefFromTrackerSourceUnsafe();
+                NativeAddRefFromTrackerSourceUnsafe();
+            }
+        }
+
+        /// <summary>
+        /// Increments the native reference count for the current <see cref="IObjectReference"/> instance from the tracker source.
+        /// </summary>
+        /// <remarks>
+        /// This method does not check for disposal, nor does it increment the managed reference count of
+        /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
+        /// </remarks>
+        internal void NativeAddRefFromTrackerSourceUnsafe()
+        {
+            IntPtr referenceTrackerPtr = GetReferenceTrackerPtrUnsafe();
+
+            if (referenceTrackerPtr != IntPtr.Zero)
+            {
+                _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).AddRefFromTrackerSource(referenceTrackerPtr);
             }
         }
 

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -37,7 +37,7 @@ namespace WinRT
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntPtr GetRefUnsafe()
         {
-            return GetThisPtrForCurrentContext();
+            return GetThisPtrForCurrentContextUnsafe();
         }
 
         /// <summary>

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -45,9 +45,13 @@ namespace WinRT
         public IntPtr GetThisPtr()
         {
             AddRefUnsafe();
-            NativeAddRefUnsafe(addRefFromTrackerSource: false);
 
             IntPtr thisPtr = GetThisPtrUnsafe();
+
+            // We could use 'NativeAddRefUnsafe', but instead we inline the logic to avoid
+            // a repeated call to the virtual 'GetThisPtrUnsafe' method. We also don't need
+            // to add a reference from the tracker source here, so we just need this call.
+            Marshal.AddRef(thisPtr);
 
             ReleaseUnsafe();
 
@@ -266,7 +270,7 @@ namespace WinRT
         /// </remarks>
         /// <exception cref="ObjectDisposedException">Thrown if the current instance is disposed.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ThrowIfDisposedUnsafe()
+        private protected void ThrowIfDisposedUnsafe()
         {
 #if NET8_0_OR_GREATER
             ObjectDisposedException.ThrowIf(_referenceTrackingMask < 0, this);

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace WinRT
+{
+    partial class IObjectReference
+    {
+        /// <summary>
+        /// Finalizes the current object instance. If the underlying native
+        /// resources are still active, it also releases them as needed.
+        /// </summary>
+        ~IObjectReference()
+        {
+            DisposeUnsafe();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            DisposeUnsafe();
+        }
+
+        /// <summary>
+        /// Gets the underlying pointer owned by the current instance.
+        /// </summary>
+        /// <returns>The underlying pointer owned by the current instance.</returns>
+        /// <remarks>
+        /// This method does not check for disposal, nor does it increment the managed reference count of
+        /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IntPtr GetRefUnsafe()
+        {
+            return GetThisPtrForCurrentContext();
+        }
+
+        /// <summary>
+        /// Increments the managed reference count for the current <see cref="IObjectReference"/> instance.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddRefUnsafe()
+        {
+#if NET8_0_OR_GREATER
+            ObjectDisposedException.ThrowIf(!TryAddRefUnsafe(), this);
+#else
+            if (!TryAddRefUnsafe())
+            {
+                throw new ObjectDisposedException(nameof(IObjectReference), "Object reference has been closed.");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Tries to increment the managed reference count for the current <see cref="IObjectReference"/> instance.
+        /// </summary>
+        /// <returns>Whether the managed reference count has been increased successfully.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryAddRefUnsafe()
+        {
+            bool success = true;
+
+            int currentValue;
+            int originalValue;
+
+            // To safely increment the reference count, the procedure is as follows:
+            //   - If the object has been disposed (ie. if Disposed() has been called),
+            //     even if the object hasn't actually released the unmanaged resources
+            //     yet, then incrementing the ref count will fail and have no effect.
+            //   - If the object hasn't been disposed, the reference count is incremented.
+            // This can be done without taking a look, as follows:
+            //   - Do an interlocked read to get the current reference tracking mask.
+            //   - If the object has been disposed, the 32nd bit will be set. Due to the
+            //     mask being a signed integer in two-complement, we can just compare and
+            //     check whether the mask is lower than 0. If that is the case, just bail.
+            //   - Do an interlocked compare exchange incrementing the reference count by 1.
+            //     If the original value is the same as the current one, it means no other
+            //     thread performed a concurrent update between our read and write, so we can
+            //     stop. Otherwise, just loop until a compare exchange completes successfully.
+            // The assumption is contention will be extremely rare, given that adding and releasing
+            // a reference is incredibly fast compared to the time other operations need.
+            do
+            {
+                currentValue = _referenceTrackingMask;
+
+                if (currentValue < 0)
+                {
+                    success = false;
+
+                    break;
+                }
+
+                originalValue = Interlocked.CompareExchange(
+                    location1: ref _referenceTrackingMask,
+                    value: currentValue + 1,
+                    comparand: currentValue);
+            }
+            while (currentValue != originalValue);
+
+            return success;
+        }
+
+        /// <inheritdoc/>
+        private void DisposeUnsafe()
+        {
+            bool isDisposed = false;
+
+            int currentValue;
+            int originalValue;
+
+            // To request a dispose operation, the procedure is as follows:
+            //   - If the dispose bit has already been set, just do nothing. This means
+            //     that another thread was the first to call Dispose(). In that case, the
+            //     actual releasing of unmanaged resources will be performed either by that
+            //     thread if there are no active callers, or by the last returned caller.
+            //   - Do an interlocked compare exchange setting the dispose bit (32nd bit).
+            //     Like above, if the original value doesn't match the current one, it means
+            //     that another thread raced against this one, so the value is invalid, and
+            //     another loop is executed. If the value matches, the loop just ends.
+            // After this atomic update, we can then check whether (1) this was the first
+            // thread to call Dispose() (ie. the dispose flag wasn't previously set and it
+            // was set successfully by this call), and (2) there are no other active callers.
+            // If both checks are true, the object is effectively dead and we can safely release
+            // unmanaged resources. All other callers will just fail to be taken after this anyway.
+            do
+            {
+                currentValue = _referenceTrackingMask;
+
+                if (currentValue < 0)
+                {
+                    isDisposed = true;
+
+                    break;
+                }
+
+                originalValue = Interlocked.CompareExchange(
+                    location1: ref _referenceTrackingMask,
+                    value: currentValue | (1 << 31),
+                    comparand: currentValue);
+            }
+            while (currentValue != originalValue);
+
+            // Only release resources if this is the first time Dispose() has been called, and
+            // there are no outstanding leases. If there is one, don't do anything now. The
+            // tracked object will just be released once the last active lease is returned.
+            if (!isDisposed && currentValue == 0)
+            {
+                ReleaseNativeObject();
+            }
+        }
+
+        /// <summary>
+        /// Decrements the managed reference count for the current <see cref="IObjectReference"/> instance.
+        /// If <see cref="Dispose()"/> has been called concurrently and this is the last caller, releases all
+        /// native resources owned by the current <see cref="IObjectReference"/> instance as well.
+        /// </summary>
+        /// <remarks>
+        /// Calls to <see cref="ReleaseUnsafe"/> should always exactly match calls to <see cref="AddRefUnsafe"/>.
+        /// </remarks>
+        public void ReleaseUnsafe()
+        {
+            // To release, we can simply do an interlocked decrement on the reference tracking
+            // mask. Each caller is guaranteed to only call this method once (the contract states to only
+            // ever use it per 'AddRefUnsafe' call), and a valid reference existing implies that the reference
+            // counting mask had previously been incremented by 1. There is also no need to check for
+            // disposal, because decrementing the count on a disposed object is perfectly valid (given that
+            // the actual disposal is deferred until all active callers have returned).
+            int currentValue = Interlocked.Decrement(ref _referenceTrackingMask);
+
+            // If Dispose() has been called and this was the last reference, release the tracked object.
+            // This is the case if the dispose bit is set (the 32nd one), and no other bit is set.
+            if (currentValue == 1 << 31)
+            {
+                ReleaseNativeObject();
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ObjectDisposedException"/> if <see cref="Dispose"/> has already been called on the current instance.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Note that calling this method does not protect callers against concurrent threads calling <see cref="Dispose"/> on the
+        /// same instance, as that behavior is explicitly undefined. Similarly, callers using this to then access the underlying
+        /// pointers should also make sure to keep the current instance alive until they're done using the pointer (unless they're
+        /// also incrementing it via <c>AddRef</c> in some way), or the GC could concurrently collect the instance and cause the
+        /// same problem (ie. the underlying pointer being in use becoming invalid right after retrieving it from the object).
+        /// </para>
+        /// <para>
+        /// This method exists mostly for backwards compatibility for older APIs. New code should always use <see cref="AddRefUnsafe"/>
+        /// and <see cref="ReleaseUnsafe"/>, and then <see cref="GetRefUnsafe"/> to access the native pointer to use for interop.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">Thrown if the current instance is disposed.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void ThrowIfDisposedUnsafe()
+        {
+#if NET8_0_OR_GREATER
+            ObjectDisposedException.ThrowIf(_referenceTrackingMask < 0, this);
+#else
+            if (_referenceTrackingMask < 0)
+            {
+                throw new ObjectDisposedException(nameof(IObjectReference), "Object reference has been closed.");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Releases all native resources owned by the current <see cref="IObjectReference"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// Callers are responsible for ensuring no active callers exist when this method is used.
+        /// Only <see cref="Dispose()"/> and <see cref="ReleaseUnsafe"/> should call this method.
+        /// </remarks>
+        private void ReleaseNativeObject()
+        {
+#if DEBUG
+            if (BreakOnDispose && System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+#endif
+
+            if (!PreventReleaseOnDispose)
+            {
+                Release();
+            }
+
+            DisposeTrackerSource();
+
+            GC.RemoveMemoryPressure(ComWrappersSupport.GC_PRESSURE_BASE);
+        }
+    }
+}

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -31,11 +31,36 @@ namespace WinRT
         /// </summary>
         /// <returns>The underlying pointer owned by the current instance.</returns>
         /// <remarks>
+        /// <para>
+        /// This method retrieves the same pointer as <see cref="ThisPtr"/>. That is,
+        /// it retrieves the pointer to the underlying object, for the current context.
+        /// </para>
+        /// <para>
         /// This method does not check for disposal, nor does it increment the managed reference count of
         /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
+        /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IntPtr GetRefUnsafe()
+        public IntPtr GetThisRefUnsafe()
+        {
+            return GetThisPtrForCurrentContextUnsafe();
+        }
+
+        /// <summary>
+        /// Gets the pointer to the reference tracker object tied to the current instance.
+        /// </summary>
+        /// <returns>The pointer to the reference tracker object tied to the current instance.</returns>
+        /// <remarks>
+        /// <para>
+        /// This method retrieves the same pointer as <see cref="ReferenceTrackerPtr"/>.
+        /// </para>
+        /// <para>
+        /// This method does not check for disposal, nor does it increment the managed reference count of
+        /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
+        /// </para>
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IntPtr GetReferenceTrackerRefUnsafe()
         {
             return GetThisPtrForCurrentContextUnsafe();
         }
@@ -194,7 +219,7 @@ namespace WinRT
         /// </para>
         /// <para>
         /// This method exists mostly for backwards compatibility for older APIs. New code should always use <see cref="AddRefUnsafe"/>
-        /// and <see cref="ReleaseUnsafe"/>, and then <see cref="GetRefUnsafe"/> to access the native pointer to use for interop.
+        /// and <see cref="ReleaseUnsafe"/>, and then <see cref="GetThisRefUnsafe"/> to access the native pointer to use for interop.
         /// </para>
         /// </remarks>
         /// <exception cref="ObjectDisposedException">Thrown if the current instance is disposed.</exception>

--- a/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
+++ b/src/WinRT.Runtime/ObjectReference.ReferenceTracking.cs
@@ -320,7 +320,7 @@ namespace WinRT
                 NativeReleaseUnsafe();
             }
 
-            DisposeTrackerSourceUnsafe();
+            NativeReleaseTrackerSourceUnsafe();
 
             GC.RemoveMemoryPressure(ComWrappersSupport.GC_PRESSURE_BASE);
         }
@@ -334,7 +334,7 @@ namespace WinRT
         /// </remarks>
         private protected virtual void NativeReleaseUnsafe()
         {
-            ReleaseFromTrackerSourceUnsafe();
+            NativeReleaseFromTrackerSourceUnsafe();
 
             Marshal.Release(GetThisPtrUnsafe());
         }
@@ -348,9 +348,49 @@ namespace WinRT
         /// </remarks>
         private protected void NativeReleaseWithoutContextUnsafe()
         {
-            ReleaseFromTrackerSourceUnsafe();
+            NativeReleaseFromTrackerSourceUnsafe();
 
             Marshal.Release(_thisPtr);
+        }
+
+        /// <summary>
+        /// Releases the reference from the tracker source.
+        /// </summary>
+        /// <remarks>
+        /// This method does not check for disposal before releasing the reference.
+        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
+        /// </remarks>
+        internal unsafe void NativeReleaseFromTrackerSourceUnsafe()
+        {
+            IntPtr referenceTrackerPtr = GetReferenceTrackerPtrUnsafe();
+
+            if (referenceTrackerPtr != IntPtr.Zero)
+            {
+                _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).ReleaseFromTrackerSource(referenceTrackerPtr);
+            }
+        }
+
+        /// <summary>
+        /// Releases the reference from the tracker source, if <see cref="PreventReleaseFromTrackerSourceOnDispose"/>
+        /// is not set, and then the reference tracker itself.
+        /// </summary>
+        /// <remarks>
+        /// This method does not check for disposal before releasing the reference.
+        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
+        /// </remarks>
+        private void NativeReleaseTrackerSourceUnsafe()
+        {
+            IntPtr referenceTrackerPtr = GetReferenceTrackerPtrUnsafe();
+
+            if (referenceTrackerPtr != IntPtr.Zero)
+            {
+                if (!PreventReleaseFromTrackerSourceOnDispose)
+                {
+                    _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).ReleaseFromTrackerSource(referenceTrackerPtr);
+                }
+
+                Marshal.Release(referenceTrackerPtr);
+            }
         }
     }
 }

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -313,46 +313,6 @@ namespace WinRT
         }
 
         /// <summary>
-        /// Releases the reference from the tracker source.
-        /// </summary>
-        /// <remarks>
-        /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
-        /// </remarks>
-        internal unsafe void ReleaseFromTrackerSourceUnsafe()
-        {
-            IntPtr referenceTrackerPtr = _referenceTrackerPtr;
-
-            if (referenceTrackerPtr != IntPtr.Zero)
-            {
-                _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).ReleaseFromTrackerSource(referenceTrackerPtr);
-            }
-        }
-
-        /// <summary>
-        /// Releases the reference from the tracker source, if <see cref="PreventReleaseFromTrackerSourceOnDispose"/>
-        /// is not set, and then the reference tracker itself.
-        /// </summary>
-        /// <remarks>
-        /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
-        /// </remarks>
-        private unsafe void DisposeTrackerSourceUnsafe()
-        {
-            IntPtr referenceTrackerPtr = _referenceTrackerPtr;
-
-            if (referenceTrackerPtr != IntPtr.Zero)
-            {
-                if (!PreventReleaseFromTrackerSourceOnDispose)
-                {
-                    _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).ReleaseFromTrackerSource(referenceTrackerPtr);
-                }
-
-                Marshal.Release(referenceTrackerPtr);
-            }
-        }
-
-        /// <summary>
         /// Gets the underlying pointer for the current context, owned by the current instance.
         /// </summary>
         /// <remarks>

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -316,7 +316,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="ReleaseNativeObject"/>.
+        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
         /// </remarks>
         protected virtual unsafe void Release()
         {
@@ -355,7 +355,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="ReleaseNativeObject"/>.
+        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
         /// </remarks>
         internal unsafe void ReleaseFromTrackerSourceUnsafe()
         {
@@ -373,7 +373,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="ReleaseNativeObject"/>.
+        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
         /// </remarks>
         private unsafe void DisposeTrackerSourceUnsafe()
         {
@@ -395,7 +395,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="ReleaseNativeObject"/>.
+        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
         /// </remarks>
         internal virtual IntPtr GetThisPtrForCurrentContextUnsafe()
         {

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -103,6 +103,8 @@ namespace WinRT
             }
         }
 
+        [Obsolete("This method is not safe. Use 'GetThisPtr()' instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected unsafe IUnknownVftbl VftblIUnknown
         {
             get
@@ -305,14 +307,6 @@ namespace WinRT
         protected virtual unsafe void Release()
         {
             NativeReleaseUnsafe();
-        }
-
-        internal unsafe bool IsReferenceToManagedObject
-        {
-            get
-            {
-                return VftblIUnknown.Equals(IUnknownVftbl.AbiToProjectionVftbl);
-            }
         }
 
         private protected virtual IntPtr GetContextToken()

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -124,15 +124,7 @@ namespace WinRT
             // pressure rather than tracking all the IObjectReferences that are connected
             // to the same object and only releasing the memory pressure once all of them
             // have been finalized.
-#if NET
-            // Disable on AOT for now until dotnet runtime #104583 is addressed to avoid making the issue happen more often.
-            if (RuntimeFeature.IsDynamicCodeCompiled)
-            {
-                GC.AddMemoryPressure(ComWrappersSupport.GC_PRESSURE_BASE);
-            }
-#else
             GC.AddMemoryPressure(ComWrappersSupport.GC_PRESSURE_BASE);
-#endif
         }
 
 #if NET

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -93,7 +93,7 @@ namespace WinRT
                 if (_referenceTrackerPtr != IntPtr.Zero)
                 {
                     Marshal.AddRef(_referenceTrackerPtr);
-                    AddRefFromTrackerSourceUnsafe();
+                    NativeAddRefFromTrackerSourceUnsafe();
                 }
             }
         }
@@ -326,16 +326,6 @@ namespace WinRT
             }
         }
 
-        internal unsafe void AddRefFromTrackerSourceUnsafe()
-        {
-            IntPtr referenceTrackerPtr = _referenceTrackerPtr;
-
-            if (referenceTrackerPtr != IntPtr.Zero)
-            {
-                _ = (**(IReferenceTrackerVftbl**)referenceTrackerPtr).AddRefFromTrackerSource(referenceTrackerPtr);
-            }
-        }
-
         /// <summary>
         /// Releases the reference from the tracker source.
         /// </summary>
@@ -407,7 +397,7 @@ namespace WinRT
             {
                 Marshal.Release(thatPtr);
             }
-            AddRefFromTrackerSourceUnsafe();
+            NativeAddRefFromTrackerSourceUnsafe();
 
             return new ObjectReferenceValue(thatPtr, ReferenceTrackerPtr, IsAggregated, this);
         }
@@ -631,7 +621,7 @@ namespace WinRT
                     Marshal.Release(thatPtr);
                 }
 
-                sourceRef.AddRefFromTrackerSourceUnsafe();
+                sourceRef.NativeAddRefFromTrackerSourceUnsafe();
 
                 objRef = Attach(ref thatPtr, iid);
                 objRef.IsAggregated = sourceRef.IsAggregated;
@@ -915,7 +905,7 @@ namespace WinRT
                     Marshal.Release(thatPtr);
                 }
 
-                sourceRef.AddRefFromTrackerSourceUnsafe();
+                sourceRef.NativeAddRefFromTrackerSourceUnsafe();
 
                 objRef = new ObjectReferenceWithContext<T>(thatPtr, Context.GetContextCallback(), Context.GetContextToken(), iid)
                 {

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -322,7 +322,7 @@ namespace WinRT
         {
             ReleaseFromTrackerSourceUnsafe();
 
-            Marshal.Release(GetThisRefUnsafe());
+            Marshal.Release(GetThisPtrUnsafe());
         }
 
         private protected unsafe void ReleaseWithoutContext()

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -349,7 +349,7 @@ namespace WinRT
         {
             ReleaseFromTrackerSourceUnsafe();
 
-            Marshal.Release(GetRefUnsafe());
+            Marshal.Release(GetThisRefUnsafe());
         }
 
         private protected unsafe void ReleaseWithoutContext()

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -290,6 +290,8 @@ namespace WinRT
             throw new InvalidOperationException($"Target type '{typeof(T)}' is not a projected type.");
         }
 
+        [Obsolete("This method is not safe. Use 'GetThisPtr()' instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IntPtr GetRef()
         {
             ThrowIfDisposedUnsafe();
@@ -298,7 +300,8 @@ namespace WinRT
         }
 
         /// <inheritdoc cref="NativeReleaseUnsafe"/>
-        [Obsolete("This method is obsoleted and should not be used. Use 'Dispose()' instead.")]
+        [Obsolete("This method is not safe. Use 'Dispose()' instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual unsafe void Release()
         {
             NativeReleaseUnsafe();

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -202,7 +202,7 @@ namespace WinRT
 
         public virtual unsafe ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)
         {
-            AddRef(true);
+            NativeAddRefUnsafe(addRefFromTrackerSource: true);
             var objRef = ObjectReference<IUnknownVftbl>.Attach(ref ptr, IID.IID_IUnknown);
             objRef.IsAggregated = IsAggregated;
             objRef.PreventReleaseOnDispose = IsAggregated;
@@ -293,22 +293,8 @@ namespace WinRT
         public IntPtr GetRef()
         {
             ThrowIfDisposedUnsafe();
-            AddRef(false);
+            NativeAddRefUnsafe(addRefFromTrackerSource: false);
             return ThisPtr;
-        }
-
-        protected virtual unsafe void AddRef(bool refFromTrackerSource)
-        {
-            Marshal.AddRef(ThisPtr);
-            if (refFromTrackerSource)
-            {
-                AddRefFromTrackerSourceUnsafe();
-            }
-        }
-
-        protected virtual unsafe void AddRef()
-        {
-            AddRef(true);
         }
 
         /// <summary>
@@ -906,7 +892,7 @@ namespace WinRT
 
         public override ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)
         {
-            AddRef(true);
+            NativeAddRefUnsafe(addRefFromTrackerSource: true);
             var objRef = new ObjectReferenceWithContext<IUnknownVftbl>(ptr, Context.GetContextCallback(), Context.GetContextToken(), IID.IID_IUnknown)
             {
                 IsAggregated = IsAggregated,

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -41,6 +41,11 @@ namespace WinRT
         /// </remarks>
         private volatile int _referenceTrackingMask;
 
+        /// <remarks>
+        /// Do <b>not</b> use this API. <see cref="ThisPtr"/> is not safe, and will be removed in a
+        /// future release. Use <see cref="GetThisPtr"/>, or use the safe-handle pattern instead.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IntPtr ThisPtr
         {
             get
@@ -282,7 +287,10 @@ namespace WinRT
             throw new InvalidOperationException($"Target type '{typeof(T)}' is not a projected type.");
         }
 
-        [Obsolete("This method is not safe. Use 'GetThisPtr()' instead.")]
+        /// <remarks>
+        /// Do <b>not</b> use this API. <see cref="GetRef"/> is not safe, and will be removed in a
+        /// future release. Use <see cref="GetThisPtr"/>, or use the safe-handle pattern instead.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IntPtr GetRef()
         {

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -46,7 +46,7 @@ namespace WinRT
             get
             {
                 ThrowIfDisposedUnsafe();
-                return GetThisPtrForCurrentContextUnsafe();
+                return GetThisPtrUnsafe();
             }
         }
 
@@ -310,18 +310,6 @@ namespace WinRT
             {
                 return VftblIUnknown.Equals(IUnknownVftbl.AbiToProjectionVftbl);
             }
-        }
-
-        /// <summary>
-        /// Gets the underlying pointer for the current context, owned by the current instance.
-        /// </summary>
-        /// <remarks>
-        /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
-        /// </remarks>
-        internal virtual IntPtr GetThisPtrForCurrentContextUnsafe()
-        {
-            return _thisPtr;
         }
 
         private protected virtual IntPtr GetContextToken()
@@ -676,15 +664,15 @@ namespace WinRT
             _iid = iid;
         }
 
-        internal override IntPtr GetThisPtrForCurrentContextUnsafe()
+        public override IntPtr GetThisPtrUnsafe()
         {
             ObjectReference<T> cachedObjRef = GetCurrentContext();
             if (cachedObjRef == null)
             {
-                return base.GetThisPtrForCurrentContextUnsafe();
+                return base.GetThisPtrUnsafe();
             }
 
-            return cachedObjRef.GetThisPtrForCurrentContextUnsafe();
+            return cachedObjRef.GetThisPtrUnsafe();
         }
 
         private protected override IntPtr GetContextToken()

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -297,25 +297,11 @@ namespace WinRT
             return ThisPtr;
         }
 
-        /// <summary>
-        /// Releases the current object (both the original object and the reference tracker source).
-        /// </summary>
-        /// <remarks>
-        /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
-        /// </remarks>
+        /// <inheritdoc cref="NativeReleaseUnsafe"/>
+        [Obsolete("This method is obsoleted and should not be used. Use 'Dispose()' instead.")]
         protected virtual unsafe void Release()
         {
-            ReleaseFromTrackerSourceUnsafe();
-
-            Marshal.Release(GetThisPtrUnsafe());
-        }
-
-        private protected unsafe void ReleaseWithoutContext()
-        {
-            ReleaseFromTrackerSourceUnsafe();
-
-            Marshal.Release(_thisPtr);
+            NativeReleaseUnsafe();
         }
 
         internal unsafe bool IsReferenceToManagedObject
@@ -331,7 +317,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
+        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
         /// </remarks>
         internal unsafe void ReleaseFromTrackerSourceUnsafe()
         {
@@ -349,7 +335,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
+        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
         /// </remarks>
         private unsafe void DisposeTrackerSourceUnsafe()
         {
@@ -371,7 +357,7 @@ namespace WinRT
         /// </summary>
         /// <remarks>
         /// This method does not check for disposal before releasing the reference.
-        /// This allows it to be used from <see cref="NativeReleaseUnsafe"/>.
+        /// This allows it to be used from <see cref="NativeDisposeUnsafe"/>.
         /// </remarks>
         internal virtual IntPtr GetThisPtrForCurrentContextUnsafe()
         {
@@ -834,7 +820,7 @@ namespace WinRT
             }
         }
 
-        protected override unsafe void Release()
+        private protected override unsafe void NativeReleaseUnsafe()
         {
             // Don't initialize cached context by calling through property if it is already null.
             if (__cachedContext != null)
@@ -860,14 +846,14 @@ namespace WinRT
             {
                 ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
 
-                @this.ReleaseFromBase();
+                @this.BaseNativeReleaseUnsafe();
             }
 
             static void ReleaseWithoutContext(object state)
             {
                 ObjectReferenceWithContext<T> @this = Unsafe.As<ObjectReferenceWithContext<T>>(state);
 
-                @this.ReleaseWithoutContext();
+                @this.NativeReleaseWithoutContextUnsafe();
             }
         }
 
@@ -875,9 +861,9 @@ namespace WinRT
         // We can't just do 'param.base.Release()' (or something like that), so the only way to specifically
         // invoke the base implementation of an overridden method on that object is to go through a helper
         // instance method invoked on it that just calls the base implementation of the method we want.
-        private void ReleaseFromBase()
+        private void BaseNativeReleaseUnsafe()
         {
-            base.Release();
+            base.NativeReleaseUnsafe();
         }
 
         public override ObjectReference<IUnknownVftbl> AsKnownPtr(IntPtr ptr)

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -46,7 +46,7 @@ namespace WinRT
             get
             {
                 ThrowIfDisposedUnsafe();
-                return GetThisPtrForCurrentContext();
+                return GetThisPtrForCurrentContextUnsafe();
             }
         }
 
@@ -415,9 +415,16 @@ namespace WinRT
             }
         }
 
-        private protected virtual IntPtr GetThisPtrForCurrentContext()
+        /// <summary>
+        /// Gets the underlying pointer for the current context, owned by the current instance.
+        /// </summary>
+        /// <remarks>
+        /// This method does not check for disposal before releasing the reference.
+        /// This allows it to be used from <see cref="ReleaseNativeObject"/>.
+        /// </remarks>
+        internal virtual IntPtr GetThisPtrForCurrentContextUnsafe()
         {
-            return ThisPtrFromOriginalContext;
+            return _thisPtr;
         }
 
         private protected virtual IntPtr GetContextToken()
@@ -772,15 +779,15 @@ namespace WinRT
             _iid = iid;
         }
 
-        private protected override IntPtr GetThisPtrForCurrentContext()
+        internal override IntPtr GetThisPtrForCurrentContextUnsafe()
         {
             ObjectReference<T> cachedObjRef = GetCurrentContext();
             if (cachedObjRef == null)
             {
-                return base.GetThisPtrForCurrentContext();
+                return base.GetThisPtrForCurrentContextUnsafe();
             }
 
-            return cachedObjRef.ThisPtr;
+            return cachedObjRef.GetThisPtrForCurrentContextUnsafe();
         }
 
         private protected override IntPtr GetContextToken()

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -27,7 +27,7 @@
     <AdoMirrorBuild Condition="'$(AdoMirrorBuild)' == ''">false</AdoMirrorBuild>
     <GitRepositoryRemoteName Condition="$(AdoMirrorBuild)">github</GitRepositoryRemoteName>
   </PropertyGroup>
-	
+    
   <!-- Configure the assembly version as needed -->
   <PropertyGroup>
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>


### PR DESCRIPTION
Another take on #1474. This ports and adapts [`ReferenceTracker` from ComputeSharp](https://github.com/Sergio0694/ComputeSharp/blob/main/src/ComputeSharp/Graphics/Interop/ReferenceTracker.cs).
Main benefits:
- Safe handling of native resources
- Modern API surface matching .NET naming conventions for unsafe APIs (ie. "Unsafe" suffix)
- Enable any number of concurrent callers as well as multiple/concurrent `Dispose()` calls

This PR only adds the new APIs. We can update all internal and generated uses in a follow up.