### PR TITLE
Fix 'Initialize' typo in several files

### DIFF
--- a/src/WinRT.Runtime/Interop/EventSourceState{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSourceState{TDelegate}.cs
@@ -111,7 +111,7 @@ namespace ABI.WinRT.Interop
             return cacheEntry;
         }
 
-        internal void InitalizeReferenceTracking(IntPtr ptr)
+        internal void InitializeReferenceTracking(IntPtr ptr)
         {
             eventInvokePtr = ptr;
             int hr = Marshal.QueryInterface(ptr, ref Unsafe.AsRef(in IID.IID_IReferenceTrackerTarget), out referenceTrackerTargetPtr);

--- a/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
+++ b/src/WinRT.Runtime/Interop/EventSource{TDelegate}.cs
@@ -112,7 +112,7 @@ namespace ABI.WinRT.Interop
                     try
                     {
                         var nativeDelegate = marshaler.GetAbi();
-                        state.InitalizeReferenceTracking(nativeDelegate);
+                        state.InitializeReferenceTracking(nativeDelegate);
 
                         EventRegistrationToken token;
 #if NET

--- a/src/WinRT.Runtime/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime/WinRT.Runtime.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <Compile Include="../cswinrt/strings/InitalizeProjection.cs" Link="cswinrt/InitalizeProjection.cs" />
+    <Compile Include="../cswinrt/strings/InitializeProjection.cs" Link="cswinrt/InitializeProjection.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/cswinrt/cswinrt.vcxproj
+++ b/src/cswinrt/cswinrt.vcxproj
@@ -120,7 +120,7 @@
     <None Include="strings\additions\Windows.UI.Xaml\Windows.UI.Xaml.SR.cs" />
     <None Include="strings\additions\Windows.UI\Windows.UI.cs" />
     <None Include="strings\ComInteropHelpers.cs" />
-    <None Include="strings\InitalizeProjection.cs" />
+    <None Include="strings\InitializeProjection.cs" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="WinRT.Interop.idl" />

--- a/src/cswinrt/cswinrt.vcxproj.filters
+++ b/src/cswinrt/cswinrt.vcxproj.filters
@@ -68,7 +68,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="strings\InitalizeProjection.cs">
+    <None Include="strings\InitializeProjection.cs">
       <Filter>strings</Filter>
     </None>
     <None Include="packages.config" />

--- a/src/cswinrt/main.cpp
+++ b/src/cswinrt/main.cpp
@@ -400,7 +400,7 @@ internal static readonly System.Collections.Generic.Dictionary<string, string> T
 };
 
 [System.Runtime.CompilerServices.ModuleInitializer]
-internal static void InitalizeProjectionTypes()
+internal static void InitializeProjectionTypes()
 {
 ComWrappersSupport.RegisterProjectionTypeBaseTypeMapping(TypeNameToBaseTypeNameMapping);
 }
@@ -430,7 +430,7 @@ internal static class AbiDelegatesInitializer
 {
 
 [System.Runtime.CompilerServices.ModuleInitializer]
-internal static void InitalizeAbiDelegates()
+internal static void InitializeAbiDelegates()
 {
 %
 }

--- a/src/cswinrt/strings/InitializeProjection.cs
+++ b/src/cswinrt/strings/InitializeProjection.cs
@@ -26,7 +26,7 @@ namespace WinRT
         /// The module initializer registering the current assembly via <see cref="ComWrappersSupport.RegisterProjectionAssembly"/>.
         /// </summary>
         [ModuleInitializer]
-        public static void InitalizeProjection()
+        public static void InitializeProjection()
         {
             ComWrappersSupport.RegisterProjectionAssembly(typeof(ProjectionInitializer).Assembly);
         }


### PR DESCRIPTION
'Initialize' wording in several files (including cswinrt generated projections) are misspelled as 'Initalize'