### PR TITLE
[CodeQL] suppress usage of SHA1 in uuidv5 generation of WinRT pinterface guids

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1621,6 +1621,7 @@ namespace Generator
         private void AddGuidAttribute(EntityHandle parentHandle, string name)
         {
             Guid guid;
+            // CodeQL [SM02196] WinRT uses UUID v5 SHA1 to generate Guids for parameterized types. Not used for authentication and must not change.
             using (SHA1 sha = new SHA1CryptoServiceProvider())
             {
                 var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(name));

--- a/src/Perf/IIDOptimizer/SignatureEmitter.cs
+++ b/src/Perf/IIDOptimizer/SignatureEmitter.cs
@@ -121,9 +121,12 @@ namespace GuidPatch
             var numBytes = Encoding.UTF8.GetBytes(stringStep.StaticSignatureString, data[Unsafe.SizeOf<Guid>()..]);
             data = data[..(Unsafe.SizeOf<Guid>() + numBytes)];
 
+            // CodeQL [SM02196] WinRT uses UUID v5 SHA1 to generate Guids for parameterized types. Not used for authentication and must not change.
             Debug.Assert(SHA1.Create().HashSize == 160);
 
             Span<byte> hash = stackalloc byte[160];
+
+            // CodeQL [SM02196] WinRT uses UUID v5 SHA1 to generate Guids for parameterized types. Not used for authentication and must not change.
             SHA1.HashData(data, hash);
 
             if (BitConverter.IsLittleEndian)

--- a/src/WinRT.Runtime/GuidGenerator.cs
+++ b/src/WinRT.Runtime/GuidGenerator.cs
@@ -341,6 +341,7 @@ namespace WinRT
 #if !NET
             var data = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Concat(wrt_pinterface_namespace.ToByteArray(), Encoding.UTF8.GetBytes(signature)));
 
+            // CodeQL [SM02196] WinRT uses UUID v5 SHA1 to generate Guids for parameterized types. Not used for authentication and must not change.
             using (SHA1 sha = new SHA1CryptoServiceProvider())
             {
                 return encode_guid(sha.ComputeHash(data));


### PR DESCRIPTION
CodeQL recently flagged some usage of the SHA1 hashing algorithm. If SHA1 was being used for authentication, that would be bad.

Here, it's used strictly for WinRT's method of calculating guids for parameterized types, which relies on UUID version 5, which utilizes SHA1 as the hashing function. In this case, it's safe to add suppression comments.