### PR TITLE
Emit `IObservableVector<T>` types

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.Delegate.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.Delegate.cs
@@ -112,7 +112,7 @@ internal partial class InteropTypeDefinitionBuilder
                     { Call, interopReferences.WindowsRuntimeObjectMarshallerConvertToManaged.Import(module) },
                     { Ldarg_2 },
                     { Call, interopReferences.WindowsRuntimeObjectMarshallerConvertToManaged.Import(module) },
-                    { Callvirt, interopReferences.DelegateInvoke(delegateType).Import(module) },
+                    { Callvirt, interopReferences.DelegateInvoke(delegateType, module).Import(module) },
                     { Ldc_I4_0 },
                     { Stloc_0 },
                     { Leave_S, ldloc_0_returnHResult.CreateLabel() },
@@ -392,7 +392,7 @@ internal partial class InteropTypeDefinitionBuilder
             module.TopLevelTypes.Add(nativeDelegateType);
 
             // Construct the 'Invoke' method on the delegate type, so we can get the constructed parameter types
-            MethodSignature invokeSignature = delegateType.Resolve()!.GetMethod("Invoke"u8).Signature!.InstantiateGenericTypes(GenericContext.FromType(delegateType));
+            MethodSignature invokeSignature = delegateType.Import(module).Resolve()!.GetMethod("Invoke"u8).Signature!.InstantiateGenericTypes(GenericContext.FromType(delegateType));
 
             // Define the 'Invoke' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
@@ -5,6 +5,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using WindowsRuntime.InteropGenerator.Factories;
+using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;
 using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
@@ -76,12 +77,14 @@ internal partial class InteropTypeDefinitionBuilder
         /// <param name="delegateType">The <see cref="TypeSignature"/> for the delegate type.</param>
         /// <param name="marshallerType">The <see cref="TypeDefinition"/> instance returned by <see cref="Delegate.Marshaller"/>.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
         /// <param name="module">The module that will contain the type being created.</param>
         /// <param name="eventSourceType">The resulting event source type.</param>
         public static void VectorChangedEventHandler1(
             GenericInstanceTypeSignature delegateType,
             TypeDefinition marshallerType,
             InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
             ModuleDefinition module,
             out TypeDefinition eventSourceType)
         {
@@ -94,6 +97,9 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences,
                 module: module,
                 eventSourceType: out eventSourceType);
+
+            // We need the event source later, for the 'IObservableVector<T>' implementation
+            emitState.TrackTypeDefinition(eventSourceType, delegateType, "EventSource");
         }
 
         /// <summary>

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
@@ -1215,8 +1215,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IMap`2<{keyType},{valueType}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: dictionaryType,
-                proxyTypeMapSourceType: dictionaryType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: dictionaryType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IEnumerable1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IEnumerable1.cs
@@ -550,8 +550,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IIterable`1<{enumerableType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: enumerableType,
-                proxyTypeMapSourceType: enumerableType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: enumerableType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IEnumerator1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IEnumerator1.cs
@@ -611,8 +611,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IIterator`1<{enumeratorType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: enumeratorType,
-                proxyTypeMapSourceType: enumeratorType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: enumeratorType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IList1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IList1.cs
@@ -1159,8 +1159,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IVector`1<{listType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: listType,
-                proxyTypeMapSourceType: listType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: listType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IList1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IList1.cs
@@ -47,6 +47,54 @@ internal partial class InteropTypeDefinitionBuilder
         }
 
         /// <summary>
+        /// Creates a new type definition for the interface type for some <c>IVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="listType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IList{T}"/> type.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="listType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="interfaceType">The resulting interface type.</param>
+        public static void Interface(
+            GenericInstanceTypeSignature listType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module,
+            out TypeDefinition interfaceType)
+        {
+            // We're declaring an 'internal abstract class' type
+            interfaceType = new TypeDefinition(
+                ns: InteropUtf8NameFactory.TypeNamespace(listType),
+                name: InteropUtf8NameFactory.TypeName(listType, "Interface"),
+                attributes: TypeAttributes.AutoLayout | TypeAttributes.Abstract | TypeAttributes.BeforeFieldInit,
+                baseType: module.CorLibTypeFactory.Object.ToTypeDefOrRef())
+            {
+                Interfaces = { new InterfaceImplementation(interopReferences.IWindowsRuntimeInterface.Import(module)) }
+            };
+
+            module.TopLevelTypes.Add(interfaceType);
+
+            // Track the type (it's needed by 'IObservableVector<T>')
+            emitState.TrackTypeDefinition(interfaceType, listType, "Interface");
+
+            // Create the public 'IID' property
+            WellKnownMemberDefinitionFactory.IID(
+                forwardedIidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out MethodDefinition get_IidMethod2,
+                out PropertyDefinition iidProperty);
+
+            interfaceType.Properties.Add(iidProperty);
+
+            // Add and implement the 'get_IID' method
+            interfaceType.AddMethodImplementation(
+                declaration: interopReferences.IWindowsRuntimeInterfaceget_IID.Import(module),
+                method: get_IidMethod2);
+        }
+
+        /// <summary>
         /// Creates a new type definition for the vtable for an <c>IVector&lt;T&gt;</c> interface.
         /// </summary>
         /// <param name="listType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IList{T}"/> type.</param>
@@ -89,12 +137,14 @@ internal partial class InteropTypeDefinitionBuilder
         /// <param name="listType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IList{T}"/> type.</param>
         /// <param name="vftblType">The type returned by <see cref="Vftbl"/>.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
         /// <param name="module">The interop module being built.</param>
         /// <param name="vectorMethodsType">The resulting methods type.</param>
         public static void IVectorMethods(
             GenericInstanceTypeSignature listType,
             TypeDefinition vftblType,
             InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
             ModuleDefinition module,
             out TypeDefinition vectorMethodsType)
         {
@@ -111,6 +161,9 @@ internal partial class InteropTypeDefinitionBuilder
             };
 
             module.TopLevelTypes.Add(vectorMethodsType);
+
+            // Track the type (it's needed by 'IObservableVector<T>')
+            emitState.TrackTypeDefinition(vectorMethodsType, listType, "IVectorMethods");
 
             // Define the 'GetAt' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IMapChangedEventArgs1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IMapChangedEventArgs1.cs
@@ -417,8 +417,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IMapChangedEventArgs`1<{argsType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: argsType,
-                proxyTypeMapSourceType: argsType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: argsType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
@@ -19,6 +20,30 @@ internal partial class InteropTypeDefinitionBuilder
     /// </summary>
     public static class IObservableVector1
     {
+        /// <summary>
+        /// Creates the 'IID' property for some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="get_IidMethod">The resulting 'IID' get method for <paramref name="vectorType"/>.</param>
+        public static void IID(
+            GenericInstanceTypeSignature vectorType,
+            InteropDefinitions interopDefinitions,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out MethodDefinition get_IidMethod)
+        {
+            InteropTypeDefinitionBuilder.IID(
+                name: InteropUtf8NameFactory.TypeName(vectorType, "IID"),
+                interopDefinitions: interopDefinitions,
+                interopReferences: interopReferences,
+                module: module,
+                iid: Guid.NewGuid(), // TODO
+                out get_IidMethod);
+        }
+
         /// <summary>
         /// Creates the cached factory type for the property for the event args for the vector.
         /// </summary>

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -536,8 +536,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IObservableVector`1<{vectorType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: vectorType,
-                proxyTypeMapSourceType: vectorType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: vectorType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -273,5 +273,45 @@ internal partial class InteropTypeDefinitionBuilder
                 declaration: interopReferences.IObservableVectorMethodsImpl1VectorChanged(elementType).Import(module),
                 method: vectorChangedMethod);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the native object for an <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="vectorMethodsType">The <see cref="TypeDefinition"/> instance returned by <see cref="Methods"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="nativeObjectType">The resulting native object type.</param>
+        public static void NativeObject(
+            GenericInstanceTypeSignature vectorType,
+            TypeDefinition vectorMethodsType,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module,
+            out TypeDefinition nativeObjectType)
+        {
+            TypeSignature elementType = vectorType.TypeArguments[0];
+
+            // Get the base interfaces for the current element type
+            TypeSignature enumerableType = interopReferences.IEnumerable1.MakeGenericReferenceType(elementType);
+            TypeSignature listType = interopReferences.IList1.MakeGenericReferenceType(elementType);
+
+            // The 'NativeObject' is deriving from 'WindowsRuntimeObservableVector<<ELEMENT_TYPE>, ...>'
+            TypeSignature windowsRuntimeObservableVector1Type = interopReferences.WindowsRuntimeObservableVector6.MakeGenericReferenceType(
+                elementType,
+                emitState.LookupTypeDefinition(enumerableType, "Interface").ToReferenceTypeSignature(),
+                emitState.LookupTypeDefinition(enumerableType, "IIterableMethods").ToReferenceTypeSignature(),
+                emitState.LookupTypeDefinition(listType, "Interface").ToReferenceTypeSignature(),
+                emitState.LookupTypeDefinition(listType, "IVectorMethods").ToReferenceTypeSignature(),
+                vectorMethodsType.ToReferenceTypeSignature());
+
+            InteropTypeDefinitionBuilder.NativeObject(
+                typeSignature: vectorType,
+                nativeObjectBaseType: windowsRuntimeObservableVector1Type,
+                interopReferences: interopReferences,
+                module: module,
+                out nativeObjectType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -24,7 +24,7 @@ internal partial class InteropTypeDefinitionBuilder
         /// <summary>
         /// Creates the 'IID' property for some <c>IObservableVector&lt;T&gt;</c> interface.
         /// </summary>
-        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IEnumerable{T}"/> type.</param>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
         /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
         /// <param name="module">The interop module being built.</param>
@@ -312,6 +312,33 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences,
                 module: module,
                 out nativeObjectType);
+        }
+
+        /// <summary>
+        /// Creates a new type definition for the implementation of the <c>IWindowsRuntimeUnsealedObjectComWrappersCallback</c> interface for some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="TypeSignature"/> for the vector type.</param>
+        /// <param name="nativeObjectType">The type returned by <see cref="NativeObject"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="vectorType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="callbackType">The resulting callback type.</param>
+        public static void ComWrappersCallbackType(
+            TypeSignature vectorType,
+            TypeDefinition nativeObjectType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition callbackType)
+        {
+            ComWrappersCallback(
+                runtimeClassName: vectorType.FullName, // TODO
+                typeSignature: vectorType,
+                nativeObjectType: nativeObjectType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out callbackType);
         }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.InteropGenerator.Factories;
+using WindowsRuntime.InteropGenerator.Generation;
+using WindowsRuntime.InteropGenerator.References;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
+
+namespace WindowsRuntime.InteropGenerator.Builders;
+
+/// <inheritdoc cref="InteropTypeDefinitionBuilder"/>
+internal partial class InteropTypeDefinitionBuilder
+{
+    /// <summary>
+    /// Helpers for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;</c> types.
+    /// </summary>
+    public static class IObservableVector1
+    {
+        /// <summary>
+        /// Creates the cached factory type for the property for the event args for the vector.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="factoryType">The resulting factory type.</param>
+        public static void EventSourceFactory(
+            GenericInstanceTypeSignature vectorType,
+            InteropDefinitions interopDefinitions,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module,
+            out TypeDefinition factoryType)
+        {
+            TypeSignature elementType = vectorType.TypeArguments[0];
+
+            // We're declaring an 'internal sealed class' type
+            factoryType = new TypeDefinition(
+                ns: InteropUtf8NameFactory.TypeNamespace(vectorType),
+                name: InteropUtf8NameFactory.TypeName(vectorType, "EventSourceFactory"),
+                attributes: TypeAttributes.AutoLayout | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+                baseType: module.CorLibTypeFactory.Object.ToTypeDefOrRef());
+
+            module.TopLevelTypes.Add(factoryType);
+
+            // 'Instance' field with the cached factory instance
+            factoryType.Fields.Add(new FieldDefinition("Instance"u8, FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly, factoryType.ToReferenceTypeSignature()));
+
+            // The actual factory is of type 'Func<WindowsRuntimeObject, WindowsRuntimeObjectReference, VectorChangedEventHandlerEventSource<<ELEMENT_TYPE>>>'
+            TypeSignature funcType = interopReferences.Func3.MakeGenericReferenceType(
+                interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature(),
+                interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                interopReferences.VectorChangedEventHandler1EventSource.MakeGenericReferenceType(elementType));
+
+            // 'Value' field with the cached factory delegate
+            factoryType.Fields.Add(new FieldDefinition("Value"u8, FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly, funcType.Import(module)));
+
+            // Add the parameterless constructor
+            factoryType.Methods.Add(MethodDefinition.CreateDefaultConstructor(module));
+
+            // Get the constructor for the generic event source type
+            MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(vectorType, "EventSource").GetConstructor(
+                comparer: SignatureComparer.IgnoreVersion,
+                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.CorLibTypeFactory.Int32])!;
+
+            // Define the 'Callback' method as follows:
+            //
+            // public static VectorChangedEventHandlerEventSource<<ELEMENT_TYPE>> Callback(WindowsRuntimeObject thisObject, WindowsRuntimeObjectReference thisReference)
+            MethodDefinition callbackMethod = new(
+                name: "Callback"u8,
+                attributes: MethodAttributes.Private | MethodAttributes.HideBySig,
+                signature: MethodSignature.CreateStatic(
+                    returnType: interopReferences.VectorChangedEventHandler1EventSource.MakeGenericReferenceType(elementType).Import(module),
+                    parameterTypes: [
+                        interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature().Import(module),
+                        interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature().Import(module)]))
+            {
+                CilInstructions =
+                {
+                    { Ldarg_2 },
+                    { Ldc_I4_6 },
+                    { Newobj, eventSourceConstructor },
+                    { Ret }
+                }
+            };
+
+            factoryType.Methods.Add(callbackMethod);
+
+            // We need the static constructor to initialize the static fields
+            MethodDefinition cctor = factoryType.GetOrCreateStaticConstructor(module);
+
+            cctor.CilInstructions.Clear();
+
+            // Create a new instance of the factory type and store it in the 'Instance' field
+            _ = cctor.CilInstructions.Add(Newobj, factoryType.GetConstructor()!);
+            _ = cctor.CilInstructions.Add(Stsfld, factoryType.Fields[0]);
+
+            // Create the delegate type and store it in the 'Value' field
+            _ = cctor.CilInstructions.Add(Ldsfld, factoryType.Fields[0]);
+            _ = cctor.CilInstructions.Add(Ldftn, callbackMethod);
+            _ = cctor.CilInstructions.Add(Newobj, interopReferences.Delegate_ctor(funcType));
+            _ = cctor.CilInstructions.Add(Stsfld, factoryType.Fields[1]);
+
+            _ = cctor.CilInstructions.Add(Ret);
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -186,12 +186,14 @@ internal partial class InteropTypeDefinitionBuilder
 
             // Define the '<get_VectorChangedTable>g__MakeVectorChanged|2_0' method as follows:
             //
+            // [MethodImpl(MethodImplOptions.NoInlining)]
             // public ConditionalWeakTable<WindowsRuntimeObject, VectorChangedEventHandlerEventSource<<ELEMENT_TYPE>>> <get_VectorChangedTable>g__MakeVectorChanged|2_0()
             MethodDefinition makeVectorChangedMethod = new(
                 name: "<get_VectorChangedTable>g__MakeVectorChanged|2_0"u8,
                 attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
                 signature: MethodSignature.CreateStatic(conditionalWeakTableType.Import(module)))
             {
+                NoInlining = true,
                 CilInstructions =
                 {
                     // _ = Interlocked.CompareExchange(ref <VectorChangedTable>k__BackingField, value: new(), comparand: null);
@@ -218,6 +220,7 @@ internal partial class InteropTypeDefinitionBuilder
                 attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Static,
                 signature: MethodSignature.CreateStatic(conditionalWeakTableType.Import(module)))
             {
+                IsAggressiveInlining = true,
                 CilInstructions =
                 {
                     { Ldsfld, methodsType.Fields[0] },

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -340,5 +340,31 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out callbackType);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the marshaller attribute of some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="nativeObjectType">The type returned by <see cref="NativeObject"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="vectorType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="marshallerType">The resulting marshaller type.</param>
+        public static void ComWrappersMarshallerAttribute(
+            GenericInstanceTypeSignature vectorType,
+            TypeDefinition nativeObjectType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition marshallerType)
+        {
+            InteropTypeDefinitionBuilder.ComWrappersMarshallerAttribute(
+                typeSignature: vectorType,
+                nativeObjectType: nativeObjectType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out marshallerType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -3,7 +3,6 @@
 
 using System;
 using AsmResolver.DotNet;
-using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
@@ -442,38 +441,13 @@ internal partial class InteropTypeDefinitionBuilder
                     returnType: module.CorLibTypeFactory.Void,
                     parameterTypes: [handlerType.Import(module)]))
             {
-                CilMethodBody = new CilMethodBody()
-                {
-                    LocalVariables =
-                    {
-                        // Declare the local variables:
-                        //   [0]: 'WindowsRuntimeObject' (for 'thisObject')
-                        //   [1]: 'WindowsRuntimeObjectReference' (for 'thisReference')
-                        new CilLocalVariable(interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature().Import(module)),
-                        new CilLocalVariable(interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature().Import(module))
-                    },
-                    Instructions =
-                    {
-                        // Cast 'this' and resolve the 'WindowsRuntimeObjectReference' instance for the interface
-                        { Ldarg_0 },
-                        { Castclass, interopReferences.WindowsRuntimeObject.Import(module) },
-                        { Stloc_0 },
-                        { Ldloc_0 },
-                        { Ldtoken, vectorType.Import(module).ToTypeDefOrRef() },
-                        { Call, interopReferences.TypeGetTypeFromHandle.Import(module) },
-                        { Callvirt, interopReferences.Typeget_TypeHandle.Import(module) },
-                        { Callvirt, interopReferences.WindowsRuntimeObjectGetObjectReferenceForInterface.Import(module) },
-                        { Stloc_1 },
-
-                        // <METHODS_TYPE>.VectorChanged(thisObject, thisReference).Subscribe(value);
-                        { Ldloc_0 },
-                        { Ldloc_1 },
-                        { Call, vectorMethodsType.GetMethod("VectorChanged"u8) },
-                        { Ldarg_1 },
-                        { Callvirt, interopReferences.EventSource1Subscribe(handlerType).Import(module) },
-                        { Ret }
-                    }
-                }
+                CilMethodBody = WellKnownCilMethodBodyFactory.DynamicInterfaceCastableImplementation(
+                    interfaceType: vectorType,
+                    handlerType: handlerType,
+                    eventMethod: vectorMethodsType.GetMethod("VectorChanged"u8),
+                    eventAccessorAttributes: MethodSemanticsAttributes.AddOn,
+                    interopReferences: interopReferences,
+                    module: module)
             };
 
             // Add and implement the 'IObservableVector<T>.VectorChanged' add accessor method
@@ -489,32 +463,13 @@ internal partial class InteropTypeDefinitionBuilder
                     returnType: module.CorLibTypeFactory.Void,
                     parameterTypes: [handlerType.Import(module)]))
             {
-                CilMethodBody = new CilMethodBody()
-                {
-                    LocalVariables =
-                    {
-                        new CilLocalVariable(interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature().Import(module)),
-                        new CilLocalVariable(interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature().Import(module))
-                    },
-                    Instructions =
-                    {
-                        { Ldarg_0 },
-                        { Castclass, interopReferences.WindowsRuntimeObject.Import(module) },
-                        { Stloc_0 },
-                        { Ldloc_0 },
-                        { Ldtoken, vectorType.Import(module).ToTypeDefOrRef() },
-                        { Call, interopReferences.TypeGetTypeFromHandle.Import(module) },
-                        { Callvirt, interopReferences.Typeget_TypeHandle.Import(module) },
-                        { Callvirt, interopReferences.WindowsRuntimeObjectGetObjectReferenceForInterface.Import(module) },
-                        { Stloc_1 },
-                        { Ldloc_0 },
-                        { Ldloc_1 },
-                        { Call, vectorMethodsType.GetMethod("VectorChanged"u8) },
-                        { Ldarg_1 },
-                        { Callvirt, interopReferences.EventSource1Unsubscribe(handlerType).Import(module) },
-                        { Ret }
-                    }
-                }
+                CilMethodBody = WellKnownCilMethodBodyFactory.DynamicInterfaceCastableImplementation(
+                    interfaceType: vectorType,
+                    handlerType: handlerType,
+                    eventMethod: vectorMethodsType.GetMethod("VectorChanged"u8),
+                    eventAccessorAttributes: MethodSemanticsAttributes.RemoveOn,
+                    interopReferences: interopReferences,
+                    module: module)
             };
 
             // Add and implement the 'IObservableVector<T>.VectorChanged' remove accessor method

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -484,12 +484,17 @@ internal partial class InteropTypeDefinitionBuilder
                 getAccessorMethod: out MethodDefinition get_VectorChangedTableMethod,
                 propertyDefinition: out PropertyDefinition vectorChangedTableProperty);
 
-            // Prepare the two exported methods
             MethodDefinition add_VectorChangedMethod = InteropMethodDefinitionFactory.IObservableVector1Impl.add_VectorChanged(
                 vectorType: vectorType,
                 get_VectorChangedTableMethod: get_VectorChangedTableMethod,
                 interopReferences: interopReferences,
                 emitState: emitState,
+                module: module);
+
+            MethodDefinition remove_VectorChangedMethod = InteropMethodDefinitionFactory.IObservableVector1Impl.remove_VectorChanged(
+                vectorType: vectorType,
+                get_VectorChangedTableMethod: get_VectorChangedTableMethod,
+                interopReferences: interopReferences,
                 module: module);
 
             Impl(
@@ -502,7 +507,7 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences,
                 module: module,
                 implType: out implType,
-                vtableMethods: [add_VectorChangedMethod]);
+                vtableMethods: [add_VectorChangedMethod, remove_VectorChangedMethod]);
 
             // Add the members for the conditional weak table
             implType.Fields.Add(vectorChangedTableField);

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -196,7 +196,7 @@ internal partial class InteropTypeDefinitionBuilder
             methodsType.Properties.Add(vectorChangedTableProperty);
 
             // Prepare the 'ConditionalWeakTable<WindowsRuntimeObject, VectorChangedEventHandlerEventSource<<ELEMENT_TYPE>>>.GetOrAdd<WindowsRuntimeObjectReference>' method
-            MethodSpecification conditionalWeakTableGetOrAddMethod = interopReferences.ConditionalWeakTableGetOrAdd(
+            MethodSpecification conditionalWeakTableGetOrAddMethod = interopReferences.ConditionalWeakTable2GetOrAdd(
                 conditionalWeakTableType: conditionalWeakTableType,
                 argType: interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature());
 
@@ -484,6 +484,14 @@ internal partial class InteropTypeDefinitionBuilder
                 getAccessorMethod: out MethodDefinition get_VectorChangedTableMethod,
                 propertyDefinition: out PropertyDefinition vectorChangedTableProperty);
 
+            // Prepare the two exported methods
+            MethodDefinition add_VectorChangedMethod = InteropMethodDefinitionFactory.IObservableVector1Impl.add_VectorChanged(
+                vectorType: vectorType,
+                get_VectorChangedTableMethod: get_VectorChangedTableMethod,
+                interopReferences: interopReferences,
+                emitState: emitState,
+                module: module);
+
             Impl(
                 interfaceType: ComInterfaceType.InterfaceIsIInspectable,
                 ns: InteropUtf8NameFactory.TypeNamespace(vectorType),
@@ -494,7 +502,7 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences,
                 module: module,
                 implType: out implType,
-                vtableMethods: []);
+                vtableMethods: [add_VectorChangedMethod]);
 
             // Add the members for the conditional weak table
             implType.Fields.Add(vectorChangedTableField);

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -366,5 +366,31 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out marshallerType);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the marshaller of some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="vectorComWrappersCallbackType">The <see cref="TypeDefinition"/> instance returned by <see cref="ComWrappersCallbackType"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="vectorType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="marshallerType">The resulting marshaller type.</param>
+        public static void Marshaller(
+            GenericInstanceTypeSignature vectorType,
+            TypeDefinition vectorComWrappersCallbackType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition marshallerType)
+        {
+            InteropTypeDefinitionBuilder.Marshaller(
+                typeSignature: vectorType,
+                interfaceComWrappersCallbackType: vectorComWrappersCallbackType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out marshallerType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -516,5 +516,32 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out proxyType);
         }
