### PR TITLE
Add .NET 6 EOL message

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -56,8 +56,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Embedded.targets" Condition="'$(CsWinRTEmbedded)' == 'true'"/>
   
-  <Target Name="CsWinRTNet5EOL" Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 5" BeforeTargets="CsWinRTPrepareProjection">
-    <Error Text="Support for .NET 5 ended with C#/WinRT 2.0. For .NET 5 support, use C#/WinRT version 1.6.5. See https://github.com/microsoft/CsWinRT/discussions/1232" />
+  <Target Name="CsWinRTNetEOL" Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) < 8" BeforeTargets="CsWinRTPrepareProjection">
+    <Error Text="Support for .NET versions lower than .NET 8 ended with C#/WinRT 2.3. Use C#/WinRT 2.2.0 for .NET 6/7 support and C#/WinRT 1.6.5 for .NET 5 support." />
   </Target>
 
   <!-- Note this runs before the msbuild editor config file is generated because that is what is used to pass properties to the source generator. -->


### PR DESCRIPTION
This is to prevent users from accidentally using the .NET Standard 2.0 WinRT.Runtime.