### PR TITLE
Add `WindowsRuntimeReferenceAssemblyAttribute`

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeReferenceAssemblyAttribute.cs
+++ b/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeReferenceAssemblyAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace WindowsRuntime;
+
+/// <summary>
+/// Identifies an assembly as a Windows Runtime reference assembly, which contains metadata but no executable code.
+/// This is analogous to <see cref="System.Runtime.CompilerServices.ReferenceAssemblyAttribute"/>, but specifically
+/// for reference assemblies for generated Windows Runtime projections for a given Windows Runtime metadata file.
+/// </summary>
+/// <remarks>
+/// This attribute is emitted by the CsWinRT generator, and it is not meant to be used directly.
+/// </remarks>
+/// <seealso cref="System.Runtime.CompilerServices.ReferenceAssemblyAttribute"/>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+public sealed class WindowsRuntimeReferenceAssemblyAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new <see cref="WindowsRuntimeReferenceAssemblyAttribute"/> instance.
+    /// </summary>
+    public WindowsRuntimeReferenceAssemblyAttribute()
+    {
+    }
+}

--- a/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeReferenceAssemblyAttribute.cs
+++ b/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeReferenceAssemblyAttribute.cs
@@ -6,9 +6,10 @@ using System;
 namespace WindowsRuntime;
 
 /// <summary>
-/// Identifies an assembly as a Windows Runtime reference assembly, which contains metadata but no executable code.
-/// This is analogous to <see cref="System.Runtime.CompilerServices.ReferenceAssemblyAttribute"/>, but specifically
-/// for reference assemblies for generated Windows Runtime projections for a given Windows Runtime metadata file.
+/// Identifies an assembly as containing generated Windows Runtime APIs from a given Windows Runtime metadata file
+/// (.winmd). The annotated assembly can either be a reference assembly, which contains metadata but no executable code
+/// (analogous to <see cref="System.Runtime.CompilerServices.ReferenceAssemblyAttribute"/>), or an implementation assembly
+/// for Windows Runtime projections consumed directly from a local project reference.
 /// </summary>
 /// <remarks>
 /// This attribute is emitted by the CsWinRT generator, and it is not meant to be used directly.


### PR DESCRIPTION
Introduces a new attribute to identify assemblies as Windows Runtime reference assemblies. This attribute is intended for use by the CsWinRT generator and is analogous to `ReferenceAssemblyAttribute`, but specific to Windows Runtime projections.