### PR TITLE
Replace null pointer function pointer call with helpful exception.

### DIFF
--- a/src/WinRT.Runtime/IWinRTObject.net5.cs
+++ b/src/WinRT.Runtime/IWinRTObject.net5.cs
@@ -68,7 +68,7 @@ namespace WinRT
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    return throwIfNotImplemented ? throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.") : false;
+                    return throwIfNotImplemented ? throw new NotSupportedException($"'IDynamicInterfaceCastable' is not supported for generic type '{type}'.") : false;
                 }
 #endif
 
@@ -104,7 +104,7 @@ namespace WinRT
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    return throwIfNotImplemented ? throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type '{type}'.") : false;
+                    return throwIfNotImplemented ? throw new NotSupportedException($"'IDynamicInterfaceCastable' is not supported for generic type '{type}'.") : false;
                 }
 #endif
 

--- a/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
+++ b/src/WinRT.Runtime/Projections/CollectionHybrid.net5.cs
@@ -24,7 +24,7 @@ namespace ABI.System.Collections.Generic
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type argument '{typeof(T)}'.");
+                    throw new NotSupportedException($"'IDynamicInterfaceCastable' is not supported for generic type argument '{typeof(T)}'.");
                 }
 #endif
 
@@ -77,7 +77,7 @@ namespace ABI.System.Collections.Generic
 #if NET
                 if (!RuntimeFeature.IsDynamicCodeCompiled)
                 {
-                    throw new NotSupportedException($"IDynamicInterfaceCastable is not supported for generic type argument '{typeof(T)}'.");
+                    throw new NotSupportedException($"'IDynamicInterfaceCastable' is not supported for generic type argument '{typeof(T)}'.");
                 }
 #endif
 

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -168,13 +168,34 @@ namespace ABI.Windows.Foundation.Collections
         internal volatile unsafe static delegate*<IObjectReference, K, void> _Remove;
         internal volatile static bool _RcwHelperInitialized;
 
+        internal static unsafe void EnsureInitialized()
+        {
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.IDictionary<K, V>)}' was called without initializing the RCW methods using 'IDictionaryMethods.InitRcwHelper'. " +
+                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+            }
+        }
+
         public static unsafe V Lookup(IObjectReference obj, K key)
         {
+            EnsureInitialized();
             return _Lookup(obj, key);
         }
 
         public static unsafe bool HasKey(IObjectReference obj, K key)
         {
+            EnsureInitialized();
             return _HasKey(obj, key);
         }
 
@@ -184,6 +205,7 @@ namespace ABI.Windows.Foundation.Collections
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 return _GetView(obj);
             }
 
@@ -210,11 +232,13 @@ namespace ABI.Windows.Foundation.Collections
 
         public static unsafe bool Insert(IObjectReference obj, K key, V value)
         {
+            EnsureInitialized();
             return _Insert(obj, key, value);
         }
 
         public static unsafe void Remove(IObjectReference obj, K key)
         {
+            EnsureInitialized();
             _Remove(obj, key);
         }
 

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -168,22 +168,25 @@ namespace ABI.Windows.Foundation.Collections
         internal volatile unsafe static delegate*<IObjectReference, K, void> _Remove;
         internal volatile static bool _RcwHelperInitialized;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void EnsureInitialized()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
             {
-                if (!_RcwHelperInitialized)
-                {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"Type '{typeof(global::System.Collections.Generic.IDictionary<K, V>)}' was called without initializing the RCW methods using 'IDictionaryMethods.InitRcwHelper'. " +
-                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
-                    }
+                return;
+            }
 
