### PR TITLE
Fix design time build error causing incremental build issue

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -299,6 +299,8 @@ $(CsWinRTInternalProjection)
     <PropertyGroup>
       <CsWinRTContinueOnError>false</CsWinRTContinueOnError>
       <CsWinRTContinueOnError Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">true</CsWinRTContinueOnError>
+      <CsWinRTProjectionExitCode>0</CsWinRTProjectionExitCode>
+      <CsWinRTPrivateProjectionExitCode>0</CsWinRTPrivateProjectionExitCode>
     </PropertyGroup>
 
     <ItemGroup>
@@ -309,10 +311,14 @@ $(CsWinRTInternalProjection)
     <WriteLinesToFile File="$(CsWinRTResponseFile)" Lines="$(CsWinRTParams)" Overwrite="true" />
     <WriteLinesToFile File="$(CsWinRTResponseFilePrivateProjection)" Lines="$(CsWinRTPrivateParams)" Overwrite="true" />
     <Message Text="$(CsWinRTCommand)" Importance="$(CsWinRTMessageImportance)" />
-    <Exec Command="$(CsWinRTCommand)" ContinueOnError="$(CsWinRTContinueOnError)" />
+    <Exec Command="$(CsWinRTCommand)" ContinueOnError="$(CsWinRTContinueOnError)">
+      <Output TaskParameter="ExitCode" PropertyName="CsWinRTProjectionExitCode" />
+    </Exec>
 
     <Message Text="$(CsWinRTCommandPrivateProjection)" Importance="$(CsWinRTMessageImportance)" />
-    <Exec Command="$(CsWinRTCommandPrivateProjection)" ContinueOnError="$(CsWinRTContinueOnError)" Condition="'$(CsWinRTPrivateProjection)' == 'true'"/>
+    <Exec Command="$(CsWinRTCommandPrivateProjection)" ContinueOnError="$(CsWinRTContinueOnError)" Condition="'$(CsWinRTPrivateProjection)' == 'true'">
+      <Output TaskParameter="ExitCode" PropertyName="CsWinRTPrivateProjectionExitCode" />
+    </Exec>
 
     <ItemGroup Condition="'$(CsWinRTComponent)' != 'true' and Exists('$(CsWinRTResponseFile)')">
       <UpToDateCheckInput Include="@(CsWinRTInputs)" Set="WinMDs" />
@@ -320,7 +326,8 @@ $(CsWinRTInternalProjection)
       <UpToDateCheckBuilt Include="$(CsWinRTResponseFile)" Set="WinMDs" />
     </ItemGroup>
 
-    <!-- Clean the output file if the target failed to indicate it needs to be rebuild -->
+    <!-- Clean the output file if the target failed to indicate it needs to be rebuild including for design time builds which won't trigger OnError. -->
+    <CallTarget Targets="CsWinRTCleanGenerateProjectionOutputs" Condition="'$(CsWinRTContinueOnError)' == 'true' AND ('$(CsWinRTProjectionExitCode)' != '0' OR '$(CsWinRTPrivateProjectionExitCode)' != '0')" />
     <OnError ExecuteTargets="CsWinRTCleanGenerateProjectionOutputs" />
   </Target>
 


### PR DESCRIPTION
If during design time build, we fail to generate a projection, we don't delete the `rsp` files as we configured it to continue on error and thereby the `OnError` handler doesn't run.  This can cause for the incremental build to report it succeeded based on `rsp` and inputs not changing when it hasn't.  Fixing it by having a separate way to delete the `rsp` file for design time builds.  Given we want the non-design time build to still stop on error, keeping `OnError` too.