### PR TITLE
Tweak WinRT.Runtime.dll

### DIFF
--- a/src/WinRT.Runtime2/ABI/System/Boolean.cs
+++ b/src/WinRT.Runtime2/ABI/System/Boolean.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Byte.cs
+++ b/src/WinRT.Runtime2/ABI/System/Byte.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Char.cs
+++ b/src/WinRT.Runtime2/ABI/System/Char.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
+++ b/src/WinRT.Runtime2/ABI/System/ComponentModel/INotifyDataErrorInfo.cs
@@ -111,7 +111,7 @@ public static unsafe class INotifyDataErrorInfoMethods
             {
                 [UnsafeAccessor(UnsafeAccessorKind.StaticMethod)]
                 static extern IEnumerable<object>? ConvertToManaged(
-                    [UnsafeAccessorType("ABI.System.Collections.Generic.<#corlib>IEnumerable`1<object>, WinRT.Interop.dll")] object? _,
+                    [UnsafeAccessorType("ABI.System.Collections.Generic.<#corlib>IEnumerable`1<object>Marshaller, WinRT.Interop.dll")] object? _,
                     void* value);
 
                 return ConvertToManaged(null, result)!;
@@ -233,7 +233,7 @@ public static unsafe class INotifyDataErrorInfoImpl
 
             [UnsafeAccessor(UnsafeAccessorKind.StaticMethod)]
             static extern EventHandler<DataErrorsChangedEventArgs>? ConvertToManaged(
-                [UnsafeAccessorType("ABI.System.<#corlib>EventHandler`1<<#corlib>System-ComponentModel-DataErrorsChangedEventArgs>, WinRT.Interop.dll")] object? _,
+                [UnsafeAccessorType("ABI.System.<#corlib>EventHandler`1<<#corlib>System-ComponentModel-DataErrorsChangedEventArgs>Marshaller, WinRT.Interop.dll")] object? _,
                 void* value);
 
             EventHandler<DataErrorsChangedEventArgs>? managedHandler = ConvertToManaged(null, handler);
@@ -284,11 +284,11 @@ public static unsafe class INotifyDataErrorInfoImpl
             IEnumerable managedResult = unboxedValue.GetErrors(HStringMarshaller.ConvertToManaged(propertyName));
 
             [UnsafeAccessor(UnsafeAccessorKind.StaticMethod)]
-            static extern void* ConvertToUnmanaged(
-                [UnsafeAccessorType("ABI.System.Collections.Generic.<#corlib>IEnumerable`1<object>, WinRT.Interop.dll")] object? _,
+            static extern WindowsRuntimeObjectReferenceValue ConvertToUnmanaged(
+                [UnsafeAccessorType("ABI.System.Collections.Generic.<#corlib>IEnumerable`1<object>Marshaller, WinRT.Interop.dll")] object? _,
                 IEnumerable<object>? value);
 
-            *result = ConvertToUnmanaged(null, (IEnumerable<object>)managedResult);
+            *result = ConvertToUnmanaged(null, (IEnumerable<object>)managedResult).DetachThisPtrUnsafe();
 
             return WellKnownErrorCodes.S_OK;
         }

--- a/src/WinRT.Runtime2/ABI/System/DateTimeOffset.cs
+++ b/src/WinRT.Runtime2/ABI/System/DateTimeOffset.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Double.cs
+++ b/src/WinRT.Runtime2/ABI/System/Double.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Guid.cs
+++ b/src/WinRT.Runtime2/ABI/System/Guid.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE0008, IDE1006
+#pragma warning disable IDE0008, IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Int16.cs
+++ b/src/WinRT.Runtime2/ABI/System/Int16.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Int32.cs
+++ b/src/WinRT.Runtime2/ABI/System/Int32.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Int64.cs
+++ b/src/WinRT.Runtime2/ABI/System/Int64.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Single.cs
+++ b/src/WinRT.Runtime2/ABI/System/Single.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/String.cs
+++ b/src/WinRT.Runtime2/ABI/System/String.cs
@@ -12,7 +12,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE0008, IDE1006
+#pragma warning disable IDE0008, IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/TimeSpan.cs
+++ b/src/WinRT.Runtime2/ABI/System/TimeSpan.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/Type.cs
+++ b/src/WinRT.Runtime2/ABI/System/Type.cs
@@ -17,7 +17,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/UInt16.cs
+++ b/src/WinRT.Runtime2/ABI/System/UInt16.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/UInt32.cs
+++ b/src/WinRT.Runtime2/ABI/System/UInt32.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/System/UInt64.cs
+++ b/src/WinRT.Runtime2/ABI/System/UInt64.cs
@@ -11,7 +11,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/CollectionChange.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/CollectionChange.cs
@@ -9,7 +9,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Point.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Point.cs
@@ -10,7 +10,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Rect.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Rect.cs
@@ -10,7 +10,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Size.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Size.cs
@@ -10,7 +10,7 @@ using WindowsRuntime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 [assembly: TypeMap<WindowsRuntimeComWrappersTypeMapGroup>(

--- a/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.InspectableArray.cs
+++ b/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.InspectableArray.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 using WindowsRuntime.InteropServices.Marshalling;
 using static System.Runtime.InteropServices.ComWrappers;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 namespace WindowsRuntime.InteropServices;
 

--- a/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.OtherType.cs
+++ b/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.OtherType.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 namespace WindowsRuntime.InteropServices;
 

--- a/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.OtherTypeArray.cs
+++ b/src/WinRT.Runtime2/InteropServices/ProjectionImpls/IPropertyValueImpl.OtherTypeArray.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
 
-#pragma warning disable IDE1006
+#pragma warning disable IDE1006, CA1416
 
 namespace WindowsRuntime.InteropServices;
 

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/CollectionChange.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/CollectionChange.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Runtime.Versioning;
 using ABI.Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
@@ -19,6 +20,7 @@ namespace Windows.Foundation.Collections;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.collectionchange"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Collections.CollectionChange>")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [CollectionChangeComWrappersMarshaller]
 public enum CollectionChange

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/CollectionChange.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/CollectionChange.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using ABI.Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -18,6 +19,7 @@ namespace Windows.Foundation.Collections;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.collectionchange"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Collections.CollectionChange>")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [CollectionChangeComWrappersMarshaller]
 public enum CollectionChange
 {

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/IMapChangedEventArgs{K}.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/IMapChangedEventArgs{K}.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -10,6 +11,7 @@ namespace Windows.Foundation.Collections;
 /// </summary>
 /// <typeparam name="K">The type of keys in the map.</typeparam>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public interface IMapChangedEventArgs<K>
 {
     /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/IObservableMap{K, V}.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/IObservableMap{K, V}.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -13,6 +14,7 @@ namespace Windows.Foundation.Collections;
 /// <typeparam name="K">The type of keys in the observable map.</typeparam>
 /// <typeparam name="V">The type of values in the observable map.</typeparam>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public interface IObservableMap<K, V> : IDictionary<K, V>, ICollection<KeyValuePair<K, V>>, IEnumerable<KeyValuePair<K, V>>, IEnumerable
 {
     /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/IObservableVector{T}.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/IObservableVector{T}.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -12,6 +13,7 @@ namespace Windows.Foundation.Collections;
 /// </summary>
 /// <typeparam name="T">The type of elements in the observable vector.</typeparam>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public interface IObservableVector<T> : IList<T>, ICollection<T>, IEnumerable<T>, IEnumerable
 {
     /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/IVectorChangedEventArgs.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -9,6 +10,7 @@ namespace Windows.Foundation.Collections;
 /// Provides data for the changed event of a vector.
 /// </summary>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public interface IVectorChangedEventArgs
 {
     /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/MapChangedEventHandler{K, V}.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/MapChangedEventHandler{K, V}.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -13,4 +14,5 @@ namespace Windows.Foundation.Collections;
 /// <param name="sender">The observable map that changed.</param>
 /// <param name="event">The description of the change that occurred in the map.</param>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public delegate void MapChangedEventHandler<K, V>(IObservableMap<K, V> sender, IMapChangedEventArgs<K> @event);

--- a/src/WinRT.Runtime2/Windows.Foundation/Collections/VectorChangedEventHandler{T}.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Collections/VectorChangedEventHandler{T}.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation.Collections;
@@ -12,4 +13,5 @@ namespace Windows.Foundation.Collections;
 /// <param name="sender">The observable vector that changed.</param>
 /// <param name="event">The description of the change that occurred in the vector.</param>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 public delegate void VectorChangedEventHandler<T>(IObservableVector<T> sender, IVectorChangedEventArgs @event);

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
@@ -5,6 +5,8 @@ using System;
 using System.Runtime.Versioning;
 using WindowsRuntime;
 
+#pragma warning disable IDE0060
+
 namespace Windows.Foundation.Metadata;
 
 /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Versioning;
+using WindowsRuntime;
+
+namespace Windows.Foundation.Metadata;
+
+/// <summary>
+/// Indicates the version of the API contract.
+/// </summary>
+/// <remarks>
+/// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
+/// </remarks>
+[WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+[SupportedOSPlatform("Windows10.0.10240.0")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
+public sealed class ContractVersionAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new <see cref="ContractVersionAttribute"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="version">The version of the API contract.</param>
+    public ContractVersionAttribute(uint version)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ContractVersionAttribute"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="contract">The type to associate with the API contract.</param>
+    /// <param name="version">The version of the API contract.</param>
+    public ContractVersionAttribute(Type contract, uint version)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ContractVersionAttribute"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="contract">The type to associate with the API contract.</param>
+    /// <param name="version">The version of the API contract.</param>
+    public ContractVersionAttribute(string contract, uint version)
+    {
+    }
+}

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/FoundationContract.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/FoundationContract.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Windows.Foundation.Metadata;
+
+/// <summary>
+/// Represents the Windows Foundation API contract.
+/// </summary>
+/// <remarks>
+/// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
+/// </remarks>
+[ContractVersion(262144u)]
+public enum FoundationContract;

--- a/src/WinRT.Runtime2/Windows.Foundation/Point.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Point.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using ABI.Windows.Foundation;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
@@ -19,6 +20,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.point"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Point>")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [PointComWrappersMarshaller]
 public struct Point : IEquatable<Point>, IFormattable

--- a/src/WinRT.Runtime2/Windows.Foundation/Point.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Point.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using ABI.Windows.Foundation;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation;
@@ -18,6 +19,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.point"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Point>")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [PointComWrappersMarshaller]
 public struct Point : IEquatable<Point>, IFormattable
 {

--- a/src/WinRT.Runtime2/Windows.Foundation/PropertyType.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/PropertyType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using System.Runtime.Versioning;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
@@ -15,6 +16,7 @@ namespace Windows.Foundation;
 /// </remarks>
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.propertytype"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public enum PropertyType : uint

--- a/src/WinRT.Runtime2/Windows.Foundation/PropertyType.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/PropertyType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation;
@@ -14,6 +15,7 @@ namespace Windows.Foundation;
 /// </remarks>
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.propertytype"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public enum PropertyType : uint
 {

--- a/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using ABI.Windows.Foundation;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
@@ -20,6 +21,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.rect"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Rect>")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [RectComWrappersMarshaller]
 public struct Rect : IEquatable<Rect>, IFormattable

--- a/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using ABI.Windows.Foundation;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 #pragma warning disable IDE0046
@@ -19,6 +20,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.rect"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Rect>")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [RectComWrappersMarshaller]
 public struct Rect : IEquatable<Rect>, IFormattable
 {

--- a/src/WinRT.Runtime2/Windows.Foundation/Size.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Size.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using ABI.Windows.Foundation;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
@@ -18,6 +19,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.size"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Size>")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [SizeComWrappersMarshaller]
 public struct Size : IEquatable<Size>, IFormattable

--- a/src/WinRT.Runtime2/Windows.Foundation/Size.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Size.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using ABI.Windows.Foundation;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.Foundation;
@@ -17,6 +18,7 @@ namespace Windows.Foundation;
 /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.size"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [WindowsRuntimeClassName("Windows.Foundation.IReference<Windows.Foundation.Size>")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [SizeComWrappersMarshaller]
 public struct Size : IEquatable<Size>, IFormattable
 {

--- a/src/WinRT.Runtime2/Windows.Foundation/TrustLevel.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/TrustLevel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
-using WindowsRuntime;
 
 namespace Windows.Foundation;
 
@@ -13,7 +12,6 @@ namespace Windows.Foundation;
 /// This type is required for ABI projection of Windows Runtime types, but marshalling it is not supported.
 /// </remarks>
 /// <see href="https://learn.microsoft.com/windows/win32/api/inspectable/ne-inspectable-trustlevel"/>
-[WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public enum TrustLevel
 {

--- a/src/WinRT.Runtime2/Windows.UI.Xaml.Interop/TypeKind.cs
+++ b/src/WinRT.Runtime2/Windows.UI.Xaml.Interop/TypeKind.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
 namespace Windows.UI.Xaml.Interop;
@@ -14,6 +15,7 @@ namespace Windows.UI.Xaml.Interop;
 /// </remarks>
 /// <see href="https://learn.microsoft.com/uwp/api/windows.ui.xaml.interop.typekind"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public enum TypeKind
 {

--- a/src/WinRT.Runtime2/Windows.UI.Xaml.Interop/TypeKind.cs
+++ b/src/WinRT.Runtime2/Windows.UI.Xaml.Interop/TypeKind.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using System.Runtime.Versioning;
 using Windows.Foundation.Metadata;
 using WindowsRuntime;
 
@@ -15,6 +16,7 @@ namespace Windows.UI.Xaml.Interop;
 /// </remarks>
 /// <see href="https://learn.microsoft.com/uwp/api/windows.ui.xaml.interop.typekind"/>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public enum TypeKind


### PR DESCRIPTION
This PR includes a few changes:
- Fixes some `[UnsafeAccessor]` uses
- Adds `FoundationContract` and `[ContractVersion]` to WinRT.Runtime.dll
- Annotates the projected types in WinRT.Runtime with `[ContractVersion]`