### PR TITLE
Fix projected covariance interfaces

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -780,7 +780,7 @@ namespace Generator
             // Out of all the C# interfaces which are valid WinRT interfaces and
             // support covariance, they all only have one generic parameter,
             // so scoping to only handle that.
-            if (type is not { IsGenericType: true, TypeParameters: [{ Variance: VarianceKind.Out, IsValueType: false }] })
+            if (type is not { IsGenericType: true, TypeParameters: [{ Variance: VarianceKind.Out }], TypeArguments: [{ IsValueType: false }] })
             {
                 return false;
             }

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -288,6 +288,26 @@ if (intToListDict[4].Count != 1 || intToListDict[4].First() != EnumValue.Two)
     return 101;
 }
 
+// Make sure for collections of value types that they don't project IEnumerable<object>
+// as it isn't a covariant interface.
+if (instance.CheckForBindableObjectInterface(new List<int>()) ||
+    instance.CheckForBindableObjectInterface(new List<EnumValue>()) ||
+    instance.CheckForBindableObjectInterface(new List<System.DateTimeOffset>()) ||
+    instance.CheckForBindableObjectInterface(new Dictionary<string, System.DateTimeOffset>()))
+{
+    return 102;
+}
+
+// Make sure for collections of object types that they do project IEnumerable<object>
+// as it is an covariant interface.
+if (!instance.CheckForBindableObjectInterface(new List<object>()) ||
+    !instance.CheckForBindableObjectInterface(new List<CustomClass>()) ||
+    !instance.CheckForBindableObjectInterface(new List<Class>()) ||
+    !instance.CheckForBindableObjectInterface(new List<IProperties1>()))
+{
+    return 103;
+}
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1667,6 +1667,16 @@ namespace winrt::TestComponentCSharp::implementation
         return true;
     }
 
+    bool Class::CheckForBindableObjectInterface(Microsoft::UI::Xaml::Interop::IBindableIterable const& iterable)
+    {
+        if (auto iterableObject = iterable.try_as<WF::Collections::IIterable<WF::IInspectable>>())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     void Class::CopyProperties(winrt::TestComponentCSharp::IProperties1 const& src)
     {
         ReadWriteProperty(src.ReadWriteProperty());

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1671,7 +1671,7 @@ namespace winrt::TestComponentCSharp::implementation
     {
         if (auto iterableObject = iterable.try_as<WF::Collections::IIterable<WF::IInspectable>>())
         {
-            return true;
+            return iterableObject.First() != nullptr;
         }
 
         return false;

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -337,6 +337,8 @@ namespace winrt::TestComponentCSharp::implementation
         void CopyProperties(TestComponentCSharp::IProperties1 const& src);
         void CopyPropertiesViaWeakReference(TestComponentCSharp::IProperties1 const& src);
 
+        bool CheckForBindableObjectInterface(Microsoft::UI::Xaml::Interop::IBindableIterable const& iterable);
+
         void CompleteAsync();
         void CompleteAsync(int32_t hr);
         void AdvanceAsync(int32_t delta);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -382,6 +382,8 @@ namespace TestComponentCSharp
         void CopyProperties(IProperties1 src);
         void CopyPropertiesViaWeakReference(IProperties1 src);
 
+        Boolean CheckForBindableObjectInterface(Microsoft.UI.Xaml.Interop.IBindableIterable iterable);
+
         // Async
         void CompleteAsync(); // Completes the in-flight async operation successfully
         void CompleteAsync(Int32 hr); // Completes the in-flight async operation with a failed HRESULT

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -986,6 +986,15 @@ namespace UnitTest
             var out_nested = (KeyValuePair<KeyValuePair<int, int>, KeyValuePair<string, string>>)TestObject.ObjectProperty;
             Assert.Equal(nested, out_nested);
 
+            // Test projected types in generic of KeyValuePair
+            TestObject.ObjectProperty = new KeyValuePair<string, IProperties1>("one", new Class());
+            TestObject.ObjectProperty = new KeyValuePair<string, Class>("two", new Class());
+            TestObject.ObjectProperty = new KeyValuePair<string, IDisposable>("two", new CustomDisposableTest());
+
+            // Test non-projected types in generic of KeyValuePair
+            TestObject.ObjectProperty = new KeyValuePair<string, PlatformID>("two", PlatformID.Win32NT);
+            TestObject.ObjectProperty = new KeyValuePair<string, Random>("two", new Random());
+
             var strings_in = new[] { "hello", "world" };
             TestObject.StringsProperty = strings_in;
             var strings_out = TestObject.StringsProperty;

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2834,6 +2834,24 @@ namespace UnitTest
             using var qiResult = ccw.As(GuidGenerator.GetIID(typeof(global::System.Collections.Generic.IEnumerable<object>).GetHelperType()));
         }
 
+        [Fact]
+        public void TestForIterableObject()
+        {
+            // Make sure for collections of value types that they don't project IEnumerable<object>
+            // as it isn't a covariant interface.
+            Assert.False(TestObject.CheckForBindableObjectInterface(new List<int>()));
+            Assert.False(TestObject.CheckForBindableObjectInterface(new List<EnumValue>()));
+            Assert.False(TestObject.CheckForBindableObjectInterface(new List<System.DateTimeOffset>()));
+            Assert.False(TestObject.CheckForBindableObjectInterface(new Dictionary<string, System.DateTimeOffset>()));
+
+            // Make sure for collections of object types that they do project IEnumerable<object>
+            // as it is an covariant interface.
+            Assert.True(TestObject.CheckForBindableObjectInterface(new List<object>()));
+            Assert.True(TestObject.CheckForBindableObjectInterface(new List<Class>()));
+            Assert.True(TestObject.CheckForBindableObjectInterface(new List<IProperties1>()));
+            Assert.True(TestObject.CheckForBindableObjectInterface(new List<ManagedType2>()));
+        }
+
         internal class ManagedType2 : List<ManagedType2> { }
 
         internal class ManagedType3 : List<ManagedType3>, IDisposable

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -380,7 +380,7 @@ namespace WinRT
                     entries.Add(ProvideIReferenceArray(type));
                 }
             }
