### PR TITLE
Add 'NoInlining' to marshalling stubs

### DIFF
--- a/src/WinRT.Runtime/IInspectable.cs
+++ b/src/WinRT.Runtime/IInspectable.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT.Interop;
 
@@ -152,6 +153,7 @@ namespace WinRT
             _obj = obj;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe string GetRuntimeClassName(bool noThrow = false)
         {
             IntPtr __retval = default;

--- a/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
+++ b/src/WinRT.Runtime/Interop/IAgileReference.net5.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace WinRT.Interop
@@ -34,6 +35,7 @@ namespace ABI.WinRT.Interop
 
     internal static class IAgileReferenceMethods
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static unsafe IObjectReference Resolve(IObjectReference _obj, Guid riid)
         {
             if (_obj == null) return null;
@@ -53,6 +55,7 @@ namespace ABI.WinRT.Interop
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static unsafe ObjectReference<T> Resolve<T>(IObjectReference _obj, Guid riid)
         {
             if (_obj == null) return null;
@@ -136,6 +139,7 @@ namespace ABI.WinRT.Interop
             _obj = ObjectReference<global::WinRT.Interop.IUnknownVftbl>.FromAbi(thisPtr, global::WinRT.Interop.IID.IID_IGlobalInterfaceTable);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IntPtr RegisterInterfaceInGlobal(IntPtr ptr, Guid riid)
         {
             IntPtr thisPtr = ThisPtr;
@@ -146,6 +150,7 @@ namespace ABI.WinRT.Interop
 
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void TryRevokeInterfaceFromGlobal(IntPtr cookie)
         {
             IntPtr thisPtr = ThisPtr;
@@ -163,6 +168,7 @@ namespace ABI.WinRT.Interop
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IObjectReference GetInterfaceFromGlobal(IntPtr cookie, Guid riid)
         {
             IntPtr thisPtr = ThisPtr;

--- a/src/WinRT.Runtime/Interop/IMarshal.net5.cs
+++ b/src/WinRT.Runtime/Interop/IMarshal.net5.cs
@@ -212,6 +212,7 @@ namespace ABI.WinRT.Interop
             _obj = obj.As<IUnknownVftbl>(IID.IID_IMarshal);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void GetUnmarshalClass(Guid* riid, IntPtr pv, MSHCTX dwDestContext, IntPtr pvDestContext, MSHLFLAGS mshlFlags, Guid* pCid)
         {
             IntPtr thisPtr = ThisPtr;
@@ -219,6 +220,7 @@ namespace ABI.WinRT.Interop
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void GetMarshalSizeMax(Guid* riid, IntPtr pv, MSHCTX dwDestContext, IntPtr pvDestContext, MSHLFLAGS mshlflags, uint* pSize)
         {
             IntPtr thisPtr = ThisPtr;
@@ -226,6 +228,7 @@ namespace ABI.WinRT.Interop
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void MarshalInterface(IntPtr pStm, Guid* riid, IntPtr pv, MSHCTX dwDestContext, IntPtr pvDestContext, MSHLFLAGS mshlflags)
         {
             IntPtr thisPtr = ThisPtr;
@@ -233,6 +236,7 @@ namespace ABI.WinRT.Interop
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void UnmarshalInterface(IntPtr pStm, Guid* riid, IntPtr* ppv)
         {
             IntPtr thisPtr = ThisPtr;
@@ -240,6 +244,7 @@ namespace ABI.WinRT.Interop
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ReleaseMarshalData(IntPtr pStm)
         {
             IntPtr thisPtr = ThisPtr;
@@ -247,6 +252,7 @@ namespace ABI.WinRT.Interop
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void DisconnectObject(uint dwReserved)
         {
             IntPtr thisPtr = ThisPtr;

--- a/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
+++ b/src/WinRT.Runtime/Interop/IWeakReferenceSource.net5.cs
@@ -90,6 +90,7 @@ namespace ABI.WinRT.Interop
 #endif
     static class IWeakReferenceSourceMethods
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static unsafe global::WinRT.Interop.IWeakReference GetWeakReference(IObjectReference _obj)
         {
             var ThisPtr = _obj.ThisPtr;
@@ -179,6 +180,7 @@ namespace ABI.WinRT.Interop
             return 0;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         IObjectReference global::WinRT.Interop.IWeakReference.Resolve(Guid riid)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::WinRT.Interop.IWeakReference).TypeHandle);

--- a/src/WinRT.Runtime/Projections/Bindable.net5.cs
+++ b/src/WinRT.Runtime/Projections/Bindable.net5.cs
@@ -160,6 +160,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
         internal static ObjectReference<IUnknownVftbl> FromAbi(IntPtr thisPtr) => ObjectReference<IUnknownVftbl>.FromAbi(thisPtr, IID.IID_IUnknown);
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe bool global::Microsoft.UI.Xaml.Interop.IBindableIterator.MoveNext()
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -178,6 +179,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
         unsafe object global::Microsoft.UI.Xaml.Interop.IBindableIterator.Current
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -198,6 +200,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
         unsafe bool global::Microsoft.UI.Xaml.Interop.IBindableIterator.HasCurrent
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -302,6 +305,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
         private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<IWinRTObject, ABI.System.Collections.IEnumerable.FromAbiHelper> _helperTable = new();
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe object global::Microsoft.UI.Xaml.Interop.IBindableVectorView.GetAt(uint index)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -319,6 +323,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe bool global::Microsoft.UI.Xaml.Interop.IBindableVectorView.IndexOf(object value, out uint index)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -346,6 +351,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 
         unsafe uint global::Microsoft.UI.Xaml.Interop.IBindableVectorView.Size
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Microsoft.UI.Xaml.Interop.IBindableIterator).TypeHandle);
@@ -586,6 +592,7 @@ namespace ABI.System.Collections
                 static (_, _this) => new FromAbiHelper((global::System.Collections.IEnumerable)_this), _this);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe global::Microsoft.UI.Xaml.Interop.IBindableIterator global::Microsoft.UI.Xaml.Interop.IBindableIterable.First()
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IEnumerable).TypeHandle);
@@ -1295,6 +1302,7 @@ namespace ABI.System.Collections
                 static (_, _this) => new FromAbiHelper((global::Microsoft.UI.Xaml.Interop.IBindableVector)_this), _this);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe object global::Microsoft.UI.Xaml.Interop.IBindableVector.GetAt(uint index)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1312,6 +1320,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe global::Microsoft.UI.Xaml.Interop.IBindableVectorView global::Microsoft.UI.Xaml.Interop.IBindableVector.GetView()
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1329,6 +1338,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe bool global::Microsoft.UI.Xaml.Interop.IBindableVector.IndexOf(object value, out uint index)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1350,6 +1360,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.SetAt(uint index, object value)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1367,6 +1378,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.InsertAt(uint index, object value)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1384,6 +1396,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.RemoveAt(uint index)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1392,6 +1405,7 @@ namespace ABI.System.Collections
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.Append(object value)
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1409,6 +1423,7 @@ namespace ABI.System.Collections
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.RemoveAtEnd()
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1417,6 +1432,7 @@ namespace ABI.System.Collections
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         unsafe void global::Microsoft.UI.Xaml.Interop.IBindableVector.Clear()
         {
             var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);
@@ -1427,6 +1443,7 @@ namespace ABI.System.Collections
 
         unsafe uint global::Microsoft.UI.Xaml.Interop.IBindableVector.Size
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::System.Collections.IList).TypeHandle);

--- a/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/DataErrorsChangedEventArgs.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
 using WinRT.Interop;
@@ -46,6 +47,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             _obj = obj;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe IObjectReference CreateInstance(string name)
         {
             IntPtr __retval = default;
@@ -65,6 +67,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe ObjectReferenceValue CreateInstanceForMarshaling(string name)
         {
             IntPtr __retval = default;

--- a/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
+++ b/src/WinRT.Runtime/Projections/IReferenceArray.net5.cs
@@ -209,6 +209,7 @@ namespace ABI.Windows.Foundation
 
         public unsafe T[] Value
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
 #if NET

--- a/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/NotifyCollectionChangedEventArgs.cs
@@ -33,6 +33,7 @@ namespace ABI.Microsoft.UI.Xaml.Interop
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe ObjectReferenceValue CreateInstanceWithAllParameters(global::System.Collections.Specialized.NotifyCollectionChangedAction action, global::System.Collections.IList newItems, global::System.Collections.IList oldItems, int newIndex, int oldIndex)
         {
             ObjectReferenceValue __newItems = default;

--- a/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
+++ b/src/WinRT.Runtime/Projections/PropertyChangedEventArgs.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
 using WinRT.Interop;
@@ -24,6 +25,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IObjectReference CreateInstance(string name, object baseInterface, out IObjectReference innerInterface)
         {
             IObjectReference __baseInterface = default;
@@ -56,6 +58,7 @@ namespace ABI.Microsoft.UI.Xaml.Data
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public ObjectReferenceValue CreateInstance(string name)
         {
             IntPtr __innerInterface = default;

--- a/src/WinRT.Runtime/Projections/Uri.cs
+++ b/src/WinRT.Runtime/Projections/Uri.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WinRT;
 using WinRT.Interop;
@@ -61,6 +62,7 @@ namespace ABI.System
             _obj = obj;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe IObjectReference CreateUri(string uri)
         {
             IntPtr __retval = default;
@@ -73,6 +75,7 @@ namespace ABI.System
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe ObjectReferenceValue CreateUriForMarshaling(string uri)
         {
             IntPtr __retval = default;

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -10907,6 +10907,7 @@ bind<write_event_invoke_args>(invokeMethodSig));
 
                 auto invoke_target = get_invoke_info(method, true);
                 w.write(R"(
+[MethodImpl(MethodImplOptions.NoInlining)]
 private static unsafe % %(IObjectReference _obj%%)
 {
 var ThisPtr = _obj.ThisPtr;
@@ -10985,6 +10986,7 @@ private static unsafe int Do_Abi_Invoke(%)
 
                 auto invoke_target = get_invoke_info(method);
                 w.write(R"(
+[MethodImpl(MethodImplOptions.NoInlining)]
 private static unsafe % %(IObjectReference _obj%%)
 {
 var ThisPtr = _obj.ThisPtr;
@@ -11007,7 +11009,8 @@ var ThisPtr = _obj.ThisPtr;
                     auto invoke_target = get_invoke_info(getter);
                     auto signature = method_signature(getter);
                     auto marshalers = get_abi_marshalers(w, signature, false, prop.Name(), false, true);
-                    w.write(R"(private static unsafe % %(IObjectReference _obj)
+                    w.write(R"([MethodImpl(MethodImplOptions.NoInlining)]
+private static unsafe % %(IObjectReference _obj)
 {
 var ThisPtr = _obj.ThisPtr;
 %}
@@ -11022,7 +11025,8 @@ var ThisPtr = _obj.ThisPtr;
                     auto signature = method_signature(setter);
                     auto marshalers = get_abi_marshalers(w, signature, false, prop.Name(), false, true);
                     marshalers[0].param_name = "value";
-                    w.write(R"(private static unsafe void %(IObjectReference _obj, % value)
+                    w.write(R"([MethodImpl(MethodImplOptions.NoInlining)]
+private static unsafe void %(IObjectReference _obj, % value)
 {
 var ThisPtr = _obj.ThisPtr;
 %}

--- a/src/cswinrt/strings/ComInteropHelpers.cs
+++ b/src/cswinrt/strings/ComInteropHelpers.cs
@@ -45,6 +45,7 @@
 #endif
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
 using Windows.Security.Credentials;
@@ -521,6 +522,7 @@ namespace Windows.ApplicationModel.DataTransfer
 
     internal static class IDataTransferManagerInteropMethods
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static unsafe global::Windows.ApplicationModel.DataTransfer.DataTransferManager GetForWindow(global::WinRT.IObjectReference _obj, global::System.IntPtr appWindow, in global::System.Guid riid)
         {
             global::System.IntPtr thisPtr = _obj.ThisPtr;
@@ -541,6 +543,7 @@ namespace Windows.ApplicationModel.DataTransfer
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static unsafe void ShowShareUIForWindow(global::WinRT.IObjectReference _obj, global::System.IntPtr appWindow)
         {
             global::System.IntPtr thisPtr = _obj.ThisPtr;

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IBufferByteAccess.cs
@@ -78,6 +78,7 @@ namespace ABI.Windows.Storage.Streams
 
         public IntPtr Buffer
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 IntPtr __retval = default;
@@ -129,6 +130,7 @@ namespace ABI.Windows.Storage.Streams
 
         IntPtr global::Windows.Storage.Streams.IBufferByteAccess.Buffer
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
                 var _obj = ((IWinRTObject)this).GetObjectReferenceForType(typeof(global::Windows.Storage.Streams.IBufferByteAccess).TypeHandle);

--- a/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
+++ b/src/cswinrt/strings/additions/Windows.Storage.Streams/IMarshal.cs
@@ -222,6 +222,7 @@ namespace ABI.Com
         }
 #endif
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void GetUnmarshalClass(Guid* riid, IntPtr pv, global::Com.MSHCTX dwDestContext, IntPtr pvDestContext, global::Com.MSHLFLAGS mshlFlags, Guid* pCid)
         {
 #if NET
@@ -233,6 +234,7 @@ namespace ABI.Com
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void GetMarshalSizeMax(Guid* riid, IntPtr pv, global::Com.MSHCTX dwDestContext, IntPtr pvDestContext, global::Com.MSHLFLAGS mshlflags, uint* pSize)
         {
 #if NET
@@ -244,6 +246,7 @@ namespace ABI.Com
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void MarshalInterface(IntPtr pStm, Guid* riid, IntPtr pv, global::Com.MSHCTX dwDestContext, IntPtr pvDestContext, global::Com.MSHLFLAGS mshlflags)
         {
 #if NET
@@ -255,6 +258,7 @@ namespace ABI.Com
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void UnmarshalInterface(IntPtr pStm, Guid* riid, IntPtr* ppv)
         {
 #if NET
@@ -266,6 +270,7 @@ namespace ABI.Com
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ReleaseMarshalData(IntPtr pStm)
         {
 #if NET
@@ -277,6 +282,7 @@ namespace ABI.Com
             GC.KeepAlive(_obj);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void DisconnectObject(uint dwReserved)
         {
 #if NET


### PR DESCRIPTION
This PR adds `NoInlining` to all marshalling stubs. This matches .NET Native and should reduce binary size.