### PR TITLE
Support [GeneratedBindableCustomProperty] on structs and records

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -145,10 +145,16 @@ namespace Generator
 
         private static bool NeedCustomPropertyImplementation(SyntaxNode node)
         {
-            return node is ClassDeclarationSyntax declaration &&
-                !declaration.Modifiers.Any(static m => m.IsKind(SyntaxKind.StaticKeyword) || m.IsKind(SyntaxKind.AbstractKeyword)) &&
-                GeneratorHelper.IsPartial(declaration) &&
-                GeneratorHelper.HasBindableCustomPropertyAttribute(declaration);
+            if ((node is ClassDeclarationSyntax classDeclaration && !classDeclaration.Modifiers.Any(static m => m.IsKind(SyntaxKind.StaticKeyword) || m.IsKind(SyntaxKind.AbstractKeyword))) ||
+                (node is RecordDeclarationSyntax recordDeclaration && !recordDeclaration.Modifiers.Any(static m => m.IsKind(SyntaxKind.StaticKeyword) || m.IsKind(SyntaxKind.AbstractKeyword))) ||
+                (node is StructDeclarationSyntax structDeclaration && !structDeclaration.Modifiers.Any(static m => m.IsKind(SyntaxKind.StaticKeyword))))
+            {
+                TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)node;
+
+                return GeneratorHelper.IsPartial(typeDeclaration) && GeneratorHelper.HasBindableCustomPropertyAttribute(typeDeclaration);
+            }
+
+            return false;
         }
 
         private static (VtableAttribute, EquatableArray<VtableAttribute>) GetVtableAttributeToAdd(

--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -255,7 +255,7 @@ namespace Generator
 #nullable enable
         private static BindableCustomProperties GetBindableCustomProperties(GeneratorSyntaxContext context)
         {
-            var symbol = context.SemanticModel.GetDeclaredSymbol((ClassDeclarationSyntax)context.Node)!;
+            var symbol = context.SemanticModel.GetDeclaredSymbol((TypeDeclarationSyntax)context.Node)!;
             INamedTypeSymbol bindableCustomPropertyAttributeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute")!;
 
             if (bindableCustomPropertyAttributeSymbol is null ||

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1696,6 +1696,14 @@ namespace Generator
                     continue;
                 }
 
+                // Skip the [GeneratedBindableCustomProperty] attribute. It is valid to add this on types in WinRT
+                // components (if they need to be exposed and implement ICustomPropertyProvider), but the attribute
+                // should never show up in the .winmd file (it would also cause build errors in the projections).
+                if (attributeType.ToString() == "WinRT.GeneratedBindableCustomPropertyAttribute")
+                {
+                    continue;
+                }
+
                 Logger.Log("attribute: " + attribute);
                 Logger.Log("attribute type: " + attributeType);
                 Logger.Log("attribute constructor: " + attribute.AttributeConstructor);

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -102,5 +102,9 @@
        name="AuthoringTest.CustomPropertyProviderWithExplicitImplementation"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+	<activatableClass
+       name="AuthoringTest.CustomPropertyRecordType"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -102,9 +102,5 @@
        name="AuthoringTest.CustomPropertyProviderWithExplicitImplementation"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
-	<activatableClass
-       name="AuthoringTest.CustomPropertyRecordType"
-       threadingModel="both"
-       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
+++ b/src/Tests/AuthoringConsumptionTest/AuthoringConsumptionTest.exe.manifest
@@ -102,5 +102,9 @@
        name="AuthoringTest.CustomPropertyProviderWithExplicitImplementation"
        threadingModel="both"
        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+       name="AuthoringTest.CustomPropertyRecordTypeFactory"
+       threadingModel="both"
+       xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>
 </assembly>

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -808,3 +808,18 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
     auto propertyValue = customProperty.GetValue(nullptr);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromRecordType");
 }
+
+TEST(AuthoringTest, CustomPropertyRecordStructTypeFactoryAndICPP)
+{
+    auto propertyProvider = CustomPropertyRecordStructTypeFactory::Create();
+
+    auto customProperty = propertyProvider.GetCustomProperty(L"Value");
+
+    EXPECT_NE(customProperty, nullptr);
+    EXPECT_TRUE(customProperty.CanRead());
+    EXPECT_FALSE(customProperty.CanWrite());
+    EXPECT_EQ(customProperty.Name(), L"Value");
+
+    auto propertyValue = customProperty.GetValue(nullptr);
+    EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromRecordStructType");
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -772,3 +772,21 @@ TEST(AuthoringTest, ExplicitlyImplementedICustomPropertyProvider)
     auto propertyValue = customProperty.GetValue(nullptr);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"TestPropertyValue");
 }
