### PR TITLE
Use specialized marshallers for generic instantiations

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -740,7 +740,8 @@ namespace Generator
                         genericParameters.Add(new GenericParameter(
                             ToFullyQualifiedString(genericParameter),
                             GeneratorHelper.GetAbiType(genericParameter, mapper),
-                            isNullable ? TypeKind.Interface : genericParameter.TypeKind));
+                            isNullable ? TypeKind.Interface : genericParameter.TypeKind,
+                            ComputeTypeFlags(genericParameter, compilation)));
                     }
 
                     genericInterfacesToAddToVtable.Add(new GenericInterface(
@@ -771,6 +772,25 @@ namespace Generator
                     interfaceToUseForRuntimeClassName = iface;
                 }
             }
+        }
+
+        private static TypeFlags ComputeTypeFlags(ITypeSymbol symbol, Compilation compilation)
+        {
+            TypeFlags typeFlags = TypeFlags.None;
+
+            // Check for exception types
+            if (symbol.TypeKind is TypeKind.Class)
+            {
+                var exceptionType = compilation.GetTypeByMetadataName("System.Exception")!;
+
+                if (SymbolEqualityComparer.Default.Equals(symbol, exceptionType) ||
+                    symbol.InheritsFromType(exceptionType))
+                {
+                    typeFlags |= TypeFlags.Exception;
+                }
+            }
+
+            return typeFlags;
         }
 
         private static bool TryGetCompatibleWindowsRuntimeTypesForVariantType(INamedTypeSymbol type, TypeMapper mapper, Stack<INamedTypeSymbol> typeStack, Func<ISymbol, TypeMapper, bool> isWinRTType, INamedTypeSymbol objectType, out IList<INamedTypeSymbol> compatibleTypes)
@@ -1873,7 +1893,8 @@ namespace Generator
     internal readonly record struct GenericParameter(
         string ProjectedType,
         string AbiType,
-        TypeKind TypeKind);
+        TypeKind TypeKind,
+        TypeFlags TypeFlags);
 
     internal readonly record struct GenericInterface(
         string Interface,
@@ -1922,6 +1943,20 @@ namespace Generator
         bool IsCsWinRTComponent,
         bool IsCsWinRTCcwLookupTableGeneratorEnabled,
         bool IsCsWinRTAotOptimizerInAutoMode);
+
+    /// <summary>
+    /// Additional flags for discovered types.
+    /// </summary>
+    [Flags]
+    internal enum TypeFlags
+    {
+        None = 0x0,
+
+        /// <summary>
+        /// The type derives from <see cref="System.Exception"/>.
+        /// </summary>
+        Exception = 0x1 << 0
+    }
 
     /// <summary>
     /// A model describing a type info in a type hierarchy.

--- a/src/Authoring/WinRT.SourceGenerator/Extensions/SymbolExtensions.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Extensions/SymbolExtensions.cs
@@ -87,4 +87,27 @@ internal static class SymbolExtensions
     {
         return compilation.IsSymbolAccessibleWithin(symbol, compilation.Assembly);
     }
+
+    /// <summary>
+    /// Checks whether or not a given <see cref="ITypeSymbol"/> inherits from a specified type.
+    /// </summary>
+    /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
+    /// <param name="baseTypeSymbol">The <see cref="ITypeSymbol"/> instane to check for inheritance from.</param>
+    /// <returns>Whether or not <paramref name="typeSymbol"/> inherits from <paramref name="baseTypeSymbol"/>.</returns>
+    public static bool InheritsFromType(this ITypeSymbol typeSymbol, ITypeSymbol baseTypeSymbol)
+    {
+        INamedTypeSymbol? currentBaseTypeSymbol = typeSymbol.BaseType;
+
+        while (currentBaseTypeSymbol is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(currentBaseTypeSymbol, baseTypeSymbol))
+            {
+                return true;
+            }
+
+            currentBaseTypeSymbol = currentBaseTypeSymbol.BaseType;
+        }
+
+        return false;
+    }
 }