-                    ThrowNotInitialized();
+            if (!_RcwHelperInitialized)
+            {
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
+                {
+                    throw new NotImplementedException(
+                        $"Type '{typeof(global::System.Collections.Generic.IDictionary<K, V>)}' was called without initializing the RCW methods using 'IDictionaryMethods.InitRcwHelper'. " +
+                        $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IDictionary.net5.cs
@@ -178,8 +178,8 @@ namespace ABI.Windows.Foundation.Collections
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IDictionary<K, V>)}' was called without initializing the RCW methods using 'IDictionaryMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.IDictionary<K, V>)}' was called without initializing the RCW methods using 'IDictionaryMethods.InitRcwHelper'. " +
+                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -44,12 +44,32 @@ namespace ABI.Windows.Foundation.Collections
         internal volatile unsafe static delegate*<IObjectReference, IEnumerator<T>> _First;
         internal volatile static bool _RcwHelperInitialized;
 
+        internal static unsafe void EnsureInitialized()
+        {
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.IEnumerable<T>)}' was called without initializing the RCW methods using 'IEnumerableMethods.InitRcwHelper'. " +
+                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+            }
+        }
+
         public unsafe static IEnumerator<T> First(IObjectReference obj)
         {
             // Early return to ensure things are trimmed correctly on NAOT.
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 return _First(obj);
             }
 
@@ -470,6 +490,25 @@ namespace ABI.System.Collections.Generic
         internal volatile unsafe static delegate*<IObjectReference, T[], uint> _GetMany;
         internal volatile static bool _RcwHelperInitialized;
 
+        internal static unsafe void EnsureInitialized()
+        {
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.IEnumerator<T>)}' was called without initializing the RCW methods using 'IEnumeratorMethods.InitRcwHelper'. " +
+                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+            }
+        }
+
         public static unsafe bool MoveNext(IObjectReference obj)
         {
             var ThisPtr = obj.ThisPtr;
@@ -485,6 +524,7 @@ namespace ABI.System.Collections.Generic
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 return _GetMany(obj, items);
             }
 
@@ -518,6 +558,7 @@ namespace ABI.System.Collections.Generic
 
         public static unsafe T get_Current(IObjectReference obj)
         {
+            EnsureInitialized();
             return _GetCurrent(obj);
         }
 

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -44,22 +45,25 @@ namespace ABI.Windows.Foundation.Collections
         internal volatile unsafe static delegate*<IObjectReference, IEnumerator<T>> _First;
         internal volatile static bool _RcwHelperInitialized;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void EnsureInitialized()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
             {
-                if (!_RcwHelperInitialized)
-                {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"Type '{typeof(global::System.Collections.Generic.IEnumerable<T>)}' was called without initializing the RCW methods using 'IEnumerableMethods.InitRcwHelper'. " +
-                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
-                    }
+                return;
+            }
 
-                    ThrowNotInitialized();
+            if (!_RcwHelperInitialized)
+            {
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
+                {
+                    throw new NotImplementedException(
+                        $"Type '{typeof(global::System.Collections.Generic.IEnumerable<T>)}' was called without initializing the RCW methods using 'IEnumerableMethods.InitRcwHelper'. " +
+                        $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 
@@ -490,22 +494,25 @@ namespace ABI.System.Collections.Generic
         internal volatile unsafe static delegate*<IObjectReference, T[], uint> _GetMany;
         internal volatile static bool _RcwHelperInitialized;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void EnsureInitialized()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
             {
-                if (!_RcwHelperInitialized)
-                {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IEnumerator<T>)}' was called without initializing the RCW methods using 'IEnumeratorMethods.InitRcwHelper'. " +
-                            $"If using IDynamicInterfaceCastable support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
-                    }
+                return;
+            }
 
-                    ThrowNotInitialized();
+            if (!_RcwHelperInitialized)
+            {
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
+                {
+                    throw new NotImplementedException(
+                        $"'{typeof(global::System.Collections.Generic.IEnumerator<T>)}' was called without initializing the RCW methods using 'IEnumeratorMethods.InitRcwHelper'. " +
+                        $"If using IDynamicInterfaceCastable support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
+++ b/src/WinRT.Runtime/Projections/IEnumerable.net5.cs
@@ -54,8 +54,8 @@ namespace ABI.Windows.Foundation.Collections
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IEnumerable<T>)}' was called without initializing the RCW methods using 'IEnumerableMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.IEnumerable<T>)}' was called without initializing the RCW methods using 'IEnumerableMethods.InitRcwHelper'. " +
+                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();
@@ -501,7 +501,7 @@ namespace ABI.System.Collections.Generic
                     {
                         throw new NotImplementedException(
                             $"'{typeof(global::System.Collections.Generic.IEnumerator<T>)}' was called without initializing the RCW methods using 'IEnumeratorMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"If using IDynamicInterfaceCastable support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -1007,8 +1007,8 @@ namespace ABI.System.Collections.Generic
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IList<T>)}' was called without initializing the RCW methods using 'IListMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.IList<T>)}' was called without initializing the RCW methods using 'IListMethods.InitRcwHelper'. " +
+                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -997,6 +997,25 @@ namespace ABI.System.Collections.Generic
         internal volatile static bool _RcwHelperInitialized;
         internal volatile unsafe static delegate*<bool> _EnsureEnumerableInitialized;
 
