### PR TITLE
Add support for GeneratedComClassAttribute on WinRT classes

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2718,7 +2718,20 @@ namespace Generator
                     {
                         // Interfaces which are allowed to be implemented on authored types but
                         // aren't WinRT interfaces.
-                        return !ImplementedInterfacesWithoutMapping.Contains(QualifiedName(namedType));
+                        bool isMapped = ImplementedInterfacesWithoutMapping.Contains(QualifiedName(namedType));
+
+                        if (isMapped)
+                            return false;
+
+                        // If the interface is publicly accessible, it is a WinRT interface.
+                        bool isPublic = namedType.IsPubliclyAccessible();
+
+                        if (isPublic)
+                            return true;
+
+                        // If it's not a publicly accessible interface, it's a WinRT interface if it has the
+                        // [WindowsRuntimeType] attribute.
+                        return namedType.GetAttributes().Any(static attribute => string.CompareOrdinal(attribute.AttributeClass.Name, "WindowsRuntimeTypeAttribute") == 0);
                     }
 
                     return namedType.SpecialType != SpecialType.System_Object &&

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -683,6 +683,12 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     winrt::com_ptr<::IUnknown> internalInterface2;
     EXPECT_EQ(unknown2->QueryInterface(internalInterface2Iid, internalInterface2.put_void()), S_OK);
 
+    IID internalInterface3Iid;
+	check_hresult(IIDFromString(L"{6234C2F7-9917-469F-BDB4-3E8C630598AF", &internalInterface3Iid));
+	winrt::com_ptr<::IUnknown> unknown3 = wrapper.as<::IUnknown>();
+	winrt::com_ptr<::IUnknown> internalInterface3;
+	EXPECT_EQ(unknown3->QueryInterface(internalInterface3Iid, internalInterface3.put_void()), S_OK);
+
     typedef int (__stdcall* GetNumber)(void*, int*);
 
     int number;
@@ -694,6 +700,10 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     // Validate the second call on IInternalInterface2
     EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface2.get()))[3])(internalInterface2.get(), &number), S_OK);
     EXPECT_EQ(number, 123);
+
+	// Validate the third call on IInternalInterface3
+	EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface3.get()))[3])(internalInterface3.get(), &number), S_OK);
+	EXPECT_EQ(number, 1);
 }
 
 TEST(AuthoringTest, GetRuntimeClassName)

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -683,8 +683,9 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     winrt::com_ptr<::IUnknown> internalInterface2;
     EXPECT_EQ(unknown2->QueryInterface(internalInterface2Iid, internalInterface2.put_void()), S_OK);
 
+    // Verify we can grab the generated COM interface
     IID internalInterface3Iid;
-	check_hresult(IIDFromString(L"{6234C2F7-9917-469F-BDB4-3E8C630598AF", &internalInterface3Iid));
+	check_hresult(IIDFromString(L"{6234C2F7-9917-469F-BDB4-3E8C630598AF}", &internalInterface3Iid));
 	winrt::com_ptr<::IUnknown> unknown3 = wrapper.as<::IUnknown>();
 	winrt::com_ptr<::IUnknown> internalInterface3;
 	EXPECT_EQ(unknown3->QueryInterface(internalInterface3Iid, internalInterface3.put_void()), S_OK);

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -685,10 +685,10 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
 
     // Verify we can grab the generated COM interface
     IID internalInterface3Iid;
-	check_hresult(IIDFromString(L"{6234C2F7-9917-469F-BDB4-3E8C630598AF}", &internalInterface3Iid));
-	winrt::com_ptr<::IUnknown> unknown3 = wrapper.as<::IUnknown>();
-	winrt::com_ptr<::IUnknown> internalInterface3;
-	EXPECT_EQ(unknown3->QueryInterface(internalInterface3Iid, internalInterface3.put_void()), S_OK);
+    check_hresult(IIDFromString(L"{6234C2F7-9917-469F-BDB4-3E8C630598AF}", &internalInterface3Iid));
+    winrt::com_ptr<::IUnknown> unknown3 = wrapper.as<::IUnknown>();
+    winrt::com_ptr<::IUnknown> internalInterface3;
+    EXPECT_EQ(unknown3->QueryInterface(internalInterface3Iid, internalInterface3.put_void()), S_OK);
 
     typedef int (__stdcall* GetNumber)(void*, int*);
 
