### PR TITLE
WinRT.Runtime.dll tweaks

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
@@ -287,9 +287,7 @@ internal static partial class InteropTypeDefinitionBuilder
         TypeSignature windowsRuntimeObjectReferenceValueType = interopReferences.WindowsRuntimeObjectReferenceValue.Import(module).ToValueTypeSignature();
 
         // Reference the instantiated 'ConvertToUnmanaged' method for the marshaller
-        MethodSpecification windowsRuntimeInterfaceMarshallerConvertToUnmanaged =
-            interopReferences.WindowsRuntimeInterfaceMarshallerConvertToUnmanaged
-            .MakeGenericInstanceMethod(typeSignature);
+        MemberReference windowsRuntimeInterfaceMarshallerConvertToUnmanaged = interopReferences.WindowsRuntimeInterfaceMarshallerConvertToUnmanaged(typeSignature);
 
         // Define the 'ConvertToUnmanaged' method as follows:
         //

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -597,9 +597,9 @@ internal sealed class InteropReferences
     public TypeReference WindowsRuntimeUnsealedObjectMarshaller => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeUnsealedObject"u8);
 
     /// <summary>
-    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeInterfaceMarshaller</c>.
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeInterfaceMarshaller&lt;T&gt;</c>.
     /// </summary>
