### PR TITLE
Fix KeyValuePair pointer reuse issue

### DIFF
--- a/src/WinRT.Runtime/Projections/KeyValuePair.cs
+++ b/src/WinRT.Runtime/Projections/KeyValuePair.cs
@@ -152,7 +152,7 @@ namespace ABI.System.Collections.Generic
 #if NET
             ComWrappersSupport.RegisterTypedRcwFactory(
                 typeof(global::System.Collections.Generic.KeyValuePair<K, V>),
-                KeyValuePair<K, V>.CreateRcw);
+                ComWrappersSupport.CreateReferenceCachingFactory(KeyValuePair<K, V>.CreateRcw));
 #endif
             KeyValuePairMethods<K, V>._RcwHelperInitialized = true;
             return true;


### PR DESCRIPTION
Fix KeyValuePair pointer reuse issue due to the reference holding IInspectable getting disposed before the returned KeyValuePair is disposed and thereby still remaining cached by ComWrappers.