### PR TITLE
Improve CI build

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -3,7 +3,7 @@ parameters:
     type: string
   - name: "BuildPlatform"
     type: string
-  - name: BuildCsWinRTOnly
+  - name: SetupForBuildOnly
     type: boolean
     default: false
     
@@ -164,16 +164,16 @@ steps:
       feedsToUse: config
       nugetConfigPath: NuGet.config
 
-# PDBs being copied for each project reference are causing out of disk space issues in the pipeline.  Making use of AllowedReferenceRelatedFileExtensions to avoid them being copied.
-  - task: VSBuild@1
-    displayName: Build cswinrt.sln
-    inputs:
-      solution: $(Build.SourcesDirectory)\src\cswinrt.sln
-      msbuildArgs: /restore /p:CIBuildReason=CI,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,CleanIntermediateDirs=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config" /bl:$(Build.SourcesDirectory)\cswinrt.binlog
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
+  - ${{ if eq(parameters.SetupForBuildOnly, false) }}:
 
-  - ${{ if eq(parameters.BuildCsWinRTOnly, false) }}:
+# PDBs being copied for each project reference are causing out of disk space issues in the pipeline.  Making use of AllowedReferenceRelatedFileExtensions to avoid them being copied.
+    - task: VSBuild@1
+      displayName: Build cswinrt.sln
+      inputs:
+        solution: $(Build.SourcesDirectory)\src\cswinrt.sln
+        msbuildArgs: /m /restore /p:CIBuildReason=CI,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config" /bl:$(Build.SourcesDirectory)\cswinrt.binlog
+        platform: $(BuildPlatform)
+        configuration: $(BuildConfiguration)
 
     - task: NuGetCommand@2
       displayName: NuGet restore TestEmbedded.sln

--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -171,7 +171,7 @@ steps:
       displayName: Build cswinrt.sln
       inputs:
         solution: $(Build.SourcesDirectory)\src\cswinrt.sln
-        msbuildArgs: /m /restore /p:CIBuildReason=CI,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config" /bl:$(Build.SourcesDirectory)\cswinrt.binlog
+        msbuildArgs: /restore /p:CIBuildReason=CI,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config" /bl:$(Build.SourcesDirectory)\cswinrt.binlog
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
 

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-GitHub.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-GitHub.yml
@@ -95,7 +95,16 @@ stages:
       parameters:
         BuildConfiguration: $(BuildConfiguration)
         BuildPlatform: $(BuildPlatform) 
-        BuildCsWinRTOnly: true
+        SetupForBuildOnly: true
+
+    - task: MSBuild@1
+      displayName: Build Object Lifetime Tests
+      condition: succeeded()
+      inputs:
+        solution: $(Build.SourcesDirectory)\src\Tests\ObjectLifetimeTests\ObjectLifetimeTests.Lifted.csproj
+        msbuildArguments: /m /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        platform: $(BuildPlatform)
+        configuration: $(BuildConfiguration)
         
 # Run Object Lifetime Tests
     - task: VSTest@3

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-GitHub.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-GitHub.yml
@@ -102,7 +102,7 @@ stages:
       condition: succeeded()
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\ObjectLifetimeTests\ObjectLifetimeTests.Lifted.csproj
-        msbuildArguments: /m /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
         

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-OneBranch.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-OneBranch.yml
@@ -142,8 +142,17 @@ jobs:
       parameters:
         BuildConfiguration: $(BuildConfiguration)
         BuildPlatform: $(BuildPlatform) 
-        BuildCsWinRTOnly: true
-        
+        SetupForBuildOnly: true
+
+    - task: MSBuild@1
+      displayName: Build Object Lifetime Tests
+      condition: succeeded()
+      inputs:
+        solution: $(Build.SourcesDirectory)\src\Tests\ObjectLifetimeTests\ObjectLifetimeTests.Lifted.csproj
+        msbuildArguments: /m /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        platform: $(BuildPlatform)
+        configuration: $(BuildConfiguration)
+
 # Run Object Lifetime Tests
     - task: VSTest@3
       displayName: Run Object Lifetime Tests

--- a/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-OneBranch.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-BuildAndTest-Stage-OneBranch.yml
@@ -149,7 +149,7 @@ jobs:
       condition: succeeded()
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\ObjectLifetimeTests\ObjectLifetimeTests.Lifted.csproj
-        msbuildArguments: /m /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /restore /p:CIBuildReason=CI,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
 

--- a/build/AzurePipelineTemplates/CsWinRT-FunctionalTest-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-FunctionalTest-Steps.yml
@@ -26,7 +26,7 @@ steps:
       condition: and(succeeded(), or(eq(variables['BuildPlatform'], 'x86'), and(eq(variables['BuildConfiguration'], 'release'), eq(variables['BuildPlatform'], 'x64'))))
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\${{ functionalTest }}.csproj
-        msbuildArguments: /t:restore /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,CleanIntermediateDirs=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /t:restore /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
   
@@ -35,7 +35,7 @@ steps:
       condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'))
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\${{ functionalTest }}.csproj
-        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net6.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,CleanIntermediateDirs=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net6.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
 
@@ -66,7 +66,7 @@ steps:
       condition: and(succeeded(), and(eq(variables['BuildConfiguration'], 'release'), eq(variables['BuildPlatform'], 'x64')))
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\${{ functionalTest }}.csproj
-        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net8.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,CleanIntermediateDirs=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net8.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
 


### PR DESCRIPTION
- Removing `CleanIntermediateDirs` as we don't seem to need it anymore and that improves our CI build time
- Build ObjectLifetimeTests directly to resolve the inconsistent build issues due to space and to avoid the need for the previous property.