### PR TITLE
Fix non-blittable array marshaling

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-FunctionalTest-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-FunctionalTest-Steps.yml
@@ -62,20 +62,20 @@ steps:
         TargetFolder: $(StagingFolder)\FunctionalTests\${{ functionalTest }}\
 
     - task: MSBuild@1
-      displayName: Publish ${{ functionalTest }} for AOT (net8.0)
+      displayName: Publish ${{ functionalTest }} for AOT (net9.0)
       condition: and(succeeded(), and(eq(variables['BuildConfiguration'], 'release'), eq(variables['BuildPlatform'], 'x64')))
       inputs:
         solution: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\${{ functionalTest }}.csproj
-        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net8.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
+        msbuildArguments: /t:publish /p:CIBuildReason=CI,RuntimeIdentifier=win-$(BuildPlatform),TargetFramework=net9.0,solutiondir=$(Build.SourcesDirectory)\src\,VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),GenerateTestProjection=true,AllowedReferenceRelatedFileExtensions=".xml;.pri;.dll.config;.exe.config"
         platform: $(BuildPlatform)
         configuration: $(BuildConfiguration)
 
     - task: CmdLine@2
-      displayName: Run ${{ functionalTest }} for AOT (net8.0)
+      displayName: Run ${{ functionalTest }} for AOT (net9.0)
       condition: and(succeeded(), and(eq(variables['BuildConfiguration'], 'release'), eq(variables['BuildPlatform'], 'x64')))
       continueOnError: True
       inputs:
-        workingDirectory: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\bin\$(BuildConfiguration)\net8.0\win-$(BuildPlatform)\publish
+        workingDirectory: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\bin\$(BuildConfiguration)\net9.0\win-$(BuildPlatform)\publish
         script: |
           dir
           echo Running ${{ functionalTest }}.exe 
@@ -86,8 +86,8 @@ steps:
           exit /b 0 
 
     - task: CopyFiles@2
-      displayName: Copy ${{ functionalTest }} for AOT (net8.0)
+      displayName: Copy ${{ functionalTest }} for AOT (net9.0)
       condition: and(eq(variables['_PublishFunctionalTests'], 'true'), and(eq(variables['BuildConfiguration'], 'release'), eq(variables['BuildPlatform'], 'x64')))
       inputs:
-        SourceFolder: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\bin\$(BuildConfiguration)\net8.0\win-$(BuildPlatform)\publish
+        SourceFolder: $(Build.SourcesDirectory)\src\Tests\FunctionalTests\${{ functionalTest }}\bin\$(BuildConfiguration)\net9.0\win-$(BuildPlatform)\publish
         TargetFolder: $(StagingFolder)\FunctionalTests\${{ functionalTest }}\

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,7 +35,7 @@
     <LibBuildTFMsNoNetStandard Condition="'$(CIBuildReason)' == 'CI'">net8.0;net9.0</LibBuildTFMsNoNetStandard>
     <TestsBuildTFMs>net8.0-windows10.0.19041.0</TestsBuildTFMs>
     <TestsBuildTFMs Condition="'$(CIBuildReason)' == 'CI'">net8.0-windows10.0.19041.0</TestsBuildTFMs>
-    <FunctionalTestsBuildTFMs>net8.0</FunctionalTestsBuildTFMs>
+    <FunctionalTestsBuildTFMs>net8.0;net9.0</FunctionalTestsBuildTFMs>
     <WindowsAppSDKVerifyWinrtRuntimeVersion>false</WindowsAppSDKVerifyWinrtRuntimeVersion>
     <CsWinRTMessageImportance>high</CsWinRTMessageImportance>
   </PropertyGroup>

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -96,6 +96,14 @@ if (!AllEqual(nestedArr, nestedArr2, outNestedArr, retNestedArr))
     return 101;
 }
 