@@ -702,9 +702,9 @@ TEST(AuthoringTest, MixedWinRTClassicCOM)
     EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface2.get()))[3])(internalInterface2.get(), &number), S_OK);
     EXPECT_EQ(number, 123);
 
-	// Validate the third call on IInternalInterface3
-	EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface3.get()))[3])(internalInterface3.get(), &number), S_OK);
-	EXPECT_EQ(number, 1);
+    // Validate the third call on IInternalInterface3
+    EXPECT_EQ(reinterpret_cast<GetNumber>((*reinterpret_cast<void***>(internalInterface3.get()))[3])(internalInterface3.get(), &number), S_OK);
+    EXPECT_EQ(number, 1);
 }
 
 TEST(AuthoringTest, GetRuntimeClassName)

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -1804,7 +1804,8 @@ namespace AuthoringTest
         }
     }
 
-    public sealed class TestMixedWinRTCOMWrapper : IGraphicsEffectSource, IPublicInterface, IInternalInterface1, SomeInternalType.IInternalInterface2
+    [System.Runtime.InteropServices.Marshalling.GeneratedComClass]
+    public sealed partial class TestMixedWinRTCOMWrapper : IGraphicsEffectSource, IPublicInterface, IInternalInterface1, SomeInternalType.IInternalInterface2, IInternalInterface3
     {
         public string HelloWorld()
         {
@@ -1823,6 +1824,11 @@ namespace AuthoringTest
             *value = 123;
 
             return 0;
+        }
+
+        int IInternalInterface3.GetNumber()
+        {
+            return 1;
         }
     }
 
@@ -1918,6 +1924,13 @@ namespace AuthoringTest
                 }
             }
         }
+    }
+
+    [System.Runtime.InteropServices.Guid("6234C2F7-9917-469F-BDB4-3E8C630598AF")]
+    [System.Runtime.InteropServices.Marshalling.GeneratedComInterface]
+    internal partial interface IInternalInterface3
+    {
+        int GetNumber();
     }
 
     [System.Runtime.InteropServices.Guid("26D8EE57-8B1B-46F4-A4F9-8C6DEEEAF53A")]

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -210,6 +210,24 @@ namespace WinRT
                 }
             }
 
+#if NET8_0_OR_GREATER
+            var comExposedDetails = System.Runtime.InteropServices.Marshalling.StrategyBasedComWrappers.DefaultIUnknownInterfaceDetailsStrategy.GetComExposedTypeDetails(type.TypeHandle);
+
+            if (comExposedDetails != null)
+            {
+                ReadOnlySpan<ComInterfaceEntry> comInterfaceEntries;
+                unsafe
+                {
+                    ComInterfaceEntry* entriesPointer = comExposedDetails.GetComInterfaceEntries(out int generatedEntriesCount);
+                    comInterfaceEntries = new ReadOnlySpan<ComInterfaceEntry>(entriesPointer, generatedEntriesCount);
+                }
+                foreach (var entry in comInterfaceEntries)
+                {
+                    entries.Add(entry);
+                }
+            }
+#endif
+
             if (winrtExposedClassAttribute != null)
             {
                 hasWinrtExposedClassAttribute = true;


### PR DESCRIPTION
Fixes #1722.
Fixes #1851.

This PR includes two changes:
- Modifying the default COM wrappers so that the vtables generated by the COM Wrappers generators are included.
- Changing how WinRT interfaces are determined in the authoring generator. To be more specific, internal interfaces are now required to include `WindowsRuntimeTypeAttribute` to be considered a WinRT type, rather than all internal interfaces (which is the current behavior)