### PR TITLE
Moving CsWinRTGenerateManagedDllGetActivationFactory to right target

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -17,8 +17,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Set the additional activation factory generation based on WinRTRuntimeClassName attribute to not be opt-in by default -->
     <CsWinRTGenerateOverridedClassNameActivationFactory Condition="'$(CsWinRTGenerateOverridedClassNameActivationFactory)' != 'true'">false</CsWinRTGenerateOverridedClassNameActivationFactory>
-    <!-- Generate a C# version of DllGetActivationFactory which matches the native export. -->
-    <CsWinRTGenerateManagedDllGetActivationFactory Condition="'$(CsWinRTGenerateManagedDllGetActivationFactory)' != 'true'">false</CsWinRTGenerateManagedDllGetActivationFactory>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -39,7 +37,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTGenerateProjection" />
     <CompilerVisibleProperty Include="CsWinRTAuthoringInputs" />
     <CompilerVisibleProperty Include="CsWinRTGenerateOverridedClassNameActivationFactory" />
-    <CompilerVisibleProperty Include="CsWinRTGenerateManagedDllGetActivationFactory" />
   </ItemGroup>
 
   <!-- Note this runs before the msbuild editor config file is generated because that is what is used to pass properties to the source generator. -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -52,6 +52,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <CsWinRTUseEnvironmentalTools Condition="'$(CsWinRTUseEnvironmentalTools)' == '' AND '$(VSCMD_VER)' != ''">true</CsWinRTUseEnvironmentalTools>
     <CsWinRTUseEnvironmentalTools Condition="'$(CsWinRTUseEnvironmentalTools)' == ''">false</CsWinRTUseEnvironmentalTools>
+
+    <!-- Generate a C# version of DllGetActivationFactory which matches the native export. -->
+    <CsWinRTGenerateManagedDllGetActivationFactory Condition="'$(CsWinRTGenerateManagedDllGetActivationFactory)' != 'true'">false</CsWinRTGenerateManagedDllGetActivationFactory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -62,6 +65,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CompilerVisibleProperty Include="CsWinRTCcwLookupTableGeneratorEnabled" />
     <CompilerVisibleProperty Include="CsWinRTMergeReferencedActivationFactories" />
     <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
+    <CompilerVisibleProperty Include="CsWinRTGenerateManagedDllGetActivationFactory" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Windows.CsWinRT.Embedded.targets" Condition="'$(CsWinRTEmbedded)' == 'true'"/>

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -5883,7 +5883,7 @@ return (eventSource.Subscribe, eventSource.Unsubscribe);
         }
     }
     
-    std::string get_vmethod_delegate_type(writer& w, MethodDef const& method, std::string vmethod_name)
+    std::string get_vmethod_delegate_type(writer& w, MethodDef const& method, std::string)
     {
         method_signature signature{ method };
         if (is_special(method))


### PR DESCRIPTION
CsWinRTGenerateManagedDllGetActivationFactory is able to be used in not authoring scenarios, so moving it to the other target.  And fixing warning that got upgraded to error in pipeline.