+
+        /// <summary>
+        /// Creates the type map attributes for some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="proxyType">The <see cref="TypeDefinition"/> instance returned by <see cref="InteropTypeDefinitionBuilder.Proxy"/>.</param>
+        /// <param name="interfaceImplType">The <see cref="TypeDefinition"/> instance returned by <see cref="InterfaceImpl"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        public static void TypeMapAttributes(
+            GenericInstanceTypeSignature vectorType,
+            TypeDefinition proxyType,
+            TypeDefinition interfaceImplType,
+            InteropReferences interopReferences,
+            ModuleDefinition module)
+        {
+            InteropTypeDefinitionBuilder.TypeMapAttributes(
+                runtimeClassName: $"Windows.Foundation.Collections.IObservableVector`1<{vectorType.TypeArguments[0]}>", // TODO
+                externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
+                externalTypeMapTrimTargetType: vectorType,
+                proxyTypeMapSourceType: vectorType,
+                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                interfaceTypeMapSourceType: vectorType,
+                interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
+                interopReferences: interopReferences,
+                module: module);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -489,5 +489,32 @@ internal partial class InteropTypeDefinitionBuilder
 
             interfaceImplType.Events.Add(observableVector1VectorChangedProperty);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the proxy type of some <c>IObservableVector&lt;T&gt;</c> interface.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="vectorComWrappersMarshallerAttributeType">The <see cref="TypeDefinition"/> instance returned by <see cref="ComWrappersMarshallerAttribute"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="proxyType">The resulting proxy type.</param>
+        public static void Proxy(
+            GenericInstanceTypeSignature vectorType,
+            TypeDefinition vectorComWrappersMarshallerAttributeType,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition proxyType)
+        {
+            string runtimeClassName = $"Windows.Foundation.Collections.IObservableVector`1<{vectorType.TypeArguments[0]}>"; // TODO
+
+            InteropTypeDefinitionBuilder.Proxy(
+                ns: InteropUtf8NameFactory.TypeNamespace(vectorType),
+                name: InteropUtf8NameFactory.TypeName(vectorType),
+                runtimeClassName: runtimeClassName,
+                comWrappersMarshallerAttributeType: vectorComWrappersMarshallerAttributeType,
+                interopReferences: interopReferences,
+                module: module,
+                out proxyType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IReadOnlyDictionary2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IReadOnlyDictionary2.cs
@@ -723,8 +723,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IMapView`2<{keyType},{valueType}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: readOnlyDictionaryType,
-                proxyTypeMapSourceType: readOnlyDictionaryType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: readOnlyDictionaryType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IReadOnlyList1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IReadOnlyList1.cs
@@ -646,8 +646,8 @@ internal partial class InteropTypeDefinitionBuilder
                 runtimeClassName: $"Windows.Foundation.Collections.IVectorView`1<{readOnlyListType.TypeArguments[0]}>", // TODO
                 externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
                 externalTypeMapTrimTargetType: readOnlyListType,
-                proxyTypeMapSourceType: readOnlyListType,
-                proxyTypeMapProxyType: proxyType.ToReferenceTypeSignature(),
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
                 interfaceTypeMapSourceType: readOnlyListType,
                 interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
@@ -626,8 +626,8 @@ internal static partial class InteropTypeDefinitionBuilder
         string? runtimeClassName,
         [NotNullIfNotNull(nameof(runtimeClassName))] TypeSignature? externalTypeMapTargetType,
         [NotNullIfNotNull(nameof(runtimeClassName))] TypeSignature? externalTypeMapTrimTargetType,
-        TypeSignature proxyTypeMapSourceType,
-        TypeSignature proxyTypeMapProxyType,
+        [NotNullIfNotNull(nameof(proxyTypeMapProxyType))] TypeSignature? proxyTypeMapSourceType,
+        [NotNullIfNotNull(nameof(proxyTypeMapSourceType))] TypeSignature? proxyTypeMapProxyType,
         [NotNullIfNotNull(nameof(interfaceTypeMapProxyType))] TypeSignature? interfaceTypeMapSourceType,
         [NotNullIfNotNull(nameof(interfaceTypeMapSourceType))] TypeSignature? interfaceTypeMapProxyType,
         InteropReferences interopReferences,
@@ -645,12 +645,16 @@ internal static partial class InteropTypeDefinitionBuilder
                 module: module));
         }
 
-        // Emit the '[TypeMapAssociation]' attribute for the proxy type map
-        module.Assembly!.CustomAttributes.Add(InteropCustomAttributeFactory.TypeMapAssociationWindowsRuntimeComWrappersTypeMapGroup(
-            source: proxyTypeMapSourceType,
-            proxy: proxyTypeMapProxyType,
-            interopReferences: interopReferences,
-            module: module));
+        // Emit the '[TypeMapAssociation]' attribute for the proxy type map.
+        // This is only needed for types that can actually be instantiated.
+        if (proxyTypeMapSourceType is not null)
+        {
+            module.Assembly!.CustomAttributes.Add(InteropCustomAttributeFactory.TypeMapAssociationWindowsRuntimeComWrappersTypeMapGroup(
+                source: proxyTypeMapSourceType,
+                proxy: proxyTypeMapProxyType!,
+                interopReferences: interopReferences,
+                module: module));
+        }
 
         // Emit the '[TypeMapAssociation]' attribute for 'IDynamicInterfaceCastable' scenarios.
         // This is not always needed, as it is specifically only for interface types.

