### PR TITLE
Fix adding error info object to Exception.Data on net framework

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,7 @@
     <IsTargetFrameworkNet8OrGreater>false</IsTargetFrameworkNet8OrGreater>
     <IsTargetFrameworkNet8OrGreater Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">true</IsTargetFrameworkNet8OrGreater>
     <AppBuildTFMs>netcoreapp3.1;net6.0</AppBuildTFMs>
-    <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">net47;netcoreapp3.1;net6.0;net8.0</AppBuildTFMs>
+    <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netcoreapp3.1;net6.0;net8.0</AppBuildTFMs>
     <LibBuildTFMs>netstandard2.0;net6.0;net8.0</LibBuildTFMs>
     <LibBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netstandard2.0;net6.0;net8.0</LibBuildTFMs>
     <LibBuildTFMsNoNetStandard>net6.0;net8.0</LibBuildTFMsNoNetStandard>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,7 @@
     <IsTargetFrameworkNet8OrGreater>false</IsTargetFrameworkNet8OrGreater>
     <IsTargetFrameworkNet8OrGreater Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">true</IsTargetFrameworkNet8OrGreater>
     <AppBuildTFMs>netcoreapp3.1;net6.0</AppBuildTFMs>
-    <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netcoreapp3.1;net6.0;net8.0</AppBuildTFMs>
+    <AppBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">net47;netcoreapp3.1;net6.0;net8.0</AppBuildTFMs>
     <LibBuildTFMs>netstandard2.0;net6.0;net8.0</LibBuildTFMs>
     <LibBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">netstandard2.0;net6.0;net8.0</LibBuildTFMs>
     <LibBuildTFMsNoNetStandard>net6.0;net8.0</LibBuildTFMsNoNetStandard>

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -835,6 +835,18 @@ namespace winrt::TestComponentCSharp::implementation
         _stringPairChanged.remove(token);
     }
 
+    Windows::Foundation::Collections::IKeyValuePair<TestComponentCSharp::EnumValue, TestComponentCSharp::EnumStruct> Class::EnumPairProperty()
+    {
+        return _enumPair;
+    }
+
+    void Class::EnumPairProperty(Windows::Foundation::Collections::IKeyValuePair<TestComponentCSharp::EnumValue, TestComponentCSharp::EnumStruct> const& value)
+    {
+        _enumPair = value;
+        _enumPair.Key();
+        _enumPair.Value();
+    }
+
     TestComponentCSharp::ProvideUri Class::GetUriDelegate() noexcept
     {
         TestComponentCSharp::ProvideUri handler = [] { return Windows::Foundation::Uri(L"http://microsoft.com"); };

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -59,6 +59,7 @@ namespace winrt::TestComponentCSharp::implementation
         winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::Uri>> _uriChanged;
         Windows::Foundation::Collections::IKeyValuePair<hstring, hstring> _stringPair;
         winrt::event<Windows::Foundation::EventHandler<Windows::Foundation::Collections::IKeyValuePair<hstring, hstring>>> _stringPairChanged;
+        Windows::Foundation::Collections::IKeyValuePair<TestComponentCSharp::EnumValue, TestComponentCSharp::EnumStruct> _enumPair;
         ComposedBlittableStruct _blittableStruct{};
         ComposedNonBlittableStruct _nonBlittableStruct{};
         std::vector<int32_t> _ints{ 1, 2, 3 };
@@ -233,6 +234,8 @@ namespace winrt::TestComponentCSharp::implementation
         void CallForStringPair(TestComponentCSharp::ProvideStringPair const& provideStringPair);
         winrt::event_token StringPairPropertyChanged(Windows::Foundation::EventHandler<Windows::Foundation::Collections::IKeyValuePair<hstring, hstring>> const& handler);
         void StringPairPropertyChanged(winrt::event_token const& token) noexcept;
+        Windows::Foundation::Collections::IKeyValuePair<TestComponentCSharp::EnumValue, TestComponentCSharp::EnumStruct> EnumPairProperty();
+        void EnumPairProperty(Windows::Foundation::Collections::IKeyValuePair<TestComponentCSharp::EnumValue, TestComponentCSharp::EnumStruct> const& value);
         TestComponentCSharp::ProvideUri GetUriDelegate() noexcept;
         BlittableStruct BlittableStructProperty();
         void BlittableStructProperty(BlittableStruct const& value);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -275,6 +275,8 @@ namespace TestComponentCSharp
         void CallForStringPair(ProvideStringPair provideStringPair);
         event Windows.Foundation.EventHandler<Windows.Foundation.Collections.IKeyValuePair<String, String> > StringPairPropertyChanged;
 
+        Windows.Foundation.Collections.IKeyValuePair<EnumValue, EnumStruct> EnumPairProperty;
+
         Windows.Foundation.Collections.IVector<IInspectable> GetUriVectorAsIInspectableVector();
         ProvideUri GetUriDelegate();
         void AddUriHandler(IUriHandler uriHandler);

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -965,6 +965,10 @@ namespace UnitTest
             TestObject.StringPairPropertyChanged +=
                 (object sender, KeyValuePair<string, string> value) => Assert.Equal(expected, value);
             TestObject.RaiseStringPairChanged();
+
+            var expected2 = new KeyValuePair<EnumValue, EnumStruct>(EnumValue.Two, new EnumStruct() { value = EnumValue.One });
+            TestObject.EnumPairProperty = expected2;
+            Assert.Equal(expected2, TestObject.EnumPairProperty);
         }
 
         [Fact]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -270,6 +270,7 @@ namespace UnitTest
             Assert.True(stream.Length == 2);
         }
 
