### PR TITLE
Add 'CsWinRTEnableManifestFreeActivation' feature switch

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -3,11 +3,11 @@ variables:
 - name: MajorVersion
   value: 2
 - name: MinorVersion
-  value: 2
+  value: 3
 - name: PatchVersion
   value: 0
 - name: WinRT.Runtime.AssemblyVersion
-  value: '2.2.0.0'
+  value: '2.3.0.0'
 - name: Net5.SDK.Feed
   value: 'https://dotnetcli.blob.core.windows.net/dotnet'
 - name: Net8.SDK.Version

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -383,7 +383,7 @@ $(CsWinRTInternalProjection)
                                     Value="$(CsWinRTEnableManifestFreeActivation)"
                                     Trim="true" />
 
-    <!-- CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION switch -->
+    <!-- CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION"
                                     Value="$(CsWinRTManifestFreeActivationReportOriginalException)"
                                     Trim="true" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -328,6 +328,7 @@ $(CsWinRTInternalProjection)
     <CsWinRTEnableICustomPropertyProviderSupport Condition="'$(CsWinRTEnableICustomPropertyProviderSupport)' == ''">true</CsWinRTEnableICustomPropertyProviderSupport>
     <CsWinRTEnableIReferenceSupport Condition="'$(CsWinRTEnableIReferenceSupport)' == ''">true</CsWinRTEnableIReferenceSupport>
     <CsWinRTEnableIDynamicInterfaceCastableSupport Condition="'$(CsWinRTEnableIDynamicInterfaceCastableSupport)' == ''">true</CsWinRTEnableIDynamicInterfaceCastableSupport>
+    <CsWinRTEnableManifestFreeActivation Condition="'$(CsWinRTEnableManifestFreeActivation)' == ''">true</CsWinRTEnableManifestFreeActivation>
 
     <!--
       Note: the 'CsWinRTUseWindowsUIXamlProjections' property and associated 'CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS' feature
@@ -374,6 +375,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE"
                                     Value="$(CsWinRTEnableIDynamicInterfaceCastableSupport)"
+                                    Trim="true" />
+
+    <!-- CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION"
+                                    Value="$(CsWinRTEnableManifestFreeActivation)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -108,7 +108,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CsWinRTCcwLookupTableGeneratorEnabled Condition="'$(CsWinRTCcwLookupTableGeneratorEnabled)' == ''">true</CsWinRTCcwLookupTableGeneratorEnabled>
 
       <!--
-	    CsWinRTAotWarningLevel decides the level of warning from the AOT analyzer.
+        CsWinRTAotWarningLevel decides the level of warning from the AOT analyzer.
             0: No warnings
            *1: Warnings for scenarios involving WinRT types that are not built-in system types mapped to WinRT.
             2: Level 1 warnings and warnings for scenarios involving built-in system types mapped to WinRT.
@@ -122,7 +122,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                                         '$(OutputType)' == 'Library' and
                                                         '$(CsWinRTHasAnyIncludes)' == 'true'">0</CsWinRTAotWarningLevel>
       <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == ''">1</CsWinRTAotWarningLevel>
-	</PropertyGroup>
+    </PropertyGroup>
   </Target>
 
   <!-- Remove WinRT.Host.dll and WinRT.Host.Shim.dll references -->
@@ -329,6 +329,7 @@ $(CsWinRTInternalProjection)
     <CsWinRTEnableIReferenceSupport Condition="'$(CsWinRTEnableIReferenceSupport)' == ''">true</CsWinRTEnableIReferenceSupport>
     <CsWinRTEnableIDynamicInterfaceCastableSupport Condition="'$(CsWinRTEnableIDynamicInterfaceCastableSupport)' == ''">true</CsWinRTEnableIDynamicInterfaceCastableSupport>
     <CsWinRTEnableManifestFreeActivation Condition="'$(CsWinRTEnableManifestFreeActivation)' == ''">true</CsWinRTEnableManifestFreeActivation>
