### PR TITLE
Fix IDIC casts failing during authoring scenarios

### DIFF
--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -1567,6 +1567,15 @@ namespace cswinrt
         default: throw_invalid("Unknown type");
         }
     }
+
+    // Returns whether the ABI interface should implement the CCW interface or not.
+    // In authoring scenarios, exclusive interfaces don't exist, so we use the CCW impl type.
+    bool does_abi_interface_implement_ccw_interface(TypeDef const& type)
+    {
+        return settings.component &&
+               settings.filter.includes(type) &&
+               is_exclusive_to(type);
+    }
 }
 
 namespace std


### PR DESCRIPTION
The ABI interfaces in authoring scenarios were previously implementing the ABI impl interfaces.  This means that IDIC casts cannot be done in cross process scenarios of authored types given the IDIC interface doesn't implement the projected interface being used in the cast.  This addresses it by having the ABI interfaces implement the projected interfaces in authoring scenarios.  This is similar to non-authoring scenarios.  The only special case is exclusive interfaces which have no projected interface and will continue to implement the ABI impl interface.