### PR TITLE
Preserve type metadata for casts to WinRT runtime classes.

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -223,7 +223,7 @@ namespace Generator
                     }
 
                     // Avoid cases where the type to be cast from is unknown, or can be done purely through static metadata.
-                    // That is, the type to be cast to inherits from the type of the expression to be cast,
+                    // That is, the type of the expression inherits from the type to be cast to,
                     // as we know the cast will always work.
                     var sourceType = context.SemanticModel.GetTypeInfo(expression).Type;
                     if (sourceType == null || GeneratorHelper.IsDerivedFromType(sourceType, namedTypeSymbol))

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -1159,6 +1159,29 @@ namespace Generator
             throw new ArgumentException();
         }
 
+#nullable enable
+        /// <summary>
+        /// Checks whether a given type is derived from a specified type.
+        /// </summary>
+        /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> instance to check.</param>
+        /// <param name="baseTypeSymbol">The base type to look for.</param>
+        /// <returns>Whether <paramref name="typeSymbol"/> derives from <paramref name="baseTypeSymbol"/>.</returns>
+        public static bool IsDerivedFromType(ITypeSymbol typeSymbol, ITypeSymbol baseTypeSymbol)
+        {
+            for (ITypeSymbol? currentSymbol = typeSymbol.BaseType;
+                 currentSymbol is { SpecialType: not SpecialType.System_Object };
+                 currentSymbol = currentSymbol.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(currentSymbol, baseTypeSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+#nullable disable
+
         public static string EscapeAssemblyNameForIdentifier(string typeName)
         {
             return Regex.Replace(typeName, """[^a-zA-Z0-9_]""", "_");

--- a/src/Authoring/WinRT.SourceGenerator/RcwReflectionFallbackGenerator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/RcwReflectionFallbackGenerator.cs
@@ -118,7 +118,7 @@ public sealed class RcwReflectionFallbackGenerator : IIncrementalGenerator
                 }
 
                 // Ignore attribute types (they're never instantiated like normal RCWs)
-                if (IsDerivedFromType(typeSymbol, attributeSymbol))
+                if (GeneratorHelper.IsDerivedFromType(typeSymbol, attributeSymbol))
                 {
                     continue;
                 }
@@ -262,27 +262,6 @@ public sealed class RcwReflectionFallbackGenerator : IIncrementalGenerator
         }
 
         return Visit(assemblySymbol.GlobalNamespace);
-    }
-
-    /// <summary>
-    /// Checks whether a given type is derived from a specified type.
-    /// </summary>
-    /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> instance to check.</param>
-    /// <param name="baseTypeSymbol">The base type to look for.</param>
-    /// <returns>Whether <paramref name="typeSymbol"/> derives from <paramref name="baseTypeSymbol"/>.</returns>
-    private static bool IsDerivedFromType(ITypeSymbol typeSymbol, ITypeSymbol baseTypeSymbol)
-    {
-        for (ITypeSymbol? currentSymbol = typeSymbol.BaseType;
-             currentSymbol is { SpecialType: not SpecialType.System_Object };
-             currentSymbol = currentSymbol.BaseType)
-        {
-            if (SymbolEqualityComparer.Default.Equals(currentSymbol, baseTypeSymbol))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/Tests/FunctionalTests/CastMetadata/CastMetadata.csproj
+++ b/src/Tests/FunctionalTests/CastMetadata/CastMetadata.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(FunctionalTestsBuildTFMs)</TargetFrameworks>
+    <Platforms>x86;x64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    <PublishProfileFullPath>$(MSBuildProjectDirectory)\..\PublishProfiles\win10-$(Platform).pubxml</PublishProfileFullPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Authoring\WinRT.SourceGenerator\WinRT.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=x64"/>
+    <ProjectReference Include="..\..\..\Projections\Test\Test.csproj" />
+    <ProjectReference Include="..\..\..\Projections\Windows\Windows.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/FunctionalTests/CastMetadata/Program.cs
+++ b/src/Tests/FunctionalTests/CastMetadata/Program.cs
@@ -1,0 +1,3 @@
+﻿using TestComponentCSharp.CastMetadata;
+
+Class castObject = (Class)ClassFactory.Create();

--- a/src/Tests/TestComponentCSharp/CastMetadata.cpp
+++ b/src/Tests/TestComponentCSharp/CastMetadata.cpp
@@ -1,0 +1,12 @@
+#include "pch.h"
+#include "CastMetadata.h"
+#include "CastMetadata.Class.g.cpp"
+#include "CastMetadata.ClassFactory.g.cpp"
+
+namespace winrt::TestComponentCSharp::CastMetadata::implementation
+{
+	winrt::Windows::Foundation::IInspectable ClassFactory::Create()
+	{
+		return winrt::make<Class>();
+	}
+}

--- a/src/Tests/TestComponentCSharp/CastMetadata.h
+++ b/src/Tests/TestComponentCSharp/CastMetadata.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "CastMetadata.Class.g.h"
+#include "CastMetadata.ClassFactory.g.h"
+
+namespace winrt::TestComponentCSharp::CastMetadata::implementation
+{
+	struct Class : ClassT<Class>
+	{
+		Class() = default;
+	};
+
+	struct ClassFactory
+	{
+		static winrt::Windows::Foundation::IInspectable Create();
+	};
+}
+
+namespace winrt::TestComponentCSharp::CastMetadata::factory_implementation
+{
+	struct Class : ClassT<Class, implementation::Class>
+	{
+	};
+
+	struct ClassFactory : ClassFactoryT<ClassFactory, implementation::ClassFactory>
+	{
+	};
+}

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -757,4 +757,19 @@ And this is another one"
             static Int32 StaticProperty { get; };
         }
     }
+
+    namespace CastMetadata
+    {
+        [default_interface]
+        runtimeclass Class
+        {
+            Class();
+        }
+
+		// Test for casting Object to a runtimeclass
+        static runtimeclass ClassFactory
+        {
+			static Object Create();
+        }
+    }
 }

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <ClInclude Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.h" />
     <ClInclude Include="AnotherAssembly.SetPropertyClass.h" />