+        internal static unsafe void EnsureInitialized()
+        {
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.IList<T>)}' was called without initializing the RCW methods using 'IListMethods.InitRcwHelper'. " +
+                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+            }
+        }
+
         public static unsafe uint get_Size(IObjectReference obj)
         {
             IntPtr ThisPtr = obj.ThisPtr;
@@ -1008,6 +1027,7 @@ namespace ABI.System.Collections.Generic
 
         public static unsafe T GetAt(IObjectReference obj, uint index)
         {
+            EnsureInitialized();
             return _GetAt(obj, index);
         }
 
@@ -1017,6 +1037,7 @@ namespace ABI.System.Collections.Generic
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 return _GetView(obj);
             }
 
@@ -1043,16 +1064,19 @@ namespace ABI.System.Collections.Generic
 
         public static unsafe bool IndexOf(IObjectReference obj, T value, out uint index)
         {
+            EnsureInitialized();
             return _IndexOf(obj, value, out index);
         }
 
         public static unsafe void SetAt(IObjectReference obj, uint index, T value)
         {
+            EnsureInitialized();
             _SetAt(obj, index, value);
         }
 
         public static unsafe void InsertAt(IObjectReference obj, uint index, T value)
         {
+            EnsureInitialized();
             _InsertAt(obj, index, value);
         }
 
@@ -1065,6 +1089,7 @@ namespace ABI.System.Collections.Generic
 
         public static unsafe void Append(IObjectReference obj, T value)
         {
+            EnsureInitialized();
             _Append(obj, value);
         }
 
@@ -1088,6 +1113,7 @@ namespace ABI.System.Collections.Generic
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 return _GetMany(obj, startIndex, items);
             }
 
@@ -1124,6 +1150,7 @@ namespace ABI.System.Collections.Generic
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 _ReplaceAll(obj, items);
 
                 return;

--- a/src/WinRT.Runtime/Projections/IList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IList.net5.cs
@@ -997,22 +997,25 @@ namespace ABI.System.Collections.Generic
         internal volatile static bool _RcwHelperInitialized;
         internal volatile unsafe static delegate*<bool> _EnsureEnumerableInitialized;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void EnsureInitialized()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
             {
-                if (!_RcwHelperInitialized)
-                {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"Type '{typeof(global::System.Collections.Generic.IList<T>)}' was called without initializing the RCW methods using 'IListMethods.InitRcwHelper'. " +
-                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
-                    }
+                return;
+            }
 
