### PR TITLE
Fix AnalyzerReleases.Shipped typo

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -47,4 +47,4 @@ CsWinRT1029 | Usage | Warning | Class implements WinRT interfaces generated usin
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-CsWinRT1030 | Usage | Warning | Project needs to be updated with '<AllowUnsafeBlocks>true</AllowUnsafeBlocks>' to allow generic interface code generation.
+CsWinRT1030 | Usage | Warning | Project needs to be updated with `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` to allow generic interface code generation.


### PR DESCRIPTION
Code wasn't correctly escaped.

Before:
![image](https://github.com/user-attachments/assets/b610db9c-f6fb-4d53-a39a-65bc2c1d5820)


After:
![image](https://github.com/user-attachments/assets/bf315707-726b-42a4-b88c-b8c069ed13bc)