+    <ClInclude Include="CastMetadata.h" />
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
     <ClInclude Include="CustomExperimentClass.h" />
     <ClInclude Include="CustomEquals.h" />
@@ -103,6 +104,7 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="ABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZabcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.cpp" />
     <ClCompile Include="AnotherAssembly.SetPropertyClass.cpp" />
+    <ClCompile Include="CastMetadata.cpp" />
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
     <ClCompile Include="CustomExperimentClass.cpp" />
     <ClCompile Include="CustomEquals.cpp" />

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
     <ClCompile Include="NonUniqueClass.cpp" />
     <ClCompile Include="CustomIterableTest.cpp" />
+    <ClCompile Include="CastMetadata.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -43,6 +44,7 @@
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
     <ClInclude Include="NonUniqueClass.h" />
     <ClInclude Include="CustomIterableTest.h" />
+    <ClInclude Include="CastMetadata.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/WinRT.Runtime/CastSupport.cs
+++ b/src/WinRT.Runtime/CastSupport.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace WinRT
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class CastSupport
+    {
+        /// <summary>
+        /// Register a runtime class in the cache.
+        /// </summary>
+        /// <param name="runtimeClassName">The runtime class name to register.</param>
+        /// <param name="runtimeClass">The runtime class type to be registered.</param>
+        /// <remarks>This method is only meant to be used in AotOptimizer, in order to allow casting from <see cref="object"/> to a WinRT class.</remarks>
+        public static void RegisterTypeName(string runtimeClassName, Type runtimeClass)
+            => TypeNameSupport.RegisterTypeName(runtimeClassName, runtimeClass);
+    }
+}

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -95,6 +95,11 @@ namespace WinRT
                 });
         }
 
+        public static void RegisterTypeName(string runtimeClassName, Type runtimeClass)
+        {
+            typeNameCache.TryAdd(runtimeClassName, runtimeClass);
+        }
+
         // Helper to get an exception if the input type is 'IReference<T>' when support for it is disabled
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception GetExceptionForUnsupportedIReferenceType(ReadOnlySpan<char> runtimeClassName)

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -86,8 +86,8 @@ if "%cswinrt_assembly_version%"=="" set cswinrt_assembly_version=0.0.0.0
 if "%cswinrt_baseline_breaking_compat_errors%"=="" set cswinrt_baseline_breaking_compat_errors=false
 if "%cswinrt_baseline_assembly_version_compat_errors%"=="" set cswinrt_baseline_assembly_version_compat_errors=false
 
-set cswinrt_functional_tests=JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW
-set cswinrt_aot_functional_tests=JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW
+set cswinrt_functional_tests=CastMetadata, JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW
+set cswinrt_aot_functional_tests=CastMetadata, JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW
 
 if "%cswinrt_platform%" EQU "x86" set run_functional_tests=true
 if "%cswinrt_platform%" EQU "x64" (


### PR DESCRIPTION
Fixes #1860.

> [!NOTE]
> You should disable whitespaces before looking at the changes.