+    <CsWinRTManifestFreeActivationReportOriginalException Condition="'$(CsWinRTManifestFreeActivationReportOriginalException)' == ''">false</CsWinRTManifestFreeActivationReportOriginalException>
 
     <!--
       Note: the 'CsWinRTUseWindowsUIXamlProjections' property and associated 'CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS' feature
@@ -380,6 +381,11 @@ $(CsWinRTInternalProjection)
     <!-- CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION switch -->
     <RuntimeHostConfigurationOption Include="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION"
                                     Value="$(CsWinRTEnableManifestFreeActivation)"
+                                    Trim="true" />
+
+    <!-- CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION switch -->
+    <RuntimeHostConfigurationOption Include="CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION"
+                                    Value="$(CsWinRTManifestFreeActivationReportOriginalException)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -49,7 +49,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTRcwFactoryFallbackGeneratorForceOptOut | true \| *false | Forces the RCW factory fallback generator to be disabled (overrides "ForceOptIn" as well)  |
 | CsWinRTMergeReferencedActivationFactories | true \| *false | Makes the native `DllGetActivationFactory` exported function for AOT scenarios also forward the activation call to all referenced WinRT components, allowing them to all be merged into a single executable or shared library |
 | CsWinRTEnableManifestFreeActivation | *true \| false | Enables the manifest-free WinRT activation path as fallback when `RoGetActivationFactory` fails to resolve a WinRT type |
-| CsWinRTManifestFreeActivationReportOriginalException | true \| **false | If 'CsWinRTEnableManifestFreeActivation' is set and activating a type fails, ensures the original exception is thrown, rather than 'NotSupportedException' |
+| CsWinRTManifestFreeActivationReportOriginalException | true \| *false | If 'CsWinRTEnableManifestFreeActivation' is set and activating a type fails, ensures the original exception is thrown, rather than 'NotSupportedException' |
 | CsWinRTAotWarningLevel | 0 \| *1 \| 2 | Specifies the warning level used by the code fixer for trimming and AOT compat (0 - no warnings, 1 - warnings for scenarios involving non built-in types, 2 - warnings for all scenarios) |
 \*Default value
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -49,6 +49,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTRcwFactoryFallbackGeneratorForceOptOut | true \| *false | Forces the RCW factory fallback generator to be disabled (overrides "ForceOptIn" as well)  |
 | CsWinRTMergeReferencedActivationFactories | true \| *false | Makes the native `DllGetActivationFactory` exported function for AOT scenarios also forward the activation call to all referenced WinRT components, allowing them to all be merged into a single executable or shared library |
 | CsWinRTEnableManifestFreeActivation | *true \| false | Enables the manifest-free WinRT activation path as fallback when `RoGetActivationFactory` fails to resolve a WinRT type |
+| CsWinRTManifestFreeActivationReportOriginalException | true \| **false | If 'CsWinRTEnableManifestFreeActivation' is set and activating a type fails, ensures the original exception is thrown, rather than 'NotSupportedException' |
 | CsWinRTAotWarningLevel | 0 \| *1 \| 2 | Specifies the warning level used by the code fixer for trimming and AOT compat (0 - no warnings, 1 - warnings for scenarios involving non built-in types, 2 - warnings for all scenarios) |
 \*Default value
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -48,6 +48,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTRcwFactoryFallbackGeneratorForceOptIn | true \| *false | Forces the RCW factory fallback generator to be enabled (it only runs on .exe projects by default)  |
 | CsWinRTRcwFactoryFallbackGeneratorForceOptOut | true \| *false | Forces the RCW factory fallback generator to be disabled (overrides "ForceOptIn" as well)  |
 | CsWinRTMergeReferencedActivationFactories | true \| *false | Makes the native `DllGetActivationFactory` exported function for AOT scenarios also forward the activation call to all referenced WinRT components, allowing them to all be merged into a single executable or shared library |
