### PR TITLE
Fix vtables not being generated for GeneratedBindableCustomPropertyAttribute classes

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1210,8 +1210,7 @@ namespace Generator
                     // In theory, another library can also be called which can call a projected function
                     // but not handling those scenarios for now.
                     (isWinRTClassOrInterface(methodSymbol.ContainingSymbol, true) ||
-                     SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly) ||
-                     isGeneratedBindableCustomPropertyClass(methodSymbol.ContainingSymbol)))
+                     SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly)))
                 {
                     // Get the concrete types directly from the argument rather than
                     // using what the method accepts, which might just be an interface, so
@@ -1237,21 +1236,26 @@ namespace Generator
             }
             else if (context.Node is AssignmentExpressionSyntax assignment)
             {
+                var isGeneratedBindableCustomProperty = false;
                 var leftSymbol = context.SemanticModel.GetSymbolInfo(assignment.Left).Symbol;
+                // Check if we are assigning to a property that is a WinRT class / interface or 
+                // a generated bindable custom property class as that will probably be binded to
+                // or is being assigned to another property in the same assembly as it might then be
+                // used elswhere after casting.
                 if (leftSymbol is IPropertySymbol propertySymbol &&
                     (isWinRTClassOrInterface(propertySymbol.ContainingSymbol, true) ||
-                     SymbolEqualityComparer.Default.Equals(propertySymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly) ||
-                     isGeneratedBindableCustomPropertyClass(propertySymbol.ContainingSymbol)))
+                     (isGeneratedBindableCustomProperty = isGeneratedBindableCustomPropertyClass(propertySymbol.ContainingSymbol)) ||
+                     SymbolEqualityComparer.Default.Equals(propertySymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly)))
                 {
-                    AddVtableAttributesForType(context.SemanticModel.GetTypeInfo(assignment.Right), propertySymbol.Type);
+                    AddVtableAttributesForType(context.SemanticModel.GetTypeInfo(assignment.Right), propertySymbol.Type, isGeneratedBindableCustomProperty);
                 }
                 else if (leftSymbol is IFieldSymbol fieldSymbol &&
                     // WinRT interfaces don't have fields, so we don't need to check for them.
-                    (isWinRTClassOrInterface(fieldSymbol.ContainingSymbol, false) || 
-                     SymbolEqualityComparer.Default.Equals(fieldSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly) ||
-                     isGeneratedBindableCustomPropertyClass(fieldSymbol.ContainingSymbol)))
+                    (isWinRTClassOrInterface(fieldSymbol.ContainingSymbol, false) ||
+                     (isGeneratedBindableCustomProperty = isGeneratedBindableCustomPropertyClass(fieldSymbol.ContainingSymbol)) ||
+                     SymbolEqualityComparer.Default.Equals(fieldSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly)))
                 {
-                    AddVtableAttributesForType(context.SemanticModel.GetTypeInfo(assignment.Right), fieldSymbol.Type);
+                    AddVtableAttributesForType(context.SemanticModel.GetTypeInfo(assignment.Right), fieldSymbol.Type, isGeneratedBindableCustomProperty);
                 }
             }
             else if (context.Node is VariableDeclarationSyntax variableDeclaration)
@@ -1350,15 +1354,15 @@ namespace Generator
             return vtableAttributes.ToImmutableArray();
 
             // Helper to directly use 'AddVtableAttributesForTypeDirect' with 'TypeInfo' values
-            void AddVtableAttributesForType(Microsoft.CodeAnalysis.TypeInfo instantiatedType, ITypeSymbol convertedToTypeSymbol)
+            void AddVtableAttributesForType(Microsoft.CodeAnalysis.TypeInfo instantiatedType, ITypeSymbol convertedToTypeSymbol, bool isGeneratedBindableCustomPropertyClass = false)
             {
-                AddVtableAttributesForTypeDirect(instantiatedType.Type, instantiatedType.ConvertedType, convertedToTypeSymbol);
+                AddVtableAttributesForTypeDirect(instantiatedType.Type, instantiatedType.ConvertedType, convertedToTypeSymbol, isGeneratedBindableCustomPropertyClass);
             }
 
             // This handles adding vtable information for types for which we can not directly put an attribute on them.
             // This includes generic types that are boxed and and non-WinRT types for which our AOT source generator hasn't
             // ran on but implements WinRT interfaces.