--- a/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
+++ b/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
@@ -107,7 +107,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for a <see cref="System.Collections.Generic.KeyValuePair{TKey, TValue}"/> type.
+    /// Failed to generate marshalling code for a <see cref="KeyValuePair{TKey, TValue}"/> type.
     /// </summary>
     public static Exception KeyValuePairTypeCodeGenerationError(string? keyValuePairType, Exception exception)
     {
@@ -171,7 +171,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IEnumerator{T}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IEnumerator{T}"/> type.
     /// </summary>
     public static Exception IEnumerator1TypeCodeGenerationError(TypeSignature enumeratorType, Exception exception)
     {
@@ -179,7 +179,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IEnumerable{T}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IEnumerable{T}"/> type.
     /// </summary>
     public static Exception IEnumerable1TypeCodeGenerationError(TypeSignature enumerableType, Exception exception)
     {
@@ -187,7 +187,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IReadOnlyList{T}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IReadOnlyList{T}"/> type.
     /// </summary>
     public static Exception IReadOnlyList1TypeCodeGenerationError(TypeSignature readOnlyListType, Exception exception)
     {
@@ -215,7 +215,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IList{T}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IList{T}"/> type.
     /// </summary>
     public static Exception IList1TypeCodeGenerationError(TypeSignature listType, Exception exception)
     {
@@ -223,7 +223,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey, TValue}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IReadOnlyDictionary{TKey, TValue}"/> type.
     /// </summary>
     public static Exception IReadOnlyDictionary2TypeCodeGenerationError(TypeSignature readOnlyDictionaryType, Exception exception)
     {
@@ -231,7 +231,7 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to generate marshalling code for an <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> type.
+    /// Failed to generate marshalling code for an <see cref="IDictionary{TKey, TValue}"/> type.
     /// </summary>
     public static Exception IDictionary2TypeCodeGenerationError(TypeSignature dictionaryType, Exception exception)
     {

--- a/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
+++ b/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
@@ -363,6 +363,14 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
+    /// Failed to generate marshalling code for an <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;</c> type.
+    /// </summary>
+    public static Exception IObservableVectorTypeCodeGenerationError(TypeSignature elementType, Exception exception)
+    {
+        return Exception(41, $"Failed to generate marshalling code for 'IObservableVector<T>' type '{elementType}'.", exception);
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     /// <param name="id">The exception id.</param>

--- a/src/WinRT.Interop.Generator/Extensions/IMemberRefParentExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/IMemberRefParentExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+
+namespace WindowsRuntime.InteropGenerator;
+
+/// <summary>
+/// Extensions for the <see cref="IMemberRefParent"/> type.
+/// </summary>
+internal static class IMemberRefParentExtensions
+{
+    extension(IMemberRefParent memberRefParent)
+    {
+        /// <summary>
+        /// Constructs a reference to a constructor for the target parent member.
+        /// </summary>
+        /// <param name="corLibTypeFactory">The <see cref="CorLibTypeFactory"/> instance to use.</param>
+        /// <param name="parameterTypes">The parameter types.</param>
+        /// <returns>The constructed reference.</returns>
+        public MemberReference CreateConstructorReference(CorLibTypeFactory corLibTypeFactory, params TypeSignature[] parameterTypes)
+        {
+            return memberRefParent.CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
+                returnType: corLibTypeFactory.Void,
+                parameterTypes: parameterTypes));
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Extensions/ImportExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ImportExtensions.cs
@@ -58,6 +58,17 @@ internal static class ImportExtensions
     /// <summary>
     /// Imports a member reference into a module using the default reference importer.
     /// </summary>
+    /// <param name="assemblyReference">The <see cref="AssemblyReference"/> instance to import.</param>
+    /// <param name="module">The module to import into.</param>
+    /// <returns>The imported <see cref="AssemblyReference"/>.</returns>
+    public static AssemblyReference Import(this AssemblyReference assemblyReference, ModuleDefinition module)
+    {
+        return assemblyReference.ImportWith(module.DefaultImporter);
+    }
+
+    /// <summary>
+    /// Imports a member reference into a module using the default reference importer.
+    /// </summary>
     /// <param name="memberReference">The <see cref="MemberReference"/> instance to import.</param>
     /// <param name="module">The module to import into.</param>
     /// <returns>The imported <see cref="MemberReference"/>.</returns>

--- a/src/WinRT.Interop.Generator/Extensions/ImportExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ImportExtensions.cs
@@ -36,12 +36,23 @@ internal static class ImportExtensions
     /// <summary>
     /// Imports a type signature into a module using the default reference importer.
     /// </summary>
-    /// <param name="methodSignature">The <see cref="TypeSignature"/> instance to import.</param>
+    /// <param name="typeSignature">The <see cref="TypeSignature"/> instance to import.</param>
     /// <param name="module">The module to import into.</param>
     /// <returns>The imported <see cref="TypeSignature"/>.</returns>
-    public static TypeSignature Import(this TypeSignature methodSignature, ModuleDefinition module)
+    public static TypeSignature Import(this TypeSignature typeSignature, ModuleDefinition module)
     {
-        return methodSignature.ImportWith(module.DefaultImporter);
+        return typeSignature.ImportWith(module.DefaultImporter);
+    }
+
+    /// <summary>
+    /// Imports a type signature into a module using the default reference importer.
+    /// </summary>
+    /// <param name="typeSignature">The <see cref="TypeSignature"/> instance to import.</param>
+    /// <param name="module">The module to import into.</param>
+    /// <returns>The imported <see cref="TypeSignature"/>.</returns>
+    public static GenericInstanceTypeSignature Import(this GenericInstanceTypeSignature typeSignature, ModuleDefinition module)
+    {
+        return (GenericInstanceTypeSignature)typeSignature.ImportWith(module.DefaultImporter);
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/Extensions/InteropGeneratorDiscoveryStateExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/InteropGeneratorDiscoveryStateExtensions.cs
@@ -56,10 +56,20 @@ internal static class InteropGeneratorDiscoveryStateExtensions
         else if (SignatureComparer.IgnoreVersion.Equals(typeSignature.GenericType, interopReferences.IObservableVector1))
         {
             discoveryState.TrackIObservableVector1Type(typeSignature);
+
+            // We need special handling for constructed 'VectorChangedEventHandler<T>' types, as those are required for each
+            // discovered 'IObservableVector<T>' type. These are not necessarily discovered in the same way, as while we are
+            // recursively constructing interfaces, we don't have the same logic for delegate types (or for types used in
+            // any signature of interface members). Because we only need this delegate type and the one below, we can just
+            // special case it. That is, we manually construct it every time we discover a constructed 'IObservableVector<T>'.
+            discoveryState.TrackGenericDelegateType(interopReferences.VectorChangedEventHandler1.MakeGenericReferenceType([.. typeSignature.TypeArguments]));
         }
         else if (SignatureComparer.IgnoreVersion.Equals(typeSignature.GenericType, interopReferences.IObservableMap2))
         {
             discoveryState.TrackIObservableMap2Type(typeSignature);
+
+            // Same handling as below for 'MapChangedEventHandler<K,V>' types
+            discoveryState.TrackGenericDelegateType(interopReferences.MapChangedEventHandler2.MakeGenericReferenceType([.. typeSignature.TypeArguments]));
         }
         else if (SignatureComparer.IgnoreVersion.Equals(typeSignature.GenericType, interopReferences.IMapChangedEventArgs1))
         {

--- a/src/WinRT.Interop.Generator/Extensions/MethodDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/MethodDefinitionExtensions.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
 namespace WindowsRuntime.InteropGenerator;
 
@@ -16,6 +19,33 @@ internal static class MethodDefinitionExtensions
 {
     extension(MethodDefinition method)
     {
+        /// <summary>
+        /// Creates a new default constructor for a type that is executed when its declaring type is loaded by the CLR.
+        /// </summary>
+        /// <param name="module">The target module the method will be added to.</param>
+        /// <returns>The constructor.</returns>
+        public static MethodDefinition CreateDefaultConstructor(ModuleDefinition module)
+        {
+            // We should call the 'object' constructor, for correctness
+            MemberReference object_ctor = module.CorLibTypeFactory.CorLibScope
+                .CreateTypeReference("System"u8, "Object"u8)
+                .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(module.CorLibTypeFactory.Void));
+
+            // Create the parameterless constructor
+            return new(
+                name: ".ctor"u8,
+                attributes: MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RuntimeSpecialName,
+                signature: MethodSignature.CreateInstance(module.CorLibTypeFactory.Void))
+            {
+                CilInstructions =
+                {
+                    { Ldarg_0 },
+                    { Call, object_ctor },
+                    { Ret }
+                }
+            };
+        }
+
         /// <inheritdoc cref="CilMethodBody.Instructions"/>
         public CilInstructionCollection CilInstructions => (method.CilMethodBody ??= new CilMethodBody()).Instructions;
 

--- a/src/WinRT.Interop.Generator/Extensions/MethodDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/MethodDefinitionExtensions.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
-using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
 using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
@@ -40,7 +39,7 @@ internal static class MethodDefinitionExtensions
                 CilInstructions =
                 {
                     { Ldarg_0 },
-                    { Call, object_ctor },
+                    { Call, object_ctor.Import(module) },
                     { Ret }
                 }
             };

--- a/src/WinRT.Interop.Generator/Factories/InteropMemberDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMemberDefinitionFactory.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.InteropGenerator.References;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
+
+namespace WindowsRuntime.InteropGenerator.Factories;
+
+/// <summary>
+/// A factory for interop member definitions.
+/// </summary>
+internal class InteropMemberDefinitionFactory
+{
+    /// <summary>
+    /// Creates a lazy, volatile, reference type, default constructor, read-only property with a backing field, factory method, and get accessor method.
+    /// </summary>
+    /// <param name="propertyName">The property name.</param>
+    /// <param name="index">The index of the property (used for the factory method name).</param>
+    /// <param name="propertyType">The type of the property.</param>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The module that will contain the type being created.</param>
+    /// <param name="backingField">The resulting backing field.</param>
+    /// <param name="factoryMethod">The resulting factory method.</param>
+    /// <param name="getAccessorMethod">The resulting get accessor method.</param>
+    /// <param name="propertyDefinition">The resulting property definition.</param>
+    public static void LazyVolatileReferenceDefaultConstructorReadOnlyProperty(
+        Utf8String propertyName,
+        int index,
+        TypeSignature propertyType,
+        InteropReferences interopReferences,
+        ModuleDefinition module,
+        out FieldDefinition backingField,
+        out MethodDefinition factoryMethod,
+        out MethodDefinition getAccessorMethod,
+        out PropertyDefinition propertyDefinition)
+    {
+        // Define the backing field
+        backingField = new FieldDefinition(
+            name: $"<{propertyName}>k__BackingField",
+            attributes: FieldAttributes.Private | FieldAttributes.Static,
+            fieldType: propertyType.Import(module));
+
+        // Define the factory method as follows:
+        //
+        // [MethodImpl(MethodImplOptions.NoInlining)]
+        // public <PROPERTY_TYPE> <get_<PROPERTY_NAME>>g__CreateValue|<INDEX>_0()
+        factoryMethod = new MethodDefinition(
+            name: $"<get_{propertyName}>g__CreateValue|{index}_0",
+            attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
+            signature: MethodSignature.CreateStatic(propertyType.Import(module)))
+        {
+            NoInlining = true,
+            CilInstructions =
+            {
+                // _ = Interlocked.CompareExchange(ref <BACKING_FIELD>, value: new(), comparand: null);
+                { Ldsflda, backingField },
+                { Newobj, propertyType.ToTypeDefOrRef().CreateConstructorReference(module.CorLibTypeFactory).Import(module) },
+                { Ldnull },
+                { Call, interopReferences.InterlockedCompareExchange1.MakeGenericInstanceMethod(propertyType).Import(module) },
+                { Pop },
+
+                // return <BACKING_FIELD>;
+                { Ldsfld, backingField },
+                { Ret }
+            }
+        };
+
+        // Label for the 'ret' (we are doing lazy-init for the backing field)
+        CilInstruction ret = new(Ret);
+
+        // Create the property getter method
+        getAccessorMethod = new MethodDefinition(
+            name: $"get_{propertyName}",
+            attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Static,
+            signature: MethodSignature.CreateStatic(propertyType.Import(module)))
+        {
+            IsAggressiveInlining = true,
+            CilInstructions =
+            {
+                { Ldsfld, backingField },
+                { Dup },
+                { Brtrue_S, ret.CreateLabel() },
+                { Pop },
+                { Call, factoryMethod },
+                { ret }
+            }
+        };
+
+        // Create the property
+        propertyDefinition = new PropertyDefinition(
+            name: propertyName,
+            attributes: PropertyAttributes.None,
+            signature: PropertySignature.FromGetMethod(getAccessorMethod))
+        {
+            GetMethod = getAccessorMethod
+        };
+    }
+}

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
@@ -210,7 +210,7 @@ internal partial class InteropMethodDefinitionFactory
             CilLocalVariable loc_2_managedHandler = new(eventHandlerType.Import(module));
             CilLocalVariable loc_3_hresult = new(module.CorLibTypeFactory.Int32);
 
-            // Create a method body for the 'add_VectorChanged' method
+            // Create a method body for the 'remove_VectorChanged' method
             remove_VectorChangedMethod.CilMethodBody = new CilMethodBody()
             {
                 LocalVariables = { loc_0_unboxedValue, loc_1_table, loc_2_managedHandler, loc_3_hresult },

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.InteropGenerator.Generation;
+using WindowsRuntime.InteropGenerator.References;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
+
+#pragma warning disable IDE1006
+
+namespace WindowsRuntime.InteropGenerator.Factories;
+
+/// <inheritdoc cref="InteropMethodDefinitionFactory"/>
+internal partial class InteropMethodDefinitionFactory
+{
+    /// <summary>
+    /// Helpers for impl types for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;</c> interfaces.
+    /// </summary>
+    public static class IObservableVector1Impl
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDefinition"/> for the <c>add_VectorChanged</c> export method.
+        /// </summary>
+        /// <param name="vectorType">The <see cref="TypeSignature"/> for the vector type.</param>
+        /// <param name="get_VectorChangedTableMethod">The <see cref="MethodDefinition"/> to get the event token table.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        public static MethodDefinition add_VectorChanged(
+            GenericInstanceTypeSignature vectorType,
+            MethodDefinition get_VectorChangedTableMethod,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module)
+        {
+            TypeSignature elementType = vectorType.TypeArguments[0];
+
+            // Prepare the 'VectorChangedEventHandler<<ELEMENT_TYPE>>' signature
+            TypeSignature eventHandlerType = interopReferences.VectorChangedEventHandler1.MakeGenericReferenceType(elementType);
+
+            // Prepare the 'EventRegistrationTokenTable<VectorChangedEventHandler<ELEMENT_TYPE>>' signature
+            TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
+
+            // Prepare the 'ConditionalWeakTable<<VECTOR_TYPE>, EventRegistrationTokenTable<VectorChangedEventHandler<<ELEMENT_TYPE>>>' signature
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
+                vectorType,
+                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+
+            // Define the 'add_VectorChanged' method as follows:
+            //
+            // [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+            // private static int add_VectorChanged(void* thisPtr, void* handler, EventRegistrationToken* token)
+            MethodDefinition add_VectorChangedMethod = new(
+                name: "add_VectorChanged"u8,
+                attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
+                signature: MethodSignature.CreateStatic(
+                    returnType: module.CorLibTypeFactory.Int32,
+                    parameterTypes: [
+                        module.CorLibTypeFactory.Void.MakePointerType(),
+                        module.CorLibTypeFactory.Void.MakePointerType(),
+                        interopReferences.EventRegistrationToken.MakePointerType().Import(module)]))
+            {
+                CustomAttributes = { InteropCustomAttributeFactory.UnmanagedCallersOnly(interopReferences, module) }
+            };
+
+            // Jump labels
+            CilInstruction ldc_i4_e_pointer = new(Ldc_I4, unchecked((int)0x80004003));
+            CilInstruction nop_beforeTry = new(Nop);
+            CilInstruction ldarg_0_tryStart = new(Ldarg_0);
+            CilInstruction callvirt_catchHResult = new(Callvirt, interopReferences.Exceptionget_HResult.Import(module));
+            CilInstruction ldloc_2_returnHResult = new(Ldloc_2);
+
+            // Declare the local variables:
+            //   [0]: '<VECTOR_TYPE>' (the 'unboxedValue' object)
+            //   [1]: 'VectorChangedEventHandler<<ELEMENT_TYPE>>' (the 'managedHandler' object)
+            //   [2]: 'int' (the 'HRESULT' to return)
+            CilLocalVariable loc_0_unboxedValue = new(vectorType.Import(module));
+            CilLocalVariable loc_1_managedHandler = new(interopReferences.VectorChangedEventHandler1.MakeGenericInstanceType(elementType).Import(module));
+            CilLocalVariable loc_2_hresult = new(module.CorLibTypeFactory.Int32);
+
+            // Create a method body for the 'add_VectorChanged' method
+            add_VectorChangedMethod.CilMethodBody = new CilMethodBody()
+            {
+                LocalVariables = { loc_0_unboxedValue, loc_1_managedHandler, loc_2_hresult },
+                Instructions =
+                {
+                    // Return 'E_POINTER' if either argument is 'null'
+                    { Ldarg_1 },
+                    { Ldc_I4_0 },
+                    { Conv_U },
+                    { Beq_S, ldc_i4_e_pointer.CreateLabel() },
+                    { Ldarg_2 },
+                    { Ldc_I4_0 },
+                    { Conv_U },
+                    { Bne_Un_S, nop_beforeTry.CreateLabel() },
+                    { ldc_i4_e_pointer },
+                    { Ret },
+                    { nop_beforeTry },
+
+                    // '.try' code
+                    { ldarg_0_tryStart },
+                    { Call, interopReferences.ComInterfaceDispatchGetInstance.MakeGenericInstanceMethod(vectorType).Import(module) },
+                    { Stloc_0 },
+                    { Ldarg_1 },
+                    { Call, emitState.LookupTypeDefinition(eventHandlerType, "Marshaller").GetMethod("ConvertToManaged"u8) },
+                    { Stloc_1 },
+
+                    // *token = VectorChangedTable.GetOrCreateValue(unboxedValue).AddEventHandler(managedHandler);
+                    { Ldarg_2 },
+                    { Call, get_VectorChangedTableMethod },
+                    { Ldloc_0 },
+                    { Callvirt, interopReferences.ConditionalWeakTable2GetOrCreateValue(conditionalWeakTableType).Import(module) },
+                    { Ldloc_1 },
+                    { Callvirt, interopReferences.EventRegistrationTokenTableAddEventHandler(eventRegistrationTokenTableType).Import(module) },
+                    { Stobj, interopReferences.EventRegistrationToken.Import(module) },
+
+                    // unboxedValue.VectorChanged += managedHandler;
+                    { Ldloc_0 },
+                    { Ldloc_1 },
+                    { Callvirt, interopReferences.IObservableVector1add_VectorChanged(elementType).Import(module) },
+                    { Ldc_I4_0 },
+                    { Stloc_2 },
+                    { Leave_S, ldloc_2_returnHResult.CreateLabel() },
+
+                    // '.catch' code
+                    { callvirt_catchHResult },
+                    { Stloc_2 },
+                    { Leave_S, ldloc_2_returnHResult.CreateLabel() },
+
+                    // Return the 'HRESULT' from location [2]
+                    { ldloc_2_returnHResult },
+                    { Ret }
+                },
+                ExceptionHandlers =
+                {
+                    new CilExceptionHandler
+                    {
+                        HandlerType = CilExceptionHandlerType.Exception,
+                        TryStart = ldarg_0_tryStart.CreateLabel(),
+                        TryEnd = callvirt_catchHResult.CreateLabel(),
+                        HandlerStart = callvirt_catchHResult.CreateLabel(),
+                        HandlerEnd = ldloc_2_returnHResult.CreateLabel(),
+                        ExceptionType = interopReferences.Exception.Import(module)
+                    }
+                }
+            };
+
+            return add_VectorChangedMethod;
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Factories/WellKnownCilMethodBodyFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownCilMethodBodyFactory.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
 using WindowsRuntime.InteropGenerator.References;
 using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
@@ -24,6 +27,9 @@ internal static class WellKnownCilMethodBodyFactory
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="module">The interop module being built.</param>
     /// <returns>The resulting method body.</returns>
+    /// <remarks>
+    /// The resulting method body is meant to be used for direct method call forwarding (i.e. not for events).
+    /// </remarks>
     public static CilMethodBody DynamicInterfaceCastableImplementation(
         TypeSignature interfaceType,
         MethodDefinition implementationMethod,
@@ -58,5 +64,67 @@ internal static class WellKnownCilMethodBodyFactory
         body.Instructions.Add(new CilInstruction(Ret));
 
         return body;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="CilMethodBody"/> for a <see cref="System.Runtime.InteropServices.DynamicInterfaceCastableImplementationAttribute"/> method.
+    /// </summary>
+    /// <param name="interfaceType">The type of the interface being implemented (used to retrieve the reference for).</param>
+    /// <param name="handlerType">The handler type for the event.</param>
+    /// <param name="eventMethod">The method returning the event table to use.</param>
+    /// <param name="eventAccessorAttributes">The kind of accessor method to generate.</param>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The interop module being built.</param>
+    /// <returns>The resulting method body.</returns>
+    /// <remarks>
+    /// The resulting method body is specifically meant to be used for event accessors.
+    /// </remarks>
+    [SuppressMessage("Style", "IDE0072", Justification = "We're intentionally only handling 'AddOn' and 'RemoveOn'.")]
+    public static CilMethodBody DynamicInterfaceCastableImplementation(
+        TypeSignature interfaceType,
+        TypeSignature handlerType,
+        MethodDefinition eventMethod,
+        MethodSemanticsAttributes eventAccessorAttributes,
+        InteropReferences interopReferences,
+        ModuleDefinition module)
+    {
+        // Get the right accessor method to invoke
+        MemberReference accessorMethod = eventAccessorAttributes switch
+        {
+            MethodSemanticsAttributes.AddOn => interopReferences.EventSource1Subscribe(handlerType),
+            MethodSemanticsAttributes.RemoveOn => interopReferences.EventSource1Unsubscribe(handlerType),
+            _ => throw new ArgumentOutOfRangeException(nameof(eventAccessorAttributes), actualValue: eventAccessorAttributes, message: null)
+        };
+
+        // Prepare the method body like above, but specifically for event accessors
+        return new()
+        {
+            LocalVariables =
+            {
+                new CilLocalVariable(interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature().Import(module)),
+                new CilLocalVariable(interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature().Import(module))
+            },
+            Instructions =
+            {
+                // Cast 'this' and resolve the 'WindowsRuntimeObjectReference' instance for the interface
+                { Ldarg_0 },
+                { Castclass, interopReferences.WindowsRuntimeObject.Import(module) },
+                { Stloc_0 },
+                { Ldloc_0 },
+                { Ldtoken, interfaceType.Import(module).ToTypeDefOrRef() },
+                { Call, interopReferences.TypeGetTypeFromHandle.Import(module) },
+                { Callvirt, interopReferences.Typeget_TypeHandle.Import(module) },
+                { Callvirt, interopReferences.WindowsRuntimeObjectGetObjectReferenceForInterface.Import(module) },
+                { Stloc_1 },
+
+                // <EVENT_METHOD>(thisObject, thisReference).<ACCESSOR_METHOD>(value);
+                { Ldloc_0 },
+                { Ldloc_1 },
+                { Call, eventMethod },
+                { Ldarg_1 },
+                { Callvirt, accessorMethod.Import(module) },
+                { Ret }
+            }
+        };
     }
 }

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -866,6 +866,75 @@ internal static partial class WellKnownTypeDefinitionFactory
     }
 
     /// <summary>
+    /// Creates a new type definition for the vtable of an 'IObservableVector`1&lt;T&gt;' instantiation for some type.
+    /// </summary>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The module that will contain the type being created.</param>
+    /// <returns>The resulting <see cref="TypeDefinition"/> instance.</returns>
+    public static TypeDefinition IObservableVectorVftbl(InteropReferences interopReferences, ModuleDefinition module)
+    {
+        TypeDefinition vftblType = new(
+            ns: null,
+            name: "<IObservableVectorVftbl>"u8,
+            attributes: TypeAttributes.SequentialLayout | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            baseType: interopReferences.ValueType.Import(module));
+
+        // Get the 'IUnknown' signatures
+        MethodSignature queryInterfaceType = WellKnownTypeSignatureFactory.QueryInterfaceImpl(interopReferences);
+        MethodSignature addRefType = WellKnownTypeSignatureFactory.AddRefImpl(interopReferences);
+        MethodSignature releaseType = WellKnownTypeSignatureFactory.ReleaseImpl(interopReferences);
+
+        // Get the 'IInspectable' signatures
+        MethodSignature getIidsType = WellKnownTypeSignatureFactory.GetIidsImpl(interopReferences);
+        MethodSignature getRuntimeClassNameType = WellKnownTypeSignatureFactory.GetRuntimeClassNameImpl(interopReferences);
+        MethodSignature getTrustLevelType = WellKnownTypeSignatureFactory.GetTrustLevelImpl(interopReferences);
+
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int>'
+        MethodSignature add_VectorChanged = new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: module.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.MakePointerType()]);
+
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int>'
+        MethodSignature remove_VectorChanged = new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: module.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
+
+        // The vtable layout for 'IObservableVector`1<T>' looks like this:
+        //
+        // public delegate* unmanaged[MemberFunction]<void*, Guid*, void**, HRESULT> QueryInterface;
+        // public delegate* unmanaged[MemberFunction]<void*, uint> AddRef;
+        // public delegate* unmanaged[MemberFunction]<void*, uint> Release;
+        // public delegate* unmanaged[MemberFunction]<void*, uint*, Guid**, HRESULT> GetIids;
+        // public delegate* unmanaged[MemberFunction]<void*, HSTRING*, HRESULT> GetRuntimeClassName;
+        // public delegate* unmanaged[MemberFunction]<void*, TrustLevel*, HRESULT> GetTrustLevel;
+        // public delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int> add_VectorChanged;
+        // public delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int> remove_VectorChanged;
+        vftblType.Fields.Add(new FieldDefinition("QueryInterface"u8, FieldAttributes.Public, queryInterfaceType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("AddRef"u8, FieldAttributes.Public, addRefType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("Release"u8, FieldAttributes.Public, releaseType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetIids"u8, FieldAttributes.Public, getIidsType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetRuntimeClassName"u8, FieldAttributes.Public, getRuntimeClassNameType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetTrustLevel"u8, FieldAttributes.Public, getTrustLevelType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("add_VectorChanged"u8, FieldAttributes.Public, add_VectorChanged.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("remove_VectorChanged"u8, FieldAttributes.Public, remove_VectorChanged.Import(module).MakeFunctionPointerType()));
+
+        return vftblType;
+    }
+
+    /// <summary>
     /// Creates a new type definition for the vtable of an 'IReferenceArray`1&lt;T&gt;' instantiation for some SZ array type.
     /// </summary>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
@@ -415,7 +415,7 @@ internal partial class InteropGenerator
         // type and member references to APIs defined in that module, so this is good enough for this scenario.
         // We also do the same for the Windows Runtime projection assembly, the exact version doesn't matter.
         Version windowsRuntimeVersion = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0, 0);
-        AssemblyReference windowsRuntimeAssembly = new("WinRT.Runtime"u8, new Version(10, 0, 0, 0));
+        AssemblyReference windowsRuntimeAssembly = new("WinRT.Runtime"u8, new Version(3, 0, 0, 0));
         AssemblyReference windowsSdkProjectionAssembly = new("Microsoft.Windows.SDK.NET"u8, new Version(10, 0, 0, 0));
 
         // Set the public keys, as it's needed to ensure references compare as equals as expected

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1282,6 +1282,14 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     out TypeDefinition nativeObjectType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.ComWrappersCallbackType(
+                    vectorType: typeSignature,
+                    nativeObjectType: nativeObjectType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition comWrappersCallbackType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1258,6 +1258,15 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
+                InteropTypeDefinitionBuilder.IObservableVector1.ImplType(
+                    vectorType: typeSignature,
+                    get_IidMethod: get_IidMethod,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    implType: out _);
+
                 InteropTypeDefinitionBuilder.IObservableVector1.EventSourceFactory(
                     vectorType: typeSignature,
                     interopDefinitions: interopDefinitions,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1335,7 +1335,13 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
+                InteropTypeDefinitionBuilder.IObservableVector1.IID(
+                    vectorType: typeSignature,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    module: module,
+                    get_IidMethod: out MethodDefinition get_IidMethod);
+
                 InteropTypeDefinitionBuilder.IObservableVector1.EventSourceFactory(
                     vectorType: typeSignature,
                     interopDefinitions: interopDefinitions,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1306,6 +1306,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.InterfaceImpl(
+                    vectorType: typeSignature,
+                    vectorMethodsType: methodsType,
+                    interopReferences: interopReferences,
+                    module: module,
+                    interfaceImplType: out TypeDefinition interfaceImplType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1516,6 +1516,7 @@ internal partial class InteropGenerator
             module.TopLevelTypes.Add(interopDefinitions.IDictionary2Vftbl);
             module.TopLevelTypes.Add(interopDefinitions.IKeyValuePairVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IKeyValuePairInterfaceEntries);
+            module.TopLevelTypes.Add(interopDefinitions.IObservableVectorVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IMapChangedEventArgsVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IReferenceArrayVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IReferenceArrayInterfaceEntries);

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -346,7 +346,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IEnumerator{T}"/> types.
+    /// Defines the interop types for <see cref="IEnumerator{T}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -452,7 +452,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IEnumerable{T}"/> types.
+    /// Defines the interop types for <see cref="IEnumerable{T}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -574,7 +574,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IReadOnlyList{T}"/> types.
+    /// Defines the interop types for <see cref="IReadOnlyList{T}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -696,7 +696,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IList{T}"/> types.
+    /// Defines the interop types for <see cref="IList{T}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -827,7 +827,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey, TValue}"/> types.
+    /// Defines the interop types for <see cref="IReadOnlyDictionary{TKey, TValue}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -949,7 +949,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> types.
+    /// Defines the interop types for <see cref="IDictionary{TKey, TValue}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
@@ -1072,7 +1072,7 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the interop types for <see cref="System.Collections.Generic.KeyValuePair{TKey, TValue}"/> types.
+    /// Defines the interop types for <see cref="KeyValuePair{TKey, TValue}"/> types.
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1256,6 +1256,15 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     factoryType: out TypeDefinition factoryType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.Methods(
+                    vectorType: typeSignature,
+                    eventSourceFactoryType: factoryType,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    methodsType: out TypeDefinition methodsType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1320,6 +1320,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition proxyType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.TypeMapAttributes(
+                    vectorType: typeSignature,
+                    proxyType: proxyType,
+                    interfaceImplType: interfaceImplType,
+                    interopReferences: interopReferences,
+                    module: module);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -218,7 +218,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' properties
                 InteropTypeDefinitionBuilder.Delegate.IIDs(
                     delegateType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -227,7 +226,6 @@ internal partial class InteropGenerator
                     get_IidMethod: out MethodDefinition get_IidMethod,
                     get_ReferenceIidMethod: out MethodDefinition get_ReferenceIidMethod);
 
-                // Define the 'NativeDelegate' type (with the extension method implementation)
                 InteropTypeDefinitionBuilder.Delegate.NativeDelegateType(
                     delegateType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -235,7 +233,6 @@ internal partial class InteropGenerator
                     module: module,
                     nativeDelegateType: out TypeDefinition nativeDelegateType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.Delegate.ComWrappersCallbackType(
                     delegateType: typeSignature,
                     nativeDelegateType: nativeDelegateType,
@@ -244,7 +241,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition delegateComWrappersCallbackType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.Delegate.Marshaller(
                     delegateType: typeSignature,
                     delegateComWrappersCallbackType: delegateComWrappersCallbackType,
@@ -254,7 +250,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'DelegateImpl' type (with the delegate interface vtable implementation)
                 InteropTypeDefinitionBuilder.Delegate.ImplType(
                     delegateType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -263,7 +258,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out TypeDefinition delegateImplType);
 
-                // Define the 'DelegateReferenceImpl' type (with the boxed delegate interface vtable implementation)
                 InteropTypeDefinitionBuilder.Delegate.ReferenceImplType(
                     delegateType: typeSignature,
                     marshallerType: marshallerType,
@@ -273,7 +267,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out TypeDefinition delegateReferenceImplType);
 
-                // Define the 'DelegateInterfaceEntriesImpl' type (with the 'ComWrappers' interface entries implementation)
                 InteropTypeDefinitionBuilder.Delegate.InterfaceEntriesImpl(
                     delegateType: typeSignature,
                     delegateImplType: delegateImplType,
@@ -283,7 +276,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceEntriesImplType: out TypeDefinition delegateInterfaceEntriesImplType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.Delegate.ComWrappersMarshallerAttribute(
                     delegateType: typeSignature,
                     delegateInterfaceEntriesImplType: delegateInterfaceEntriesImplType,
@@ -294,7 +286,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition delegateComWrappersMarshallerType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.Delegate.Proxy(
                     delegateType: typeSignature,
                     delegateComWrappersMarshallerAttributeType: delegateComWrappersMarshallerType,
@@ -302,7 +293,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.Delegate.TypeMapAttributes(
                     delegateType: typeSignature,
                     proxyType: proxyType,
@@ -378,7 +368,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IEnumerator1.IID(
                     enumeratorType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -386,7 +375,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IEnumerator1.ImplType(
                     enumeratorType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -396,7 +384,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IIteratorMethods' type (with the public thunks for 'IIterator<T>' native calls)
                 InteropTypeDefinitionBuilder.IEnumerator1.IIteratorMethods(
                     enumeratorType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -404,7 +391,6 @@ internal partial class InteropGenerator
                     module: module,
                     iteratorMethodsType: out TypeDefinition iteratorMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IEnumerator1.NativeObject(
                     enumeratorType: typeSignature,
                     iteratorMethodsType: iteratorMethodsType,
@@ -412,7 +398,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IEnumerator1.ComWrappersCallbackType(
                     enumeratorType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -421,7 +406,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition enumeratorComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IEnumerator1.ComWrappersMarshallerAttribute(
                     enumeratorType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -430,7 +414,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition enumeratorComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IEnumerator1.Marshaller(
                     enumeratorType: typeSignature,
                     enumeratorComWrappersCallbackType: enumeratorComWrappersCallbackType,
@@ -440,7 +423,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IEnumerator1.InterfaceImpl(
                     enumeratorType: typeSignature,
                     iteratorMethodsType: iteratorMethodsType,
@@ -448,7 +430,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IEnumerator1.Proxy(
                     enumeratorType: typeSignature,
                     enumeratorComWrappersMarshallerAttributeType: enumeratorComWrappersMarshallerType,
@@ -456,7 +437,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IEnumerator1.TypeMapAttributes(
                     enumeratorType: typeSignature,
                     proxyType: proxyType,
@@ -494,7 +474,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IEnumerable1.IID(
                     enumerableType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -502,7 +481,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Interface' type (with the IID property)
                 InteropTypeDefinitionBuilder.IEnumerable1.Interface(
                     enumerableType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -511,7 +489,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceType: out _);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IEnumerable1.ImplType(
                     enumerableType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -521,7 +498,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IIterableMethods' type (with the public thunks for 'IIterable<T>' native calls)
                 InteropTypeDefinitionBuilder.IEnumerable1.IIterableMethods(
                     enumerableType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -530,7 +506,6 @@ internal partial class InteropGenerator
                     module: module,
                     iterableMethodsType: out TypeDefinition iterableMethodsType);
 
-                // Define the 'IEnumerableMethods' type (with the public thunks for 'IEnumerable<T>' calls)
                 InteropTypeDefinitionBuilder.IEnumerable1.IEnumerableMethods(
                     enumerableType: typeSignature,
                     iterableMethodsType: iterableMethodsType,
@@ -539,7 +514,6 @@ internal partial class InteropGenerator
                     module: module,
                     enumerableMethodsType: out TypeDefinition enumerableMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IEnumerable1.NativeObject(
                     enumerableType: typeSignature,
                     iterableMethodsType: iterableMethodsType,
@@ -547,7 +521,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IEnumerable1.ComWrappersCallbackType(
                     enumerableType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -556,7 +529,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition enumerableComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IEnumerable1.ComWrappersMarshallerAttribute(
                     enumerableType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -565,7 +537,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition enumerableComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IEnumerable1.Marshaller(
                     enumerableType: typeSignature,
                     enumerableComWrappersCallbackType: enumerableComWrappersCallbackType,
@@ -574,7 +545,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IEnumerable1.InterfaceImpl(
                     enumerableType: typeSignature,
                     iterableMethodsType: iterableMethodsType,
@@ -582,7 +552,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IEnumerable1.Proxy(
                     enumerableType: typeSignature,
                     enumerableComWrappersMarshallerAttributeType: enumerableComWrappersMarshallerType,
@@ -590,7 +559,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IEnumerable1.TypeMapAttributes(
                     enumerableType: typeSignature,
                     proxyType: proxyType,
@@ -628,7 +596,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IReadOnlyList1.IID(
                     readOnlyListType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -636,7 +603,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Vftbl' type
                 InteropTypeDefinitionBuilder.IReadOnlyList1.Vftbl(
                     readOnlyListType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -644,7 +610,6 @@ internal partial class InteropGenerator
                     module: module,
                     vftblType: out TypeDefinition vftblType);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.ImplType(
                     readOnlyListType: typeSignature,
                     vftblType: vftblType,
@@ -655,7 +620,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IVectorViewMethods' type (with the public thunks for 'IVectorView<T>' native calls)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.IVectorViewMethods(
                     readOnlyListType: typeSignature,
                     vftblType: vftblType,
@@ -663,7 +627,6 @@ internal partial class InteropGenerator
                     module: module,
                     vectorViewMethodsType: out TypeDefinition vectorViewMethodsType);
 
-                // Define the 'IReadOnlyListMethods' type
                 InteropTypeDefinitionBuilder.IReadOnlyList1.IReadOnlyListMethods(
                     readOnlyListType: typeSignature,
                     vectorViewMethodsType: vectorViewMethodsType,
@@ -671,7 +634,6 @@ internal partial class InteropGenerator
                     module: module,
                     readOnlyListMethodsType: out TypeDefinition readOnlyListMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.NativeObject(
                     readOnlyListType: typeSignature,
                     readOnlyListMethodsType: readOnlyListMethodsType,
@@ -680,7 +642,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.ComWrappersCallbackType(
                     readOnlyListType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -689,7 +650,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition readOnlyListComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IReadOnlyList1.ComWrappersMarshallerAttribute(
                     readOnlyListType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -698,7 +658,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition readOnlyListComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.Marshaller(
                     readOnlyListType: typeSignature,
                     readOnlyListComWrappersCallbackType: readOnlyListComWrappersCallbackType,
@@ -707,7 +666,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IReadOnlyList1.InterfaceImpl(
                     readOnlyListType: typeSignature,
                     readOnlyListMethodsType: readOnlyListMethodsType,
@@ -716,7 +674,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IReadOnlyList1.Proxy(
                     readOnlyListType: typeSignature,
                     readOnlyListComWrappersMarshallerAttributeType: readOnlyListComWrappersMarshallerType,
@@ -724,7 +681,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IReadOnlyList1.TypeMapAttributes(
                     readOnlyListType: typeSignature,
                     proxyType: proxyType,
@@ -762,7 +718,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IList1.IID(
                     listType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -770,7 +725,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Vftbl' type
                 InteropTypeDefinitionBuilder.IList1.Vftbl(
                     listType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -778,7 +732,6 @@ internal partial class InteropGenerator
                     module: module,
                     vftblType: out TypeDefinition vftblType);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IList1.ImplType(
                     listType: typeSignature,
                     vftblType: vftblType,
@@ -789,7 +742,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IVectorMethods' type (with the public thunks for 'IVector<T>' native calls)
                 InteropTypeDefinitionBuilder.IList1.IVectorMethods(
                     listType: typeSignature,
                     vftblType: vftblType,
@@ -797,7 +749,6 @@ internal partial class InteropGenerator
                     module: module,
                     vectorMethodsType: out TypeDefinition vectorMethodsType);
 
-                // Define the 'ListMethods' type
                 InteropTypeDefinitionBuilder.IList1.IListMethods(
                     listType: typeSignature,
                     vectorMethodsType: vectorMethodsType,
@@ -805,7 +756,6 @@ internal partial class InteropGenerator
                     module: module,
                     listMethodsType: out TypeDefinition listMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IList1.NativeObject(
                     listType: typeSignature,
                     vectorMethodsType: vectorMethodsType,
@@ -814,7 +764,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IList1.ComWrappersCallbackType(
                     listType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -823,7 +772,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition listComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IList1.ComWrappersMarshallerAttribute(
                     listType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -832,7 +780,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition listComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IList1.Marshaller(
                     listType: typeSignature,
                     listComWrappersCallbackType: listComWrappersCallbackType,
@@ -841,7 +788,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IList1.InterfaceImpl(
                     listType: typeSignature,
                     listMethodsType: listMethodsType,
@@ -850,7 +796,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IList1.Proxy(
                     listType: typeSignature,
                     listComWrappersMarshallerAttributeType: listComWrappersMarshallerType,
@@ -858,7 +803,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IList1.TypeMapAttributes(
                     listType: typeSignature,
                     proxyType: proxyType,
@@ -896,7 +840,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.IID(
                     readOnlyDictionaryType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -904,7 +847,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Vftbl' type
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.Vftbl(
                     readOnlyDictionaryType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -913,7 +855,6 @@ internal partial class InteropGenerator
                     module: module,
                     vftblType: out TypeDefinition vftblType);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.ImplType(
                     readOnlyDictionaryType: typeSignature,
                     vftblType: vftblType,
@@ -924,7 +865,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IMapViewMethods' type (with the public thunks for 'IMapView<K, V>' native calls)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.IMapViewMethods(
                     readOnlyDictionaryType: typeSignature,
                     vftblType: vftblType,
@@ -932,7 +872,6 @@ internal partial class InteropGenerator
                     module: module,
                     mapViewMethodsType: out TypeDefinition mapViewMethodsType);
 
-                // Define the 'ReadOnlyDictionaryMethods' type
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.IReadOnlyDictionaryMethods(
                     readOnlyDictionaryType: typeSignature,
                     mapViewMethodsType: mapViewMethodsType,
@@ -940,7 +879,6 @@ internal partial class InteropGenerator
                     module: module,
                     readOnlyDictionaryMethodsType: out TypeDefinition readOnlyDictionaryMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.NativeObject(
                     readOnlyDictionaryType: typeSignature,
                     mapViewMethodsType: mapViewMethodsType,
@@ -949,7 +887,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.ComWrappersCallbackType(
                     readOnlyDictionaryType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -958,7 +895,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition readOnlyDictionaryComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.ComWrappersMarshallerAttribute(
                     readOnlyDictionaryType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -967,7 +903,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition readOnlyDictionaryComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.Marshaller(
                     readOnlyDictionaryType: typeSignature,
                     readOnlyDictionaryComWrappersCallbackType: readOnlyDictionaryComWrappersCallbackType,
@@ -976,7 +911,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.InterfaceImpl(
                     readOnlyDictionaryType: typeSignature,
                     readOnlyDictionaryMethodsType: readOnlyDictionaryMethodsType,
@@ -984,7 +918,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.Proxy(
                     readOnlyDictionaryType: typeSignature,
                     readOnlyDictionaryComWrappersMarshallerAttributeType: readOnlyDictionaryComWrappersMarshallerType,
@@ -992,7 +925,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IReadOnlyDictionary2.TypeMapAttributes(
                     readOnlyDictionaryType: typeSignature,
                     proxyType: proxyType,
@@ -1030,7 +962,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IDictionary2.IID(
                     dictionaryType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1038,7 +969,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Vftbl' type
                 InteropTypeDefinitionBuilder.IDictionary2.Vftbl(
                     dictionaryType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1047,7 +977,6 @@ internal partial class InteropGenerator
                     module: module,
                     vftblType: out TypeDefinition vftblType);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IDictionary2.ImplType(
                     dictionaryType: typeSignature,
                     vftblType: vftblType,
@@ -1058,7 +987,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'IMapMethods' type (with the public thunks for 'IMap<K, V>' native calls)
                 InteropTypeDefinitionBuilder.IDictionary2.IMapMethods(
                     dictionaryType: typeSignature,
                     vftblType: vftblType,
@@ -1066,7 +994,6 @@ internal partial class InteropGenerator
                     module: module,
                     mapMethodsType: out TypeDefinition mapMethodsType);
 
-                // Define the 'DictionaryMethods' type
                 InteropTypeDefinitionBuilder.IDictionary2.IDictionaryMethods(
                     dictionaryType: typeSignature,
                     mapMethodsType: mapMethodsType,
@@ -1075,7 +1002,6 @@ internal partial class InteropGenerator
                     module: module,
                     dictionaryMethodsType: out TypeDefinition dictionaryMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IDictionary2.NativeObject(
                     dictionaryType: typeSignature,
                     mapMethodsType: mapMethodsType,
@@ -1084,7 +1010,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IDictionary2.ComWrappersCallbackType(
                     dictionaryType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -1093,7 +1018,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition dictionaryComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IDictionary2.ComWrappersMarshallerAttribute(
                     dictionaryType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -1102,7 +1026,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition dictionaryComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IDictionary2.Marshaller(
                     dictionaryType: typeSignature,
                     dictionaryComWrappersCallbackType: dictionaryComWrappersCallbackType,
@@ -1111,7 +1034,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IDictionary2.InterfaceImpl(
                     dictionaryType: typeSignature,
                     dictionaryMethodsType: dictionaryMethodsType,
@@ -1119,7 +1041,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IDictionary2.Proxy(
                     dictionaryType: typeSignature,
                     dictionaryComWrappersMarshallerAttributeType: dictionaryComWrappersMarshallerType,
@@ -1127,7 +1048,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IDictionary2.TypeMapAttributes(
                     dictionaryType: typeSignature,
                     proxyType: proxyType,
@@ -1163,7 +1083,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.KeyValuePair.IID(
                     keyValuePairType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1171,7 +1090,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'KeyValuePairImpl' type (with the delegate interface vtable implementation)
                 InteropTypeDefinitionBuilder.KeyValuePair.ImplType(
                     keyValuePairType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -1180,7 +1098,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out TypeDefinition keyValuePairTypeImplType);
 
-                // Define the 'KeyValuePairInterfaceEntriesImpl' type (with the 'ComWrappers' interface entries implementation)
                 InteropTypeDefinitionBuilder.KeyValuePair.InterfaceEntriesImplType(
                     keyValuePairType: typeSignature,
                     keyValuePairTypeImplType: keyValuePairTypeImplType,
@@ -1219,7 +1136,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.IID(
                     argsType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1227,7 +1143,6 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Impl' type (with the CCW vtable implementation)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.ImplType(
                     argsType: typeSignature,
                     get_IidMethod: get_IidMethod,
@@ -1237,7 +1152,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out _);
 
-                // Define the 'Methods' type (with the public thunks for 'IMapChangedEventArgs<K>' native calls)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.Methods(
                     argsType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1245,7 +1159,6 @@ internal partial class InteropGenerator
                     module: module,
                     argsMethodsType: out TypeDefinition argsMethodsType);
 
-                // Define the 'NativeObject' type (with the RCW implementation)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.NativeObject(
                     argsType: typeSignature,
                     argsMethodsType: argsMethodsType,
@@ -1253,7 +1166,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition nativeObjectType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeUnsealedObjectComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.ComWrappersCallbackType(
                     argsType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -1262,7 +1174,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition argsComWrappersCallbackType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.ComWrappersMarshallerAttribute(
                     argsType: typeSignature,
                     nativeObjectType: nativeObjectType,
@@ -1271,7 +1182,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition argsComWrappersMarshallerType);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.Marshaller(
                     argsType: typeSignature,
                     argsComWrappersCallbackType: argsComWrappersCallbackType,
@@ -1281,7 +1191,6 @@ internal partial class InteropGenerator
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'InterfaceImpl' type (with '[DynamicInterfaceCastableImplementation]')
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.InterfaceImpl(
                     argsType: typeSignature,
                     argsMethodsType: argsMethodsType,
@@ -1289,7 +1198,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.Proxy(
                     argsType: typeSignature,
                     argsComWrappersMarshallerAttributeType: argsComWrappersMarshallerType,
@@ -1297,7 +1205,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.IMapChangedEventArgs1.TypeMapAttributes(
                     argsType: typeSignature,
                     proxyType: proxyType,
@@ -1378,7 +1285,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the 'IID' property
                 InteropTypeDefinitionBuilder.SzArray.IID(
                     arrayType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -1386,14 +1292,12 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
-                // Define the 'Marshaller' type (with the static marshaller methods)
                 InteropTypeDefinitionBuilder.SzArray.Marshaller(
                     arrayType: typeSignature,
                     interopReferences: interopReferences,
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
 
-                // Define the 'ComWrappersCallback' type (with the 'IWindowsRuntimeArrayComWrappersCallback' implementation)
                 InteropTypeDefinitionBuilder.SzArray.ComWrappersCallback(
                     arrayType: typeSignature,
                     marshallerType: marshallerType,
@@ -1401,7 +1305,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition arrayComWrappersCallbackType);
 
-                // Define the 'ArrayImpl' type (with the boxed delegate interface vtable implementation)
                 InteropTypeDefinitionBuilder.SzArray.ArrayImpl(
                     arrayType: typeSignature,
                     marshallerType: marshallerType,
@@ -1411,7 +1314,6 @@ internal partial class InteropGenerator
                     module: module,
                     implType: out TypeDefinition arrayImplType);
 
-                // Define the 'ArrayInterfaceEntriesImpl' type (with the 'ComWrappers' interface entries implementation)
                 InteropTypeDefinitionBuilder.SzArray.InterfaceEntriesImpl(
                     arrayType: typeSignature,
                     implType: arrayImplType,
@@ -1420,7 +1322,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceEntriesImplType: out TypeDefinition arrayInterfaceEntriesImplType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.SzArray.ComWrappersMarshallerAttribute(
                     arrayType: typeSignature,
                     arrayInterfaceEntriesImplType: arrayInterfaceEntriesImplType,
@@ -1431,7 +1332,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition arrayComWrappersMarshallerType);
 
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.SzArray.Proxy(
                     arrayType: typeSignature,
                     arrayComWrappersMarshallerAttributeType: arrayComWrappersMarshallerType,
@@ -1439,7 +1339,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.SzArray.TypeMapAttributes(
                     arrayType: typeSignature,
                     proxyType: proxyType,
@@ -1487,7 +1386,6 @@ internal partial class InteropGenerator
                 // Get the first user-defined with this vtable set as reference
                 typeSignature = discoveryState.UserDefinedAndVtableTypes.First(kvp => kvp.Value.Equals(vtableTypes)).Key;
 
-                // Define the 'InterfaceEntriesImpl' type (with the 'ComWrappers' interface entries implementation)
                 InteropTypeDefinitionBuilder.UserDefinedType.InterfaceEntriesImpl(
                     userDefinedType: typeSignature,
                     vtableTypes: vtableTypes,
@@ -1497,7 +1395,6 @@ internal partial class InteropGenerator
                     module: module,
                     interfaceEntriesImplType: out TypeDefinition interfaceEntriesImplType);
 
-                // Define the 'ComWrappersMarshallerAttribute' type
                 InteropTypeDefinitionBuilder.UserDefinedType.ComWrappersMarshallerAttribute(
                     userDefinedType: typeSignature,
                     vtableTypes: vtableTypes,
@@ -1523,7 +1420,6 @@ internal partial class InteropGenerator
 
             try
             {
-                // Define the proxy type (for the type map)
                 InteropTypeDefinitionBuilder.UserDefinedType.Proxy(
                     userDefinedType: typeSignature,
                     comWrappersMarshallerAttributeType: marshallerAttributeMap[vtableTypes],
@@ -1531,7 +1427,6 @@ internal partial class InteropGenerator
                     module: module,
                     out TypeDefinition proxyType);
 
-                // Define the type map attributes
                 InteropTypeDefinitionBuilder.UserDefinedType.TypeMapAttributes(
                     userDefinedType: typeSignature,
                     proxyType: proxyType,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -725,6 +725,14 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
+                InteropTypeDefinitionBuilder.IList1.Interface(
+                    listType: typeSignature,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    interfaceType: out _);
+
                 InteropTypeDefinitionBuilder.IList1.Vftbl(
                     listType: typeSignature,
                     interopDefinitions: interopDefinitions,
@@ -746,6 +754,7 @@ internal partial class InteropGenerator
                     listType: typeSignature,
                     vftblType: vftblType,
                     interopReferences: interopReferences,
+                    emitState: emitState,
                     module: module,
                     vectorMethodsType: out TypeDefinition vectorMethodsType);
 
@@ -1265,6 +1274,14 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     methodsType: out TypeDefinition methodsType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.NativeObject(
+                    vectorType: typeSignature,
+                    vectorMethodsType: methodsType,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    out TypeDefinition nativeObjectType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1313,6 +1313,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.Proxy(
+                    vectorType: typeSignature,
+                    vectorComWrappersMarshallerAttributeType: comWrappersMarshallerType,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition proxyType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1298,6 +1298,14 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition comWrappersMarshallerType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.Marshaller(
+                    vectorType: typeSignature,
+                    vectorComWrappersCallbackType: comWrappersMarshallerType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    marshallerType: out TypeDefinition marshallerType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -320,6 +320,9 @@ internal partial class InteropGenerator
                 }
                 else if (SignatureComparer.IgnoreVersion.Equals(typeSignature.GenericType, interopReferences.VectorChangedEventHandler1))
                 {
+                    // We need the marshaller type for the 'IObservableVector<T>' implementation
+                    emitState.TrackTypeDefinition(marshallerType, typeSignature, "Marshaller");
+
                     InteropTypeDefinitionBuilder.EventSource.VectorChangedEventHandler1(
                         delegateType: typeSignature,
                         marshallerType: marshallerType,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -57,7 +57,7 @@ internal partial class InteropGenerator
         args.Token.ThrowIfCancellationRequested();
 
         // Emit interop types for generic delegates
-        DefineGenericDelegateTypes(args, discoveryState, interopDefinitions, interopReferences, module);
+        DefineGenericDelegateTypes(args, discoveryState, emitState, interopDefinitions, interopReferences, module);
 
         args.Token.ThrowIfCancellationRequested();
 
@@ -98,6 +98,11 @@ internal partial class InteropGenerator
 
         // Emit interop types for 'IMapChangedEventArgs<>' types
         DefineIMapChangedEventArgsTypes(args, discoveryState, emitState, interopDefinitions, interopReferences, module);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Emit interop types for 'IObservableVector<>' types
+        DefineIObservableVectorTypes(args, discoveryState, emitState, interopDefinitions, interopReferences, module);
 
         args.Token.ThrowIfCancellationRequested();
 
@@ -195,12 +200,14 @@ internal partial class InteropGenerator
     /// </summary>
     /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
+    /// <param name="emitState">The emit state for this invocation.</param>
     /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="module">The interop module being built.</param>
     private static void DefineGenericDelegateTypes(
         InteropGeneratorArgs args,
         InteropGeneratorDiscoveryState discoveryState,
+        InteropGeneratorEmitState emitState,
         InteropDefinitions interopDefinitions,
         InteropReferences interopReferences,
         ModuleDefinition module)
@@ -327,6 +334,7 @@ internal partial class InteropGenerator
                         delegateType: typeSignature,
                         marshallerType: marshallerType,
                         interopReferences: interopReferences,
+                        emitState: emitState,
                         module: module,
                         eventSourceType: out _);
                 }
@@ -1300,6 +1308,45 @@ internal partial class InteropGenerator
             catch (Exception e) when (!e.IsWellKnown)
             {
                 throw WellKnownInteropExceptions.IMapChangedEventArgs1TypeCodeGenerationError(typeSignature, e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Defines the interop types for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;</c> types.
+    /// </summary>
+    /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
+    /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
+    /// <param name="emitState">The emit state for this invocation.</param>
+    /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The interop module being built.</param>
+    private static void DefineIObservableVectorTypes(
+        InteropGeneratorArgs args,
+        InteropGeneratorDiscoveryState discoveryState,
+        InteropGeneratorEmitState emitState,
+        InteropDefinitions interopDefinitions,
+        InteropReferences interopReferences,
+        ModuleDefinition module)
+    {
+        foreach (GenericInstanceTypeSignature typeSignature in discoveryState.IObservableVector1Types)
+        {
+            args.Token.ThrowIfCancellationRequested();
+
+            try
+            {
+                // Define the 'IID' property
+                InteropTypeDefinitionBuilder.IObservableVector1.EventSourceFactory(
+                    vectorType: typeSignature,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    factoryType: out TypeDefinition factoryType);
+            }
+            catch (Exception e) when (!e.IsWellKnown)
+            {
+                throw WellKnownInteropExceptions.IObservableVectorTypeCodeGenerationError(typeSignature, e);
             }
         }
     }

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1290,6 +1290,14 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition comWrappersCallbackType);
+
+                InteropTypeDefinitionBuilder.IObservableVector1.ComWrappersMarshallerAttribute(
+                    vectorType: typeSignature,
+                    nativeObjectType: nativeObjectType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition comWrappersMarshallerType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
+++ b/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
@@ -134,6 +134,12 @@ internal sealed class InteropDefinitions
     public TypeDefinition IMapChangedEventArgsVftbl => field ??= WellKnownTypeDefinitionFactory.IMapChangedEventArgsVftbl(_interopReferences, _interopModule);
 
     /// <summary>
+    /// Gets the <see cref="TypeDefinition"/> for the <c>IObservableVectorVftbl</c> type.
+    /// </summary>
+    [field: MaybeNull, AllowNull]
+    public TypeDefinition IObservableVectorVftbl => field ??= WellKnownTypeDefinitionFactory.IObservableVectorVftbl(_interopReferences, _interopModule);
+
+    /// <summary>
     /// Gets the <see cref="TypeDefinition"/> for the <c>IReferenceArrayVftbl</c> type.
     /// </summary>
     public TypeDefinition IReferenceArrayVftbl => field ??= WellKnownTypeDefinitionFactory.ReferenceArrayVftbl(_interopReferences, _interopModule);

--- a/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
+++ b/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
@@ -136,7 +136,6 @@ internal sealed class InteropDefinitions
     /// <summary>
     /// Gets the <see cref="TypeDefinition"/> for the <c>IObservableVectorVftbl</c> type.
     /// </summary>
-    [field: MaybeNull, AllowNull]
     public TypeDefinition IObservableVectorVftbl => field ??= WellKnownTypeDefinitionFactory.IObservableVectorVftbl(_interopReferences, _interopModule);
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -23,23 +23,23 @@ internal sealed class InteropReferences
     /// <summary>
     /// The <see cref="ModuleDefinition"/> for the Windows Runtime assembly.
     /// </summary>
-    private readonly ModuleDefinition _windowsRuntimeModule;
+    private readonly IResolutionScope _windowsRuntimeModule;
 
     /// <summary>
     /// The <see cref="ModuleDefinition"/> for the Windows SDK projection assembly.
     /// </summary>
-    private readonly ModuleDefinition _windowsSdkProjectionModule;
+    private readonly IResolutionScope _windowsSdkProjectionModule;
 
     /// <summary>
     /// Creates a new <see cref="InteropReferences"/> instance.
     /// </summary>
     /// <param name="corLibTypeFactory">The <see cref="AsmResolver.DotNet.Signatures.CorLibTypeFactory"/> currently in use.</param>
-    /// <param name="windowsRuntimeModule">The <see cref="ModuleDefinition"/> for the Windows Runtime assembly.</param>
-    /// <param name="windowsSdkProjectionModule">The <see cref="ModuleDefinition"/> for the Windows SDK projection assembly.</param>
+    /// <param name="windowsRuntimeModule">The <see cref="IResolutionScope"/> for the Windows Runtime assembly.</param>
+    /// <param name="windowsSdkProjectionModule">The <see cref="IResolutionScope"/> for the Windows SDK projection assembly.</param>
     public InteropReferences(
         CorLibTypeFactory corLibTypeFactory,
-        ModuleDefinition windowsRuntimeModule,
-        ModuleDefinition windowsSdkProjectionModule)
+        IResolutionScope windowsRuntimeModule,
+        IResolutionScope windowsSdkProjectionModule)
     {
         _corLibTypeFactory = corLibTypeFactory;
         _windowsRuntimeModule = windowsRuntimeModule;
@@ -54,12 +54,12 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="ModuleDefinition"/> for the Windows Runtime assembly.
     /// </summary>
-    public ModuleDefinition WindowsRuntimeModule => _windowsRuntimeModule;
+    public IResolutionScope WindowsRuntimeModule => _windowsRuntimeModule;
 
     /// <summary>
     /// Gets the <see cref="ModuleDefinition"/> for the Windows Runtine foundation projection assembly.
     /// </summary>
-    public ModuleDefinition WindowsFoundationModule => _windowsSdkProjectionModule;
+    public IResolutionScope WindowsFoundationModule => _windowsSdkProjectionModule;
 
     /// <summary>
     /// Gets the <see cref="AssemblyReference"/> for <c>System.Runtime.InteropServices.dll</c>.
@@ -695,13 +695,13 @@ internal sealed class InteropReferences
     /// Gets the <see cref="MemberReference"/> for <see cref="Attribute.Attribute()"/>.
     /// </summary>
     public MemberReference Attribute_ctor => field ??= Attribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void));
+        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="NotSupportedException.NotSupportedException()"/>.
     /// </summary>
     public MemberReference NotSupportedException_ctor => field ??= NotSupportedException
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void));
+        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="Type.GetTypeFromHandle"/>.
@@ -777,10 +777,10 @@ internal sealed class InteropReferences
     public MemberReference ReadOnlySpanByte_ctor => field ??= ReadOnlySpanByte
         .ToTypeDefOrRef()
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of <see cref="int"/>).
@@ -788,10 +788,10 @@ internal sealed class InteropReferences
     public MemberReference ReadOnlySpanInt32_ctor => field ??= ReadOnlySpanInt32
         .ToTypeDefOrRef()
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s indexer (of <see cref="char"/>).
@@ -818,10 +818,10 @@ internal sealed class InteropReferences
     public MemberReference ReadOnlySpanUInt16_ctor => field ??= ReadOnlySpanUInt16
         .ToTypeDefOrRef()
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MethodSpecification"/> for <see cref="System.MemoryExtensions.SequenceEqual{T}(Span{T}, ReadOnlySpan{T})"/> (for <see cref="ReadOnlySpanChar"/>).
@@ -915,7 +915,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IUnknownImplget_Vtable => field ??= IUnknownImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IInspectableImpl.get_IID()</c>.
@@ -929,7 +929,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IInspectableImplget_Vtable => field ??= IInspectableImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IPropertyValueImpl.get_IID()</c>.
@@ -943,21 +943,21 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IPropertyValueImplget_OtherTypeVtable => field ??= IPropertyValueImpl
         .CreateMemberReference("get_OtherTypeVtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IPropertyValueImpl.get_OtherTypeArrayVtable()</c>.
     /// </summary>
     public MemberReference IPropertyValueImplget_OtherTypeArrayVtable => field ??= IPropertyValueImpl
         .CreateMemberReference("get_OtherTypeArrayVtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IPropertyValueImpl.get_InspectableArrayVtable()</c>.
     /// </summary>
     public MemberReference IPropertyValueImplget_InspectableArrayVtable => field ??= IPropertyValueImpl
         .CreateMemberReference("get_InspectableArrayVtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IStringableImpl.get_IID()</c>.
@@ -971,7 +971,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IStringableImplget_Vtable => field ??= IStringableImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IMarshalImpl.get_IID()</c>.
@@ -985,7 +985,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IMarshalImplget_Vtable => field ??= IMarshalImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IWeakReferenceSourceImpl.get_IID()</c>.
@@ -999,7 +999,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IWeakReferenceSourceImplget_Vtable => field ??= IWeakReferenceSourceImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IAgileObjectImpl.get_IID()</c>.
@@ -1013,7 +1013,7 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IAgileObjectImplget_Vtable => field ??= IAgileObjectImpl
         .CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.IntPtr));
+            returnType: _corLibTypeFactory.IntPtr));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectReference.AsValue()</c>.
@@ -1061,7 +1061,7 @@ internal sealed class InteropReferences
             returnType: _corLibTypeFactory.Void,
             parameterTypes: [
                 WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IReadOnlyListMethods.Count</c>.
@@ -1130,19 +1130,19 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference IWindowsRuntimeObjectComWrappersCallbackCreateObject => field ??= IWindowsRuntimeObjectComWrappersCallback
         .CreateMemberReference("CreateObject"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Object,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            returnType: _corLibTypeFactory.Object,
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IWindowsRuntimeUnsealedObjectComWrappersCallback.TryCreateObject</c>.
     /// </summary>
     public MemberReference IWindowsRuntimeUnsealedObjectComWrappersCallbackTryCreateObject => field ??= IWindowsRuntimeUnsealedObjectComWrappersCallback
         .CreateMemberReference("TryCreateObject"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+            returnType: _corLibTypeFactory.Boolean,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 ReadOnlySpanChar,
-                _windowsRuntimeModule.CorLibTypeFactory.Object.MakeByReferenceType(),
+                _corLibTypeFactory.Object.MakeByReferenceType(),
                 CreatedWrapperFlags.MakeByReferenceType()]));
 
     /// <summary>
@@ -1152,97 +1152,97 @@ internal sealed class InteropReferences
         .CreateMemberReference("CreateArray"u8, MethodSignature.CreateStatic(
             returnType: Array.ToReferenceTypeSignature(),
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.UInt32,
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+                _corLibTypeFactory.UInt32,
+                _corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectReferenceValue.GetThisPtrUnsafe()</c>.
     /// </summary>
     public MemberReference WindowsRuntimeObjectReferenceValueGetThisPtrUnsafe => field ??= WindowsRuntimeObjectReferenceValue
-        .CreateMemberReference("GetThisPtrUnsafe"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()));
+        .CreateMemberReference("GetThisPtrUnsafe"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void.MakePointerType()));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectReferenceValue.DetachThisPtrUnsafe()</c>.
     /// </summary>
     public MemberReference WindowsRuntimeObjectReferenceValueDetachThisPtrUnsafe => field ??= WindowsRuntimeObjectReferenceValue
-        .CreateMemberReference("DetachThisPtrUnsafe"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()));
+        .CreateMemberReference("DetachThisPtrUnsafe"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void.MakePointerType()));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectReferenceValue.Dispose()</c>.
     /// </summary>
     public MemberReference WindowsRuntimeObjectReferenceValueDispose => field ??= WindowsRuntimeObjectReferenceValue
-        .CreateMemberReference("Dispose"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void));
+        .CreateMemberReference("Dispose"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.ctor()</c>.
     /// </summary>
     public MemberReference WindowsRuntimeComWrappersMarshallerAttribute_ctor => field ??= WindowsRuntimeComWrappersMarshallerAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_windowsRuntimeModule.CorLibTypeFactory.Void));
+        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TEventArgs&gt;.ctor(...)</c>.
     /// </summary>
     public MemberReference EventHandler1EventSource_ctor => field ??= EventHandler1EventSource
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
                 WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TSender, TEventArgs&gt;.ctor(...)</c>.
     /// </summary>
     public MemberReference EventHandler2EventSource_ctor => field ??= EventHandler2EventSource
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
                 WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="VectorChangedEventHandler1EventSource"/>'s constructor.
     /// </summary>
     public MemberReference VectorChangedEventHandler1EventSource_ctor => field ??= VectorChangedEventHandler1EventSource
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
                 WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="MapChangedEventHandler2EventSource"/>'s constructor.
     /// </summary>
     public MemberReference MapChangedEventHandler2EventSource_ctor => field ??= MapChangedEventHandler2EventSource
         .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
                 WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _windowsRuntimeModule.CorLibTypeFactory.Int32]));
+                _corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.GetOrCreateComInterfaceForObject(object)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeComWrappersMarshallerAttributeGetOrCreateComInterfaceForObject => field ??= WindowsRuntimeComWrappersMarshallerAttribute
         .CreateMemberReference("GetOrCreateComInterfaceForObject"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Object]));
+            returnType: _corLibTypeFactory.Void.MakePointerType(),
+            parameterTypes: [_corLibTypeFactory.Object]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.ComputeVtables(out int)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeComWrappersMarshallerAttributeComputeVtables => field ??= WindowsRuntimeComWrappersMarshallerAttribute
         .CreateMemberReference("ComputeVtables"u8, MethodSignature.CreateStatic(
-            returnType: new TypeReference(_windowsRuntimeModule.CorLibTypeFactory.CorLibScope, "System.Runtime.InteropServices"u8, "ComWrappers/ComInterfaceEntry"u8).MakePointerType(),
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Int32.MakeByReferenceType()]));
+            returnType: new TypeReference(_corLibTypeFactory.CorLibScope, "System.Runtime.InteropServices"u8, "ComWrappers/ComInterfaceEntry"u8).MakePointerType(),
+            parameterTypes: [_corLibTypeFactory.Int32.MakeByReferenceType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.CreateObject(void*)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeComWrappersMarshallerAttributeCreateObject => field ??= WindowsRuntimeComWrappersMarshallerAttribute
         .CreateMemberReference("CreateObject"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Object,
+            returnType: _corLibTypeFactory.Object,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 CreatedWrapperFlags.ToValueTypeSignature()]));
 
     /// <summary>
@@ -1250,9 +1250,9 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference WindowsRuntimeMarshalGetOrCreateComInterfaceForObject => field ??= WindowsRuntimeMarshal
         .CreateMemberReference("GetOrCreateComInterfaceForObject"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+            returnType: _corLibTypeFactory.Void.MakePointerType(),
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Object,
+                _corLibTypeFactory.Object,
                 CreateComInterfaceFlags.ToValueTypeSignature()]));
 
     /// <summary>
@@ -1262,7 +1262,7 @@ internal sealed class InteropReferences
         .CreateMemberReference("CreateObjectReference"u8, MethodSignature.CreateStatic(
             returnType: WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 Guid.MakeByReferenceType(),
                 CreatedWrapperFlags.MakeByReferenceType()]));
 
@@ -1273,7 +1273,7 @@ internal sealed class InteropReferences
         .CreateMemberReference("CreateObjectReferenceUnsafe"u8, MethodSignature.CreateStatic(
             returnType: WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 Guid.MakeByReferenceType(),
                 CreatedWrapperFlags.MakeByReferenceType()]));
 
@@ -1283,7 +1283,7 @@ internal sealed class InteropReferences
     public MemberReference WindowsRuntimeObjectMarshallerConvertToUnmanaged => field ??= WindowsRuntimeObjectMarshaller
         .CreateMemberReference("ConvertToUnmanaged"u8, MethodSignature.CreateStatic(
             returnType: WindowsRuntimeObjectReferenceValue.ToValueTypeSignature(),
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Object]));
+            parameterTypes: [_corLibTypeFactory.Object]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectMarshaller.ConvertToManaged(void*)</c>.
@@ -1291,15 +1291,15 @@ internal sealed class InteropReferences
     public MemberReference WindowsRuntimeObjectMarshallerConvertToManaged => field ??= WindowsRuntimeObjectMarshaller
         .CreateMemberReference("ConvertToManaged"u8, MethodSignature.CreateStatic(
             returnType: Delegate.ToReferenceTypeSignature(),
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeObjectMarshaller.Free(void*)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeObjectMarshallerFree => field ??= WindowsRuntimeObjectMarshaller
         .CreateMemberReference("Free"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            returnType: _corLibTypeFactory.Void,
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeUnsealedObject.ConvertToManaged</c>.
@@ -1308,7 +1308,7 @@ internal sealed class InteropReferences
         .CreateMemberReference("ConvertToManaged"u8, MethodSignature.CreateStatic(
             returnType: Delegate.ToReferenceTypeSignature(),
             genericParameterCount: 1,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeDelegateMarshaller.ConvertToUnmanaged(Delegate, in Guid)</c>.
@@ -1327,7 +1327,7 @@ internal sealed class InteropReferences
         .CreateMemberReference("ConvertToManaged"u8, MethodSignature.CreateStatic(
             returnType: Delegate.ToReferenceTypeSignature(),
             genericParameterCount: 1,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeDelegateMarshaller.BoxToUnmanaged(Delegate, in Guid)</c>.
@@ -1346,7 +1346,7 @@ internal sealed class InteropReferences
         .CreateMemberReference("UnboxToManaged"u8, MethodSignature.CreateStatic(
             returnType: Delegate.ToReferenceTypeSignature(),
             genericParameterCount: 1,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+            parameterTypes: [_corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeDelegateMarshaller.UnboxToManaged&lt;TCallback&gt;(void*, in Guid)</c>.
@@ -1356,7 +1356,7 @@ internal sealed class InteropReferences
             returnType: Delegate.ToReferenceTypeSignature(),
             genericParameterCount: 1,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 Guid.MakeByReferenceType()]));
 
     /// <summary>
@@ -1367,7 +1367,7 @@ internal sealed class InteropReferences
             returnType: Array.ToReferenceTypeSignature(),
             genericParameterCount: 1,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType(),
+                _corLibTypeFactory.Void.MakePointerType(),
                 Guid.MakeByReferenceType()]));
 
     /// <summary>
@@ -1399,37 +1399,37 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference RestrictedErrorInfoThrowExceptionForHR => field ??= RestrictedErrorInfo
         .CreateMemberReference("ThrowExceptionForHR"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
-            parameterTypes: [_windowsRuntimeModule.CorLibTypeFactory.Int32]));
+            returnType: _corLibTypeFactory.Void,
+            parameterTypes: [_corLibTypeFactory.Int32]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeArrayHelpers.FreeHStringArrayUnsafe</c>.
     /// </summary>
     public MemberReference WindowsRuntimeArrayHelpersFreeHStringArrayUnsafe => field ??= WindowsRuntimeArrayHelpers
         .CreateMemberReference("FreeHStringArrayUnsafe"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.UInt32,
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]));
+                _corLibTypeFactory.UInt32,
+                _corLibTypeFactory.Void.MakePointerType().MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeArrayHelpers.FreeObjectArrayUnsafe</c>.
     /// </summary>
     public MemberReference WindowsRuntimeArrayHelpersFreeObjectArrayUnsafe => field ??= WindowsRuntimeArrayHelpers
         .CreateMemberReference("FreeObjectArrayUnsafe"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.UInt32,
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]));
+                _corLibTypeFactory.UInt32,
+                _corLibTypeFactory.Void.MakePointerType().MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeArrayHelpers.FreeTypeArrayUnsafe</c>.
     /// </summary>
     public MemberReference WindowsRuntimeArrayHelpersFreeTypeArrayUnsafe => field ??= WindowsRuntimeArrayHelpers
         .CreateMemberReference("FreeTypeArrayUnsafe"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.UInt32,
+                _corLibTypeFactory.UInt32,
                 ABIType.MakePointerType()]));
 
     /// <summary>
@@ -1437,18 +1437,18 @@ internal sealed class InteropReferences
     /// </summary>
     public MemberReference WindowsRuntimeArrayHelpersFreeBlittableArrayUnsafe => field ??= WindowsRuntimeArrayHelpers
         .CreateMemberReference("FreeBlittableArrayUnsafe"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+            returnType: _corLibTypeFactory.Void,
             parameterTypes: [
-                _windowsRuntimeModule.CorLibTypeFactory.UInt32,
-                _windowsRuntimeModule.CorLibTypeFactory.Void.MakePointerType()]));
+                _corLibTypeFactory.UInt32,
+                _corLibTypeFactory.Void.MakePointerType()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.Marshalling.RestrictedErrorInfoExceptionMarshaller.ConvertToUnmanaged(Exception)</c>.
     /// </summary>
     public MemberReference RestrictedErrorInfoExceptionMarshallerConvertToUnmanaged => field ??= RestrictedErrorInfoExceptionMarshaller
         .CreateMemberReference("ConvertToUnmanaged"u8, MethodSignature.CreateStatic(
-            returnType: _windowsRuntimeModule.CorLibTypeFactory.Int32,
-            parameterTypes: [new TypeReference(_windowsRuntimeModule.CorLibTypeFactory.CorLibScope, "System"u8, "Exception"u8).ToReferenceTypeSignature()]));
+            returnType: _corLibTypeFactory.Int32,
+            parameterTypes: [new TypeReference(_corLibTypeFactory.CorLibScope, "System"u8, "Exception"u8).ToReferenceTypeSignature()]));
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of an SZ array type).
@@ -1459,7 +1459,7 @@ internal sealed class InteropReferences
             .MakeGenericValueType(arrayType.BaseType)
             .ToTypeDefOrRef()
             .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 parameterTypes: [arrayType]));
     }
 
@@ -1626,7 +1626,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("get_HasCurrent"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean));
+                returnType: _corLibTypeFactory.Boolean));
     }
 
     /// <summary>
@@ -1639,7 +1639,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("MoveNext"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean));
+                returnType: _corLibTypeFactory.Boolean));
     }
 
     /// <summary>
@@ -1655,7 +1655,7 @@ internal sealed class InteropReferences
                 returnType: new GenericParameterSignature(GenericParameterType.Type, 0),
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.UInt32]));
+                    _corLibTypeFactory.UInt32]));
     }
 
     /// <summary>
@@ -1668,10 +1668,10 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("SetAt"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.UInt32,
+                    _corLibTypeFactory.UInt32,
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
     }
 
@@ -1685,7 +1685,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Append"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
@@ -1701,11 +1701,11 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("IndexOf"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0),
-                    _windowsRuntimeModule.CorLibTypeFactory.UInt32.MakeByReferenceType()]));
+                    _corLibTypeFactory.UInt32.MakeByReferenceType()]));
     }
 
     /// <summary>
@@ -1718,10 +1718,10 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("InsertAt"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.UInt32,
+                    _corLibTypeFactory.UInt32,
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
     }
 
@@ -1738,7 +1738,7 @@ internal sealed class InteropReferences
                 returnType: new GenericParameterSignature(GenericParameterType.Type, 0),
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.UInt32]));
+                    _corLibTypeFactory.UInt32]));
     }
 
     /// <summary>
@@ -1950,7 +1950,7 @@ internal sealed class InteropReferences
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32]))
+                    _corLibTypeFactory.Int32]))
             .MakeGenericInstanceMethod(vectorMethods.ToReferenceTypeSignature());
     }
 
@@ -1965,11 +1965,11 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Item"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32,
+                    _corLibTypeFactory.Int32,
                     new GenericParameterSignature(GenericParameterType.Type, 0)]))
             .MakeGenericInstanceMethod(vectorMethods.ToReferenceTypeSignature());
     }
@@ -1985,7 +1985,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Add"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2004,7 +2004,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Contains"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2023,12 +2023,12 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("CopyTo"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0).MakeSzArrayType(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32]))
+                    _corLibTypeFactory.Int32]))
             .MakeGenericInstanceMethod(vectorMethods.ToReferenceTypeSignature());
     }
 
@@ -2043,7 +2043,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Remove"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2062,7 +2062,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("IndexOf"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Int32,
+                returnType: _corLibTypeFactory.Int32,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2081,11 +2081,11 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Insert"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32,
+                    _corLibTypeFactory.Int32,
                     new GenericParameterSignature(GenericParameterType.Type, 0)]))
             .MakeGenericInstanceMethod(vectorMethods.ToReferenceTypeSignature());
     }
@@ -2105,7 +2105,7 @@ internal sealed class InteropReferences
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32]))
+                    _corLibTypeFactory.Int32]))
             .MakeGenericInstanceMethod(vectorViewMethods.ToReferenceTypeSignature());
     }
 
@@ -2120,7 +2120,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("HasKey"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
@@ -2154,7 +2154,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Insert"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0),
@@ -2172,7 +2172,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Remove"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
@@ -2189,7 +2189,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("HasKey"u8, MethodSignature.CreateInstance(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                     new GenericParameterSignature(GenericParameterType.Type, 0)]));
@@ -2244,7 +2244,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Item"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2265,7 +2265,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Add"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2286,7 +2286,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("ContainsKey"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2306,7 +2306,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Remove"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2326,7 +2326,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("TryGetValue"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2347,7 +2347,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Add"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2369,7 +2369,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Contains"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2396,7 +2396,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("CopyTo"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Void,
+                returnType: _corLibTypeFactory.Void,
                 genericParameterCount: 2,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2404,7 +2404,7 @@ internal sealed class InteropReferences
                     KeyValuePair.MakeGenericValueType(
                         new GenericParameterSignature(GenericParameterType.Type, 0),
                         new GenericParameterSignature(GenericParameterType.Type, 1)).MakeSzArrayType(),
-                    _windowsRuntimeModule.CorLibTypeFactory.Int32]))
+                    _corLibTypeFactory.Int32]))
             .MakeGenericInstanceMethod(mapMethods.ToReferenceTypeSignature(), iterableMethods.ToReferenceTypeSignature());
     }
 
@@ -2420,7 +2420,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("Remove"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2462,7 +2462,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("ContainsKey"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
@@ -2482,7 +2482,7 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
             .CreateMemberReference("TryGetValue"u8, MethodSignature.CreateStatic(
-                returnType: _windowsRuntimeModule.CorLibTypeFactory.Boolean,
+                returnType: _corLibTypeFactory.Boolean,
                 genericParameterCount: 1,
                 parameterTypes: [
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature(),

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -157,6 +157,11 @@ internal sealed class InteropReferences
     public GenericInstanceTypeSignature ReadOnlySpanInt32 => field ??= ReadOnlySpan1.MakeGenericValueType(_corLibTypeFactory.Int32);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <see cref="Func{T1, T2, TResult}"/>.
+    /// </summary>
+    public TypeReference Func3 => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "Func`3"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Exception"/>.
     /// </summary>
     public TypeReference Exception => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "Exception"u8);

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -1483,6 +1483,21 @@ internal sealed class InteropReferences
     }
 
     /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>RemoveEventHandler</c> for <see cref="EventRegistrationTokenTable1"/>.
+    /// </summary>
+    /// <param name="eventRegistrationTokenTableType">The input table type.</param>
+    public MemberReference EventRegistrationTokenTableRemoveEventHandler(TypeSignature eventRegistrationTokenTableType)
+    {
+        return eventRegistrationTokenTableType
+            .ToTypeDefOrRef()
+            .CreateMemberReference("RemoveEventHandler"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Boolean,
+                parameterTypes: [
+                    EventRegistrationToken.ToValueTypeSignature(),
+                    new GenericParameterSignature(GenericParameterType.Type, 0).MakeByReferenceType()]));
+    }
+
+    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of an SZ array type).
     /// </summary>
     public MemberReference ReadOnlySpan1_ctor(SzArrayTypeSignature arrayType)
@@ -1582,6 +1597,21 @@ internal sealed class InteropReferences
             .CreateMemberReference("GetOrCreateValue"u8, MethodSignature.CreateInstance(
                 returnType: new GenericParameterSignature(GenericParameterType.Type, 1),
                 parameterTypes: [new GenericParameterSignature(GenericParameterType.Type, 0)]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MethodSpecification"/> for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}.TryGetValue"/>.
+    /// </summary>
+    /// <param name="conditionalWeakTableType">The input table type.</param>
+    public MemberReference ConditionalWeakTable2TryGetValue(TypeSignature conditionalWeakTableType)
+    {
+        return conditionalWeakTableType
+            .ToTypeDefOrRef()
+            .CreateMemberReference("TryGetValue"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Boolean,
+                parameterTypes: [
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    new GenericParameterSignature(GenericParameterType.Type, 1).MakeByReferenceType()]));
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -1515,8 +1515,16 @@ internal sealed class InteropReferences
     /// Gets the <see cref="MemberReference"/> for the <c>Invoke</c> method of a given delegate type.
     /// </summary>
     /// <param name="delegateType">The input delegate type.</param>
-    public MemberReference DelegateInvoke(GenericInstanceTypeSignature delegateType)
+    /// <param name="module">The optional <see cref="ModuleDefinition"/> to use to import <paramref name="delegateType"/> before resolving it.</param>
+    public MemberReference DelegateInvoke(GenericInstanceTypeSignature delegateType, ModuleDefinition? module = null)
     {
+        // Optionally import the signature, if needed (if required to properly resolve it)
+        if (module is not null)
+        {
+            // TODO: use new 'Resolve' overload in beta 5
+            delegateType = delegateType.Import(module);
+        }
+
         // Get the 'Invoke' method of the delegate type (this will remove the type arguments)
         MethodDefinition invokeMethod = delegateType.Resolve()!.GetMethod("Invoke"u8);
 

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -282,6 +282,11 @@ internal sealed class InteropReferences
     public TypeReference MemoryExtensions => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "MemoryExtensions"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <see cref="System.Threading.Interlocked"/>.
+    /// </summary>
+    public TypeReference Interlocked => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Threading"u8, "Interlocked"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.InteropServices.MemoryMarshal"/>.
     /// </summary>
     public TypeReference MemoryMarshal => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.InteropServices"u8, "MemoryMarshal"u8);
@@ -317,6 +322,11 @@ internal sealed class InteropReferences
     public TypeReference DynamicInterfaceCastableImplementationAttribute => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.InteropServices"u8, "DynamicInterfaceCastableImplementationAttribute"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.IsVolatile"/>.
+    /// </summary>
+    public TypeReference IsVolatile => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.CompilerServices"u8, "IsVolatile"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.IsReadOnlyAttribute"/>.
     /// </summary>
     public TypeReference IsReadOnlyAttribute => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.CompilerServices"u8, "IsReadOnlyAttribute"u8);
@@ -335,6 +345,11 @@ internal sealed class InteropReferences
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.CallConvMemberFunction"/>.
     /// </summary>
     public TypeReference CallConvMemberFunction => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.CompilerServices"u8, "CallConvMemberFunction"u8);
+
+    /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}"/>.
+    /// </summary>
+    public TypeReference ConditionalWeakTable2 => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Runtime.CompilerServices"u8, "ConditionalWeakTable`2"u8);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute"/>.
@@ -440,6 +455,11 @@ internal sealed class InteropReferences
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.IMapViewMethodsImpl&lt;K, V&gt;</c>.
     /// </summary>
     public TypeReference IMapViewMethodsImpl2 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "IMapViewMethodsImpl`2"u8);
+
+    /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.IObservableVectorMethodsImpl&lt;T&gt;</c>.
+    /// </summary>
+    public TypeReference IObservableVectorMethodsImpl1 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "IObservableVectorMethodsImpl`1"u8);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.IMapChangedEventArgsImpl&lt;K&gt;</c>.
@@ -827,6 +847,18 @@ internal sealed class InteropReferences
         .CreateMemberReference("AsSpan"u8, MethodSignature.CreateStatic(
             returnType: ReadOnlySpanChar,
             parameterTypes: [_corLibTypeFactory.String]));
+
+    /// <summary>
+    /// Gets the <see cref="MethodSpecification"/> for <see cref="System.Threading.Interlocked.CompareExchange{T}(ref T, T, T)"/>.
+    /// </summary>
+    public MemberReference InterlockedCompareExchange1 => field ??= Interlocked
+        .CreateMemberReference("CompareExchange"u8, MethodSignature.CreateStatic(
+            returnType: new GenericParameterSignature(GenericParameterType.Method, 0),
+            genericParameterCount: 1,
+            parameterTypes: [
+                new GenericParameterSignature(GenericParameterType.Method, 0).MakeByReferenceType(),
+                new GenericParameterSignature(GenericParameterType.Method, 0),
+                new GenericParameterSignature(GenericParameterType.Method, 0)]));
 
     /// <summary>
     /// Gets the <see cref="MethodSpecification"/> for <see cref="System.Runtime.InteropServices.MemoryMarshal.CreateSpan"/>.
@@ -1504,6 +1536,28 @@ internal sealed class InteropReferences
             .CreateMemberReference("Invoke"u8, MethodSignature.CreateInstance(
                 returnType: invokeSignature.ReturnType,
                 parameterTypes: invokeSignature.ParameterTypes));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MethodSpecification"/> for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}.GetOrAdd{TArg}(TKey, Func{TKey, TArg, TValue}, TArg)"/>.
+    /// </summary>
+    /// <param name="conditionalWeakTableType">The input table type.</param>
+    /// <param name="argType">The argument type.</param>
+    public MethodSpecification ConditionalWeakTableGetOrAdd(TypeSignature conditionalWeakTableType, TypeSignature argType)
+    {
+        return conditionalWeakTableType
+            .ToTypeDefOrRef()
+            .CreateMemberReference("GetOrAdd"u8, MethodSignature.CreateInstance(
+                returnType: new GenericParameterSignature(GenericParameterType.Type, 1),
+                genericParameterCount: 1,
+                parameterTypes: [
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    Func3.MakeGenericReferenceType(
+                        new GenericParameterSignature(GenericParameterType.Type, 0),
+                        new GenericParameterSignature(GenericParameterType.Method, 0),
+                        new GenericParameterSignature(GenericParameterType.Type, 1)),
+                    new GenericParameterSignature(GenericParameterType.Method, 0)]))
+            .MakeGenericInstanceMethod(argType);
     }
 
     /// <summary>
@@ -2661,6 +2715,22 @@ internal sealed class InteropReferences
                 parameterTypes: [
                     new GenericParameterSignature(GenericParameterType.Type, 0),
                     new GenericParameterSignature(GenericParameterType.Type, 1).MakeByReferenceType()]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IObservableVectorMethodsImpl1&lt;T&gt;.VectorChanged</c>.
+    /// </summary>
+    /// <param name="elementType">The input element type.</param>
+    public MemberReference IObservableVectorMethodsImpl1VectorChanged(TypeSignature elementType)
+    {
+        return IObservableVectorMethodsImpl1
+            .MakeGenericReferenceType(elementType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("VectorChanged"u8, MethodSignature.CreateInstance(
+                returnType: new GenericParameterSignature(GenericParameterType.Type, 0),
+                parameterTypes: [
+                    WindowsRuntimeObject.ToReferenceTypeSignature(),
+                    WindowsRuntimeObjectReference.ToReferenceTypeSignature()]));
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -732,6 +732,11 @@ internal sealed class InteropReferences
     public MemberReference Attribute_ctor => field ??= Attribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <see cref="Exception.HResult"/>.
+    /// </summary>
+    public MemberReference Exceptionget_HResult => field ??= Exception.CreateMemberReference("get_HResult"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Int32));
+
+    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="NotSupportedException.NotSupportedException()"/>.
     /// </summary>
     public MemberReference NotSupportedException_ctor => field ??= NotSupportedException.CreateConstructorReference(_corLibTypeFactory);
@@ -1465,6 +1470,19 @@ internal sealed class InteropReferences
             parameterTypes: [new TypeReference(_corLibTypeFactory.CorLibScope, "System"u8, "Exception"u8).ToReferenceTypeSignature()]));
 
     /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>AddEventHandler</c> for <see cref="EventRegistrationTokenTable1"/>.
+    /// </summary>
+    /// <param name="eventRegistrationTokenTableType">The input table type.</param>
+    public MemberReference EventRegistrationTokenTableAddEventHandler(TypeSignature eventRegistrationTokenTableType)
+    {
+        return eventRegistrationTokenTableType
+            .ToTypeDefOrRef()
+            .CreateMemberReference("AddEventHandler"u8, MethodSignature.CreateInstance(
+                returnType: EventRegistrationToken.ToValueTypeSignature(),
+                parameterTypes: [new GenericParameterSignature(GenericParameterType.Type, 0)]));
+    }
+
+    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of an SZ array type).
     /// </summary>
     public MemberReference ReadOnlySpan1_ctor(SzArrayTypeSignature arrayType)
@@ -1554,11 +1572,24 @@ internal sealed class InteropReferences
     }
 
     /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}.GetOrCreateValue"/>.
+    /// </summary>
+    /// <param name="conditionalWeakTableType">The input table type.</param>
+    public MemberReference ConditionalWeakTable2GetOrCreateValue(TypeSignature conditionalWeakTableType)
+    {
+        return conditionalWeakTableType
+            .ToTypeDefOrRef()
+            .CreateMemberReference("GetOrCreateValue"u8, MethodSignature.CreateInstance(
+                returnType: new GenericParameterSignature(GenericParameterType.Type, 1),
+                parameterTypes: [new GenericParameterSignature(GenericParameterType.Type, 0)]));
+    }
+
+    /// <summary>
     /// Gets the <see cref="MethodSpecification"/> for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}.GetOrAdd{TArg}(TKey, Func{TKey, TArg, TValue}, TArg)"/>.
     /// </summary>
     /// <param name="conditionalWeakTableType">The input table type.</param>
     /// <param name="argType">The argument type.</param>
-    public MethodSpecification ConditionalWeakTableGetOrAdd(TypeSignature conditionalWeakTableType, TypeSignature argType)
+    public MethodSpecification ConditionalWeakTable2GetOrAdd(TypeSignature conditionalWeakTableType, TypeSignature argType)
     {
         return conditionalWeakTableType
             .ToTypeDefOrRef()

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -632,6 +632,11 @@ internal sealed class InteropReferences
     public TypeReference RestrictedErrorInfoExceptionMarshaller => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices.Marshalling"u8, "RestrictedErrorInfoExceptionMarshaller"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventRegistrationToken</c>.
+    /// </summary>
+    public TypeReference EventRegistrationToken => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventRegistrationToken"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TEventArgs&gt;</c>.
     /// </summary>
     public TypeReference EventHandler1EventSource => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventHandlerEventSource`1"u8);

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -667,6 +667,11 @@ internal sealed class InteropReferences
     public TypeReference EventRegistrationToken => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventRegistrationToken"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventRegistrationTokenTable&lt;T&gt;</c>.
+    /// </summary>
+    public TypeReference EventRegistrationTokenTable1 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventRegistrationTokenTable`1"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventSource&lt;T&gt;</c>.
     /// </summary>
     public TypeReference EventSource1 => field ??= _windowsSdkProjectionModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventSource`1"u8);

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -667,6 +667,11 @@ internal sealed class InteropReferences
     public TypeReference EventRegistrationToken => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventRegistrationToken"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventSource&lt;T&gt;</c>.
+    /// </summary>
+    public TypeReference EventSource1 => field ??= _windowsSdkProjectionModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventSource`1"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TEventArgs&gt;</c>.
     /// </summary>
     public TypeReference EventHandler1EventSource => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "EventHandlerEventSource`1"u8);
@@ -2723,7 +2728,35 @@ internal sealed class InteropReferences
     }
 
     /// <summary>
-    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.IObservableVectorMethodsImpl1&lt;T&gt;.VectorChanged</c>.
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;.VectorChanged</c>'s adder.
+    /// </summary>
+    /// <param name="elementType">The input element type.</param>
+    public MemberReference IObservableVector1add_VectorChanged(TypeSignature elementType)
+    {
+        return IObservableVector1
+            .MakeGenericReferenceType(elementType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("add_VectorChanged"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [VectorChangedEventHandler1.MakeGenericReferenceType(new GenericParameterSignature(GenericParameterType.Type, 0))]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;.VectorChanged</c>'s remover.
+    /// </summary>
+    /// <param name="elementType">The input element type.</param>
+    public MemberReference IObservableVector1remove_VectorChanged(TypeSignature elementType)
+    {
+        return IObservableVector1
+            .MakeGenericReferenceType(elementType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("remove_VectorChanged"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [VectorChangedEventHandler1.MakeGenericReferenceType(new GenericParameterSignature(GenericParameterType.Type, 0))]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;.VectorChanged</c>'s getter.
     /// </summary>
     /// <param name="elementType">The input element type.</param>
     public MemberReference IObservableVectorMethodsImpl1VectorChanged(TypeSignature elementType)
@@ -2774,6 +2807,34 @@ internal sealed class InteropReferences
             .CreateMemberReference("Key"u8, MethodSignature.CreateStatic(
                 returnType: new GenericParameterSignature(GenericParameterType.Type, 0),
                 parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature()]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventSource&lt;T&gt;.Subscribe(...)</c>.
+    /// </summary>
+    /// <param name="delegateType">The input delegate type.</param>
+    public MemberReference EventSource1Subscribe(TypeSignature delegateType)
+    {
+        return EventSource1
+            .MakeGenericReferenceType(delegateType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("Subscribe"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [new GenericParameterSignature(GenericParameterType.Type, 0)]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventSource&lt;T&gt;.Unsubscribe(...)</c>.
+    /// </summary>
+    /// <param name="delegateType">The input delegate type.</param>
+    public MemberReference EventSource1Unsubscribe(TypeSignature delegateType)
+    {
+        return EventSource1
+            .MakeGenericReferenceType(delegateType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("Unsubscribe"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [new GenericParameterSignature(GenericParameterType.Type, 0)]));
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -694,14 +694,12 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="Attribute.Attribute()"/>.
     /// </summary>
-    public MemberReference Attribute_ctor => field ??= Attribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
+    public MemberReference Attribute_ctor => field ??= Attribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="NotSupportedException.NotSupportedException()"/>.
     /// </summary>
-    public MemberReference NotSupportedException_ctor => field ??= NotSupportedException
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
+    public MemberReference NotSupportedException_ctor => field ??= NotSupportedException.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="Type.GetTypeFromHandle"/>.
@@ -721,10 +719,9 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)"/>.
     /// </summary>
-    public MemberReference AttributeUsageAttribute_ctor_AttributeTargets => field ??= AttributeUsageAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [AttributeTargets.ToValueTypeSignature()]));
+    public MemberReference AttributeUsageAttribute_ctor_AttributeTargets => field ??= AttributeUsageAttribute.CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [AttributeTargets.ToValueTypeSignature()]);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.InteropServices.TypeMapAttribute{TTypeMapGroup}.TypeMapAttribute(string, System.Type, System.Type)"/>, using <see cref="WindowsRuntimeComWrappersTypeMapGroup"/>.
@@ -774,24 +771,16 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of <see cref="byte"/>).
     /// </summary>
-    public MemberReference ReadOnlySpanByte_ctor => field ??= ReadOnlySpanByte
-        .ToTypeDefOrRef()
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                _corLibTypeFactory.Void.MakePointerType(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference ReadOnlySpanByte_ctor => field ??= ReadOnlySpanByte.ToTypeDefOrRef().CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [_corLibTypeFactory.Void.MakePointerType(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of <see cref="int"/>).
     /// </summary>
-    public MemberReference ReadOnlySpanInt32_ctor => field ??= ReadOnlySpanInt32
-        .ToTypeDefOrRef()
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                _corLibTypeFactory.Void.MakePointerType(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference ReadOnlySpanInt32_ctor => field ??= ReadOnlySpanInt32.ToTypeDefOrRef().CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [_corLibTypeFactory.Void.MakePointerType(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s indexer (of <see cref="char"/>).
@@ -815,13 +804,9 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="ReadOnlySpan{T}"/>'s constructor (of <see cref="ushort"/>).
     /// </summary>
-    public MemberReference ReadOnlySpanUInt16_ctor => field ??= ReadOnlySpanUInt16
-        .ToTypeDefOrRef()
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                _corLibTypeFactory.Void.MakePointerType(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference ReadOnlySpanUInt16_ctor => field ??= ReadOnlySpanUInt16.ToTypeDefOrRef().CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [_corLibTypeFactory.Void.MakePointerType(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MethodSpecification"/> for <see cref="System.MemoryExtensions.SequenceEqual{T}(Span{T}, ReadOnlySpan{T})"/> (for <see cref="ReadOnlySpanChar"/>).
@@ -857,32 +842,27 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.FixedAddressValueTypeAttribute.FixedAddressValueTypeAttribute()"/>.
     /// </summary>
-    public MemberReference FixedAddressValueTypeAttribute_ctor => field ??= FixedAddressValueTypeAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(returnType: _corLibTypeFactory.Void));
+    public MemberReference FixedAddressValueTypeAttribute_ctor => field ??= FixedAddressValueTypeAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.InteropServices.DynamicInterfaceCastableImplementationAttribute.DynamicInterfaceCastableImplementationAttribute()"/>.
     /// </summary>
-    public MemberReference DynamicInterfaceCastableImplementationAttribute_ctor => field ??= DynamicInterfaceCastableImplementationAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(returnType: _corLibTypeFactory.Void));
+    public MemberReference DynamicInterfaceCastableImplementationAttribute_ctor => field ??= DynamicInterfaceCastableImplementationAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.IsReadOnlyAttribute.IsReadOnlyAttribute()"/>.
     /// </summary>
-    public MemberReference IsReadOnlyAttribute_ctor => field ??= IsReadOnlyAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(returnType: _corLibTypeFactory.Void));
+    public MemberReference IsReadOnlyAttribute_ctor => field ??= IsReadOnlyAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.CompilerServices.ScopedRefAttribute.ScopedRefAttribute()"/>.
     /// </summary>
-    public MemberReference ScopedRefAttribute_ctor => field ??= ScopedRefAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(returnType: _corLibTypeFactory.Void));
+    public MemberReference ScopedRefAttribute_ctor => field ??= ScopedRefAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="TypeReference"/> for <see cref="System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.UnmanagedCallersOnlyAttribute()"/>.
     /// </summary>
-    public MemberReference UnmanagedCallersOnlyAttribute_ctor => field ??= UnmanagedCallersOnlyAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(returnType: _corLibTypeFactory.Void));
+    public MemberReference UnmanagedCallersOnlyAttribute_ctor => field ??= UnmanagedCallersOnlyAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="System.Runtime.InteropServices.ComWrappers.ComInterfaceDispatch.GetInstance"/>.
@@ -1176,48 +1156,35 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.ctor()</c>.
     /// </summary>
-    public MemberReference WindowsRuntimeComWrappersMarshallerAttribute_ctor => field ??= WindowsRuntimeComWrappersMarshallerAttribute
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(_corLibTypeFactory.Void));
+    public MemberReference WindowsRuntimeComWrappersMarshallerAttribute_ctor => field ??= WindowsRuntimeComWrappersMarshallerAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TEventArgs&gt;.ctor(...)</c>.
     /// </summary>
-    public MemberReference EventHandler1EventSource_ctor => field ??= EventHandler1EventSource
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference EventHandler1EventSource_ctor => field ??= EventHandler1EventSource.CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.EventHandlerEventSource&lt;TSender, TEventArgs&gt;.ctor(...)</c>.
     /// </summary>
-    public MemberReference EventHandler2EventSource_ctor => field ??= EventHandler2EventSource
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference EventHandler2EventSource_ctor => field ??= EventHandler2EventSource.CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="VectorChangedEventHandler1EventSource"/>'s constructor.
     /// </summary>
-    public MemberReference VectorChangedEventHandler1EventSource_ctor => field ??= VectorChangedEventHandler1EventSource
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference VectorChangedEventHandler1EventSource_ctor => field ??= VectorChangedEventHandler1EventSource.CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <see cref="MapChangedEventHandler2EventSource"/>'s constructor.
     /// </summary>
-    public MemberReference MapChangedEventHandler2EventSource_ctor => field ??= MapChangedEventHandler2EventSource
-        .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                _corLibTypeFactory.Int32]));
+    public MemberReference MapChangedEventHandler2EventSource_ctor => field ??= MapChangedEventHandler2EventSource.CreateConstructorReference(
+        corLibTypeFactory: _corLibTypeFactory,
+        parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.GetOrCreateComInterfaceForObject(object)</c>.
@@ -1458,9 +1425,7 @@ internal sealed class InteropReferences
         return ReadOnlySpan1
             .MakeGenericValueType(arrayType.BaseType)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
-                parameterTypes: [arrayType]));
+            .CreateConstructorReference(_corLibTypeFactory, [arrayType]);
     }
 
     /// <summary>
@@ -1472,12 +1437,12 @@ internal sealed class InteropReferences
         return TypeMapAttribute1
             .MakeGenericReferenceType(typeMapGroup)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
                 parameterTypes: [
                     _corLibTypeFactory.String,
                     Type.ToReferenceTypeSignature(),
-                    Type.ToReferenceTypeSignature()]));
+                    Type.ToReferenceTypeSignature()]);
     }
 
     /// <summary>
