### PR TITLE
Omit static constructors when not needed

### DIFF
--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -88,6 +88,11 @@ namespace cswinrt
         return get_category(type) == category::class_type && type.Flags().Abstract();
     }
 
+    bool is_static(MethodDef const& method)
+    {
+        return method.Flags().Static();
+    }
+
     bool is_constructor(MethodDef const& method)
     {
         return method.Flags().RTSpecialName() && method.Name() == ".ctor";
@@ -108,14 +113,27 @@ namespace cswinrt
         return false;
     }
 
+    bool has_static_constructor(TypeDef const& type)
+    {
+        XLANG_ASSERT(get_category(type) == category::class_type);
+
+        for (auto&& method : type.MethodList())
+        {
+            if (is_constructor(method) && is_static(method))
+            {
+                // Static constructors can't have parameters
+                XLANG_ASSERT(size(method.ParamList()) == 0);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     bool is_special(MethodDef const& method)
     {
         return method.SpecialName() || method.Flags().RTSpecialName();
-    }
-
-    bool is_static(MethodDef const& method)
-    {
-        return method.Flags().Static();
     }
 
     auto get_delegate_invoke(TypeDef const& type)

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -98,6 +98,11 @@ namespace cswinrt
         return method.Flags().RTSpecialName() && method.Name() == ".ctor";
     }
 
+    bool is_static_constructor(MethodDef const& method)
+    {
+        return method.Flags().RTSpecialName() && method.Name() == ".cctor";
+    }
+
     bool has_default_constructor(TypeDef const& type)
     {
         XLANG_ASSERT(get_category(type) == category::class_type);
@@ -119,9 +124,10 @@ namespace cswinrt
 
         for (auto&& method : type.MethodList())
         {
-            if (is_constructor(method) && is_static(method))
+            if (is_static_constructor(method))
             {
-                // Static constructors can't have parameters
+                // Sanity check, these should always be true
+                XLANG_ASSERT(is_static(method));
                 XLANG_ASSERT(size(method.ParamList()) == 0);
 
                 return true;


### PR DESCRIPTION
This PR removes calls to `RuntimeHelpers.RunClassConstructor` when definitely not needed.
Pretty much the same optimization we did in the XAML compiler.