### PR TITLE
Implement stub .exe support for apps + WinRT components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *_i.c
 *_p.c
 *.c
+!nuget/sources/*.c
 *.winmd
 *test*.xml
 obj

--- a/nuget/Microsoft.Windows.CsWinRT.BeforeMicrosoftNetSdk.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.BeforeMicrosoftNetSdk.targets
@@ -1,0 +1,27 @@
+<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+  
+    <!-- We need to set the final value of this property here, as if that's set, we need to do additional work before the .NET SDK .targets -->
+    <CsWinRTMergeReferencedActivationFactories Condition="'$(CsWinRTMergeReferencedActivationFactories)' == ''">false</CsWinRTMergeReferencedActivationFactories>
+  </PropertyGroup>
+
+  <!--
+    If we need to merge activation factories and the project is an executable, we need to emit a stub .exe,
+    so in order to do that we need to tell the .NET SDK to export a custom main, and compile to a .dll instead.
+    These two properties have to be set before the Native AOT toolchain runs, that's why it's done from here.
+  -->
+  <PropertyGroup Condition="'$(CsWinRTMergeReferencedActivationFactories)' == 'true' AND ('$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe')">
+    <NativeLib>Shared</NativeLib>
+    <CustomNativeMain>true</CustomNativeMain>
+
+    <!-- Activate our custom target to produce the stub .exe after the publish step -->
+    <_CsWinRTEnableStubExeGeneration>true</_CsWinRTEnableStubExeGeneration>
+  </PropertyGroup>
+
+</Project>

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -69,6 +69,8 @@
 
     <file src="..\src\WinRT.Runtime\Configuration\*.cs" exclude="..\src\WinRT.Runtime\Configuration\*.net*.cs"  target="embedded\any\" />
 
-    <file src="$guid_patch$" target ="build\tools\IIDOptimizer"/>
+    <file src="sources\StubExe.c" target="build\sources"/>
+
+    <file src="$guid_patch$" target="build\tools\IIDOptimizer"/>
   </files>
 </package>

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -22,6 +22,7 @@
     <file src="NOTICE.txt"/>
     <file src="$cswinrt_exe$"/>
     <file src="Microsoft.Windows.CsWinRT.props" target="build"/>
+    <file src="Microsoft.Windows.CsWinRT.BeforeMicrosoftNetSdk.targets" target="build"/>
     <file src="Microsoft.Windows.CsWinRT.targets" target="build"/>
     <file src="Microsoft.Windows.CsWinRT.Authoring.targets" target="build"/>
     <file src="Microsoft.Windows.CsWinRT.Embedded.targets" target="build"/>

--- a/nuget/Microsoft.Windows.CsWinRT.props
+++ b/nuget/Microsoft.Windows.CsWinRT.props
@@ -8,6 +8,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <CsWinRTPath Condition="'$(CsWinRTPath)'==''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..'))</CsWinRTPath>
     <CsWinRTExe>$(CsWinRTPath)cswinrt.exe</CsWinRTExe>
+
+    <!-- Wire up the .targets that should be imported before the .NET SDK -->
+    <BeforeMicrosoftNETSdkTargets>$(BeforeMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.BeforeMicrosoftNetSdk.targets</BeforeMicrosoftNETSdkTargets>
   </PropertyGroup>
 
 </Project>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -391,15 +391,6 @@ int wmain(int argc, wchar_t** argv)
     <WriteLinesToFile Lines="$(_StubExeSourceFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(_StubExeSourceFilePath)" />
 
     <!--
-      We want to invoke MSVC in the folder where we also want the .exe to be produced in.
-      So we also need to adjust the input paths to be relative to that working directory.
-    -->
-    <PropertyGroup>
-      <_StubExeSourceFilePathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeSourceFilePath)))</_StubExeSourceFilePathRelative>
-      <_StubExeNativeLibraryPathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeNativeLibraryPath)))</_StubExeNativeLibraryPathRelative>
-    </PropertyGroup>
-
-    <!--
       Get the path of 'cl.exe' from the Native AOT tooling, which finds the install folder for MSVC already.
       By doing this, we make sure that this can work from a normal terminal too, not just a VS Developer cmd.
     -->
@@ -489,7 +480,7 @@ int wmain(int argc, wchar_t** argv)
     
     <!-- Invoke MSVC to produce the native executable -->
     <Exec
-      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgsText)'
+      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePath)" "$(_StubExeNativeLibraryPath)" $(_StubExeMsvcArgsText)'
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -316,6 +316,82 @@ $(CsWinRTInternalProjection)
     </ItemGroup>
   </Target>
 
+  <!-- Produces a stub .exe for the application, if requested -->
+  <Target
+    Name="_CsWinRTGenerateStubExe"
+    AfterTargets="Publish"
+    Condition="'$(CsWinRTGenerateStubExe)' == 'true'">
+
+    <PropertyGroup>
+    
+      <!-- Prepare the generated files directory -->
+      <_StubExeFolderName>StubExe</_StubExeFolderName>
+      <_StubExeGeneratedFilesDir Condition="'$(_StubExeGeneratedFilesDir)' == '' AND '$(GeneratedFilesDir)' != ''">$(GeneratedFilesDir)\$(_StubExeFolderName)\</_StubExeGeneratedFilesDir>
+      <_StubExeGeneratedFilesDir Condition="'$(_StubExeGeneratedFilesDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'Generated Files', '$(_StubExeFolderName)'))</_StubExeGeneratedFilesDir>
+    
+      <!-- The path of the .lib file produced by the Native AOT toolchain, which we need for the linker -->
+      <_StubExeNativeLibraryPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath), $(AssemblyName).lib))</_StubExeNativeLibraryPath>
+    
+      <!-- Prepare the path of the .c file with the stub .exe source we need to compile -->
+      <_StubExeSourceFileName>$(AssemblyName).c</_StubExeSourceFileName>
+      <_StubExeSourceFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeSourceFileName)))</_StubExeSourceFilePath>
+    
+      <!-- Prepare the output path of the resulting stub .exe -->
+      <_StubExeBinaryFileName>$(AssemblyName).exe</_StubExeBinaryFileName>
+      <_StubExeBinaryOutputFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeBinaryFileName)))</_StubExeBinaryOutputFilePath>
+      <_StubExeBinaryDestinationFilePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(PublishDir), $(_StubExeBinaryFileName)))</_StubExeBinaryDestinationFilePath>
+    </PropertyGroup>
+    
+    <!--
+      This is a simple C source file just jumping into the special 'Main' program of the current project.
+      Note that we need to use '%3B' to escape the semicolons, as otherwise it'll be skipped entirely.
+    -->
+    <PropertyGroup>
+      <_StubExeSourceFileLines>
+        <![CDATA[#include <wchar.h>
+
+// Declare the import for '__managed__Main', which is a special export produced by the
+// Native AOT runtime to allow jumping into the real 'Main' of an application. This is
+// exported automatically when the 'CustomNativeMain' property is set to 'true'.
+__declspec(dllimport)
+int __stdcall __managed__Main(int argc, wchar_t** argv)%3B
+
+// Our entry point is simply a direct jump into the entry point from Native AOT
+int wmain(int argc, wchar_t** argv)
+{
+    return __managed__Main(argc, argv)%3B
+}]]>
+      </_StubExeSourceFileLines>
+    </PropertyGroup>
+    
+    <!-- This whole target might take a minute (and it might fail), so notify the user to help debug issues -->
+    <Message Text="Generating stub .exe" />
+
+    <!-- Ensure the folder exists, or writing to the source file will fail -->
+    <MakeDir Directories="$(_StubExeGeneratedFilesDir)"/>
+      
+    <!-- Write the stub .exe source -->
+    <WriteLinesToFile Lines="$(_StubExeSourceFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(_StubExeSourceFilePath)" />
+
+    <!--
+      We want to invoke MSVC in the folder where we also want the .exe to be produced in.
+      So we also need to adjust the input paths to be relative to that working directory.
+    -->
+    <PropertyGroup>
+      <_StubExeSourceFilePathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeSourceFilePath)))</_StubExeSourceFilePathRelative>
+      <_StubExeNativeLibraryPathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeNativeLibraryPath)))</_StubExeNativeLibraryPathRelative>
+    </PropertyGroup>
+    
+    <!-- Invoke MSVC to produce the native executable -->
+    <Exec
+      Command='cl -nologo "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" /O2'
+      ConsoleToMsBuild="true"
+      WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
+    
+    <!-- Copy the resulting executable to the publish directory -->
+    <Copy SourceFiles="$(_StubExeBinaryOutputFilePath)" DestinationFiles="$(_StubExeBinaryDestinationFilePath)" />
+  </Target>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets')"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Authoring.targets" Condition="'$(CsWinRTComponent)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.IIDOptimizer.targets" Condition="'$(CsWinRTIIDOptimizerOptOut)' != 'true'"/>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -424,6 +424,12 @@ int wmain(int argc, wchar_t** argv)
       <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
       <_StubExeMsvcArgs Include="/link" />
 
+      <!-- Hide the copyright banner for the linker as well -->
+      <_StubExeMsvcArgs Include="/NOLOGO" />
+
+      <!-- Skip generating a manifest file, matching Native AOT (https://learn.microsoft.com/cpp/build/reference/manifest-create-side-by-side-assembly-manifest) -->
+      <_StubExeMsvcArgs Include="/MANIFEST:NO" />
+
       <!--
         Change the behavior for VCRUNTIME140 to be statically linked (the default would be to dynamically link it, due to '/MD').
         See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library.
@@ -432,12 +438,42 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeMsvcArgs Include="/DEFAULTLIB:libvcruntime.lib" />
       <_StubExeMsvcArgs Include="/NODEFAULTLIB:vcruntime.lib" />
 
+      <!--
+        Ignore the following warning (https://learn.microsoft.com/cpp/build/reference/ignore-ignore-specific-warnings):
+        "LINK : warning LNK4098: defaultlib 'libvcruntime.lib' conflicts with use of other libs; use /NODEFAULTLIB:library".
+        This is not an issue in this scenario.
+      -->
+      <_StubExeMsvcArgs Include="/IGNORE:4098" />
+
       <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
       <_StubExeMsvcArgs Include="/INCREMENTAL:NO" />
 
       <!-- Enable COMDAT folding and remove unreferenced code (https://learn.microsoft.com/cpp/build/reference/opt-optimizations) -->
       <_StubExeMsvcArgs Include="/OPT:ICF" />
       <_StubExeMsvcArgs Include="/OPT:REF" />
+
+      <!--
+        Set the bit for AppContainer, for UWP apps (https://learn.microsoft.com/cpp/build/reference/appcontainer-windows-store-app).
+        This is not strictly needed on new Windows versions, but doing so matches the behavior of .NET Native as well.
+      -->
+      <_StubExeMsvcArgs Condition="'$(UseUwpTools)' == 'true'" Include="/APPCONTAINER" />
+
+      <!-- Set the right subsystem type, to match the project type (https://learn.microsoft.com/cpp/build/reference/subsystem-specify-subsystem) -->
+      <_StubExeMsvcArgs Condition="'$(OutputType)' == 'WinExe'" Include="/SUBSYSTEM:WINDOWS" />
+      <_StubExeMsvcArgs Condition="'$(OutputType)' != 'WinExe'" Include="/SUBSYSTEM:CONSOLE" />
+
+      <!-- Enable CFG, if requested (https://learn.microsoft.com/cpp/build/reference/guard-enable-control-flow-guard) -->
+      <_StubExeMsvcArgs Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
+
+      <!-- Configure the CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat) -->
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(Platform)' == 'x64'" Include="/CETCOMPAT" />
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' == 'false' and '$(Platform)' == 'x64'" Include="/CETCOMPAT:NO" />
+
+      <!--
+        Enable EH continuation metadata if CET is not disabled and CFG is enabled, to match what Native AOT does.
+        See: https://learn.microsoft.com/cpp/build/reference/guard-enable-eh-continuation-metadata.
+      -->
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(Platform)' == 'x64' and '$(ControlFlowGuard)' == 'Guard'" Include="/guard:ehcont"/>
     </ItemGroup>
 
     <!-- Combine all arguments, separated by a space (also, using a property makes it easier to inspect them, for debugging) -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -395,9 +395,14 @@ int wmain(int argc, wchar_t** argv)
       By doing this, we make sure that this can work from a normal terminal too, not just a VS Developer cmd.
     -->
     <PropertyGroup>
-      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(_CppToolsDirectory)' != ''">$([System.IO.Path]::Combine($(_CppToolsDirectory), 'cl.exe'))</_ClExeFilePath>
-      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == ''">cl</_ClExeFilePath>
+      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(CsWinRTUseEnvironmentalTools)' == 'true'">cl</_ClExeFilePath>
+      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(_CppToolsDirectory)' != ''">"$([System.IO.Path]::Combine($(_CppToolsDirectory), 'cl.exe'))"</_ClExeFilePath>
     </PropertyGroup>
+
+    <!-- Fail if we can't find any 'cl.exe' -->
+    <Error
+      Condition="'$(_ClExeFilePath)' == ''"
+      Text="Failed to find 'cl.exe', which is needed to compile the project in the current configuration. Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
 
     <!-- Prepare the arguments for MSVC -->
     <ItemGroup>
@@ -495,8 +500,7 @@ int wmain(int argc, wchar_t** argv)
 
     <!-- Also mark the stub .exe as being part of the published items (so it's gathered by the PRI/MSIX tools) -->
     <ItemGroup>
-      <ResolvedFileToPublish Include="$(_StubExeBinaryDestinationFilePath)"
-                             Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
+      <ResolvedFileToPublish Include="$(_StubExeBinaryDestinationFilePath)" Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
         <RelativePath>$(_StubExeBinaryFileName)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -327,11 +327,18 @@ $(CsWinRTInternalProjection)
     <Error Text="The 'CsWinRTMergeReferencedActivationFactories' property can only be set when publishing with Native AOT. Make sure to set the 'PublishAot' property to 'true'." />
   </Target>
 
-  <!-- Produces a stub .exe for the application, if requested -->
+  <!--
+    Produces a stub .exe for the application, if requested. This target is only executed when publishing, and
+    it's injected right after Native AOT invokes MSVC to produce the final binary, and before gathering all
+    publish artifacts. It's important for this target to run right after that, so that we can make sure that
+    the resulting stub .exe is gathered by the following MSIX packaging steps, which need to include it too.
+  -->
   <Target
     Name="_CsWinRTGenerateStubExe"
-    AfterTargets="Publish"
-    Condition="'$(_CsWinRTEnableStubExeGeneration)' == 'true'">
+    DependsOnTargets="PrepareForPublish"
+    AfterTargets="LinkNative"
+    BeforeTargets="ComputeLinkedFilesToPublish"
+    Condition="'$(CsWinRTMergeReferencedActivationFactories)' == 'true' AND '$(PublishAot)' == 'true'">
     <PropertyGroup>
     
       <!-- Prepare the generated files directory -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -407,28 +407,37 @@ int wmain(int argc, wchar_t** argv)
       <!-- Hide the copyright banner, to reduce visual clutter (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) -->
       <_StubExeMsvcArgs Include="/nologo" />
 
+      <!--
+        Configure the binary to dynamically link the C runtime library (the default would be to statically link it).
+        This library (UCRT) has the implementation of all standard C runtime methods, like 'printf'. The dynamically
+        linked version ships in the OS as 'ucrt.dll'. This matches the behavior of Native AOT as well, which links
+        UCRT dynamically, and VCRUNTIME140 (the MSVC-specific part of the C runtime) statically. The latter is much
+        smaller in size, so it does not matter. Dynamically linking UCRT reduces the size from 98 KB to 20 KB.
+        For additional info, see https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library.
+      -->
+      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include=" /MDd" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include=" /MD" />
+
       <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
       <_StubExeMsvcArgs Include=" /O2" />
-
-      <!--
-        Remove some buffer overrun validation code that requires additional CRT support. This is not needed for the stub .exe,
-        as we are literally only jumping into the custom entry point of the app (which will have its own buffer overrun checks)
-        (https://learn.microsoft.com/cpp/build/reference/gs-buffer-security-check).
-      -->
-      <_StubExeMsvcArgs Include="/GS-" />
 
       <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
       <_StubExeMsvcArgs Include="/link" />
 
-      <!-- Skip the relocation section, as it's not needed for .exe files (https://learn.microsoft.com/cpp/build/reference/fixed-fixed-base-address) -->
-      <_StubExeMsvcArgs Include="/fixed" />
+      <!--
+        Change the behavior for VCRUNTIME140 to be statically linked (the default would be to dynamically link it, due to '/MD').
+        See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library.
+        Also see: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries.
+      -->
+      <_StubExeMsvcArgs Include="/DEFAULTLIB:libvcruntime.lib" />
+      <_StubExeMsvcArgs Include="/NODEFAULTLIB:vcruntime.lib" />
 
       <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
-      <_StubExeMsvcArgs Include="/incremental:no" />
+      <_StubExeMsvcArgs Include="/INCREMENTAL:NO" />
 
       <!-- Enable COMDAT folding and remove unreferenced code (https://learn.microsoft.com/cpp/build/reference/opt-optimizations) -->
-      <_StubExeMsvcArgs Include="/opt:icf" />
-      <_StubExeMsvcArgs Include="/opt:ref" />
+      <_StubExeMsvcArgs Include="/OPT:ICF" />
+      <_StubExeMsvcArgs Include="/OPT:REF" />
     </ItemGroup>
 
     <!-- Combine all arguments, separated by a space (also, using a property makes it easier to inspect them, for debugging) -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -392,6 +392,15 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeNativeLibraryPathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeNativeLibraryPath)))</_StubExeNativeLibraryPathRelative>
     </PropertyGroup>
 
+    <!--
+      Get the path of 'cl.exe' from the Native AOT tooling, which finds the install folder for MSVC already.
+      By doing this, we make sure that this can work from a normal terminal too, not just a VS Developer cmd.
+    -->
+    <PropertyGroup>
+      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(_CppToolsDirectory)' != ''">$([System.IO.Path]::Combine($(_CppToolsDirectory), 'cl.exe'))</_ClExeFilePath>
+      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == ''">cl</_ClExeFilePath>
+    </PropertyGroup>
+
     <!-- Prepare the arguments for MSVC -->
     <PropertyGroup>
 
@@ -430,7 +439,7 @@ int wmain(int argc, wchar_t** argv)
     
     <!-- Invoke MSVC to produce the native executable -->
     <Exec
-      Command='cl "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgs)'
+      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgs)'
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -355,6 +355,9 @@ $(CsWinRTInternalProjection)
       <!-- Prepare the path of the .c file with the stub .exe source we need to compile -->
       <_StubExeSourceFileName>$(AssemblyName).c</_StubExeSourceFileName>
       <_StubExeSourceFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeSourceFileName)))</_StubExeSourceFilePath>
+
+      <!-- Get the path to the source in the NuGet package -->
+      <_StubExeOriginalSourceFilePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), 'sources', 'StubExe.c'))</_StubExeOriginalSourceFilePath>
     
       <!-- Prepare the output path of the resulting stub .exe -->
       <_StubExeBinaryFileName>$(AssemblyName).exe</_StubExeBinaryFileName>
@@ -366,28 +369,6 @@ $(CsWinRTInternalProjection)
       <_StubExePlatform Condition="'$(_StubExePlatform)' == '' AND '$(PlatformTarget)' != ''">$(PlatformTarget)</_StubExePlatform>
     </PropertyGroup>
     
-    <!--
-      This is a simple C source file just jumping into the special 'Main' program of the current project.
-      Note that we need to use '%3B' to escape the semicolons, as otherwise it'll be skipped entirely.
-    -->
-    <PropertyGroup>
-      <_StubExeSourceFileLines>
-        <![CDATA[#include <wchar.h>
-
-// Declare the import for '__managed__Main', which is a special export produced by the
-// Native AOT runtime to allow jumping into the real 'Main' of an application. This is
-// exported automatically when the 'CustomNativeMain' property is set to 'true'.
-__declspec(dllimport)
-int __stdcall __managed__Main(int argc, wchar_t** argv)%3B
-
-// Our entry point is simply a direct jump into the entry point from Native AOT
-int wmain(int argc, wchar_t** argv)
-{
-    return __managed__Main(argc, argv)%3B
-}]]>
-      </_StubExeSourceFileLines>
-    </PropertyGroup>
-    
     <!-- This whole target might take a minute (and it might fail), so notify the user to help debug issues -->
     <Message Text="Generating stub .exe" />
 
@@ -395,7 +376,7 @@ int wmain(int argc, wchar_t** argv)
     <MakeDir Directories="$(_StubExeGeneratedFilesDir)"/>
       
     <!-- Write the stub .exe source -->
-    <WriteLinesToFile Lines="$(_StubExeSourceFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" File="$(_StubExeSourceFilePath)" />
+    <Copy SourceFiles="$(_StubExeOriginalSourceFilePath)" DestinationFiles="$(_StubExeSourceFilePath)" />
 
     <!--
       Get the path of 'cl.exe' from the Native AOT tooling, which finds the install folder for MSVC already.

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -402,33 +402,38 @@ int wmain(int argc, wchar_t** argv)
     </PropertyGroup>
 
     <!-- Prepare the arguments for MSVC -->
-    <PropertyGroup>
+    <ItemGroup>
 
       <!-- Hide the copyright banner, to reduce visual clutter (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /nologo</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/nologo" />
 
       <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /O2</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include=" /O2" />
 
       <!--
         Remove some buffer overrun validation code that requires additional CRT support. This is not needed for the stub .exe,
         as we are literally only jumping into the custom entry point of the app (which will have its own buffer overrun checks)
         (https://learn.microsoft.com/cpp/build/reference/gs-buffer-security-check).
       -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /GS-</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/GS-" />
 
       <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /link</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/link" />
 
       <!-- Skip the relocation section, as it's not needed for .exe files (https://learn.microsoft.com/cpp/build/reference/fixed-fixed-base-address) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /fixed</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/fixed" />
 
       <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /incremental:no</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/incremental:no" />
 
       <!-- Enable COMDAT folding and remove unreferenced code (https://learn.microsoft.com/cpp/build/reference/opt-optimizations) -->
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /opt:icf</_StubExeMsvcArgs>
-      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /opt:ref</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs Include="/opt:icf" />
+      <_StubExeMsvcArgs Include="/opt:ref" />
+    </ItemGroup>
+
+    <!-- Combine all arguments, separated by a space (also, using a property makes it easier to inspect them, for debugging) -->
+    <PropertyGroup>
+      <_StubExeMsvcArgsText>@(_StubExeMsvcArgs, ' ')</_StubExeMsvcArgsText>
     </PropertyGroup>
     
     <!--
@@ -439,7 +444,7 @@ int wmain(int argc, wchar_t** argv)
     
     <!-- Invoke MSVC to produce the native executable -->
     <Exec
-      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgs)'
+      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgsText)'
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -46,7 +46,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
     <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(TargetPlatformVersion)</CsWinRTWindowsMetadata>
 
-    <!-- Default to not using the environment tools -->
+    <!--
+      Default to using the environment tools if in a Visual Studio Developer Command Prompt (or PowerShell).
+      See: https://learn.microsoft.com/visualstudio/ide/reference/command-prompt-powershell#developer-command-prompt.
+    -->
+    <CsWinRTUseEnvironmentalTools Condition="'$(CsWinRTUseEnvironmentalTools)' == '' AND '$(VSCMD_VER)' != ''">true</CsWinRTUseEnvironmentalTools>
     <CsWinRTUseEnvironmentalTools Condition="'$(CsWinRTUseEnvironmentalTools)' == ''">false</CsWinRTUseEnvironmentalTools>
   </PropertyGroup>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -14,8 +14,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CsWinRTGenerateProjection Condition="!$(CsWinRTEnabled)">false</CsWinRTGenerateProjection>
     <CsWinRTGenerateProjection Condition="'$(CsWinRTGenerateProjection)' == ''">true</CsWinRTGenerateProjection>
     <AllowUnsafeBlocks Condition="$(CsWinRTEnabled)">true</AllowUnsafeBlocks>
-    <!-- Making sure ResolveAssemblyReferences runs before CoreCompile runs as we have seen it not run in WPF scenarios
-         causing for our targeting pack to not get included or conflicts to be resolved. -->
+
+    <!--
+      Making sure ResolveAssemblyReferences runs before CoreCompile runs as we have seen it not run
+      in WPF scenarios causing for our targeting pack to not get included or conflicts to be resolved.
+    -->
     <CoreCompileDependsOn>ResolveAssemblyReferences;CsWinRTIncludeProjection;CsWinRTRemoveWinMDReferences;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     <TrackFileAccess Condition="'$(CsWinRTComponent)' != 'true'">false</TrackFileAccess>
     <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
@@ -316,12 +319,19 @@ $(CsWinRTInternalProjection)
     </ItemGroup>
   </Target>
 
+  <!-- Emit a warning when 'CsWinRTMergeReferencedActivationFactories' is used incorrectly -->
+  <Target
+    Name="_CsWinRTErrorForInvalidMergeReferencedActivationFactories"
+    BeforeTargets="BeforeCompile"
+    Condition="'$(CsWinRTMergeReferencedActivationFactories)' == 'true' AND '$(PublishAot)' != 'true'">
+    <Error Text="The 'CsWinRTMergeReferencedActivationFactories' property can only be set when publishing with Native AOT. Make sure to set the 'PublishAot' property to 'true'." />
+  </Target>
+
   <!-- Produces a stub .exe for the application, if requested -->
   <Target
     Name="_CsWinRTGenerateStubExe"
     AfterTargets="Publish"
-    Condition="'$(CsWinRTGenerateStubExe)' == 'true'">
-
+    Condition="'$(_CsWinRTEnableStubExeGeneration)' == 'true'">
     <PropertyGroup>
     
       <!-- Prepare the generated files directory -->
@@ -447,11 +457,6 @@ int wmain(int argc, wchar_t** argv)
       Note: the 'CsWinRTUseWindowsUIXamlProjections' property and associated 'CSWINRT_USE_WINDOWS_UI_XAML_PROJECTIONS' feature
       switch are set by the .NET SDK, so that the right projection mode is enabled even when CsWinRT is not directly referenced.
     -->
-  </PropertyGroup>
-
-  <!-- Default values for all other CsWinRT properties (without feature switches) -->
-  <PropertyGroup>
-    <CsWinRTMergeReferencedActivationFactories Condition="'$(CsWinRTMergeReferencedActivationFactories)' == ''">false</CsWinRTMergeReferencedActivationFactories>
   </PropertyGroup>
 
   <!--

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -45,6 +45,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CsWinRTExeTFM Condition="'$(CsWinRTExeTFM)' == ''">netstandard2.0</CsWinRTExeTFM>
     <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
     <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(TargetPlatformVersion)</CsWinRTWindowsMetadata>
+
+    <!-- Default to not using the environment tools -->
+    <CsWinRTUseEnvironmentalTools Condition="'$(CsWinRTUseEnvironmentalTools)' == ''">false</CsWinRTUseEnvironmentalTools>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -381,10 +381,46 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeSourceFilePathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeSourceFilePath)))</_StubExeSourceFilePathRelative>
       <_StubExeNativeLibraryPathRelative>$([MSBuild]::MakeRelative($(_StubExeGeneratedFilesDir), $(_StubExeNativeLibraryPath)))</_StubExeNativeLibraryPathRelative>
     </PropertyGroup>
+
+    <!-- Prepare the arguments for MSVC -->
+    <PropertyGroup>
+
+      <!-- Hide the copyright banner, to reduce visual clutter (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /nologo</_StubExeMsvcArgs>
+
+      <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /O2</_StubExeMsvcArgs>
+
+      <!--
+        Remove some buffer overrun validation code that requires additional CRT support. This is not needed for the stub .exe,
+        as we are literally only jumping into the custom entry point of the app (which will have its own buffer overrun checks)
+        (https://learn.microsoft.com/cpp/build/reference/gs-buffer-security-check).
+      -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /GS-</_StubExeMsvcArgs>
+
+      <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /link</_StubExeMsvcArgs>
+
+      <!-- Skip the relocation section, as it's not needed for .exe files (https://learn.microsoft.com/cpp/build/reference/fixed-fixed-base-address) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /fixed</_StubExeMsvcArgs>
+
+      <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /incremental:no</_StubExeMsvcArgs>
+
+      <!-- Enable COMDAT folding and remove unreferenced code (https://learn.microsoft.com/cpp/build/reference/opt-optimizations) -->
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /opt:icf</_StubExeMsvcArgs>
+      <_StubExeMsvcArgs>$(_StubExeMsvcArgs) /opt:ref</_StubExeMsvcArgs>
+    </PropertyGroup>
+    
+    <!--
+      Remove the broken .exe, if present (see https://github.com/dotnet/runtime/issues/111313). We want to do this before
+      compiling the binary, to ensure users won't ever see the wrong one in the publish folder and use that by accident.
+    -->
+    <Delete Files="$(_StubExeBinaryDestinationFilePath)" />
     
     <!-- Invoke MSVC to produce the native executable -->
     <Exec
-      Command='cl -nologo "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" /O2'
+      Command='cl "$(_StubExeSourceFilePathRelative)" "$(_StubExeNativeLibraryPathRelative)" $(_StubExeMsvcArgs)'
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -474,8 +474,10 @@ $(CsWinRTInternalProjection)
         See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library.
         Also see: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries.
       -->
-      <_StubExeMsvcArgs Include="/NODEFAULTLIB:libucrt.lib" />
-      <_StubExeMsvcArgs Include="/DEFAULTLIB:ucrt.lib" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/NODEFAULTLIB:libucrtd.lib" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/NODEFAULTLIB:libucrt.lib" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/DEFAULTLIB:ucrtd.lib" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/DEFAULTLIB:ucrt.lib" />
 
       <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
       <_StubExeMsvcArgs Include="/INCREMENTAL:NO" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -338,7 +338,7 @@ $(CsWinRTInternalProjection)
     DependsOnTargets="PrepareForPublish"
     AfterTargets="LinkNative"
     BeforeTargets="ComputeLinkedFilesToPublish"
-    Condition="'$(CsWinRTMergeReferencedActivationFactories)' == 'true' AND '$(PublishAot)' == 'true'">
+    Condition="'$(_CsWinRTEnableStubExeGeneration)' == 'true' AND '$(PublishAot)' == 'true'">
     <PropertyGroup>
     
       <!-- Prepare the generated files directory -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -360,6 +360,10 @@ $(CsWinRTInternalProjection)
       <_StubExeBinaryFileName>$(AssemblyName).exe</_StubExeBinaryFileName>
       <_StubExeBinaryOutputFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeBinaryFileName)))</_StubExeBinaryOutputFilePath>
       <_StubExeBinaryDestinationFilePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath), $(_StubExeBinaryFileName)))</_StubExeBinaryDestinationFilePath>
+
+      <!-- Get the target platform (we either use 'Platform', if set and not 'AnyCPU', or fallback to 'PlatformTarget' ) -->
+      <_StubExePlatform Condition="'$(_StubExePlatform)' == '' AND '$(Platform)' != '' AND '$(Platform)' != 'AnyCPU'">$(Platform)</_StubExePlatform>
+      <_StubExePlatform Condition="'$(_StubExePlatform)' == '' AND '$(PlatformTarget)' != ''">$(PlatformTarget)</_StubExePlatform>
     </PropertyGroup>
     
     <!--
@@ -407,11 +411,55 @@ int wmain(int argc, wchar_t** argv)
       Condition="'$(_ClExeFilePath)' == ''"
       Text="Failed to find 'cl.exe', which is needed to compile the project in the current configuration. Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
 
+    <!-- Get the path to the include directories, if not using the environmental tools -->
+    <PropertyGroup Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'">
+
+      <!-- Find the 'include' folder in the MSVC install folder -->
+      <_MsvcCurrentVersionInstallDirectory>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($(_CppToolsDirectory), '..', '..', '..'))))</_MsvcCurrentVersionInstallDirectory>
+      <_MsvcIncludePath>$([System.IO.Path]::Combine($(_MsvcCurrentVersionInstallDirectory), 'include'))</_MsvcIncludePath>
+      <_MsvcLibPath>$([System.IO.Path]::Combine($(_MsvcCurrentVersionInstallDirectory), 'lib', '$(_StubExePlatform)'))</_MsvcLibPath>
+      <_MsvcLibWildcardPath>$([System.IO.Path]::Combine($(_MsvcLibPath), '*.lib'))</_MsvcLibWildcardPath>
+
+      <!-- Also get the root for the Windows SDK headers -->
+      <_WindowsSdk10InstallDirectory Condition="'$(_WindowsSdk10InstallDirectory)' == '' AND '$(WindowsSdkPath)' != ''">$(WindowsSdkPath)</_WindowsSdk10InstallDirectory>
+      <_WindowsSdk10InstallDirectory Condition="'$(_WindowsSdk10InstallDirectory)' == ''">C:\Program Files (x86)\Windows Kits\10</_WindowsSdk10InstallDirectory>
+      <_WindowsSdkIncludePath Condition="'$(TargetPlatformVersion)' != ''">$([System.IO.Path]::Combine($(_WindowsSdk10InstallDirectory), 'Include', '$(TargetPlatformVersion)'))</_WindowsSdkIncludePath>
+      <_WindowsSdk-ucrt-IncludePath>$([System.IO.Path]::Combine($(_WindowsSdkIncludePath), 'ucrt'))</_WindowsSdk-ucrt-IncludePath>
+      <_WindowsSdk-um-IncludePath>$([System.IO.Path]::Combine($(_WindowsSdkIncludePath), 'um'))</_WindowsSdk-um-IncludePath>
+
+      <!-- Do the same for libs as well -->
+      <_WindowsSdkLibPath Condition="'$(TargetPlatformVersion)' != ''">$([System.IO.Path]::Combine($(_WindowsSdk10InstallDirectory), 'Lib', '$(TargetPlatformVersion)'))</_WindowsSdkLibPath>
+      <_WindowsSdk-ucrt-LibPath>$([System.IO.Path]::Combine($(_WindowsSdkLibPath), 'ucrt', '$(_StubExePlatform)'))</_WindowsSdk-ucrt-LibPath>
+      <_WindowsSdk-um-LibPath>$([System.IO.Path]::Combine($(_WindowsSdkLibPath), 'um', '$(_StubExePlatform)'))</_WindowsSdk-um-LibPath>
+      <_WindowsSdk-ucrt-LibWildcardPath>$([System.IO.Path]::Combine($(_WindowsSdk-ucrt-LibPath), '*.lib'))</_WindowsSdk-ucrt-LibWildcardPath>
+      <_WindowsSdk-um-LibWildcardPath>$([System.IO.Path]::Combine($(_WindowsSdk-um-LibPath), '*.lib'))</_WindowsSdk-um-LibWildcardPath>
+    </PropertyGroup>
+
+    <!-- We can't find some of the additional include folders -->
+    <Error
+      Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true' AND ('$(_MsvcIncludePath)' == '' OR !Exists('$(_MsvcIncludePath)') OR '$(_WindowsSdkIncludePath)' == '' OR !Exists('$(_WindowsSdkIncludePath)'))"
+      Text="Failed to find the paths for the include folders to pass to MSVC, which are needed to compile the project in the current configuration. Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
+    
+    <!-- Error on unsupported platforms -->
+    <Error
+      Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true' AND '$(_StubExePlatform)' != 'arm64' AND '$(_StubExePlatform)' != 'x64' AND '$(_StubExePlatform)' != 'x86'"
+      Text="Invalid platform selected to invoke MSVC. Make sure to set 'Platform' to either 'arm64', 'x64', or 'x86'. Alternatively, try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
+
     <!-- Prepare the arguments for MSVC -->
     <ItemGroup>
 
+      <!-- If not using the environmental tools, manually pass the paths to the required libs -->
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_MsvcLibWildcardPath)"' />
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_WindowsSdk-ucrt-LibWildcardPath)"' />
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_WindowsSdk-um-LibWildcardPath)"' />
+
       <!-- Hide the copyright banner, to reduce visual clutter (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) -->
       <_StubExeMsvcArgs Include="/nologo" />
+
+      <!-- If not using the environmental tools, also pass the paths to the necessary include folders -->
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_MsvcIncludePath)"' />
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_WindowsSdk-ucrt-IncludePath)"' />
+      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_WindowsSdk-um-IncludePath)"' />
 
       <!--
         Configure the binary to statically link the C runtime library (https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library).
@@ -471,14 +519,14 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeMsvcArgs Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
 
       <!-- Configure the CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat) -->
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(Platform)' == 'x64'" Include="/CETCOMPAT" />
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' == 'false' and '$(Platform)' == 'x64'" Include="/CETCOMPAT:NO" />
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(_StubExePlatform)' == 'x64'" Include="/CETCOMPAT" />
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' == 'false' and '$(_StubExePlatform)' == 'x64'" Include="/CETCOMPAT:NO" />
 
       <!--
         Enable EH continuation metadata if CET is not disabled and CFG is enabled, to match what Native AOT does.
         See: https://learn.microsoft.com/cpp/build/reference/guard-enable-eh-continuation-metadata.
       -->
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(Platform)' == 'x64' and '$(ControlFlowGuard)' == 'Guard'" Include="/guard:ehcont"/>
+      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(_StubExePlatform)' == 'x64' and '$(ControlFlowGuard)' == 'Guard'" Include="/guard:ehcont"/>
     </ItemGroup>
 
     <!-- Combine all arguments, separated by a space (also, using a property makes it easier to inspect them, for debugging) -->
@@ -494,7 +542,7 @@ int wmain(int argc, wchar_t** argv)
     
     <!-- Invoke MSVC to produce the native executable -->
     <Exec
-      Command='"$(_ClExeFilePath)" "$(_StubExeSourceFilePath)" "$(_StubExeNativeLibraryPath)" $(_StubExeMsvcArgsText)'
+      Command='$(_ClExeFilePath) "$(_StubExeSourceFilePath)" "$(_StubExeNativeLibraryPath)" $(_StubExeMsvcArgsText)'
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -486,6 +486,15 @@ int wmain(int argc, wchar_t** argv)
     
     <!-- Copy the resulting executable to the publish directory -->
     <Copy SourceFiles="$(_StubExeBinaryOutputFilePath)" DestinationFiles="$(_StubExeBinaryDestinationFilePath)" />
+
+    <!-- Also mark the stub .exe as being part of the published items (so it's gathered by the PRI/MSIX tools) -->
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(_StubExeBinaryDestinationFilePath)"
+                             Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
+        <RelativePath>$(_StubExeBinaryFileName)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Prerelease.targets')"/>

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -418,11 +418,11 @@ int wmain(int argc, wchar_t** argv)
         smaller in size, so it does not matter. Dynamically linking UCRT reduces the size from 98 KB to 20 KB. The reason why we're not configuring
         libraries to be dynamically linked, and then just having an opt-out for VCRUNTIME140, is that doing so causes a linker warning.
       -->
-      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include=" /MTd" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include=" /MT" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/MTd" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/MT" />
 
       <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
-      <_StubExeMsvcArgs Include=" /O2" />
+      <_StubExeMsvcArgs Include="/O2" />
 
       <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
       <_StubExeMsvcArgs Include="/link" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -453,6 +453,12 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeMsvcArgs Condition="'$(OutputType)' == 'WinExe'" Include="/SUBSYSTEM:WINDOWS" />
       <_StubExeMsvcArgs Condition="'$(OutputType)' != 'WinExe'" Include="/SUBSYSTEM:CONSOLE" />
 
+      <!--
+        Always set 'wmainCRTStartup' as the entry point (https://learn.microsoft.com/cpp/build/reference/entry-entry-point-symbol).
+        This matches what Native AOT does, and it allows us to always use 'wmain' for all application types, including 'WinExe'.
+      -->
+      <_StubExeMsvcArgs Include="/ENTRY:wmainCRTStartup" />
+
       <!-- Enable CFG, if requested (https://learn.microsoft.com/cpp/build/reference/guard-enable-control-flow-guard) -->
       <_StubExeMsvcArgs Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -356,7 +356,7 @@ $(CsWinRTInternalProjection)
       <!-- Prepare the output path of the resulting stub .exe -->
       <_StubExeBinaryFileName>$(AssemblyName).exe</_StubExeBinaryFileName>
       <_StubExeBinaryOutputFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeBinaryFileName)))</_StubExeBinaryOutputFilePath>
-      <_StubExeBinaryDestinationFilePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(PublishDir), $(_StubExeBinaryFileName)))</_StubExeBinaryDestinationFilePath>
+      <_StubExeBinaryDestinationFilePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath), $(_StubExeBinaryFileName)))</_StubExeBinaryDestinationFilePath>
     </PropertyGroup>
     
     <!--
@@ -490,7 +490,7 @@ int wmain(int argc, wchar_t** argv)
       ConsoleToMsBuild="true"
       WorkingDirectory="$(_StubExeGeneratedFilesDir)" />
     
-    <!-- Copy the resulting executable to the publish directory -->
+    <!-- Copy the resulting executable to the native directory -->
     <Copy SourceFiles="$(_StubExeBinaryOutputFilePath)" DestinationFiles="$(_StubExeBinaryDestinationFilePath)" />
 
     <!-- Also mark the stub .exe as being part of the published items (so it's gathered by the PRI/MSIX tools) -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -408,15 +408,15 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeMsvcArgs Include="/nologo" />
 
       <!--
-        Configure the binary to dynamically link the C runtime library (the default would be to statically link it).
-        This library (UCRT) has the implementation of all standard C runtime methods, like 'printf'. The dynamically
-        linked version ships in the OS as 'ucrt.dll'. This matches the behavior of Native AOT as well, which links
-        UCRT dynamically, and VCRUNTIME140 (the MSVC-specific part of the C runtime) statically. The latter is much
-        smaller in size, so it does not matter. Dynamically linking UCRT reduces the size from 98 KB to 20 KB.
-        For additional info, see https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library.
+        Configure the binary to statically link the C runtime library (https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library).
+        This library (UCRT) has the implementation of all standard C runtime methods, like 'printf'. We want to actually link it dynamically, so we
+        will opt-in that individual library below. The dynamically linked version ships in the OS as 'ucrt.dll'. This matches the behavior of
+        Native AOT as well, which links UCRT dynamically, and VCRUNTIME140 (the MSVC-specific part of the C runtime) statically. The latter is much
+        smaller in size, so it does not matter. Dynamically linking UCRT reduces the size from 98 KB to 20 KB. The reason why we're not configuring
+        libraries to be dynamically linked, and then just having an opt-out for VCRUNTIME140, is that doing so causes a linker warning.
       -->
-      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include=" /MDd" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include=" /MD" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include=" /MTd" />
+      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include=" /MT" />
 
       <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
       <_StubExeMsvcArgs Include=" /O2" />
@@ -431,19 +431,12 @@ int wmain(int argc, wchar_t** argv)
       <_StubExeMsvcArgs Include="/MANIFEST:NO" />
 
       <!--
-        Change the behavior for VCRUNTIME140 to be statically linked (the default would be to dynamically link it, due to '/MD').
+        Change the behavior for UCRT to be dynamically linked (the default would be to statically link it, due to '/MT[d]').
         See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library.
         Also see: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries.
       -->
-      <_StubExeMsvcArgs Include="/DEFAULTLIB:libvcruntime.lib" />
-      <_StubExeMsvcArgs Include="/NODEFAULTLIB:vcruntime.lib" />
-
-      <!--
-        Ignore the following warning (https://learn.microsoft.com/cpp/build/reference/ignore-ignore-specific-warnings):
-        "LINK : warning LNK4098: defaultlib 'libvcruntime.lib' conflicts with use of other libs; use /NODEFAULTLIB:library".
-        This is not an issue in this scenario.
-      -->
-      <_StubExeMsvcArgs Include="/IGNORE:4098" />
+      <_StubExeMsvcArgs Include="/NODEFAULTLIB:libucrt.lib" />
+      <_StubExeMsvcArgs Include="/DEFAULTLIB:ucrt.lib" />
 
       <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
       <_StubExeMsvcArgs Include="/INCREMENTAL:NO" />

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -50,6 +50,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTMergeReferencedActivationFactories | true \| *false | Makes the native `DllGetActivationFactory` exported function for AOT scenarios also forward the activation call to all referenced WinRT components, allowing them to all be merged into a single executable or shared library |
 | CsWinRTEnableManifestFreeActivation | *true \| false | Enables the manifest-free WinRT activation path as fallback when `RoGetActivationFactory` fails to resolve a WinRT type |
 | CsWinRTManifestFreeActivationReportOriginalException | true \| *false | If 'CsWinRTEnableManifestFreeActivation' is set and activating a type fails, ensures the original exception is thrown, rather than 'NotSupportedException' |
+| CsWinRTUseEnvironmentalTools | true \| *false | Makes the invocation of MSVC to produce a stub .exe (for Native AOT scenarios) rely on environmental tools, rather than looking up the MSVC install path |
 | CsWinRTAotWarningLevel | 0 \| *1 \| 2 | Specifies the warning level used by the code fixer for trimming and AOT compat (0 - no warnings, 1 - warnings for scenarios involving non built-in types, 2 - warnings for all scenarios) |
 \*Default value
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -50,7 +50,7 @@ C#/WinRT behavior can be customized with these project properties:
 | CsWinRTMergeReferencedActivationFactories | true \| *false | Makes the native `DllGetActivationFactory` exported function for AOT scenarios also forward the activation call to all referenced WinRT components, allowing them to all be merged into a single executable or shared library |
 | CsWinRTEnableManifestFreeActivation | *true \| false | Enables the manifest-free WinRT activation path as fallback when `RoGetActivationFactory` fails to resolve a WinRT type |
 | CsWinRTManifestFreeActivationReportOriginalException | true \| *false | If 'CsWinRTEnableManifestFreeActivation' is set and activating a type fails, ensures the original exception is thrown, rather than 'NotSupportedException' |
-| CsWinRTUseEnvironmentalTools | true \| *false | Makes the invocation of MSVC to produce a stub .exe (for Native AOT scenarios) rely on environmental tools, rather than looking up the MSVC install path |
+| CsWinRTUseEnvironmentalTools | *true \| false | Makes the invocation of MSVC to produce a stub .exe (for Native AOT scenarios) rely on environmental tools, rather than looking up the MSVC install path. This is enabled by default when running in a Visual Studio Developer Command Prompt (or PowerShell), and false otherwise. |
 | CsWinRTAotWarningLevel | 0 \| *1 \| 2 | Specifies the warning level used by the code fixer for trimming and AOT compat (0 - no warnings, 1 - warnings for scenarios involving non built-in types, 2 - warnings for all scenarios) |
 \*Default value
 

--- a/nuget/sources/StubExe.c
+++ b/nuget/sources/StubExe.c
@@ -1,0 +1,13 @@
+#include <wchar.h>
+
+// Declare the import for '__managed__Main', which is a special export produced by the
+// Native AOT runtime to allow jumping into the real 'Main' of an application. This is
+// exported automatically when the 'CustomNativeMain' property is set to 'true'.
+__declspec(dllimport)
+int __stdcall __managed__Main(int argc, wchar_t** argv);
+
+// Our entry point is simply a direct jump into the entry point from Native AOT
+int wmain(int argc, wchar_t** argv)
+{
+    return __managed__Main(argc, argv);
+}

--- a/src/Authoring/WinRT.SourceGenerator/Generator.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Generator.cs
@@ -271,13 +271,16 @@ namespace Generator
 
                 """);
 
-            // There's three possible cases for this method:
+            // There's four possible cases for this method:
             //   1a) The project is a standalone WinRT component
             //   1b) The project is a WinRT component, and we're chaining other WinRT components
             //   2)  The project is an app/library, but we also want to chain other WinRT components
+            //   4)  There's no possible types to activate (ie. no authored ones, no dependent ones)
             if (context.IsCsWinRTComponent())
             {
-                builder.AppendLine("IntPtr obj = GetActivationFactory(fullyQualifiedTypeName);");
+                builder.AppendLine("""
+                                    IntPtr obj = GetActivationFactory(fullyQualifiedTypeName);
+                    """);
                 builder.AppendLine();
 
                 // Only emit this call if we have actually generated that. We want to avoid generating
@@ -295,7 +298,18 @@ namespace Generator
             }
             else if (ShouldEmitCallToTryGetDependentActivationFactory(context))
             {
-                builder.AppendLine("IntPtr obj = TryGetDependentActivationFactory(fullyQualifiedTypeName);");
+                builder.AppendLine("""
+                                   IntPtr obj = TryGetDependentActivationFactory(fullyQualifiedTypeName);
+                    """);
+                builder.AppendLine();
+            }
+            else
+            {
+                // This ensures we don't get build errors if someone sets 'CsWinRTMergeReferencedActivationFactories'
+                // but there's no referenced activation factories defined yet (ie. no WinRT components referenced).
+                builder.AppendLine("""
+                                   IntPtr obj = IntPtr.Zero;
+                    """);
                 builder.AppendLine();
             }
 


### PR DESCRIPTION
This PR adds support for generating a stub .exe for an app that's merging WinRT components.
We can split the general "stub .exe" feature into two steps:
- This PR covers the stub .exe for the application entry point
- A follow up PR can add support for additional stub .exe-s for custom entry points

This uses a normal binary with standard options.
We can optimize the size to skip CRT in a follow up.