@@ -1489,11 +1454,11 @@ internal sealed class InteropReferences
         return TypeMapAssociationAttribute1
             .MakeGenericReferenceType(typeMapGroup)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-            returnType: _corLibTypeFactory.Void,
-            parameterTypes: [
-                Type.ToReferenceTypeSignature(),
-                Type.ToReferenceTypeSignature()]));
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
+                parameterTypes: [
+                    Type.ToReferenceTypeSignature(),
+                    Type.ToReferenceTypeSignature()]);
     }
 
     /// <summary>
@@ -1506,9 +1471,9 @@ internal sealed class InteropReferences
         // a delegate instance that directly wraps our 'WindowsRuntimeObjectReference' object and 'Invoke' method.
         return delegateType
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
-                parameterTypes: [_corLibTypeFactory.Object, _corLibTypeFactory.IntPtr]));
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
+                parameterTypes: [_corLibTypeFactory.Object, _corLibTypeFactory.IntPtr]);
     }
 
     /// <summary>
@@ -2792,9 +2757,7 @@ internal sealed class InteropReferences
     {
         return enumeratorType
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
-                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature()]));
+            .CreateConstructorReference(_corLibTypeFactory, WindowsRuntimeObjectReference.ToReferenceTypeSignature()!); // TODO: file issue
     }
 
     /// <summary>
