### PR TITLE
Don't report RPC errors for completion handlers due to the other process is gone

### DIFF
--- a/src/cswinrt/strings/additions/Windows.Foundation/ExceptionDispatchHelper.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/ExceptionDispatchHelper.cs
@@ -7,18 +7,30 @@ namespace System.Threading.Tasks
 {
     using System;
     using System.Runtime.ExceptionServices;
+    using System.Runtime.InteropServices;
     using System.Threading;
     internal static class ExceptionDispatchHelper
     {
+        private const int RPC_E_DISCONNECTED = unchecked((int)0x80010108);
+        private const int RPC_S_SERVER_UNAVAILABLE = unchecked((int)0x800706BA);
+        private const int JSCRIPT_E_CANTEXECUTE = unchecked((int)0x89020001);
+
         internal static void ThrowAsync(Exception exception, SynchronizationContext targetContext)
         {
             if (exception == null)
                 return;
 
-            // TODO - decide how to cleanly do it so it lights up if TA is defined
-            //if (exception is ThreadAbortException)
-            //    return;
-
+            // If this is an error indicating the RPC called failed,
+            // it is most likely due to the other process is gone.
+            // We ignore it as it just means we weren't able to report
+            // the completion and not actually an error in the other process.
+            if (exception is COMException comException &&
+                (comException.HResult == RPC_E_DISCONNECTED ||
+                 comException.HResult == RPC_S_SERVER_UNAVAILABLE ||
+                 comException.HResult == JSCRIPT_E_CANTEXECUTE))
+            {
+                return;
+            }
 
             ExceptionDispatchInfo exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
 

--- a/src/cswinrt/strings/additions/Windows.Foundation/ExceptionDispatchHelper.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/ExceptionDispatchHelper.cs
@@ -25,9 +25,7 @@ namespace System.Threading.Tasks
             // We ignore it as it just means we weren't able to report
             // the completion and not actually an error in the other process.
             if (exception is COMException comException &&
-                (comException.HResult == RPC_E_DISCONNECTED ||
-                 comException.HResult == RPC_S_SERVER_UNAVAILABLE ||
-                 comException.HResult == JSCRIPT_E_CANTEXECUTE))
+                comException.HResult is RPC_E_DISCONNECTED or RPC_S_SERVER_UNAVAILABLE or JSCRIPT_E_CANTEXECUTE)
             {
                 return;
             }


### PR DESCRIPTION
We are seeing crashes for scenarios where there was a completion handler registered by another process on an async operation.  When the current process finishes the async operation and triggers the completion, the other process is already gone and COM reports an RPC error.  We propagate that exception to the process running the async operation which results in a fail fast.  But in reality, in this scenario, if the other process asking for reporting on completion is gone, there is nothing the current process can do and it can't catch the exception resulting in a fail fast either.  So, we will instead silently handle that error which is similar to what CppWinRT does.

For other errors, we will still rethrow them but that will be investigated separately if there is any opportunity to improve the reporting of those errors too or if those should also be handled silently.