+EnumValue[] enumArr = new EnumValue[] { EnumValue.One, EnumValue.Two };
+instance.EnumsProperty = enumArr;
+EnumValue[] retEnumArr = instance.EnumsProperty;
+if (!AllEqual(enumArr, retEnumArr))
+{
+    return 101;
+}
+
 #endif
 
 IStringable[] stringableArr = new IStringable[] {

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using test_component_derived.Nested;
 using TestComponentCSharp;
+using Windows.Foundation;
 
 var instance = new Class();
 
@@ -36,6 +37,76 @@ float[] floatArr2 = new float[floatArr.Length];
 float[] outFloatArr;
 float[] retFloatArr = instance2.Array9(floatArr, floatArr2, out outFloatArr);
 if (!AllEqual(floatArr, floatArr2, outFloatArr, retFloatArr))
+{
+    return 101;
+}
+
+string[] stringArr = new string[] { "apples", "oranges", "pears" };
+string[] stringArr2 = new string[stringArr.Length];
+string[] outStringArr;
+string[] retStringArr = instance2.Array12(stringArr, stringArr2, out outStringArr);
+if (!AllEqual(stringArr, stringArr2, outStringArr, retStringArr))
+{
+    return 101;
+}
+
+TestComponent.Blittable[] blittableArr = new TestComponent.Blittable[] {
+                new TestComponent.Blittable(1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, typeof(TestComponent.ITests).GUID),
+                new TestComponent.Blittable(10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, typeof(IStringable).GUID)
+            };
+TestComponent.Blittable[] blittableArr2 = new TestComponent.Blittable[blittableArr.Length];
+TestComponent.Blittable[] outBlittableArr;
+TestComponent.Blittable[] retBlittableArr = instance2.Array13(blittableArr, blittableArr2, out outBlittableArr);
+if (!AllEqual(blittableArr, blittableArr2, outBlittableArr, retBlittableArr))
+{
+    return 101;
+}
+
+#if NET9_0_OR_GREATER
+
+TestComponent.NonBlittable[] nonBlittableArr = new TestComponent.NonBlittable[] {
+                new TestComponent.NonBlittable(false, 'X', "First", (long?)PropertyValue.CreateInt64(123)),
+                new TestComponent.NonBlittable(true, 'Y', "Second", (long?)PropertyValue.CreateInt64(456)),
+                new TestComponent.NonBlittable(false, 'Z', "Third", (long?)PropertyValue.CreateInt64(789))
+            };
+TestComponent.NonBlittable[] nonBlittableArr2 = new TestComponent.NonBlittable[nonBlittableArr.Length];
+TestComponent.NonBlittable[] outNonBlittableArr;
+TestComponent.NonBlittable[] retNonBlittableArr = instance2.Array14(nonBlittableArr, nonBlittableArr2, out outNonBlittableArr);
+if (!AllEqual(nonBlittableArr, nonBlittableArr2, outNonBlittableArr, retNonBlittableArr))
+{
+    return 101;
+}
+
+TestComponent.Nested[] nestedArr = new TestComponent.Nested[]{
+                new TestComponent.Nested(
+                    new TestComponent.Blittable(1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, typeof(TestComponent.ITests).GUID),
+                    new TestComponent.NonBlittable(false, 'X', "First", (long?)PropertyValue.CreateInt64(123))),
+                new TestComponent.Nested(
+                    new TestComponent.Blittable(10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, typeof(IStringable).GUID),
+                    new TestComponent.NonBlittable(true, 'Y', "Second", (long?)PropertyValue.CreateInt64(456))),
+                new TestComponent.Nested(
+                    new TestComponent.Blittable(1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, typeof(WinRT.IInspectable).GUID),
+                    new TestComponent.NonBlittable(false, 'Z', "Third", (long?)PropertyValue.CreateInt64(789)))
+            };
+TestComponent.Nested[] nestedArr2 = new TestComponent.Nested[nestedArr.Length];
+TestComponent.Nested[] outNestedArr;
+TestComponent.Nested[] retNestedArr = instance2.Array15(nestedArr, nestedArr2, out outNestedArr);
+if (!AllEqual(nestedArr, nestedArr2, outNestedArr, retNestedArr))
+{
+    return 101;
+}
+
+#endif
+
+IStringable[] stringableArr = new IStringable[] {
+                Windows.Data.Json.JsonValue.CreateNumberValue(3),
+                Windows.Data.Json.JsonValue.CreateNumberValue(4),
+                Windows.Data.Json.JsonValue.CreateNumberValue(5.0)
+            };
+IStringable[] stringableArr2 = new IStringable[stringableArr.Length];
+IStringable[] outStringableArr;
+IStringable[] retStringableArr = instance2.Array16(stringableArr, stringableArr2, out outStringableArr);
+if (!AllEqual(stringableArr, stringableArr2, outStringableArr, retStringableArr))
 {
     return 101;
 }

--- a/src/Tests/FunctionalTests/JsonValueFunctionCalls/JsonValueFunctionCalls.csproj
+++ b/src/Tests/FunctionalTests/JsonValueFunctionCalls/JsonValueFunctionCalls.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Authoring\WinRT.SourceGenerator.Roslyn4080\WinRT.SourceGenerator.Roslyn4080.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=x64"/>
+    <ProjectReference Include="..\..\..\Authoring\WinRT.SourceGenerator.Roslyn4120\WinRT.SourceGenerator.Roslyn4120.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=x64" />
     <ProjectReference Include="..\..\..\Projections\Test\Test.csproj" />
     <ProjectReference Include="..\..\..\Projections\Windows\Windows.csproj" />
   </ItemGroup>

--- a/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
+++ b/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Windows.Foundation;
 
-
 // Static function calls and create RCW for existing object.
 IStringable[] a = new IStringable[] {
                 Windows.Data.Json.JsonValue.CreateNumberValue(3),

--- a/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
+++ b/src/Tests/FunctionalTests/JsonValueFunctionCalls/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Windows.Foundation;
 
+
 // Static function calls and create RCW for existing object.
 IStringable[] a = new IStringable[] {
                 Windows.Data.Json.JsonValue.CreateNumberValue(3),
@@ -19,10 +20,16 @@ foreach (var str in a)
 // Class function call
 result += (int)(a[1] as Windows.Data.Json.JsonValue).GetNumber();
 
-var enumVal = TestComponentCSharp.Class.BoxedEnum;
-if (enumVal is TestComponentCSharp.EnumValue val && val == TestComponentCSharp.EnumValue.Two)
-{
-    result += 1;
-}
+CheckBoxedEnum();
 
 return result == 17 ? 100 : 101;
+
+[WinRT.DynamicWindowsRuntimeCast(typeof(TestComponentCSharp.EnumValue))]
+void CheckBoxedEnum()
+{
+    var enumVal = TestComponentCSharp.Class.BoxedEnum;
+    if (enumVal is TestComponentCSharp.EnumValue val && val == TestComponentCSharp.EnumValue.Two)
+    {
+        result += 1;
+    }
+}

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -685,6 +685,32 @@ namespace WinRT
                 DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
                 DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
             }
+            else if (typeof(T).IsEnum)
+            {
+                Func<T, object> ReturnTypedParameterFunc = (T value) => value;
+                AbiType = typeof(T);
+                CreateMarshaler = ReturnTypedParameterFunc;
+                CreateMarshaler2 = CreateMarshaler;
+                GetAbi = Marshaler.ReturnParameterFunc;
+                FromAbi = (object value) => (T)value;
+                FromManaged = ReturnTypedParameterFunc;
+                DisposeMarshaler = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                DisposeAbi = ABI.System.NonBlittableMarshallingStubs.NoOpFunc;
+                if (typeof(T).IsEnum)
+                {
+                    // For marshaling non-blittable enum arrays via MarshalNonBlittable
+                    if (typeof(T).GetEnumUnderlyingType() == typeof(int))
+                    {
+                        CopyAbi = Marshaler.CopyIntEnumFunc;
+                        CopyManaged = Marshaler.CopyIntEnumDirectFunc.WithTypedT1<T>();
+                    }
+                    else
+                    {
+                        CopyAbi = Marshaler.CopyUIntEnumFunc;
+                        CopyManaged = Marshaler.CopyUIntEnumDirectFunc.WithTypedT1<T>();
+                    }
+                }
+            }
             else if (typeof(T).IsValueType)
             {
                 // Value types can have custom marshaller types and use value types in places where we can't construct

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1114,6 +1114,9 @@ namespace WinRT
                 {
                     foreach (var marshaler in _marshalers)
                     {
+                        // We make use of MarshalNonBlittable for array marshaling when T is non-blittable or when it is an enum.
+                        // Both scenarios are handled by MarshalNonBlittable for marshaling T itself, so we just directly use that
+                        // here and below without needing to go through Marshaler<T>.
                         MarshalNonBlittable<T>.DisposeMarshaler(marshaler);
                     }
                 }

--- a/src/WinRT.Runtime/Marshalers.cs
+++ b/src/WinRT.Runtime/Marshalers.cs
@@ -1088,7 +1088,7 @@ namespace WinRT
                 {
                     foreach (var marshaler in _marshalers)
                     {
-                        Marshaler<T>.DisposeMarshaler(marshaler);
+                        MarshalNonBlittable<T>.DisposeMarshaler(marshaler);
                     }
                 }
                 if (_array != IntPtr.Zero)
@@ -1103,7 +1103,7 @@ namespace WinRT
 
         public static new unsafe MarshalerArray CreateMarshalerArray(T[] array)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1131,8 +1131,8 @@ namespace WinRT
                 var element = (byte*)m._array.ToPointer();
                 for (int i = 0; i < length; i++)
                 {
-                    m._marshalers[i] = Marshaler<T>.CreateMarshaler(array[i]);
-                    Marshaler<T>.CopyAbi(m._marshalers[i], (IntPtr)element);
+                    m._marshalers[i] = MarshalNonBlittable<T>.CreateMarshaler(array[i]);
+                    MarshalNonBlittable<T>.CopyAbi(m._marshalers[i], (IntPtr)element);
                     element += abi_element_size;
                 }
 #pragma warning restore IL3050
@@ -1156,7 +1156,7 @@ namespace WinRT
 
         public static new unsafe T[] FromAbiArray(object box)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1188,7 +1188,7 @@ namespace WinRT
 #else
                     Marshal.PtrToStructure((IntPtr)data, AbiType);
 #endif
-                array[i] = Marshaler<T>.FromAbi(abi_element);
+                array[i] = MarshalNonBlittable<T>.FromAbi(abi_element);
                 data += abi_element_size;
             }
 #pragma warning restore IL3050
@@ -1197,7 +1197,7 @@ namespace WinRT
 
         public static unsafe void CopyAbiArray(T[] array, object box)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1224,7 +1224,7 @@ namespace WinRT
 #else
                     Marshal.PtrToStructure((IntPtr)data, AbiType);
 #endif
-                array[i] = Marshaler<T>.FromAbi(abi_element);
+                array[i] = MarshalNonBlittable<T>.FromAbi(abi_element);
                 data += abi_element_size;
             }
 #pragma warning restore IL3050
@@ -1232,7 +1232,7 @@ namespace WinRT
 
         public static new unsafe (int length, IntPtr data) FromManagedArray(T[] array)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1260,7 +1260,7 @@ namespace WinRT
                 var bytes = (byte*)data.ToPointer();
                 for (i = 0; i < length; i++)
                 {
-                    Marshaler<T>.CopyManaged(array[i], (IntPtr)bytes);
+                    MarshalNonBlittable<T>.CopyManaged(array[i], (IntPtr)bytes);
                     bytes += abi_element_size;
                 }
 #pragma warning restore IL3050
@@ -1278,7 +1278,7 @@ namespace WinRT
 
         public static unsafe void CopyManagedArray(T[] array, IntPtr data)
         {
-#if NET
+#if NET && !NET9_0_OR_GREATER
             if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
                 throw new NotSupportedException($"Cannot handle array marshalling for non blittable type '{typeof(T)}'.");
@@ -1304,7 +1304,7 @@ namespace WinRT
                 var bytes = (byte*)data.ToPointer();
                 for (i = 0; i < length; i++)
                 {
-                    Marshaler<T>.CopyManaged(array[i], (IntPtr)bytes);
+                    MarshalNonBlittable<T>.CopyManaged(array[i], (IntPtr)bytes);
                     bytes += abi_element_size;
                 }
 #pragma warning restore IL3050


### PR DESCRIPTION
- Added AOT tests for more array scenarios including non-blittable arrays
- Enabled them for .NET 9 to validate non-blittable array support
- Enabled the non-blittable array support and made it not rely on Marshaler<T>