+| CsWinRTEnableManifestFreeActivation | *true \| false | Enables the manifest-free WinRT activation path as fallback when `RoGetActivationFactory` fails to resolve a WinRT type |
 | CsWinRTAotWarningLevel | 0 \| *1 \| 2 | Specifies the warning level used by the code fixer for trimming and AOT compat (0 - no warnings, 1 - warnings for scenarios involving non built-in types, 2 - warnings for all scenarios) |
 \*Default value
 

--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -213,25 +213,25 @@ namespace WinRT
         /// <summary>
         /// Activates a WinRT type with the specified runtime class name.
         /// </summary>
-        /// <param name="activatableClassId">The ID of the activatable class (the fully qualified type name).</param>
+        /// <param name="typeName">The ID of the activatable class (the fully qualified type name).</param>
         /// <returns>An <see cref="IObjectReference"/> instance wrapping an instance of the activated WinRT type.</returns>
-        /// <exception cref="NotSupportedException">Thrown if <paramref name="activatableClassId"/> is not registered, and <c>CsWinRTEnableManifestFreeActivation</c> is disabled.</exception>
+        /// <exception cref="NotSupportedException">Thrown if <paramref name="typeName"/> is not registered, and <c>CsWinRTEnableManifestFreeActivation</c> is disabled.</exception>
         /// <exception cref="Exception">Thrown for any failure to activate the specified type (the exact exception type might be a derived type).</exception>
         /// <remarks>
         /// This method will try to activate the target type as follows:
         /// <list type="bullet">
         ///   <item>If <see cref="ActivationHandler"/> is set, it will be used first.</item>
         ///   <item>Otherwise, <a href="https://learn.microsoft.com/windows/win32/api/roapi/nf-roapi-rogetactivationfactory"><c>RoGetActivationFactory</c></a> will be used.</item>
-        ///   <item>Otherwise, the manifest-free fallback path will be used to try to resolve the target .dll to load based on <paramref name="activatableClassId"/>.</item>
+        ///   <item>Otherwise, the manifest-free fallback path will be used to try to resolve the target .dll to load based on <paramref name="typeName"/>.</item>
         /// </list>
         /// </remarks>