+
+TEST(AuthoringTest, GeneratedCustomPropertyStructType)
+{
+    CustomPropertyStructType userObject;
+
+    // We should be able to cast to 'ICustomPropertyProvider'
+    auto propertyProvider = winrt::box_value(userObject).as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
+
+    auto customProperty = propertyProvider.GetCustomProperty(L"Value");
+
+    EXPECT_NE(customProperty, nullptr);
+    EXPECT_TRUE(customProperty.CanRead());
+    EXPECT_FALSE(customProperty.CanWrite());
+    EXPECT_EQ(customProperty.Name(), L"Value");
+
+    auto propertyValue = customProperty.GetValue(nullptr);
+    EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromStructType");
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -811,7 +811,10 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
 
 TEST(AuthoringTest, CustomPropertyRecordStructTypeFactoryAndICPP)
 {
-    auto propertyProvider = CustomPropertyRecordStructTypeFactory::Create();
+    auto userObject = CustomPropertyRecordStructTypeFactory::Create();
+
+    // We should be able to cast to 'ICustomPropertyProvider'
+    auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
 
     auto customProperty = propertyProvider.GetCustomProperty(L"Value");
 

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -790,3 +790,21 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
     auto propertyValue = customProperty.GetValue(nullptr);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromStructType");
 }
+
+TEST(AuthoringTest, GeneratedCustomPropertyStructType)
+{
+    CustomPropertyRecordType userObject;
+
+    // We should be able to cast to 'ICustomPropertyProvider'
+    auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
+
+    auto customProperty = propertyProvider.GetCustomProperty(L"Value");
+
+    EXPECT_NE(customProperty, nullptr);
+    EXPECT_TRUE(customProperty.CanRead());
+    EXPECT_FALSE(customProperty.CanWrite());
+    EXPECT_EQ(customProperty.Name(), L"Value");
+
+    auto propertyValue = customProperty.GetValue(nullptr);
+    EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromRecordType");
+}

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -791,9 +791,9 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromStructType");
 }
 
-TEST(AuthoringTest, GeneratedCustomPropertyStructType)
+TEST(AuthoringTest, GeneratedCustomPropertyRecordType)
 {
-    CustomPropertyRecordType userObject;
+    auto userObject = CustomPropertyRecordTypeFactory::CreateRecord();
 
     // We should be able to cast to 'ICustomPropertyProvider'
     auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
@@ -811,7 +811,7 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
 
 TEST(AuthoringTest, CustomPropertyRecordStructTypeFactoryAndICPP)
 {
-    auto userObject = CustomPropertyRecordStructTypeFactory::Create();
+    auto userObject = CustomPropertyRecordTypeFactory::CreateRecordStruct();
 
     // We should be able to cast to 'ICustomPropertyProvider'
     auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -775,10 +775,10 @@ TEST(AuthoringTest, ExplicitlyImplementedICustomPropertyProvider)
 
 TEST(AuthoringTest, GeneratedCustomPropertyStructType)
 {
-    CustomPropertyStructType userObject;
+    auto userObject = CustomPropertyRecordTypeFactory::CreateStruct();
 
     // We should be able to cast to 'ICustomPropertyProvider'
-    auto propertyProvider = winrt::box_value(userObject).as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
+    auto propertyProvider = userObject.as<Microsoft::UI::Xaml::Data::ICustomPropertyProvider>();
 
     auto customProperty = propertyProvider.GetCustomProperty(L"Value");
 
@@ -787,7 +787,7 @@ TEST(AuthoringTest, GeneratedCustomPropertyStructType)
     EXPECT_FALSE(customProperty.CanWrite());
     EXPECT_EQ(customProperty.Name(), L"Value");
 
-    auto propertyValue = customProperty.GetValue(nullptr);
+    auto propertyValue = customProperty.GetValue(userObject);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromStructType");
 }
 
@@ -805,7 +805,7 @@ TEST(AuthoringTest, GeneratedCustomPropertyRecordType)
     EXPECT_FALSE(customProperty.CanWrite());
     EXPECT_EQ(customProperty.Name(), L"Value");
 
-    auto propertyValue = customProperty.GetValue(nullptr);
+    auto propertyValue = customProperty.GetValue(userObject);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromRecordType");
 }
 
@@ -823,6 +823,6 @@ TEST(AuthoringTest, CustomPropertyRecordStructTypeFactoryAndICPP)
     EXPECT_FALSE(customProperty.CanWrite());
     EXPECT_EQ(customProperty.Name(), L"Value");
 
-    auto propertyValue = customProperty.GetValue(nullptr);
+    auto propertyValue = customProperty.GetValue(userObject);
     EXPECT_EQ(winrt::unbox_value<hstring>(propertyValue), L"CsWinRTFromRecordStructType");
 }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -222,10 +222,15 @@ namespace AuthoringTest
     }
 
     [GeneratedBindableCustomProperty]
