### PR TITLE
Stop relying on UB in 'IContextCallback' dispatch logic

### DIFF
--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -70,6 +70,11 @@ namespace ABI.WinRT.Interop
 
             int hresult;
 
+            // We use a thread local static field to efficiently store the state that's used by the callback. Note that this
+            // is safe with respect to reentrancy, as the target callback will never try to switch back on the original thread.
+            // We're only ever switching once on the original context, only to release the object reference that is passed as
+            // state. There is no way for that to possibly switch back on the starting thread. As such, using a thread static
+            // field to pass the state to the target context (we need to store it somewhere on the managed heap) is fine.
             fixed (object* statePtr = &CallbackData.PerThreadObject)
             {
                 CallbackData callbackData;

--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -62,10 +62,8 @@ namespace ABI.WinRT.Interop
                 }
             }
 
-            ComCallData comCallData;
-            comCallData.dwDispid = 0;
-            comCallData.dwReserved = 0;
-
+            // Store the state object in the thread static to pass to the callback.
+            // We don't need a volatile write here, we have a memory barrier below.
             CallbackData.PerThreadObject = state;
 
             int hresult;
@@ -80,6 +78,11 @@ namespace ABI.WinRT.Interop
                 CallbackData callbackData;
                 callbackData.Callback = callback;
                 callbackData.StatePtr = statePtr;
+
+                ComCallData comCallData;
+                comCallData.dwDispid = 0;
+                comCallData.dwReserved = 0;
+                comCallData.pUserDefined = (IntPtr)(void*)&callbackData;
 
                 Guid iid = IID.IID_ICallbackWithNoReentrancyToApplicationSTA;
 


### PR DESCRIPTION
See https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#cross-thread-access-to-local-variables. This PR fixes accessing the callback state (which is a managed object) from the native callback invoked on the target thread.