-        public static IObjectReference Get(string activatableClassId)
+        public static IObjectReference Get(string typeName)
         {
 #if NET
             // Check hook first
             if (ActivationHandler != null)
             {
-                var factoryFromhandler = GetFromActivationHandler(activatableClassId, IID.IID_IActivationFactory);
+                var factoryFromhandler = GetFromActivationHandler(typeName, IID.IID_IActivationFactory);
                 if (factoryFromhandler != null)
                 {
                     return factoryFromhandler;
@@ -242,26 +242,26 @@ namespace WinRT
             // Prefer the RoGetActivationFactory HRESULT failure over the LoadLibrary/etc. failure
             int hr;
             ObjectReference<IUnknownVftbl> factory;
-            (factory, hr) = WinRTModule.GetActivationFactory<IUnknownVftbl>(activatableClassId, IID.IID_IActivationFactory);
+            (factory, hr) = WinRTModule.GetActivationFactory<IUnknownVftbl>(typeName, IID.IID_IActivationFactory);
             if (factory != null)
             {
                 return factory;
             }
 
-            ThrowIfClassNotRegisteredAndManifestFreeActivationDisabled(activatableClassId, hr);
+            ThrowIfClassNotRegisteredAndManifestFreeActivationDisabled(typeName, hr);
 
-            return ManifestFreeGet(activatableClassId, hr);
+            return ManifestFreeGet(typeName, hr);
         }
 
         /// <summary>
         /// Activates a WinRT type with the specified runtime class name and interface ID.
         /// </summary>
-        /// <param name="activatableClassId">The ID of the activatable class (the fully qualified type name).</param>
+        /// <param name="typeName">The ID of the activatable class (the fully qualified type name).</param>
         /// <param name="iid">The interface ID to use to dispatch the activated type.</param>
         /// <returns>An <see cref="IObjectReference"/> instance wrapping an instance of the activated WinRT type, dispatched with the specified interface ID.</returns>
         /// <inheritdoc cref="Get(string)"/>
 #if NET
-        public static IObjectReference Get(string activatableClassId, Guid iid)
+        public static IObjectReference Get(string typeName, Guid iid)
 #else
         public static ObjectReference<I> Get<I>(string typeName, Guid iid)
 #endif
@@ -270,7 +270,7 @@ namespace WinRT
             // Check hook first
             if (ActivationHandler != null)
             {
-                var factoryFromhandler = GetFromActivationHandler(activatableClassId, iid);
+                var factoryFromhandler = GetFromActivationHandler(typeName, iid);
                 if (factoryFromhandler != null)
                 {
                     return factoryFromhandler;
@@ -282,15 +282,15 @@ namespace WinRT
             int hr;
 #if NET
             ObjectReference<IUnknownVftbl> factory;
-            (factory, hr) = WinRTModule.GetActivationFactory<IUnknownVftbl>(activatableClassId, iid);
+            (factory, hr) = WinRTModule.GetActivationFactory<IUnknownVftbl>(typeName, iid);
             if (factory != null)
             {
                 return factory;
             }
 
-            ThrowIfClassNotRegisteredAndManifestFreeActivationDisabled(activatableClassId, hr);
+            ThrowIfClassNotRegisteredAndManifestFreeActivationDisabled(typeName, hr);
 
-            return ManifestFreeGet(activatableClassId, iid, hr);
+            return ManifestFreeGet(typeName, iid, hr);
 #else
             ObjectReference<I> factory;
             (factory, hr) = WinRTModule.GetActivationFactory<I>(typeName, iid);

--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -192,7 +192,6 @@ namespace WinRT
     }
 
 #nullable enable
-
     /// <summary>
     /// Provides support for activating WinRT types.
     /// </summary>
@@ -420,4 +419,5 @@ namespace WinRT
         }
 #endif
     }
+#nullable restore
 }

--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -384,7 +384,7 @@ namespace WinRT
                 {
                     throw new NotSupportedException(
                         $"Failed to activate type with runtime class name '{typeName}' with 'RoGetActivationFactory' (it returned 0x80040154, ie. 'REGDB_E_CLASSNOTREG'). Make sure to add the activatable class id for the type " +
-                        "to the APPX manifest, or enable the manifest free activation fallback path by disabling the 'CsWinRTEnableManifestFreeActivation' property (note: the fallback path incurs a performance hit).", exception);
+                        "to the APPX manifest, or enable the manifest free activation fallback path by setting the 'CsWinRTEnableManifestFreeActivation' property (note: the fallback path incurs a performance hit).", exception);
                 }
 
                 return exception;

--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -214,7 +214,7 @@ namespace WinRT
         /// </summary>
         /// <param name="typeName">The ID of the activatable class (the fully qualified type name).</param>
         /// <returns>An <see cref="IObjectReference"/> instance wrapping an instance of the activated WinRT type.</returns>
-        /// <exception cref="NotSupportedException">Thrown if <paramref name="typeName"/> is not registered, and <c>CsWinRTEnableManifestFreeActivation</c> is disabled.</exception>
+        /// <exception cref="NotSupportedException">Thrown if <paramref name="typeName"/> is not registered, <c>CsWinRTEnableManifestFreeActivation</c> is disabled, and <c>CsWinRTManifestFreeActivationReportOriginalException</c> is not set.</exception>
         /// <exception cref="Exception">Thrown for any failure to activate the specified type (the exact exception type might be a derived type).</exception>
         /// <remarks>
         /// This method will try to activate the target type as follows:
