### PR TITLE
Bump Mono.Cecil to 0.11.6

### DIFF
--- a/src/Perf/IIDOptimizer/IIDOptimizer.csproj
+++ b/src/Perf/IIDOptimizer/IIDOptimizer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This most importantly fixes alignment for RVA fields.