--- a/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
+++ b/src/Authoring/WinRT.SourceGenerator/GenericVtableInitializerStrings.cs
@@ -18,11 +18,19 @@ namespace Generator
             }
             else if (genericInterface == "System.Collections.Generic.IList`1")
             {
-                return GetIListInstantiation(genericParameters[0].ProjectedType, genericParameters[0].AbiType, genericParameters[0].TypeKind);
+                return GetIListInstantiation(
+                    genericParameters[0].ProjectedType,
+                    genericParameters[0].AbiType,
+                    genericParameters[0].TypeKind,
+                    genericParameters[0].TypeFlags);
             }
             else if (genericInterface == "System.Collections.Generic.IReadOnlyList`1")
             {
-                return GetIReadOnlyListInstantiation(genericParameters[0].ProjectedType, genericParameters[0].AbiType, genericParameters[0].TypeKind);
+                return GetIReadOnlyListInstantiation(
+                    genericParameters[0].ProjectedType,
+                    genericParameters[0].AbiType,
+                    genericParameters[0].TypeKind,
+                    genericParameters[0].TypeFlags);
             }
             else if (genericInterface == "System.Collections.Generic.IDictionary`2")
             {
@@ -46,7 +54,11 @@ namespace Generator
             }
             else if (genericInterface == "System.Collections.Generic.IEnumerator`1")
             {
-                return GetIEnumeratorInstantiation(genericParameters[0].ProjectedType, genericParameters[0].AbiType, genericParameters[0].TypeKind);
+                return GetIEnumeratorInstantiation(
+                    genericParameters[0].ProjectedType,
+                    genericParameters[0].AbiType,
+                    genericParameters[0].TypeKind,
+                    genericParameters[0].TypeFlags);
             }
             else if (genericInterface == "System.Collections.Generic.KeyValuePair`2")
             {
@@ -222,7 +234,7 @@ namespace Generator
             return iEnumerableInstantiation;
         }
 
-        private static string GetIEnumeratorInstantiation(string genericType, string abiType, TypeKind typeKind)
+        private static string GetIEnumeratorInstantiation(string genericType, string abiType, TypeKind typeKind, TypeFlags typeFlags)
         {
             string iEnumeratorInstantiation = $$"""
              internal static class IEnumerator_{{GeneratorHelper.EscapeTypeNameForIdentifier(genericType)}}
@@ -271,7 +283,7 @@ namespace Generator
                      try
                      {
                          ____return_value__ = global::ABI.System.Collections.Generic.IEnumeratorMethods<{{genericType}}>.Abi_GetMany_3(thisPtr, ref __items);
-                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind)}}.CopyManagedArray(__items, items);
+                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind, typeFlags)}}.CopyManagedArray(__items, items);
                          *__return_value__ = ____return_value__;
                      }
                      catch (global::System.Exception __exception__)
@@ -326,7 +338,7 @@ namespace Generator
             return iEnumeratorInstantiation;
         }
 
-        private static string GetIListInstantiation(string genericType, string abiType, TypeKind typeKind)
+        private static string GetIListInstantiation(string genericType, string abiType, TypeKind typeKind, TypeFlags typeFlags)
         {
             string iListInstantiation = $$"""
              internal static class IList_{{GeneratorHelper.EscapeTypeNameForIdentifier(genericType)}}
@@ -513,7 +525,7 @@ namespace Generator
                      try
                      {
                          ____return_value__ = global::ABI.System.Collections.Generic.IListMethods<{{genericType}}>.Abi_GetMany_10(thisPtr, startIndex, ref __items);
-                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind)}}.CopyManagedArray(__items, items);
+                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind, typeFlags)}}.CopyManagedArray(__items, items);
                          *__return_value__ = ____return_value__;
                      }
                      catch (global::System.Exception __exception__)
@@ -563,7 +575,7 @@ namespace Generator
             return iListInstantiation;
         }
 