-            void AddVtableAttributesForTypeDirect(ITypeSymbol instantiatedTypeSymbol, ITypeSymbol instantiatedConvertedTypeSymbol, ITypeSymbol convertedToTypeSymbol)
+            void AddVtableAttributesForTypeDirect(ITypeSymbol instantiatedTypeSymbol, ITypeSymbol instantiatedConvertedTypeSymbol, ITypeSymbol convertedToTypeSymbol, bool isGeneratedBindableCustomPropertyClass = false)
             {
                 // This handles the case where there is an WinRT array possibly being assigned
                 // to an object type or a list. In this case, the IList interfaces of the array
@@ -1435,8 +1439,8 @@ namespace Generator
                                 // doesn't handle which we handle here is if it is a generic type implementing generic WinRT interfaces.
                                 (!SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly) ||
                                   GeneratorHelper.HasNonInstantiatedWinRTGeneric(instantiatedTypeSymbol.OriginalDefinition, typeMapper)) &&
-                                // Make sure the type we are passing is being boxed or cast to another interface.
-                                !SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol, convertedToTypeSymbol);
+                                // Make sure the type we are passing is being boxed or cast to another interface or being assigned to a member in a bindable class.
+                                (!SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol, convertedToTypeSymbol) || isGeneratedBindableCustomPropertyClass);
                         }
                         else if (!isWinRTType(instantiatedTypeSymbol, typeMapper))
                         {
@@ -1445,8 +1449,8 @@ namespace Generator
                                 // If the type is defined in the same assembly as what the source generator is running on,
                                 // we let the WinRTExposedType attribute generator handle it.
                                 !SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol.ContainingAssembly, context.SemanticModel.Compilation.Assembly) &&
-                                // Make sure the type we are passing is being boxed or cast to another interface.
-                                !SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol, convertedToTypeSymbol);
+                                // Make sure the type we are passing is being boxed or cast to another interface or being assigned to a member in a bindable class.
+                                (!SymbolEqualityComparer.Default.Equals(instantiatedTypeSymbol, convertedToTypeSymbol) || isGeneratedBindableCustomPropertyClass);
                         }
 
                         if (addClassOnLookupTable)

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -405,6 +405,18 @@ namespace Generator
             return compilation is CSharpCompilation csharpCompilation && csharpCompilation.Options.AllowUnsafe;
         }
 
+        // Returns whether the class is marked with the GeneratedBindableCustomProperty attribute or not.
+        public static Func<ISymbol, bool> IsGeneratedBindableCustomPropertyClass(Compilation compilation)
+        {
+            var generatedBindableCustomPropertyAttribute = compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute");
+            return IsGeneratedBindableCustomPropertyClassHelper;
+
+            bool IsGeneratedBindableCustomPropertyClassHelper(ISymbol type)
+            {
+                return HasAttributeWithType(type, generatedBindableCustomPropertyAttribute);
+            }
+        }
+
         // Returns whether it is a WinRT class or interface.
         // If the bool parameter is true, then custom mapped interfaces are also considered.
         // This function is similar to whether it is a WinRT type, but custom type mapped

--- a/src/Authoring/WinRT.SourceGenerator/Helper.cs
+++ b/src/Authoring/WinRT.SourceGenerator/Helper.cs
@@ -406,15 +406,10 @@ namespace Generator
         }
 
         // Returns whether the class is marked with the GeneratedBindableCustomProperty attribute or not.
-        public static Func<ISymbol, bool> IsGeneratedBindableCustomPropertyClass(Compilation compilation)
+        public static bool IsGeneratedBindableCustomPropertyClass(Compilation compilation, ISymbol type)
         {
             var generatedBindableCustomPropertyAttribute = compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute");
-            return IsGeneratedBindableCustomPropertyClassHelper;
-
-            bool IsGeneratedBindableCustomPropertyClassHelper(ISymbol type)
-            {
-                return HasAttributeWithType(type, generatedBindableCustomPropertyAttribute);
-            }
+            return HasAttributeWithType(type, generatedBindableCustomPropertyAttribute);
         }
 
         // Returns whether it is a WinRT class or interface.


### PR DESCRIPTION
- Classes attributed with `GeneratedBindableCustomProperty` are used for binding via the `ICustomPropertyProvider` support. This means even though they are not being used together with a CsWinRT projected class, the properties within them are still being passed across an ABI boundary.  Due to this, we do need to generate the vtables for them.  This change addresses that by taking that into account.

Fixes #2001