-                    ThrowNotInitialized();
+            if (!_RcwHelperInitialized)
+            {
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
+                {
+                    throw new NotImplementedException(
+                        $"Type '{typeof(global::System.Collections.Generic.IList<T>)}' was called without initializing the RCW methods using 'IListMethods.InitRcwHelper'. " +
+                        $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -114,13 +114,34 @@ namespace ABI.Windows.Foundation.Collections
             void> _Split;
         internal volatile static bool _RcwHelperInitialized;
 
+        internal static unsafe void EnsureInitialized()
+        {
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>)}' was called without initializing the RCW methods using 'IReadOnlyDictionaryMethods.InitRcwHelper'. " +
+                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+            }
+        }
+
         public static unsafe V Lookup(IObjectReference obj, K key)
         {
+            EnsureInitialized();
             return _Lookup(obj, key);
         }
 
         public static unsafe bool HasKey(IObjectReference obj, K key)
         {
+            EnsureInitialized();
             return _HasKey(obj, key);
         }
 
@@ -130,8 +151,8 @@ namespace ABI.Windows.Foundation.Collections
             // See https://github.com/dotnet/runtime/blob/main/docs/design/tools/illink/feature-checks.md.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
+                EnsureInitialized();
                 _Split(obj, out first, out second);
-
                 return;
             }
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -124,8 +124,8 @@ namespace ABI.Windows.Foundation.Collections
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>)}' was called without initializing the RCW methods using 'IReadOnlyDictionaryMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>)}' was called without initializing the RCW methods using 'IReadOnlyDictionaryMethods.InitRcwHelper'. " +
+                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyDictionary.net5.cs
@@ -114,22 +114,25 @@ namespace ABI.Windows.Foundation.Collections
             void> _Split;
         internal volatile static bool _RcwHelperInitialized;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void EnsureInitialized()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (RuntimeFeature.IsDynamicCodeCompiled)
             {
-                if (!_RcwHelperInitialized)
-                {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"Type '{typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>)}' was called without initializing the RCW methods using 'IReadOnlyDictionaryMethods.InitRcwHelper'. " +
-                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
-                    }
+                return;
+            }
 
-                    ThrowNotInitialized();
+            if (!_RcwHelperInitialized)
+            {
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
+                {
+                    throw new NotImplementedException(
+                        $"Type '{typeof(global::System.Collections.Generic.IReadOnlyDictionary<K, V>)}' was called without initializing the RCW methods using 'IReadOnlyDictionaryMethods.InitRcwHelper'. " +
+                        $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -128,22 +128,21 @@ namespace ABI.Windows.Foundation.Collections
                         initRcwHelperFallback();
                     }
                 }
+
+                return;
             }
 
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (!_RcwHelperInitialized)
             {
-                if (!_RcwHelperInitialized)
+                [DoesNotReturn]
+                static void ThrowNotInitialized()
                 {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
-                    static void ThrowNotInitialized()
-                    {
-                        throw new NotImplementedException(
-                            $"Type '{typeof(global::System.Collections.Generic.IReadOnlyList<T>)}' was called without initializing the RCW methods using 'IReadOnlyListMethods.InitRcwHelper'. " +
-                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
-                    }
-
-                    ThrowNotInitialized();
+                    throw new NotImplementedException(
+                        $"Type '{typeof(global::System.Collections.Generic.IReadOnlyList<T>)}' was called without initializing the RCW methods using 'IReadOnlyListMethods.InitRcwHelper'. " +
+                        $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                 }
+
+                ThrowNotInitialized();
             }
         }
 

--- a/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReadOnlyList.net5.cs
@@ -138,8 +138,8 @@ namespace ABI.Windows.Foundation.Collections
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.IReadOnlyList<T>)}' was called without initializing the RCW methods using 'IReadOnlyListMethods.InitRcwHelper'. " +
-                            $"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.IReadOnlyList<T>)}' was called without initializing the RCW methods using 'IReadOnlyListMethods.InitRcwHelper'. " +
+                            $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -47,7 +47,7 @@ namespace ABI.System.Collections.Generic
             ComWrappersSupport.RegisterHelperType(typeof(global::System.Collections.Generic.KeyValuePair<K, V>), typeof(global::ABI.System.Collections.Generic.KeyValuePair<K, V>));
         }
 
