### PR TITLE
Use FormatMessage for exception messages in cases where the stowed/language exception doesn't contain a message

### DIFF
--- a/src/Tests/UnitTest/ExceptionTests.cs
+++ b/src/Tests/UnitTest/ExceptionTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using WinRT;
+using Xunit;
+
+namespace UnitTest
+{
+    public class ExceptionTests
+    {
+        [Fact]
+        public void TestGetExceptionForHR_WithValidHResult_ReturnsSystemFormattedException()
+        {
+            const int RPC_E_WRONG_THREAD = unchecked((int)0x8001010E);
+
+            Exception exception = ExceptionHelpers.GetExceptionForHR(RPC_E_WRONG_THREAD);
+            Assert.NotNull(exception);
+            Assert.False(string.IsNullOrWhiteSpace(exception.Message));
+            if (CultureInfo.CurrentUICulture.Name == "en-US")
+            {
+                Assert.Equal("The application called an interface that was marshalled for a different thread. (0x8001010E)", exception.Message);
+            }
+        }
+    }
+}

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -227,7 +227,7 @@ namespace WinRT
                 }
             }
 
-            if (string.IsNullOrEmpty(errorMessage))
+            if (string.IsNullOrWhiteSpace(errorMessage))
             {
                 char* message = default;
                 if (Platform.FormatMessageW(0x13FF /* FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK */,

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -227,6 +227,27 @@ namespace WinRT
                 }
             }
 
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                char* message = default;
+                if (Platform.FormatMessageW(0x13FF /* FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK */,
+                                            null,
+                                            (uint)hr,
+                                            0,
+                                            &message,
+                                            0,
+                                            null) > 0)
+                {
+                    errorMessage = $"{new string(message)}(0x{hr:X8})";
+
+                    // LocalHandle isn't needed since FormatMessage uses LMEM_FIXED,
+                    // and while we can use Marshal.FreeHGlobal since it uses LocalFree internally,
+                    // it's not guranteed that this behavior stays the same in the future,
+                    // especially considering the method's name, so it's safer to use LocalFree directly.
+                    Platform.LocalFree(message);
+                }
+            }
+
             switch (hr)
             {
                 case E_CHANGED_STATE:

--- a/src/WinRT.Runtime/ExceptionHelpers.cs
+++ b/src/WinRT.Runtime/ExceptionHelpers.cs
@@ -369,7 +369,7 @@ See https://aka.ms/cswinrt/interop#windows-sdk",
                     break;
 
                 default:
-                    ex = new COMException(errorMessage, hr);
+                    ex = !string.IsNullOrEmpty(errorMessage) ? new COMException(errorMessage, hr) : new COMException($"0x{hr:X8}", hr);
                     break;
             }
 

--- a/src/WinRT.Runtime/Platform.cs
+++ b/src/WinRT.Runtime/Platform.cs
@@ -49,10 +49,10 @@ namespace WinRT.Interop
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         public static extern unsafe int CoCreateFreeThreadedMarshaler(IntPtr outer, IntPtr* marshalerPtr);
 
-        [DllImport("Kernel32.dll")]
+        [DllImport("kernel32.dll")]
         public static extern unsafe uint FormatMessageW(uint dwFlags, void* lpSource, uint dwMessageId, uint dwLanguageId, char** lpBuffer, uint nSize, void* pArguments);
 
-        [DllImport("Kernel32.dll")]
+        [DllImport("kernel32.dll")]
         public static extern unsafe void* LocalFree(void* hMem);
     }
 

--- a/src/WinRT.Runtime/Platform.cs
+++ b/src/WinRT.Runtime/Platform.cs
@@ -48,6 +48,12 @@ namespace WinRT.Interop
 
         [DllImport("api-ms-win-core-com-l1-1-0.dll")]
         public static extern unsafe int CoCreateFreeThreadedMarshaler(IntPtr outer, IntPtr* marshalerPtr);
+
+        [DllImport("Kernel32.dll")]
+        public static extern unsafe uint FormatMessageW(uint dwFlags, void* lpSource, uint dwMessageId, uint dwLanguageId, char** lpBuffer, uint nSize, void* pArguments);
+
+        [DllImport("Kernel32.dll")]
+        public static extern unsafe void* LocalFree(void* hMem);
     }
 
     // Handcrafted P/Invoke with TFM-specific handling, or thin high-level abstractions (eg. 'TryGetProcAddress'/'GetProcAddress')


### PR DESCRIPTION
Updated HRESULT to Exception conversion logic to fall back to system-formatted error messages via the Win32 FormatMessage API when custom error text is not available or is blank. This ensures more consistent and informative exception messages by leveraging Windows' built-in error descriptions.

Example:
<img width="1026" height="454" alt="image" src="https://github.com/user-attachments/assets/83d27c98-40ac-4b05-a643-21bf74595549" />