@@ -372,6 +372,12 @@ namespace WinRT
             if (FeatureSwitches.EnableManifestFreeActivation)
             {
                 return;
+            }
+
+            // Throw the exception directly, if the user requested to preserve it
+            if (FeatureSwitches.ManifestFreeActivationReportOriginalException)
+            {
+                Marshal.ThrowExceptionForHR(hr);
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/WinRT.Runtime/ActivationFactory.cs
+++ b/src/WinRT.Runtime/ActivationFactory.cs
@@ -191,6 +191,8 @@ namespace WinRT
         }
     }
 
+#nullable enable
+
 #if EMBED
     internal
 #else
@@ -202,7 +204,7 @@ namespace WinRT
         /// <summary>
         /// This provides a hook into activation to hook/mock activation of WinRT types.
         /// </summary>
-        public static Func<string, Guid, IntPtr> ActivationHandler { get; set; }
+        public static Func<string, Guid, IntPtr>? ActivationHandler { get; set; }
 #endif
 
         public static IObjectReference Get(string typeName)
@@ -291,7 +293,7 @@ namespace WinRT
                 }
                 moduleName = moduleName.Remove(lastSegment);
 
-                DllModule module = null;
+                DllModule? module = null;
                 if (DllModule.TryLoad(moduleName + ".dll", out module))
                 {
                     (ObjectReference<IUnknownVftbl> factory, hr) = module.GetActivationFactory(typeName);
@@ -351,7 +353,7 @@ namespace WinRT
             [MethodImpl(MethodImplOptions.NoInlining)]
             static Exception GetException(string typeName, int hr)
             {
-                Exception exception = Marshal.GetExceptionForHR(hr);
+                Exception exception = Marshal.GetExceptionForHR(hr)!;
 
                 if (hr == ExceptionHelpers.REGDB_E_CLASSNOTREG)
                 {
@@ -369,7 +371,7 @@ namespace WinRT
         }
 
 #if NET
-        private static IObjectReference GetFromActivationHandler(string typeName, Guid iid)
+        private static IObjectReference? GetFromActivationHandler(string typeName, Guid iid)
         {
             var activationHandler = ActivationHandler;
             if (activationHandler != null)

--- a/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
@@ -1,4 +1,6 @@
 Compat issues with assembly WinRT.Runtime:
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.GeneratedBindableCustomPropertyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class, Inherited=false, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.WinRTExposedTypeAttribute' in the contract but not the implementation.
-Total Issues: 2
+ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
+ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String, System.Guid)' is 'activatableClassId' in the implementation but 'typeName' in the contract.
+Total Issues: 4

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -52,6 +52,11 @@ namespace WinRT
         private const string EnableIDynamicInterfaceCastableSupportPropertyName = "CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE";
 
         /// <summary>
+        /// The configuration property name for <see cref="EnableManifestFreeActivation"/>.
+        /// </summary>
+        private const string EnableManifestFreeActivationPropertyName = "CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION";
+
+        /// <summary>
         /// The configuration property name for <see cref="UseWindowsUIXamlProjections"/>.
         /// </summary>
         private const string UseWindowsUIXamlProjectionsPropertyName = "CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS";
@@ -85,6 +90,11 @@ namespace WinRT
         /// The backing field for <see cref="EnableIDynamicInterfaceCastableSupport"/>.
         /// </summary>
         private static int _enableIDynamicInterfaceCastableSupport;
+
+        /// <summary>
+        /// The backing field for <see cref="EnableManifestFreeActivation"/>.
+        /// </summary>
+        private static int _enableManifestFreeActivation;
 
         /// <summary>
         /// The backing field for <see cref="UseWindowsUIXamlProjections"/>.
@@ -143,6 +153,15 @@ namespace WinRT
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetConfigurationValue(EnableIDynamicInterfaceCastableSupportPropertyName, ref _enableIDynamicInterfaceCastableSupport, true);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not manifest free WinRT activation is supported (defaults to <see langword="true"/>).
+        /// </summary>
+        public static bool EnableManifestFreeActivation
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(EnableManifestFreeActivationPropertyName, ref _enableManifestFreeActivation, true);
         }
 
         /// <summary>

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -57,6 +57,11 @@ namespace WinRT
         private const string EnableManifestFreeActivationPropertyName = "CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION";
 
         /// <summary>
+        /// The configuration property name for <see cref="ManifestFreeActivationReportOriginalException"/>.
+        /// </summary>
+        private const string ManifestFreeActivationReportOriginalExceptionPropertyName = "CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION";
+
+        /// <summary>
         /// The configuration property name for <see cref="UseWindowsUIXamlProjections"/>.
         /// </summary>
         private const string UseWindowsUIXamlProjectionsPropertyName = "CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS";
@@ -95,6 +100,11 @@ namespace WinRT
         /// The backing field for <see cref="EnableManifestFreeActivation"/>.
         /// </summary>
         private static int _enableManifestFreeActivation;
+
+        /// <summary>
+        /// The backing field for <see cref="ManifestFreeActivationReportOriginalException"/>.
+        /// </summary>
+        private static int _manifestFreeActivationReportOriginalException;
 
         /// <summary>
         /// The backing field for <see cref="UseWindowsUIXamlProjections"/>.
@@ -162,6 +172,15 @@ namespace WinRT
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetConfigurationValue(EnableManifestFreeActivationPropertyName, ref _enableManifestFreeActivation, true);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the original exception should be thrown if activation fails when <see cref="EnableManifestFreeActivation"/> is disabled (defaults to <see langword="false"/>).
+        /// </summary>
+        public static bool ManifestFreeActivationReportOriginalException
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetConfigurationValue(ManifestFreeActivationReportOriginalExceptionPropertyName, ref _manifestFreeActivationReportOriginalException, true);
         }
 
         /// <summary>