-    public partial record struct CustomPropertyRecordStructType
+    internal partial record struct CustomPropertyRecordStructType
     {
         public int Number => 4;
         public string Value => "CsWinRTFromRecordStructType";
+    }
+
+    public static class CustomPropertyRecordStructTypeFactory
+    {
+        public static ICustomPropertyProvider Create() => default(CustomPropertyRecordStructType);
     }
 
     public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -210,6 +210,9 @@ namespace AuthoringTest
     [GeneratedBindableCustomProperty]
     public partial struct CustomPropertyStructType
     {
+        // Public WinRT struct types must have at least one field
+        public int Dummy;
+
         public int Number => 4;
         public string Value => "CsWinRTFromStructType";
     }

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -207,6 +207,13 @@ namespace AuthoringTest
         public string Value => "CsWinRT";
     }
 
+    [GeneratedBindableCustomProperty]
+    public sealed partial struct CustomPropertyStructType
+    {
+        public int Number { get; } = 4;
+        public string Value => "CsWinRTFromStructType";
+    }
+
     public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider
     {
         public Type Type => typeof(CustomPropertyProviderWithExplicitImplementation);

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -233,6 +233,8 @@ namespace AuthoringTest
 
     public static class CustomPropertyRecordTypeFactory
     {
+        public static object CreateStruct() => new CustomPropertyStructType();
+        
         public static object CreateRecord() => new CustomPropertyRecordType();
 
         public static object CreateRecordStruct() => default(CustomPropertyRecordStructType);

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -233,7 +233,7 @@ namespace AuthoringTest
 
     public static class CustomPropertyRecordStructTypeFactory
     {
-        public static ICustomPropertyProvider Create() => default(CustomPropertyRecordStructType);
+        public static object Create() => default(CustomPropertyRecordStructType);
     }
 
     public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -218,7 +218,7 @@ namespace AuthoringTest
     }
 
     [GeneratedBindableCustomProperty]
-    public sealed partial record CustomPropertyRecordType
+    internal sealed partial record CustomPropertyRecordType
     {
         public int Number { get; } = 4;
         public string Value => "CsWinRTFromRecordType";
@@ -231,9 +231,11 @@ namespace AuthoringTest
         public string Value => "CsWinRTFromRecordStructType";
     }
 
-    public static class CustomPropertyRecordStructTypeFactory
+    public static class CustomPropertyRecordTypeFactory
     {
-        public static object Create() => default(CustomPropertyRecordStructType);
+        public static object CreateRecord() => new CustomPropertyRecordType();
+
+        public static object CreateRecordStruct() => default(CustomPropertyRecordStructType);
     }
 
     public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -208,10 +208,24 @@ namespace AuthoringTest
     }
 
     [GeneratedBindableCustomProperty]
-    public sealed partial struct CustomPropertyStructType
+    public partial struct CustomPropertyStructType
+    {
+        public int Number => 4;
+        public string Value => "CsWinRTFromStructType";
+    }
+
+    [GeneratedBindableCustomProperty]
+    public sealed partial record CustomPropertyRecordType
     {
         public int Number { get; } = 4;
-        public string Value => "CsWinRTFromStructType";
+        public string Value => "CsWinRTFromRecordType";
+    }
+
+    [GeneratedBindableCustomProperty]
+    public partial record struct CustomPropertyRecordStructType
+    {
+        public int Number => 4;
+        public string Value => "CsWinRTFromRecordStructType";
     }
 
     public sealed partial class CustomPropertyProviderWithExplicitImplementation : ICustomPropertyProvider

--- a/src/WinRT.Runtime/Attributes.cs
+++ b/src/WinRT.Runtime/Attributes.cs
@@ -231,10 +231,13 @@ namespace WinRT
     }
 
     /// <summary>
-    /// An attribute used to indicate the properties which are bindable via the <see cref="Microsoft.UI.Xaml.Data.ICustomProperty"/> implementation provided for use in WinUI scenarios.
-    /// The type which this attribute is placed on also needs to be marked partial and needs to be non-generic.
+    /// An attribute used to indicate the properties which are bindable via the <see cref="Microsoft.UI.Xaml.Data.ICustomProperty"/> implementation
+    /// provided for use in WinUI scenarios. The type which this attribute is placed on also needs to be marked partial and needs to be non-generic.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    /// <remarks>
+    /// This type also provides equivalent support for the UWP XAML interface (as it shares the same IID as the WinUI type).
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
 #if EMBED
     internal
 #else


### PR DESCRIPTION
This PR enables using `[GeneratedBindableCustomProperty]` on record and struct types as well.
For struct types, it allows binding to boxed value types coming from some properties in XAML.