@@ -2807,11 +2770,11 @@ internal sealed class InteropReferences
         return DictionaryKeyCollection2
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
                 parameterTypes: [ICollection1.MakeGenericReferenceType(KeyValuePair.MakeGenericValueType(
                     new GenericParameterSignature(GenericParameterType.Type, 0),
-                    new GenericParameterSignature(GenericParameterType.Type, 1)))]));
+                    new GenericParameterSignature(GenericParameterType.Type, 1)))]);
     }
 
     /// <summary>
@@ -2824,11 +2787,11 @@ internal sealed class InteropReferences
         return DictionaryValueCollection2
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
                 parameterTypes: [ICollection1.MakeGenericReferenceType(KeyValuePair.MakeGenericValueType(
                     new GenericParameterSignature(GenericParameterType.Type, 0),
-                    new GenericParameterSignature(GenericParameterType.Type, 1)))]));
+                    new GenericParameterSignature(GenericParameterType.Type, 1)))]);
     }
 
     /// <summary>
@@ -2841,11 +2804,11 @@ internal sealed class InteropReferences
         return ReadOnlyDictionaryKeyCollection2
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
                 parameterTypes: [IEnumerable1.MakeGenericReferenceType(KeyValuePair.MakeGenericValueType(
                     new GenericParameterSignature(GenericParameterType.Type, 0),
-                    new GenericParameterSignature(GenericParameterType.Type, 1)))]));
+                    new GenericParameterSignature(GenericParameterType.Type, 1)))]);
     }
 
     /// <summary>