+#if !NET47
         [Fact]
         public void TestBufferAsStreamUsingAsBufferWithOffset()
         {
@@ -304,6 +305,7 @@ namespace UnitTest
             Assert.Equal((byte)0x06, arr[2]);
             Assert.Equal((byte)0x07, arr[3]);
         }
+#endif
 
         [Fact]
         public void TestBufferAsStreamWithEmptyBuffer()
@@ -1457,6 +1459,7 @@ namespace UnitTest
             Assert.Equal("ComImports", MarshalString.FromAbi(hstr));
         }
 
+#if !NET47
         [Fact]
         public unsafe void TestMarshalString_FromAbiUnsafe()
         {
@@ -1488,6 +1491,7 @@ namespace UnitTest
             Assert.True(Unsafe.Add(ref MemoryMarshal.GetReference(span), span.Length) == '\0');
             MarshalString.DisposeAbi(hstr);
         }
+#endif
 
         [Fact]
         public void TestFundamentalGeneric()

--- a/src/WinRT.Runtime/Interop/StandardDelegates.cs
+++ b/src/WinRT.Runtime/Interop/StandardDelegates.cs
@@ -268,5 +268,7 @@ namespace WinRT.Interop
     internal unsafe delegate int _invoke_IntPtr_Type(void* thisPtr, IntPtr sender, ABI.System.Type args);
     internal unsafe delegate int _invoke_Type_IntPtr(void* thisPtr, ABI.System.Type sender, IntPtr args);
     internal unsafe delegate int _invoke_Type_Type(void* thisPtr, ABI.System.Type sender, ABI.System.Type args);
+
+    internal unsafe delegate int _get_Key_IntPtr(IntPtr thisPtr, IntPtr* __return_value__);
 #endif
 }

--- a/src/WinRT.Runtime/Projections.cs
+++ b/src/WinRT.Runtime/Projections.cs
@@ -735,6 +735,8 @@ namespace WinRT
             [new Type[] { typeof(void*), typeof(IntPtr), typeof(ABI.System.Type), typeof(int) }] = typeof(Interop._invoke_IntPtr_Type),
             [new Type[] { typeof(void*), typeof(ABI.System.Type), typeof(IntPtr), typeof(int) }] = typeof(Interop._invoke_Type_IntPtr),
             [new Type[] { typeof(void*), typeof(ABI.System.Type), typeof(ABI.System.Type), typeof(int) }] = typeof(Interop._invoke_Type_Type),
+            // IKeyValuePair
+            [new Type[] { typeof(IntPtr), typeof(IntPtr*), typeof(int) }] = typeof(Interop._get_Key_IntPtr),
         };
 
         public static void RegisterAbiDelegate(Type[] delegateSignature, Type delegateType)

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -10472,8 +10472,8 @@ bind<write_event_invoke_args>(invokeMethodSig));
                     abiDelegateEntries.insert(generic_abi_delegate
                         {
                             w.write_temp("_get_Key_%", escapedAbiType),
-                            w.write_temp("internal unsafe delegate int _get_Key_%(void* thisPtr, out % __return_value__);", escapedAbiType, abiType),
-                            w.write_temp("new global::System.Type[] { typeof(void*), typeof(%).MakeByRefType(), typeof(int) }", abiType)
+                            w.write_temp("internal unsafe delegate int _get_Key_%(IntPtr thisPtr, %* __return_value__);", escapedAbiType, abiType),
+                            w.write_temp("new global::System.Type[] { typeof(IntPtr), typeof(%*), typeof(int) }", abiType)
                         });
                 }
 
@@ -10485,8 +10485,8 @@ bind<write_event_invoke_args>(invokeMethodSig));
                     abiDelegateEntries.insert(generic_abi_delegate
                         {
                             w.write_temp("_get_Value_%", escapedAbiType),
-                            w.write_temp("internal unsafe delegate int _get_Value_%(void* thisPtr, out % __return_value__);", escapedAbiType, abiType),
-                            w.write_temp("new global::System.Type[] { typeof(void*), typeof(%).MakeByRefType(), typeof(int) }", abiType)
+                            w.write_temp("internal unsafe delegate int _get_Value_%(IntPtr thisPtr, %* __return_value__);", escapedAbiType, abiType),
+                            w.write_temp("new global::System.Type[] { typeof(IntPtr), typeof(%*), typeof(int) }", abiType)
                         });
                 }
             }


### PR DESCRIPTION
- Restore part of #1453 for .NET Standard projections.  On .NET framework, adding a non-serializable object to `Exception.Data` throws an exception, so we need the serializable restricted error object class.
- Fix `KeyValuePair` delegates on .NET Framework as the signature we use for it is different than what we were generating.