--- a/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
+++ b/src/WinRT.Runtime/Configuration/FeatureSwitches.cs
@@ -180,7 +180,7 @@ namespace WinRT
         public static bool ManifestFreeActivationReportOriginalException
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetConfigurationValue(ManifestFreeActivationReportOriginalExceptionPropertyName, ref _manifestFreeActivationReportOriginalException, true);
+            get => GetConfigurationValue(ManifestFreeActivationReportOriginalExceptionPropertyName, ref _manifestFreeActivationReportOriginalException, false);
         }
 
         /// <summary>

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -30,6 +30,10 @@
       <method signature="System.Boolean get_EnableManifestFreeActivation()" body="stub" value="false" feature="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION" featurevalue="false"/>
       <method signature="System.Boolean get_EnableManifestFreeActivation()" body="stub" value="true" feature="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION" featurevalue="true"/>
 
+      <!-- CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION switch -->
+      <method signature="System.Boolean get_ManifestFreeActivationReportOriginalException()" body="stub" value="false" feature="CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION" featurevalue="false"/>
+      <method signature="System.Boolean get_ManifestFreeActivationReportOriginalException()" body="stub" value="true" feature="CSWINRT_MANIFEST_FREE_ACTIVATION_REPORT_ORIGINAL_EXCEPTION" featurevalue="true"/>
+
       <!-- CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS switch -->
       <method signature="System.Boolean get_UseWindowsUIXamlProjections()" body="stub" value="false" feature="CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS" featurevalue="false" />
       <method signature="System.Boolean get_UseWindowsUIXamlProjections()" body="stub" value="true" feature="CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS" featurevalue="true" />

--- a/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
+++ b/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml
@@ -25,6 +25,10 @@
       <!-- CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE switch -->
       <method signature="System.Boolean get_EnableIDynamicInterfaceCastableSupport()" body="stub" value="false" feature="CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE" featurevalue="false"/>
       <method signature="System.Boolean get_EnableIDynamicInterfaceCastableSupport()" body="stub" value="true" feature="CSWINRT_ENABLE_IDYNAMICINTERFACECASTABLE" featurevalue="true"/>