@@ -2858,10 +2821,10 @@ internal sealed class InteropReferences
         return ReadOnlyDictionaryValueCollection2
             .MakeGenericReferenceType(keyType, valueType)
             .ToTypeDefOrRef()
-            .CreateMemberReference(".ctor"u8, MethodSignature.CreateInstance(
-                returnType: _corLibTypeFactory.Void,
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
                 parameterTypes: [IEnumerable1.MakeGenericReferenceType(KeyValuePair.MakeGenericValueType(
                     new GenericParameterSignature(GenericParameterType.Type, 0),
-                    new GenericParameterSignature(GenericParameterType.Type, 1)))]));
+                    new GenericParameterSignature(GenericParameterType.Type, 1)))]);
     }
 }

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -547,6 +547,11 @@ internal sealed class InteropReferences
     public TypeReference WindowsRuntimeReadOnlyDictionary5 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeReadOnlyDictionary`5"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.WindowsRuntimeObservableVector&lt;T, ...&gt;</c>.
+    /// </summary>
+    public TypeReference WindowsRuntimeObservableVector6 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeObservableVector`6"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.WindowsRuntimeMapChangedEventArgs&lt;TKey, ...&gt;</c>.
     /// </summary>
     public TypeReference WindowsRuntimeMapChangedEventArgs2 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeMapChangedEventArgs`2"u8);

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeDictionary{TKey, TValue}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeDictionary{TKey, TValue}.cs
@@ -68,7 +68,7 @@ public abstract class WindowsRuntimeDictionary<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -78,7 +78,7 @@ public abstract class WindowsRuntimeDictionary<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIIterableObjectReference();
         }
     }
 

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeList{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeList{T}.cs
@@ -55,7 +55,7 @@ public abstract class WindowsRuntimeList<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -65,7 +65,7 @@ public abstract class WindowsRuntimeList<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIIterableObjectReference();
         }
     }
 

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Windows.Foundation.Collections;
+using WindowsRuntime.InteropServices;
+
+#pragma warning disable CA1816
+
+namespace WindowsRuntime;
+
+/// <summary>
+/// The implementation of all projected Windows Runtime <see cref="IObservableVector{T}"/> types.
+/// </summary>
+/// <typeparam name="T">The type of objects to enumerate.</typeparam>
+/// <typeparam name="TIIterable">The <c>Windows.Foundation.Collections.IIterable&lt;T&gt;</c> interface type.</typeparam>
+/// <typeparam name="TIIterableMethods">The <c>Windows.Foundation.Collections.IIterable&lt;T&gt;</c> implementation type.</typeparam>
+/// <typeparam name="TIVector">The <c>Windows.Foundation.Collections.IVector&lt;T&gt;</c> interface type.</typeparam>
+/// <typeparam name="TIVectorMethods">The <c>Windows.Foundation.Collections.IVector&lt;T&gt;</c> implementation type.</typeparam>
+/// <typeparam name="TIObservableVectorMethods">The <c>Windows.Foundation.Collections.IObservableVector&lt;T&gt;</c> implementation type.</typeparam>
+/// <remarks>
+/// This type should only be used as a base type by generated generic instantiations.
+/// </remarks>
+/// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1"/>
+[Obsolete("This type is an implementation detail, and it's only meant to be consumed by 'cswinrtgen'")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class WindowsRuntimeObservableVector<
+    T,
+    TIIterable,
+    TIIterableMethods,
+    TIVector,
+    TIVectorMethods,
+    TIObservableVectorMethods> : WindowsRuntimeList<T, TIIterable, TIIterableMethods, TIVectorMethods>,
+    IObservableVector<T>,
+    IWindowsRuntimeInterface<IObservableVector<T>>
+    where TIIterable : IWindowsRuntimeInterface
+    where TIIterableMethods : IIterableMethodsImpl<T>
+    where TIVector : IWindowsRuntimeInterface
+    where TIVectorMethods : IVectorMethodsImpl<T>
+    where TIObservableVectorMethods : IObservableVectorMethodsImpl<T>
+{
+    /// <summary>
+    /// The cached object reference for <see cref="IObservableVector{T}"/> for the current object.
+    /// </summary>
+    private readonly WindowsRuntimeObjectReference _observableVectorObjectReference;
+
+    /// <summary>
+    /// Creates a <see cref="WindowsRuntimeList{T, TIIterable, TIEnumerableMethods, TIListMethods}"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="nativeObjectReference">The inner Windows Runtime object reference to wrap in the current instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="nativeObjectReference"/> is <see langword="null"/>.</exception>
+    protected WindowsRuntimeObservableVector(WindowsRuntimeObjectReference nativeObjectReference)
+        : base(nativeObjectReference.As(in TIVector.IID))
+    {
+        _observableVectorObjectReference = nativeObjectReference;
+    }
+
+    /// <inheritdoc/>
+    public event VectorChangedEventHandler<T>? VectorChanged
+    {
+        add => TIObservableVectorMethods.VectorChanged(this, _observableVectorObjectReference).Subscribe(value);
+        remove => TIObservableVectorMethods.VectorChanged(this, _observableVectorObjectReference).Unsubscribe(value);
+    }
+
+    /// <inheritdoc/>
+    public WindowsRuntimeObjectReferenceValue GetInterface()
+    {
+        return _observableVectorObjectReference.AsValue();
+    }
+}

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Windows.Foundation.Collections;
 using WindowsRuntime.InteropServices;
 
@@ -31,9 +35,13 @@ public abstract class WindowsRuntimeObservableVector<
     TIIterableMethods,
     TIVector,
     TIVectorMethods,
-    TIObservableVectorMethods> : WindowsRuntimeList<T, TIIterable, TIIterableMethods, TIVectorMethods>,
+    TIObservableVectorMethods> : WindowsRuntimeObject,
     IObservableVector<T>,
-    IWindowsRuntimeInterface<IObservableVector<T>>
+    IList<T>,
+    IReadOnlyList<T>,
+    IWindowsRuntimeInterface<IObservableVector<T>>,
+    IWindowsRuntimeInterface<IList<T>>,
+    IWindowsRuntimeInterface<IEnumerable<T>>
     where TIIterable : IWindowsRuntimeInterface
     where TIIterableMethods : IIterableMethodsImpl<T>
     where TIVector : IWindowsRuntimeInterface
@@ -41,31 +49,161 @@ public abstract class WindowsRuntimeObservableVector<
     where TIObservableVectorMethods : IObservableVectorMethodsImpl<T>
 {
     /// <summary>
-    /// The cached object reference for <see cref="IObservableVector{T}"/> for the current object.
-    /// </summary>
-    private readonly WindowsRuntimeObjectReference _observableVectorObjectReference;
-
-    /// <summary>
-    /// Creates a <see cref="WindowsRuntimeList{T, TIIterable, TIEnumerableMethods, TIListMethods}"/> instance with the specified parameters.
+    /// Creates a <see cref="WindowsRuntimeObservableVector{T, TIIterable, TIIterableMethods, TIVector, TIVectorMethods, TIObservableVectorMethods}"/> instance with the specified parameters.
     /// </summary>
     /// <param name="nativeObjectReference">The inner Windows Runtime object reference to wrap in the current instance.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="nativeObjectReference"/> is <see langword="null"/>.</exception>
     protected WindowsRuntimeObservableVector(WindowsRuntimeObjectReference nativeObjectReference)
-        : base(nativeObjectReference.As(in TIVector.IID))
+        : base(nativeObjectReference)
     {
-        _observableVectorObjectReference = nativeObjectReference;
+    }
+
+    /// <summary>
+    /// Gets the lazy-loaded, cached object reference for <c>Windows.Foundation.Collections.IVector&lt;T&gt;</c> for the current object.
+    /// </summary>
+    private WindowsRuntimeObjectReference IVectorObjectReference
+    {
+        get
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            {
+                _ = Interlocked.CompareExchange(
+                    location1: ref field,
+                    value: NativeObjectReference.As(in TIVector.IID),
+                    comparand: null);
+
+                return field;
+            }
+
+            return field ?? InitializeInspectableObjectReference();
+        }
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeReadOnlyList{T, TIIterable, TIEnumerableMethods, TIReadOnlyListMethods}.IIterableObjectReference"/>
+    private WindowsRuntimeObjectReference IIterableObjectReference
+    {
+        get
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            {
+                _ = Interlocked.CompareExchange(
+                    location1: ref field,
+                    value: NativeObjectReference.As(in TIIterable.IID),
+                    comparand: null);
+
+                return field;
+            }
+
+            return field ?? InitializeInspectableObjectReference();
+        }
     }
 
     /// <inheritdoc/>
     public event VectorChangedEventHandler<T>? VectorChanged
     {
-        add => TIObservableVectorMethods.VectorChanged(this, _observableVectorObjectReference).Subscribe(value);
-        remove => TIObservableVectorMethods.VectorChanged(this, _observableVectorObjectReference).Unsubscribe(value);
+        add => TIObservableVectorMethods.VectorChanged(this, NativeObjectReference).Subscribe(value);
+        remove => TIObservableVectorMethods.VectorChanged(this, NativeObjectReference).Unsubscribe(value);
+    }
+
+    /// <inheritdoc/>
+    protected internal sealed override bool HasUnwrappableNativeObjectReference => true;
+
+    /// <inheritdoc/>
+    public int Count => IListMethods.Count(IVectorObjectReference);
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public T this[int index]
+    {
+        get => IListMethods<T>.Item<TIVectorMethods>(IVectorObjectReference, index);
+        set => IListMethods<T>.Item<TIVectorMethods>(IVectorObjectReference, index, value);
+    }
+
+    /// <inheritdoc/>
+    public int IndexOf(T item)
+    {
+        return IListMethods<T>.IndexOf<TIVectorMethods>(IVectorObjectReference, item);
+    }
+
+    /// <inheritdoc/>
+    public void Insert(int index, T item)
+    {
+        IListMethods<T>.Insert<TIVectorMethods>(IVectorObjectReference, index, item);
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        IListMethods.RemoveAt(IVectorObjectReference, index);
+    }
+
+    /// <inheritdoc/>
+    public void Add(T item)
+    {
+        IListMethods<T>.Add<TIVectorMethods>(IVectorObjectReference, item);
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        IListMethods.Clear(IVectorObjectReference);
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+    {
+        return IListMethods<T>.Contains<TIVectorMethods>(IVectorObjectReference, item);
+    }
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        IListMethods<T>.CopyTo<TIVectorMethods>(IVectorObjectReference, array, arrayIndex);
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        return IListMethods<T>.Remove<TIVectorMethods>(IVectorObjectReference, item);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator()
+    {
+        return TIIterableMethods.First(IIterableObjectReference);
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 
     /// <inheritdoc/>
     WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IObservableVector<T>>.GetInterface()
     {
-        return _observableVectorObjectReference.AsValue();
+        return NativeObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IList<T>>.GetInterface()
+    {
+        return IVectorObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IEnumerable<T>>.GetInterface()
+    {
+        return IIterableObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    protected sealed override bool IsOverridableInterface(in Guid iid)
+    {
+        return false;
     }
 }

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
@@ -66,7 +66,7 @@ public abstract class WindowsRuntimeObservableVector<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIVectorObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -76,7 +76,7 @@ public abstract class WindowsRuntimeObservableVector<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIVectorObjectReference();
         }
     }
 
@@ -86,7 +86,7 @@ public abstract class WindowsRuntimeObservableVector<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -96,7 +96,7 @@ public abstract class WindowsRuntimeObservableVector<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIIterableObjectReference();
         }
     }
 

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableVector{T}.cs
@@ -64,7 +64,7 @@ public abstract class WindowsRuntimeObservableVector<
     }
 
     /// <inheritdoc/>
-    public WindowsRuntimeObjectReferenceValue GetInterface()
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IObservableVector<T>>.GetInterface()
     {
         return _observableVectorObjectReference.AsValue();
     }

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeReadOnlyDictionary{TKey, TValue}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeReadOnlyDictionary{TKey, TValue}.cs
@@ -67,7 +67,7 @@ public abstract class WindowsRuntimeReadOnlyDictionary<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -77,7 +77,7 @@ public abstract class WindowsRuntimeReadOnlyDictionary<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIIterableObjectReference();
         }
     }
 

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeReadOnlyList{T}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeReadOnlyList{T}.cs
@@ -54,7 +54,7 @@ public abstract class WindowsRuntimeReadOnlyList<
         get
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            WindowsRuntimeObjectReference InitializeInspectableObjectReference()
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
             {
                 _ = Interlocked.CompareExchange(
                     location1: ref field,
@@ -64,7 +64,7 @@ public abstract class WindowsRuntimeReadOnlyList<
                 return field;
             }
 
-            return field ?? InitializeInspectableObjectReference();
+            return field ?? InitializeIIterableObjectReference();
         }
     }
 

--- a/src/WinRT.Runtime2/InteropServices/Collections/IObservableVectorMethodsImpl{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Collections/IObservableVectorMethodsImpl{T}.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace WindowsRuntime.InteropServices;
+
+/// <summary>
+/// An interface for implementations of <see cref="Windows.Foundation.Collections.IObservableVector{T}"/> types.
+/// </summary>
+/// <typeparam name="T">The type of elements in the observable vector.</typeparam>
+/// <remarks>
+/// This type should only be used by generated code.
+/// </remarks>
+[Obsolete("This type is an implementation detail, and it's only meant to be consumed by 'cswinrtgen'")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IObservableVectorMethodsImpl<T>
+{
+    /// <summary>
+    /// Returns the <see cref="EventSource{T}"/> instance associated with <see cref="Windows.Foundation.Collections.IObservableVector{T}.VectorChanged"/>.
+    /// </summary>
+    /// <param name="thisObject">The <see cref="WindowsRuntimeObject"/> instance to use.</param>
+    /// <param name="thisReference">The <see cref="WindowsRuntimeObjectReference"/> instance to use to invoke the native method.</param>
+    /// <returns>The <see cref="EventSource{T}"/> instance associated with <see cref="Windows.Foundation.Collections.IObservableVector{T}.VectorChanged"/>.</returns>
+    /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.vectorchanged"/>
+    static abstract VectorChangedEventHandlerEventSource<T> VectorChanged(WindowsRuntimeObject thisObject, WindowsRuntimeObjectReference thisReference);
+}


### PR DESCRIPTION
This PR updates cswinrtgen to emit code for `IObservableVector<T>` types.
Also includes some WinRT.Runtime tweaks in related supporting code.