### PR TITLE
Fix scenario where one authoring component project references another

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -444,7 +444,7 @@ namespace Generator
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + qualifiedTypeName) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataType(qualifiedTypeName)) != null;
                 }
             }
 
@@ -484,7 +484,7 @@ namespace Generator
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + qualifiedTypeName) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataType(qualifiedTypeName)) != null;
                 }
             }
 
@@ -1338,6 +1338,11 @@ namespace Generator
             }
 
             return assemblyName;
+        }
+
+        public static string GetAuthoringMetadataType(string authoringType)
+        {
+            return $"ABI.Impl.{authoringType}";
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -444,7 +444,7 @@ namespace Generator
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataType(qualifiedTypeName)) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataTypeName(qualifiedTypeName)) != null;
                 }
             }
 
@@ -484,7 +484,7 @@ namespace Generator
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataType(qualifiedTypeName)) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName(GetAuthoringMetadataTypeName(qualifiedTypeName)) != null;
                 }
             }
 
@@ -1340,9 +1340,9 @@ namespace Generator
             return assemblyName;
         }
 
-        public static string GetAuthoringMetadataType(string authoringType)
+        public static string GetAuthoringMetadataTypeName(string authoringTypeName)
         {
-            return $"ABI.Impl.{authoringType}";
+            return $"ABI.Impl.{authoringTypeName}";
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -439,6 +439,12 @@ namespace Generator
             if (!isProjectedType & type.ContainingNamespace != null)
             {
                 isProjectedType = mapper.HasMappingForType(string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName));
+
+                // Check if CsWinRT component projected type from another project.
+                if (!isProjectedType)
+                {
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + type.MetadataName) != null;
+                }
             }
 
             // Ensure all generic parameters are WinRT types.
@@ -472,6 +478,12 @@ namespace Generator
             if (!isProjectedType & type.ContainingNamespace != null)
             {
                 isProjectedType = mapper.HasMappingForType(string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName));
+
+                // Check if CsWinRT component projected type from another project.
+                if (!isProjectedType)
+                {
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + type.MetadataName) != null;
+                }
             }
 
             // Ensure all generic parameters are WinRT types.

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -438,12 +438,13 @@ namespace Generator
 
             if (!isProjectedType & type.ContainingNamespace != null)
             {
-                isProjectedType = mapper.HasMappingForType(string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName));
+                string qualifiedTypeName = string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName);
+                isProjectedType = mapper.HasMappingForType(qualifiedTypeName);
 
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + type.MetadataName) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + qualifiedTypeName) != null;
                 }
             }
 
@@ -477,12 +478,13 @@ namespace Generator
             bool isProjectedType = HasAttributeWithType(type, winrtRuntimeTypeAttribute);
             if (!isProjectedType & type.ContainingNamespace != null)
             {
-                isProjectedType = mapper.HasMappingForType(string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName));
+                string qualifiedTypeName = string.Join(".", type.ContainingNamespace.ToDisplayString(), type.MetadataName);
+                isProjectedType = mapper.HasMappingForType(qualifiedTypeName);
 
                 // Check if CsWinRT component projected type from another project.
                 if (!isProjectedType)
                 {
-                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + type.MetadataName) != null;
+                    isProjectedType = type.ContainingAssembly.GetTypeByMetadataName("ABI.Impl." + qualifiedTypeName) != null;
                 }
             }
 

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2531,7 +2531,7 @@ namespace Generator
                 AddProjectedType(type);
             }
             // Check if CsWinRT component projected type from another project.
-            else if (Model.Compilation.GetTypeByMetadataName("ABI.Impl." + qualifiedName) != null)
+            else if (Model.Compilation.GetTypeByMetadataName(GeneratorHelper.GetAuthoringMetadataType(qualifiedName)) != null)
             {
                 AddProjectedType(type);
             }

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2530,6 +2530,11 @@ namespace Generator
                 // Prioritize any mapped types before treating an attribute as a projected type.
                 AddProjectedType(type);
             }
+            // Check if CsWinRT component projected type from another project.
+            else if (Model.Compilation.GetTypeByMetadataName("ABI.Impl." + qualifiedName) != null)
+            {
+                AddProjectedType(type);
+            }
             else
             {
                 AddComponentType(type);

--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -2531,7 +2531,7 @@ namespace Generator
                 AddProjectedType(type);
             }
             // Check if CsWinRT component projected type from another project.
-            else if (Model.Compilation.GetTypeByMetadataName(GeneratorHelper.GetAuthoringMetadataType(qualifiedName)) != null)
+            else if (Model.Compilation.GetTypeByMetadataName(GeneratorHelper.GetAuthoringMetadataTypeName(qualifiedName)) != null)
             {
                 AddProjectedType(type);
             }


### PR DESCRIPTION
It is possible to have a CsWinRT component project reference another CsWinRT component project and for one to define interfaces while the other implements them.  We were previously not treating the types from the referenced component project as a CsWinRT or WinRT component and were redefining them or not putting them on the vtable.  This addresses those issues by looking for if our authoring metadata type where we define all our attributes for authoring types (ABI.Impl.<TypeName>) exists or not.  If it does exist, we treat that as an existing projected WinRT type.