-    public TypeReference WindowsRuntimeInterfaceMarshaller => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeInterfaceMarshaller"u8);
+    public TypeReference WindowsRuntimeInterfaceMarshaller1 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeInterfaceMarshaller`1"u8);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeDelegateMarshaller</c>.
@@ -1301,17 +1301,6 @@ internal sealed class InteropReferences
             parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
-    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged</c>.
-    /// </summary>
-    public MemberReference WindowsRuntimeInterfaceMarshallerConvertToUnmanaged => field ??= WindowsRuntimeInterfaceMarshaller
-        .CreateMemberReference("ConvertToUnmanaged"u8, MethodSignature.CreateStatic(
-            returnType: WindowsRuntimeObjectReferenceValue.ToValueTypeSignature(),
-            genericParameterCount: 1,
-            parameterTypes: [
-                new GenericParameterSignature(GenericParameterType.Method, 0),
-                Guid.MakeByReferenceType()]));
-
-    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeDelegateMarshaller.ConvertToUnmanaged(Delegate, in Guid)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeDelegateMarshallerConvertToUnmanaged => field ??= WindowsRuntimeDelegateMarshaller
@@ -1571,6 +1560,23 @@ internal sealed class InteropReferences
             .ToTypeDefOrRef()
             .CreateMemberReference("GetEnumerator"u8, MethodSignature.CreateInstance(
                 returnType: IEnumerator1.MakeGenericReferenceType(new GenericParameterSignature(GenericParameterType.Type, 0))));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged</c>.
+    /// </summary>
+    /// <param name="interfaceType">The input interface type.</param>
+    public MemberReference WindowsRuntimeInterfaceMarshallerConvertToUnmanaged(TypeSignature interfaceType)
+    {
+        return WindowsRuntimeInterfaceMarshaller1
+            .MakeGenericReferenceType(interfaceType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("ConvertToUnmanaged"u8, MethodSignature.CreateStatic(
+                returnType: WindowsRuntimeObjectReferenceValue.ToValueTypeSignature(),
+                genericParameterCount: 1,
+                parameterTypes: [
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    Guid.MakeByReferenceType()]));
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
+++ b/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
@@ -10,11 +10,34 @@ using System.Threading;
 using Windows.Foundation;
 using WindowsRuntime;
 using WindowsRuntime.InteropServices;
+using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
 #pragma warning disable IDE0008, IDE1006
 
 namespace ABI.System.Collections.Specialized;
+
+/// <summary>
+/// Marshaller for <see cref="global::System.Collections.Specialized.INotifyCollectionChanged"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class INotifyCollectionChangedMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.Collections.Specialized.INotifyCollectionChanged? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value,
+            in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
+                ? ref WellKnownInterfaceIds.IID_WUX_INotifyCollectionChanged
+                : ref WellKnownInterfaceIds.IID_MUX_INotifyCollectionChanged);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.Collections.Specialized.INotifyCollectionChanged? ConvertToManaged(void* value)
+    {
+        return (global::System.Collections.Specialized.INotifyCollectionChanged?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
 
 /// <summary>
 /// Interop methods for <see cref="global::System.Collections.Specialized.INotifyCollectionChanged"/>.

--- a/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
+++ b/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
@@ -26,8 +26,9 @@ public static unsafe class INotifyCollectionChangedMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.Collections.Specialized.INotifyCollectionChanged? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value,
-            in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
+        return WindowsRuntimeInterfaceMarshaller<global::System.Collections.Specialized.INotifyCollectionChanged>.ConvertToUnmanaged(
+            value: value,
+            iid: in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
                 ? ref WellKnownInterfaceIds.IID_WUX_INotifyCollectionChanged
                 : ref WellKnownInterfaceIds.IID_MUX_INotifyCollectionChanged);
     }

--- a/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
+++ b/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
@@ -19,6 +19,25 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace ABI.System.ComponentModel;
 
 /// <summary>
+/// Marshaller for <see cref="global::System.ComponentModel.INotifyDataErrorInfo"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class INotifyDataErrorInfoMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.ComponentModel.INotifyDataErrorInfo? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_INotifyDataErrorInfo);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.ComponentModel.INotifyDataErrorInfo? ConvertToManaged(void* value)
+    {
+        return (global::System.ComponentModel.INotifyDataErrorInfo?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
+
+/// <summary>
 /// Interop methods for <see cref="global::System.ComponentModel.INotifyDataErrorInfo"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
+++ b/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
@@ -27,7 +27,9 @@ public static unsafe class INotifyDataErrorInfoMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.ComponentModel.INotifyDataErrorInfo? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_INotifyDataErrorInfo);
+        return WindowsRuntimeInterfaceMarshaller<global::System.ComponentModel.INotifyDataErrorInfo>.ConvertToUnmanaged(
+            value: value,
+            iid: in WellKnownInterfaceIds.IID_INotifyDataErrorInfo);
     }
 
     /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>

--- a/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyPropertyChanged.cs
+++ b/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyPropertyChanged.cs
@@ -25,8 +25,9 @@ public static unsafe class INotifyPropertyChangedMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.ComponentModel.INotifyPropertyChanged? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value,
-            in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
+        return WindowsRuntimeInterfaceMarshaller<global::System.ComponentModel.INotifyPropertyChanged>.ConvertToUnmanaged(
+            value: value,
+            iid: in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
                 ? ref WellKnownInterfaceIds.IID_WUX_INotifyPropertyChanged
                 : ref WellKnownInterfaceIds.IID_MUX_INotifyPropertyChanged);
     }

--- a/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyPropertyChanged.cs
+++ b/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyPropertyChanged.cs
@@ -9,11 +9,34 @@ using System.Threading;
 using Windows.Foundation;
 using WindowsRuntime;
 using WindowsRuntime.InteropServices;
+using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
 #pragma warning disable IDE0008, IDE1006
 
 namespace ABI.System.ComponentModel;
+
+/// <summary>
+/// Marshaller for <see cref="global::System.ComponentModel.INotifyPropertyChanged"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class INotifyPropertyChangedMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.ComponentModel.INotifyPropertyChanged? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value,
+            in WindowsRuntimeFeatureSwitches.UseWindowsUIXamlProjections
+                ? ref WellKnownInterfaceIds.IID_WUX_INotifyPropertyChanged
+                : ref WellKnownInterfaceIds.IID_MUX_INotifyPropertyChanged);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.ComponentModel.INotifyPropertyChanged? ConvertToManaged(void* value)
+    {
+        return (global::System.ComponentModel.INotifyPropertyChanged?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
 
 /// <summary>
 /// Interop methods for <see cref="global::System.ComponentModel.INotifyPropertyChanged"/>.

--- a/src/WinRT.Runtime2/ABI/System/IDisposable.cs
+++ b/src/WinRT.Runtime2/ABI/System/IDisposable.cs
@@ -16,6 +16,25 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace ABI.System;
 
 /// <summary>
+/// Marshaller for <see cref="global::System.IDisposable"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class IDisposableMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.IDisposable? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IDisposable);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.IDisposable? ConvertToManaged(void* value)
+    {
+        return (global::System.IDisposable?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
+
+/// <summary>
 /// Interop methods for <see cref="global::System.IDisposable"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime2/ABI/System/IDisposable.cs
+++ b/src/WinRT.Runtime2/ABI/System/IDisposable.cs
@@ -24,7 +24,7 @@ public static unsafe class IDisposableMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.IDisposable? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IDisposable);
+        return WindowsRuntimeInterfaceMarshaller<global::System.IDisposable>.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IDisposable);
     }
 
     /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>

--- a/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
+++ b/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
@@ -16,6 +16,25 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace ABI.System;
 
 /// <summary>
+/// Marshaller for <see cref="global::System.IServiceProvider"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class IServiceProviderMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.IServiceProvider? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IServiceProvider);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.IServiceProvider? ConvertToManaged(void* value)
+    {
+        return (global::System.IServiceProvider?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
+
+/// <summary>
 /// Interop methods for <see cref="global::System.IServiceProvider"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -77,6 +96,11 @@ public static unsafe class IServiceProviderImpl
 
         Vftbl.GetService = &GetService;
     }
+
+    /// <summary>
+    /// Gets the IID for <see cref="global::System.IServiceProvider"/>.
+    /// </summary>
+    public static ref readonly Guid IID => ref WellKnownInterfaceIds.IID_IServiceProvider;
 
     /// <summary>
     /// Gets a pointer to the managed <see cref="global::System.IServiceProvider"/> implementation.

--- a/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
+++ b/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
@@ -24,7 +24,7 @@ public static unsafe class IServiceProviderMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.IServiceProvider? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IServiceProvider);
+        return WindowsRuntimeInterfaceMarshaller<global::System.IServiceProvider>.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IServiceProvider);
     }
 
     /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>

--- a/src/WinRT.Runtime2/ABI/System/Type.cs
+++ b/src/WinRT.Runtime2/ABI/System/Type.cs
@@ -63,13 +63,33 @@ public static unsafe class TypeMarshaller
     /// </summary>
     /// <param name="value">The managed <see cref="global::System.Type"/> value.</param>
     /// <returns>The unmanaged <see cref="Type"/> value.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>"
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
     public static Type ConvertToUnmanaged(global::System.Type value)
+    {
+        ConvertToUnmanagedUnsafe(value, out TypeReference reference);
+
+        return reference.ConvertToUnmanaged();
+    }
+
+    /// <summary>
+    /// Converts a managed <see cref="global::System.Type"/> to an unmanaged <see cref="Type"/> with fast-pass.
+    /// </summary>
+    /// <param name="value">The managed <see cref="global::System.Type"/> value.</param>
+    /// <param name="reference">
+    /// The resulting <see cref="TypeReference"/> instance. This must be kept in scope as long
+    /// as the <see cref="Type"/> value retrieved from it is being used. It is not valid to escape that
+    /// value, as the reference is required to exist for the fast-pass <see cref="Type"/> to be valid.
+    /// </param>
+    /// <returns>The unmanaged <see cref="Type"/> value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
+    public static void ConvertToUnmanagedUnsafe(global::System.Type value, out TypeReference reference)
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        // TODO
-        return default;
+        string abiName = ""; // TODO
+        TypeKind kind = default; // TODO
+
+        reference = new TypeReference { Name = abiName, Kind = kind };
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/ABI/System/Windows.Input/ICommand.cs
+++ b/src/WinRT.Runtime2/ABI/System/Windows.Input/ICommand.cs
@@ -25,7 +25,9 @@ public static unsafe class ICommandMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.Windows.Input.ICommand? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_ICommand);
+        return WindowsRuntimeInterfaceMarshaller<global::System.Windows.Input.ICommand>.ConvertToUnmanaged(
+            value: value,
+            iid: in WellKnownInterfaceIds.IID_ICommand);
     }
 
     /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>

--- a/src/WinRT.Runtime2/ABI/System/Windows.Input/ICommand.cs
+++ b/src/WinRT.Runtime2/ABI/System/Windows.Input/ICommand.cs
@@ -17,6 +17,25 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace ABI.System.Windows.Input;
 
 /// <summary>
+/// Marshaller for <see cref="global::System.Windows.Input.ICommand"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class ICommandMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::System.Windows.Input.ICommand? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_ICommand);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::System.Windows.Input.ICommand? ConvertToManaged(void* value)
+    {
+        return (global::System.Windows.Input.ICommand?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
+
+/// <summary>
 /// Interop methods for <see cref="global::System.Windows.Input.ICommand"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
@@ -25,7 +25,9 @@ public static unsafe class IVectorChangedEventArgsMarshaller
     /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
     public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::Windows.Foundation.Collections.IVectorChangedEventArgs? value)
     {
-        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IVectorChangedEventArgs);
+        return WindowsRuntimeInterfaceMarshaller<global::Windows.Foundation.Collections.IVectorChangedEventArgs>.ConvertToUnmanaged(
+            value: value,
+            iid: in WellKnownInterfaceIds.IID_IVectorChangedEventArgs);
     }
 
     /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
@@ -17,6 +17,25 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace ABI.System.ComponentModel;
 
 /// <summary>
+/// Marshaller for <see cref="global::Windows.Foundation.Collections.IVectorChangedEventArgs"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static unsafe class IVectorChangedEventArgsMarshaller
+{
+    /// <inheritdoc cref="WindowsRuntimeObjectMarshaller.ConvertToUnmanaged"/>
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(global::Windows.Foundation.Collections.IVectorChangedEventArgs? value)
+    {
+        return WindowsRuntimeInterfaceMarshaller.ConvertToUnmanaged(value, in WellKnownInterfaceIds.IID_IVectorChangedEventArgs);
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeDelegateMarshaller.ConvertToManaged"/>
+    public static global::Windows.Foundation.Collections.IVectorChangedEventArgs? ConvertToManaged(void* value)
+    {
+        return (global::Windows.Foundation.Collections.IVectorChangedEventArgs?)WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+    }
+}
+
+/// <summary>
 /// Interop methods for <see cref="global::Windows.Foundation.Collections.IVectorChangedEventArgs"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/TypeReference.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/TypeReference.cs
@@ -27,6 +27,18 @@ public unsafe ref struct TypeReference
     /// </summary>
     /// <returns>The resulting <see cref="ABI.System.Type"/> value for marshalling.</returns>
     /// <remarks>
+    /// Unlike <see cref="ConvertToUnmanagedUnsafe"/>, this method will not use a fast-pass <c>HSTRING</c>, so it doesn't need pinning.
+    /// </remarks>
+    public ABI.System.Type ConvertToUnmanaged()
+    {
+        return new() { Name = HStringMarshaller.ConvertToUnmanaged(Name), Kind = Kind };
+    }
+
+    /// <summary>
+    /// Converts the current <see cref="TypeReference"/> value into a <see cref="ABI.System.Type"/> value for marshalling.
+    /// </summary>
+    /// <returns>The resulting <see cref="ABI.System.Type"/> value for marshalling.</returns>
+    /// <remarks>
     /// This method can only be used within a <see langword="fixed"/> block on <see cref="GetPinnableReference"/>.
     /// Calling this method while the <see cref="TypeReference"/> value is not fixed this way is undefined behavior.
     /// </remarks>

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/TypeReference.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/TypeReference.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using Windows.UI.Xaml.Interop;
+
+namespace WindowsRuntime.InteropServices.Marshalling;
+
+/// <summary>
+/// Represents a reference to a <see cref="System.Type"/> value, for fast marshalling to native.
+/// </summary>
+public unsafe ref struct TypeReference
+{
+    /// <inheritdoc cref="ABI.System.Type.Name"/>
+    internal string? Name;
+
+    /// <inheritdoc cref = "ABI.System.Type.Kind" />
+    internal TypeKind Kind;
+
+    /// <summary>
+    /// The <see cref="HStringReference"/> to use for marshalling.
+    /// </summary>
+    private HStringReference NameRef;
+
+    /// <summary>
+    /// Converts the current <see cref="TypeReference"/> value into a <see cref="ABI.System.Type"/> value for marshalling.
+    /// </summary>
+    /// <returns>The resulting <see cref="ABI.System.Type"/> value for marshalling.</returns>
+    /// <remarks>
+    /// This method can only be used within a <see langword="fixed"/> block on <see cref="GetPinnableReference"/>.
+    /// Calling this method while the <see cref="TypeReference"/> value is not fixed this way is undefined behavior.
+    /// </remarks>
+    public ABI.System.Type ConvertToUnmanagedUnsafe()
+    {
+        HStringMarshaller.ConvertToUnmanagedUnsafe(
+            (char*)Unsafe.AsPointer(in Name!.GetPinnableReference()),
+            Name?.Length,
+            out NameRef);
+
+        return new() { Name = NameRef.HString, Kind = Kind };
+    }
+
+    /// <summary>
+    /// Returns a pinnable reference for the current <see cref="TypeReference"/> value.
+    /// </summary>
+    /// <returns>A pinnable reference for the current <see cref="TypeReference"/> value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly ref byte GetPinnableReference()
+    {
+        return ref Unsafe.As<char, byte>(ref Unsafe.AsRef(in Name!.GetPinnableReference()));
+    }
+}

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/WindowsRuntimeInterfaceMarshaller{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/WindowsRuntimeInterfaceMarshaller{T}.cs
@@ -10,12 +10,13 @@ namespace WindowsRuntime.InteropServices.Marshalling;
 /// <summary>
 /// A marshaller for Windows Runtime interfaces.
 /// </summary>
-public static unsafe class WindowsRuntimeInterfaceMarshaller
+/// <typeparam name="T">The type of the interface being marshalled.</typeparam>
+public static unsafe class WindowsRuntimeInterfaceMarshaller<T>
+    where T : class
 {
     /// <summary>
     /// Marshals a Windows Runtime interface to a <see cref="WindowsRuntimeObjectReferenceValue"/> instance.
     /// </summary>
-    /// <typeparam name="T">The type of the interface being marshalled.</typeparam>
     /// <param name="value">The input <typeparamref name="T"/> object to marshal.</param>
     /// <param name="iid">The IID for the interface being marshalled.</param>
     /// <returns>A <see cref="WindowsRuntimeObjectReferenceValue"/> instance for the requested interface.</returns>
@@ -35,8 +36,7 @@ public static unsafe class WindowsRuntimeInterfaceMarshaller
     /// Calling this method with <typeparamref name="T"/> being a non-interface type results in undefined behavior.
     /// </para>
     /// </remarks>
-    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged<T>(T? value, scoped in Guid iid)
-        where T : class
+    public static WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(T? value, scoped in Guid iid)
     {
         if (value is null)
         {


### PR DESCRIPTION
This PR includes a few changes to the runtime:
- Add `TypeReference` and implement fast-pass `Type` marshalling
- Add missing marshaller types for custom-mapped interface types
- Refactor `WindowsRuntimeInterfaceMarshaller` to match [`ComInterfaceMarshaller<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalling.cominterfacemarshaller-1?view=net-9.0)