### PR TITLE
Skip lambda allocation in 'EventSourceCache'

### DIFF
--- a/src/WinRT.Runtime/Interop/EventSourceCache.cs
+++ b/src/WinRT.Runtime/Interop/EventSourceCache.cs
@@ -157,6 +157,10 @@ namespace ABI.WinRT.Interop
         }
 
 #if NET
+        // We're intentionally using a separate type and not a value tuple, because creating generic
+        // type instantiations with this type when delegates are involved results in additional
+        // metadata being preserved after trimming. This can save a few KBs in binary size on Native AOT.
+        // See: https://github.com/dotnet/runtime/pull/111204#issuecomment-2599397292.
         private readonly struct CachesFactoryArgs(
             global::WinRT.Interop.IWeakReference target,
             int index,


### PR DESCRIPTION
Small optimization on .NET 8+, where we have the additional overload taking args.
This skips allocating the delegate + display class for the closure every time the method is called.