### PR TITLE
Avoid `QueryInterface' + 'Release' when wrapping managed CCWs

### DIFF
--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -167,7 +167,7 @@ namespace WinRT
         public static IObjectReference CreateCCWForObject(object obj)
         {
             IntPtr ccw = ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.TrackerSupport);
-            return ObjectReference<IUnknownVftbl>.Attach(ref ccw, IID.IID_IUnknown);
+            return ObjectReference<IUnknownVftbl>.AttachFreeThreadedUnsafe(ref ccw);
         }
 
         internal static IntPtr CreateCCWForObjectForABI(object obj, Guid iid)

--- a/src/WinRT.Runtime/ObjectReference.cs
+++ b/src/WinRT.Runtime/ObjectReference.cs
@@ -542,6 +542,27 @@ namespace WinRT
             }
         }
 
+        /// <summary>
+        /// Creates an <see cref="ObjectReference{T}"/> instance for a COM pointer to an agile object, without validation.
+        /// </summary>
+        /// <param name="thisPtr">The COM pointer to wrap.</param>
+        /// <returns>The resulting <see cref="ObjectReference{T}"/> instance.</returns>
+        /// <remarks>
+        /// This method will not validate that the target COM object is actually free-threaded.
+        /// It is the responsibility of callers to ensure only free-threaded objects are used.
+        /// </remarks>
+        internal static ObjectReference<T> AttachFreeThreadedUnsafe(ref IntPtr thisPtr)
+        {
+            if (thisPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var obj = new ObjectReference<T>(thisPtr);
+            thisPtr = IntPtr.Zero;
+            return obj;
+        }
+
         public static ObjectReference<T> Attach(ref IntPtr thisPtr, Guid iid)
         {
             if (thisPtr == IntPtr.Zero)


### PR DESCRIPTION
This PR does a small optimization when creating `IObjectReference`-s wrapping CCWs produced by ComWrappers over managed objects. All CCWs produced by ComWrappers implement `IAgileObject`, meaning they're all always free-threaded. The original code didn't rely on this fact, and instead tested for the presence of that interface every single time. This PR removes that unnecessary work by adding a new 'AttachFreeThreadedUnsafe' method that can be used specifically when wrapping CCWs produced by ComWrappers, which skips the checks and always just wraps the objects as agile objects.