+        
+      <!-- CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION switch -->
+      <method signature="System.Boolean get_EnableManifestFreeActivation()" body="stub" value="false" feature="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION" featurevalue="false"/>
+      <method signature="System.Boolean get_EnableManifestFreeActivation()" body="stub" value="true" feature="CSWINRT_ENABLE_MANIFEST_FREE_ACTIVATION" featurevalue="true"/>
 
       <!-- CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS switch -->
       <method signature="System.Boolean get_UseWindowsUIXamlProjections()" body="stub" value="false" feature="CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS" featurevalue="false" />

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -53,6 +53,7 @@ namespace WinRT
         private const int ERROR_BAD_FORMAT = unchecked((int)0x8007000b);
         private const int ERROR_CANCELLED = unchecked((int)0x800704c7);
         private const int ERROR_TIMEOUT = unchecked((int)0x800705b4);
+        internal const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
 
         private static delegate* unmanaged[Stdcall]<IntPtr*, int> getRestrictedErrorInfo;
         private static delegate* unmanaged[Stdcall]<IntPtr, int> setRestrictedErrorInfo;

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -6,4 +6,6 @@ TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory.ActivationHandler' in the implementation but not the reference.
-Total Issues: 7
+ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String)' is 'typeName' in the reference but 'activatableClassId' in the implementation.
+ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String, System.Guid)' is 'typeName' in the reference but 'activatableClassId' in the implementation.
+Total Issues: 9

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -6,6 +6,4 @@ TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory.ActivationHandler' in the implementation but not the reference.
-ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String)' is 'typeName' in the reference but 'activatableClassId' in the implementation.
-ParameterNamesCannotChange : Parameter name on member 'WinRT.ActivationFactory.Get(System.String, System.Guid)' is 'typeName' in the reference but 'activatableClassId' in the implementation.
-Total Issues: 9
+Total Issues: 7

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -3,4 +3,7 @@ TypesMustExist : Type 'WinRT.GeneratedWinRTExposedExternalTypeAttribute' does no
 TypesMustExist : Type 'WinRT.GeneratedWinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.GeneratedBindableCustomPropertyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]' in the implementation to '[AttributeUsageAttribute(AttributeTargets.Class, Inherited=false, AllowMultiple=false)]' in the reference.
 TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the reference but it does exist in the implementation.
-Total Issues: 4
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableContextAttribute' exists on 'WinRT.ActivationFactory' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.NullableAttribute' exists on 'WinRT.ActivationFactory.ActivationHandler' in the implementation but not the reference.
+Total Issues: 7

--- a/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
+++ b/src/WinRT.Runtime/Projections/ICustomPropertyProvider.net5.cs
@@ -409,7 +409,6 @@ namespace ABI.Microsoft.UI.Xaml.Data
                 {
                     throw new NotSupportedException(
                         $"ICustomProperty support used by XAML binding for type '{target.GetType()}' (property '{_name}') requires the type to marked with 'WinRT.GeneratedBindableCustomPropertyAttribute'. " +
-
                         $"If this is a built-in type or a type that can't be marked, a wrapper type should be used around it that is marked to enable this support.");
                 }
 


### PR DESCRIPTION
This PR adds the new "CsWinRTEnableManifestFreeActivation" feature switch (enabled by default), which allows disabling the manifest-free fallback path for WinRT activation. When disabled, all fallback code will be removed, and trying to activate a type that is not registered will throw `NotSupportedException`. This can be useful to:
- Trim more code when manifest free is not needed
- Make it easy to identify ACIDs that are unintentionally missing from the APPX manifest

Ideally, packaged apps should strive to be able to run with this feature switch disabled, for best performance.