-        private static string GetIReadOnlyListInstantiation(string genericType, string abiType, TypeKind typeKind)
+        private static string GetIReadOnlyListInstantiation(string genericType, string abiType, TypeKind typeKind, TypeFlags typeFlags)
         {
             string iReadOnlylistInstantiation = $$"""
              internal static class IReadOnlyList_{{GeneratorHelper.EscapeTypeNameForIdentifier(genericType)}}
@@ -633,7 +645,7 @@ namespace Generator
                      try
                      {
                          ____return_value__ = global::ABI.System.Collections.Generic.IReadOnlyListMethods<{{genericType}}>.Abi_GetMany_3(thisPtr, startIndex, ref __items);
-                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind)}}.CopyManagedArray(__items, items);
+                         {{GeneratorHelper.GetCopyManagedArrayMarshaler(genericType, abiType, typeKind, typeFlags)}}.CopyManagedArray(__items, items);
                          *__return_value__ = ____return_value__;
                      }
                      catch (global::System.Exception __exception__)

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -987,12 +987,21 @@ namespace Generator
             }
         }
 
-        public static string GetCopyManagedArrayMarshaler(string type, string abiType, TypeKind kind)
+        public static string GetCopyManagedArrayMarshaler(string type, string abiType, TypeKind kind, TypeFlags typeFlags)
         {
             if (kind == TypeKind.Class || kind == TypeKind.Delegate)
             {
-                // TODO: Classes and delegates are missing CopyManagedArray.
-                return $$"""Marshaler<{{type}}>""";
+                if (type is "System.String") return "global::WinRT.MarshalString";
+                if (type is "System.Type") return "global::ABI.System.Type";
+                if (type is "System.Object") return "global::WinRT.MarshalInspectable<object>";
+
+                if (typeFlags.HasFlag(TypeFlags.Exception))
+                {
+                    return "global::WinRT.MarshalNonBlittable<Exception>";
+                }
+
+                // Handles all other classes and delegate types
+                return $"global::WinRT.MarshalGenericHelper<{type}>";
             }
             else
             {

--- a/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net6.0.txt
@@ -1,2 +1,3 @@
 Compat issues with assembly WinRT.Runtime:
-Total Issues: 0
+TypesMustExist : Type 'WinRT.MarshalGenericHelper<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 1

--- a/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/ApiCompatBaseline.net8.0.txt
@@ -1,4 +1,5 @@
 Compat issues with assembly WinRT.Runtime:
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.GeneratedBindableCustomPropertyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class, Inherited=false, AllowMultiple=false)]' in the contract to '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'WinRT.WinRTExposedTypeAttribute' in the contract but not the implementation.
-Total Issues: 2
+TypesMustExist : Type 'WinRT.MarshalGenericHelper<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 3

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -990,7 +991,17 @@ namespace WinRT
         }
     }
 
-    internal static class MarshalGenericHelper<T>
+    /// <summary>
+    /// This type is only meant to be used by generated marshalling stubs. Its API surface might change in the future.
+    /// </summary>
+    /// <typeparam name="T">The managed type to marshal.</typeparam>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if EMBED
+    internal
+#else
+    public
+#endif
+    static class MarshalGenericHelper<T>
     {
         private static unsafe void CopyManagedFallback(T value, IntPtr dest)
         {
@@ -1006,7 +1017,7 @@ namespace WinRT
             }
         }
 
-        internal static unsafe void CopyManagedArray(T[] array, IntPtr data) => MarshalInterfaceHelper<T>.CopyManagedArray(array, data, MarshalGeneric<T>.CopyManaged ?? CopyManagedFallback);
+        public static unsafe void CopyManagedArray(T[] array, IntPtr data) => MarshalInterfaceHelper<T>.CopyManagedArray(array, data, MarshalGeneric<T>.CopyManaged ?? CopyManagedFallback);
     }
 
 #if EMBED

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net6.0.txt
@@ -1,2 +1,3 @@
 Compat issues with assembly WinRT.Runtime:
-Total Issues: 0
+TypesMustExist : Type 'WinRT.MarshalGenericHelper<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 1

--- a/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
+++ b/src/WinRT.Runtime/MatchingRefApiCompatBaseline.net8.0.txt
@@ -3,4 +3,5 @@ TypesMustExist : Type 'WinRT.GeneratedWinRTExposedExternalTypeAttribute' does no
 TypesMustExist : Type 'WinRT.GeneratedWinRTExposedTypeAttribute' does not exist in the reference but it does exist in the implementation.
 CannotChangeAttribute : Attribute 'System.AttributeUsageAttribute' on 'WinRT.GeneratedBindableCustomPropertyAttribute' changed from '[AttributeUsageAttribute(AttributeTargets.Class | AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]' in the implementation to '[AttributeUsageAttribute(AttributeTargets.Class, Inherited=false, AllowMultiple=false)]' in the reference.
 TypesMustExist : Type 'WinRT.WinRTManagedOnlyTypeDetails' does not exist in the reference but it does exist in the implementation.
-Total Issues: 4
+TypesMustExist : Type 'WinRT.MarshalGenericHelper<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 5


### PR DESCRIPTION
Extracted from #1907. This change is backward-compatible and much smaller in scope. This should go out in 2.2.1 (assuming we publish it), so that we can give more time for projections to be ready for the changes in the other PR once 2.3 ships.

> [!NOTE]
> Review **with whitespaces off**.