-            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>))
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>) && Projections.IsTypeWindowsRuntimeType(type))
             {
                 if (KeyValuePairHelper.KeyValuePairCCW.TryGetValue(type, out var entry))
                 {

--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -332,6 +333,9 @@ namespace WinRT
             return CreateIID(type);
         }
 
+#if NET8_0_OR_GREATER
+        [SkipLocalsInit]
+#endif
         internal static Guid CreateIIDForGenericType(string signature)
         {
 #if !NET
@@ -342,15 +346,38 @@ namespace WinRT
                 return encode_guid(sha.ComputeHash(data));
             }
 #else
-            var maxBytes = UTF8Encoding.UTF8.GetMaxByteCount(signature.Length);
+#nullable enable
+            // Get the maximum UTF8 byte size and allocate a buffer for the encoding.
+            // If the minimum buffer is small enough, we can stack-allocate it.
+            // The 512 threshold is the smallest one that will contain generally all
+            // enum types names. Eg. we'd get signature strings like this:
+            // 'pinterface({61c17706-2d65-11e0-9ae8-d48564015472};enum(Windows.UI.Xaml.Visibility;u4))'.
+            // Which would result in a number of bytes ~280, including the GUID size.
+            int maxUtf8ByteCount = Encoding.UTF8.GetMaxByteCount(signature.Length);
+            int minimumPooledLength = 16 /* Number of bytes in a GUID */ + maxUtf8ByteCount;
+            byte[]? utf8BytesFromPool = null;
+            Span<byte> utf8Bytes = minimumPooledLength <= 512
+                ? stackalloc byte[512]
+                : (utf8BytesFromPool = ArrayPool<byte>.Shared.Rent(minimumPooledLength));
 
-            var data = new byte[16 /* Number of bytes in a GUID */ + maxBytes];
-            Span<byte> dataSpan = data;
-            wrt_pinterface_namespace.TryWriteBytes(dataSpan);
-            var numBytes = UTF8Encoding.UTF8.GetBytes(signature, dataSpan[16..]);
-            data = data[..(16 + numBytes)];
+            wrt_pinterface_namespace.TryWriteBytes(utf8Bytes);
 
-            return encode_guid(SHA1.HashData(data));
+            int encodedUtf8BytesWritten = Encoding.UTF8.GetBytes(signature, utf8Bytes[16..]);
+            Span<byte> sha1Bytes = stackalloc byte[20]; // 'SHA1.HashSizeInBytes' does not exist on .NET 6, update this when that's dropped
+
+            // Hash the encoded signature (the bytes written are guaranteed to always match the span)
+            _ = SHA1.HashData(utf8Bytes[..(16 + encodedUtf8BytesWritten)], sha1Bytes);
+
+            Guid iid = encode_guid(sha1Bytes);
+
+            // Before exiting, make sure to return the array from the pool, if we rented one
+            if (utf8BytesFromPool is not null)
+            {
+                ArrayPool<byte>.Shared.Return(utf8BytesFromPool);
+            }
+
+            return iid;
+#nullable restore
 #endif
         }
     }

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -502,7 +502,7 @@ namespace WinRT
                 }
             }
 
-            Type baseType = type.BaseType;
+            Type baseType = type.IsInterface ? typeof(object) : type.BaseType;
             while (baseType != null)
             {
                 if (IsTypeWindowsRuntimeTypeNoArray(baseType))


### PR DESCRIPTION
- In the AOT optimizer, for collection types with value types as the generic instantiation, we were projecting a covariant interface on the vtable for IEnumerable<object> when it isn't a covariant interface.  This addresses that by fixing the check for it.
- Added tests to validate scenarios where the interface should be projected and shouldn't.
- During testing, it was discovered for collections of interfaces, we were not projecting object as a covariance given `BaseType` returns null for interfaces.  This is addressed by an interface check that was added.