-        internal static unsafe bool EnsureInitialized()
+        internal static unsafe void EnsureInitialized()
         {
 #if NET
             // Early return to ensure things are trimmed correctly on NAOT.
@@ -55,7 +55,20 @@ namespace ABI.System.Collections.Generic
             // Here we just always return true and rely on the AOT generator doing what's needed.
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
-                return true;
+                if (!_RcwHelperInitialized)
+                {
+                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    static void ThrowNotInitialized()
+                    {
+                        throw new NotImplementedException(
+                            $"'{typeof(global::System.Collections.Generic.KeyValuePair<K, V>)}' was called without initializing the RCW methods using 'KeyValuePairMethods.InitRcwHelper'. " +
+                            $"Ensure InitRcwHelper is called.");
+                    }
+
+                    ThrowNotInitialized();
+                }
+
+                return;
             }
 #endif
 #pragma warning disable IL3050 // https://github.com/dotnet/runtime/issues/97273
@@ -81,8 +94,6 @@ namespace ABI.System.Collections.Generic
                     initRcwHelperFallback();
                 }
             }
-
-            return true;
         }
 
         internal static unsafe K GetKey(IObjectReference obj)

--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -57,12 +57,12 @@ namespace ABI.System.Collections.Generic
             {
                 if (!_RcwHelperInitialized)
                 {
-                    [MethodImpl(MethodImplOptions.NoInlining)]
+                    [DoesNotReturn]
                     static void ThrowNotInitialized()
                     {
                         throw new NotImplementedException(
-                            $"'{typeof(global::System.Collections.Generic.KeyValuePair<K, V>)}' was called without initializing the RCW methods using 'KeyValuePairMethods.InitRcwHelper'. " +
-                            $"Ensure InitRcwHelper is called.");
+                            $"Type '{typeof(global::System.Collections.Generic.KeyValuePair<K, V>)}' was called without initializing the RCW methods using 'KeyValuePairMethods.InitRcwHelper'. " +
+                            $"Ensure the 'InitRcwHelper' method is called.");
                     }
 
                     ThrowNotInitialized();

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5494,8 +5494,8 @@ if (!_RcwHelperInitialized)
 static void ThrowNotInitialized()
 {
 throw new NotImplementedException(
-$"'{typeof(%)}' was called without initializing the RCW methods using '@Methods.InitRcwHelper'. " +
-$"If using IDynamicCastableInterface support to do a dynamic cast to this interface, ensure InitRcwHelper is called.");
+$"Type '{typeof(%)}' was called without initializing the RCW methods using '@Methods.InitRcwHelper'. " +
+$"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this interface, ensure the 'InitRcwHelper' method is called.");
 }
 
 ThrowNotInitialized();

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5484,13 +5484,15 @@ static void set_%Fallback(IObjectReference _genericObj, % value)
         if (writeEnsureRcwMethodsInitialized)
         {
             w.write(R"(
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
 internal static unsafe void _EnsureRcwMethodsInitialized()
 {
-if (!RuntimeFeature.IsDynamicCodeCompiled)
+if (RuntimeFeature.IsDynamicCodeCompiled)
 {
+return;
+}
 if (!_RcwHelperInitialized)
 {
-[MethodImpl(MethodImplOptions.NoInlining)]
 static void ThrowNotInitialized()
 {
 throw new NotImplementedException(
@@ -5499,7 +5501,6 @@ $"If using 'IDynamicInterfaceCastable' support to do a dynamic cast to this inte
 }
 
 ThrowNotInitialized();
-}
 }
 }
 )",


### PR DESCRIPTION
Previously in these scenarios you would have got a null reference exception which may not have been obvious why when looking at how the stack is reported in VS.  Now you will instead get a helpful exception.