### PR TITLE
Emit `IObservableMap<K, V>` types

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
@@ -108,24 +108,29 @@ internal partial class InteropTypeDefinitionBuilder
         /// <param name="delegateType">The <see cref="TypeSignature"/> for the delegate type.</param>
         /// <param name="marshallerType">The <see cref="TypeDefinition"/> instance returned by <see cref="Delegate.Marshaller"/>.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
         /// <param name="module">The module that will contain the type being created.</param>
         /// <param name="eventSourceType">The resulting event source type.</param>
         public static void MapChangedEventHandler2(
             GenericInstanceTypeSignature delegateType,
             TypeDefinition marshallerType,
             InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
             ModuleDefinition module,
             out TypeDefinition eventSourceType)
         {
             DerivedEventSource(
                 delegateType: delegateType,
-                baseEventSourceType: interopReferences.EventHandler2EventSource,
+                baseEventSourceType: interopReferences.MapChangedEventHandler2EventSource,
                 baseEventSource_ctor: interopReferences.MapChangedEventHandler2EventSource_ctor,
                 baseEventSourceConvertToUnmanaged: interopReferences.MapChangedEventHandler2EventSourceConvertToUnmanaged(delegateType),
                 marshallerType: marshallerType,
                 interopReferences: interopReferences,
                 module: module,
                 eventSourceType: out eventSourceType);
+
+            // We need the event source later, for the 'IObservableMap<K, V>' implementation
+            emitState.TrackTypeDefinition(eventSourceType, delegateType, "EventSource");
         }
 
         /// <summary>

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
@@ -812,7 +812,9 @@ internal partial class InteropTypeDefinitionBuilder
                 Interfaces =
                 {
                     new InterfaceImplementation(dictionaryType.Import(module).ToTypeDefOrRef()),
-                    new InterfaceImplementation(collectionType.Import(module).ToTypeDefOrRef())
+                    new InterfaceImplementation(collectionType.Import(module).ToTypeDefOrRef()),
+                    new InterfaceImplementation(enumerableType.Import(module).ToTypeDefOrRef()),
+                    new InterfaceImplementation(interopReferences.IEnumerable.Import(module))
                 }
             };
 

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
@@ -47,6 +47,54 @@ internal partial class InteropTypeDefinitionBuilder
         }
 
         /// <summary>
+        /// Creates a new type definition for the interface type for some <c>IMap&lt;K, V&gt;</c> interface.
+        /// </summary>
+        /// <param name="dictionaryType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> type.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="dictionaryType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="interfaceType">The resulting interface type.</param>
+        public static void Interface(
+            GenericInstanceTypeSignature dictionaryType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module,
+            out TypeDefinition interfaceType)
+        {
+            // We're declaring an 'internal abstract class' type
+            interfaceType = new TypeDefinition(
+                ns: InteropUtf8NameFactory.TypeNamespace(dictionaryType),
+                name: InteropUtf8NameFactory.TypeName(dictionaryType, "Interface"),
+                attributes: TypeAttributes.AutoLayout | TypeAttributes.Abstract | TypeAttributes.BeforeFieldInit,
+                baseType: module.CorLibTypeFactory.Object.ToTypeDefOrRef())
+            {
+                Interfaces = { new InterfaceImplementation(interopReferences.IWindowsRuntimeInterface.Import(module)) }
+            };
+
+            module.TopLevelTypes.Add(interfaceType);
+
+            // Track the type (it's needed by 'IObservableMap<K, V>')
+            emitState.TrackTypeDefinition(interfaceType, dictionaryType, "Interface");
+
+            // Create the public 'IID' property
+            WellKnownMemberDefinitionFactory.IID(
+                forwardedIidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out MethodDefinition get_IidMethod2,
+                out PropertyDefinition iidProperty);
+
+            interfaceType.Properties.Add(iidProperty);
+
+            // Add and implement the 'get_IID' method
+            interfaceType.AddMethodImplementation(
+                declaration: interopReferences.IWindowsRuntimeInterfaceget_IID.Import(module),
+                method: get_IidMethod2);
+        }
+
+        /// <summary>
         /// Creates a new type definition for the vtable for an <c>IMap&lt;K, V&gt;</c> interface.
         /// </summary>
         /// <param name="dictionaryType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> type.</param>

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IDictionary2.cs
@@ -168,12 +168,14 @@ internal partial class InteropTypeDefinitionBuilder
         /// <param name="dictionaryType">The <see cref="GenericInstanceTypeSignature"/> for the <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> type.</param>
         /// <param name="vftblType">The type returned by <see cref="Vftbl"/>.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
         /// <param name="module">The interop module being built.</param>
         /// <param name="mapMethodsType">The resulting methods type.</param>
         public static void IMapMethods(
             GenericInstanceTypeSignature dictionaryType,
             TypeDefinition vftblType,
             InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
             ModuleDefinition module,
             out TypeDefinition mapMethodsType)
         {
@@ -191,6 +193,9 @@ internal partial class InteropTypeDefinitionBuilder
             };
 
             module.TopLevelTypes.Add(mapMethodsType);
+
+            // Track the type (it's needed by 'IObservableMap<K, V>')
+            emitState.TrackTypeDefinition(mapMethodsType, dictionaryType, "IMapMethods");
 
             // Define the 'HasKey' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -483,5 +483,35 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out proxyType);
         }
+
+        /// <summary>
+        /// Creates the type map attributes for some <c>IObservableMap&lt;K,V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
+        /// <param name="proxyType">The <see cref="TypeDefinition"/> instance returned by <see cref="InteropTypeDefinitionBuilder.Proxy"/>.</param>
+        /// <param name="interfaceImplType">The <see cref="TypeDefinition"/> instance returned by <see cref="InterfaceImpl"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        public static void TypeMapAttributes(
+            GenericInstanceTypeSignature mapType,
+            TypeDefinition proxyType,
+            TypeDefinition interfaceImplType,
+            InteropReferences interopReferences,
+            ModuleDefinition module)
+        {
+            TypeSignature keyType = mapType.TypeArguments[0];
+            TypeSignature valueType = mapType.TypeArguments[1];
+
+            InteropTypeDefinitionBuilder.TypeMapAttributes(
+                runtimeClassName: $"Windows.Foundation.Collections.IObservableMap`2<{keyType},{valueType}>", // TODO
+                externalTypeMapTargetType: proxyType.ToReferenceTypeSignature(),
+                externalTypeMapTrimTargetType: mapType,
+                proxyTypeMapSourceType: null,
+                proxyTypeMapProxyType: null,
+                interfaceTypeMapSourceType: mapType,
+                interfaceTypeMapProxyType: interfaceImplType.ToReferenceTypeSignature(),
+                interopReferences: interopReferences,
+                module: module);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -323,5 +323,31 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out marshallerType);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the marshaller of some <c>IObservableMap&lt;K, V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
+        /// <param name="mapComWrappersCallbackType">The <see cref="TypeDefinition"/> instance returned by <see cref="ComWrappersCallbackType"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="mapType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="marshallerType">The resulting marshaller type.</param>
+        public static void Marshaller(
+            GenericInstanceTypeSignature mapType,
+            TypeDefinition mapComWrappersCallbackType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition marshallerType)
+        {
+            InteropTypeDefinitionBuilder.Marshaller(
+                typeSignature: mapType,
+                interfaceComWrappersCallbackType: mapComWrappersCallbackType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out marshallerType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -453,5 +453,35 @@ internal partial class InteropTypeDefinitionBuilder
 
             interfaceImplType.Events.Add(observableMap2MapChangedProperty);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the proxy type of some <c>IObservableMap&lt;K,V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
+        /// <param name="mapComWrappersMarshallerAttributeType">The <see cref="TypeDefinition"/> instance returned by <see cref="ComWrappersMarshallerAttribute"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="proxyType">The resulting proxy type.</param>
+        public static void Proxy(
+            GenericInstanceTypeSignature mapType,
+            TypeDefinition mapComWrappersMarshallerAttributeType,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition proxyType)
+        {
+            TypeSignature keyType = mapType.TypeArguments[0];
+            TypeSignature valueType = mapType.TypeArguments[1];
+
+            string runtimeClassName = $"Windows.Foundation.Collections.IObservableMap`2<{keyType},{valueType}>"; // TODO
+
+            InteropTypeDefinitionBuilder.Proxy(
+                ns: InteropUtf8NameFactory.TypeNamespace(mapType),
+                name: InteropUtf8NameFactory.TypeName(mapType),
+                runtimeClassName: runtimeClassName,
+                comWrappersMarshallerAttributeType: mapComWrappersMarshallerAttributeType,
+                interopReferences: interopReferences,
+                module: module,
+                out proxyType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -274,7 +274,7 @@ internal partial class InteropTypeDefinitionBuilder
         /// <summary>
         /// Creates a new type definition for the implementation of the <c>IWindowsRuntimeUnsealedObjectComWrappersCallback</c> interface for some <c>IObservableMap&lt;K, V&gt;</c> interface.
         /// </summary>
-        /// <param name="mapType">The <see cref="TypeSignature"/> for the vector type.</param>
+        /// <param name="mapType">The <see cref="TypeSignature"/> for the map type.</param>
         /// <param name="nativeObjectType">The type returned by <see cref="NativeObject"/>.</param>
         /// <param name="get_IidMethod">The 'IID' get method for <paramref name="mapType"/>.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
@@ -296,6 +296,32 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences,
                 module: module,
                 out callbackType);
+        }
+
+        /// <summary>
+        /// Creates a new type definition for the marshaller attribute of some <c>IObservableMap&lt;K, V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
+        /// <param name="nativeObjectType">The type returned by <see cref="NativeObject"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="mapType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The module that will contain the type being created.</param>
+        /// <param name="marshallerType">The resulting marshaller type.</param>
+        public static void ComWrappersMarshallerAttribute(
+            GenericInstanceTypeSignature mapType,
+            TypeDefinition nativeObjectType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition marshallerType)
+        {
+            InteropTypeDefinitionBuilder.ComWrappersMarshallerAttribute(
+                typeSignature: mapType,
+                nativeObjectType: nativeObjectType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out marshallerType);
         }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -514,7 +514,7 @@ internal partial class InteropTypeDefinitionBuilder
                 interfaceType: ComInterfaceType.InterfaceIsIInspectable,
                 ns: InteropUtf8NameFactory.TypeNamespace(mapType),
                 name: InteropUtf8NameFactory.TypeName(mapType, "Impl"),
-                vftblType: interopDefinitions.IObservableVectorVftbl,
+                vftblType: interopDefinitions.IObservableMapVftbl,
                 get_IidMethod: get_IidMethod,
                 interopDefinitions: interopDefinitions,
                 interopReferences: interopReferences,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -270,5 +270,32 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 out nativeObjectType);
         }
+
+        /// <summary>
+        /// Creates a new type definition for the implementation of the <c>IWindowsRuntimeUnsealedObjectComWrappersCallback</c> interface for some <c>IObservableMap&lt;K, V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="TypeSignature"/> for the vector type.</param>
+        /// <param name="nativeObjectType">The type returned by <see cref="NativeObject"/>.</param>
+        /// <param name="get_IidMethod">The 'IID' get method for <paramref name="mapType"/>.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="callbackType">The resulting callback type.</param>
+        public static void ComWrappersCallbackType(
+            TypeSignature mapType,
+            TypeDefinition nativeObjectType,
+            MethodDefinition get_IidMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out TypeDefinition callbackType)
+        {
+            ComWrappersCallback(
+                runtimeClassName: mapType.FullName, // TODO
+                typeSignature: mapType,
+                nativeObjectType: nativeObjectType,
+                get_IidMethod: get_IidMethod,
+                interopReferences: interopReferences,
+                module: module,
+                out callbackType);
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -4,8 +4,12 @@
 using System;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using CommunityToolkit.HighPerformance;
 using WindowsRuntime.InteropGenerator.Factories;
+using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
 namespace WindowsRuntime.InteropGenerator.Builders;
 
@@ -20,7 +24,7 @@ internal partial class InteropTypeDefinitionBuilder
         /// <summary>
         /// Creates the 'IID' property for some <c>IObservableMap&lt;K, V&gt;</c> interface.
         /// </summary>
-        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
         /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
         /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
         /// <param name="module">The interop module being built.</param>
@@ -39,6 +43,99 @@ internal partial class InteropTypeDefinitionBuilder
                 module: module,
                 iid: Guid.NewGuid(), // TODO
                 out get_IidMethod);
+        }
+
+        /// <summary>
+        /// Creates the cached factory type for the property for the event args for the map.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the map type.</param>
+        /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="factoryType">The resulting factory type.</param>
+        public static void EventSourceFactory(
+            GenericInstanceTypeSignature mapType,
+            InteropDefinitions interopDefinitions,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module,
+            out TypeDefinition factoryType)
+        {
+            TypeSignature keyType = mapType.TypeArguments[0];
+            TypeSignature valueType = mapType.TypeArguments[1];
+
+            // We're declaring an 'internal sealed class' type
+            factoryType = new TypeDefinition(
+                ns: InteropUtf8NameFactory.TypeNamespace(mapType),
+                name: InteropUtf8NameFactory.TypeName(mapType, "EventSourceFactory"),
+                attributes: TypeAttributes.AutoLayout | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+                baseType: module.CorLibTypeFactory.Object.ToTypeDefOrRef());
+
+            module.TopLevelTypes.Add(factoryType);
+
+            // 'Instance' field with the cached factory instance
+            factoryType.Fields.Add(new FieldDefinition("Instance"u8, FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly, factoryType.ToReferenceTypeSignature()));
+
+            // The actual factory is of type 'Func<WindowsRuntimeObject, WindowsRuntimeObjectReference, MapChangedEventHandlerEventSource<<KEY_TYPE>, <VALUE_TYPE>>>'
+            TypeSignature funcType = interopReferences.Func3.MakeGenericReferenceType(
+                interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature(),
+                interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                interopReferences.MapChangedEventHandler2EventSource.MakeGenericReferenceType(keyType, valueType));
+
+            // 'Value' field with the cached factory delegate
+            factoryType.Fields.Add(new FieldDefinition("Value"u8, FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly, funcType.Import(module)));
+
+            // Add the parameterless constructor
+            factoryType.Methods.Add(MethodDefinition.CreateDefaultConstructor(module));
+
+            // The key for the lookup below is the associated handler type (which we need to construct), not the interface type
+            TypeSignature handlerType = interopReferences.MapChangedEventHandler2.MakeGenericReferenceType(keyType, valueType);
+
+            // Get the constructor for the generic event source type
+            MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
+                comparer: SignatureComparer.IgnoreVersion,
+                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.CorLibTypeFactory.Int32])!;
+
+            // Define the 'Callback' method as follows:
+            //
+            // public MapChangedEventHandlerEventSource<<KEY_TYPE>, <VALUE_TYPE>> Callback(WindowsRuntimeObject thisObject, WindowsRuntimeObjectReference thisReference)
+            MethodDefinition callbackMethod = new(
+                name: "Callback"u8,
+                attributes: MethodAttributes.Private | MethodAttributes.HideBySig,
+                signature: MethodSignature.CreateInstance(
+                    returnType: interopReferences.MapChangedEventHandler2EventSource.MakeGenericReferenceType(keyType, valueType).Import(module),
+                    parameterTypes: [
+                        interopReferences.WindowsRuntimeObject.ToReferenceTypeSignature().Import(module),
+                        interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature().Import(module)]))
+            {
+                CilInstructions =
+                {
+                    { Ldarg_2 },
+                    { Ldc_I4_6 },
+                    { Newobj, eventSourceConstructor },
+                    { Ret }
+                }
+            };
+
+            factoryType.Methods.Add(callbackMethod);
+
+            // We need the static constructor to initialize the static fields
+            MethodDefinition cctor = factoryType.GetOrCreateStaticConstructor(module);
+
+            cctor.CilInstructions.Clear();
+
+            // Create a new instance of the factory type and store it in the 'Instance' field
+            _ = cctor.CilInstructions.Add(Newobj, factoryType.GetConstructor()!);
+            _ = cctor.CilInstructions.Add(Stsfld, factoryType.Fields[0]);
+
+            // Create the delegate type and store it in the 'Value' field
+            _ = cctor.CilInstructions.Add(Ldsfld, factoryType.Fields[0]);
+            _ = cctor.CilInstructions.Add(Ldftn, callbackMethod);
+            _ = cctor.CilInstructions.Add(Newobj, interopReferences.Delegate_ctor(funcType).Import(module));
+            _ = cctor.CilInstructions.Add(Stsfld, factoryType.Fields[1]);
+
+            _ = cctor.CilInstructions.Add(Ret);
         }
     }
 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.InteropGenerator.Factories;
+using WindowsRuntime.InteropGenerator.References;
+
+namespace WindowsRuntime.InteropGenerator.Builders;
+
+/// <inheritdoc cref="InteropTypeDefinitionBuilder"/>
+internal partial class InteropTypeDefinitionBuilder
+{
+    /// <summary>
+    /// Helpers for <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> types.
+    /// </summary>
+    public static class IObservableMap2
+    {
+        /// <summary>
+        /// Creates the 'IID' property for some <c>IObservableMap&lt;K, V&gt;</c> interface.
+        /// </summary>
+        /// <param name="mapType">The <see cref="GenericInstanceTypeSignature"/> for the vector type.</param>
+        /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The interop module being built.</param>
+        /// <param name="get_IidMethod">The resulting 'IID' get method for <paramref name="mapType"/>.</param>
+        public static void IID(
+            GenericInstanceTypeSignature mapType,
+            InteropDefinitions interopDefinitions,
+            InteropReferences interopReferences,
+            ModuleDefinition module,
+            out MethodDefinition get_IidMethod)
+        {
+            InteropTypeDefinitionBuilder.IID(
+                name: InteropUtf8NameFactory.TypeName(mapType, "IID"),
+                interopDefinitions: interopDefinitions,
+                interopReferences: interopReferences,
+                module: module,
+                iid: Guid.NewGuid(), // TODO
+                out get_IidMethod);
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
+++ b/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
@@ -371,6 +371,14 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
+    /// Failed to generate marshalling code for an <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> type.
+    /// </summary>
+    public static Exception IObservableMapTypeCodeGenerationError(TypeSignature elementType, Exception exception)
+    {
+        return Exception(42, $"Failed to generate marshalling code for 'IObservableMap<K, V>' type '{elementType}'.", exception);
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     /// <param name="id">The exception id.</param>

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
@@ -47,9 +47,7 @@ internal partial class InteropMethodDefinitionFactory
             TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
 
             // Prepare the 'ConditionalWeakTable<<MAP_TYPE>, EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>>' signature
-            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
-                mapType,
-                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(mapType, eventRegistrationTokenTableType);
 
             // Define the 'add_MapChanged' method as follows:
             //
@@ -176,9 +174,7 @@ internal partial class InteropMethodDefinitionFactory
             TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
 
             // Prepare the 'ConditionalWeakTable<<MAP_TYPE>, EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>>' signature
-            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
-                mapType,
-                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(mapType, eventRegistrationTokenTableType);
 
             // Define the 'remove_MapChanged' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
@@ -208,7 +208,7 @@ internal partial class InteropMethodDefinitionFactory
             CilLocalVariable loc_2_managedHandler = new(eventHandlerType.Import(module));
             CilLocalVariable loc_3_hresult = new(module.CorLibTypeFactory.Int32);
 
-            // Create a method body for the 'add_MapChanged' method
+            // Create a method body for the 'remove_MapChanged' method
             remove_MapChangedMethod.CilMethodBody = new CilMethodBody()
             {
                 LocalVariables = { loc_0_unboxedValue, loc_1_table, loc_2_managedHandler, loc_3_hresult },

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableMap2Impl.cs
@@ -1,0 +1,278 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.InteropGenerator.Generation;
+using WindowsRuntime.InteropGenerator.References;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
+
+#pragma warning disable IDE1006
+
+namespace WindowsRuntime.InteropGenerator.Factories;
+
+/// <inheritdoc cref="InteropMethodDefinitionFactory"/>
+internal partial class InteropMethodDefinitionFactory
+{
+    /// <summary>
+    /// Helpers for impl types for <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;</c> interfaces.
+    /// </summary>
+    public static class IObservableMap2Impl
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDefinition"/> for the <c>add_MapChanged</c> export method.
+        /// </summary>
+        /// <param name="mapType">The <see cref="TypeSignature"/> for the map type.</param>
+        /// <param name="get_MapChangedTableMethod">The <see cref="MethodDefinition"/> to get the event token table.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="emitState">The emit state for this invocation.</param>
+        /// <param name="module">The interop module being built.</param>
+        public static MethodDefinition add_MapChanged(
+            GenericInstanceTypeSignature mapType,
+            MethodDefinition get_MapChangedTableMethod,
+            InteropReferences interopReferences,
+            InteropGeneratorEmitState emitState,
+            ModuleDefinition module)
+        {
+            TypeSignature keyType = mapType.TypeArguments[0];
+            TypeSignature valueType = mapType.TypeArguments[1];
+
+            // Prepare the 'MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>' signature
+            TypeSignature eventHandlerType = interopReferences.MapChangedEventHandler2.MakeGenericReferenceType(keyType, valueType);
+
+            // Prepare the 'EventRegistrationTokenTable<MapChangedEventHandler<KEY_TYPE>, <VALUE_TYPE>>' signature
+            TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
+
+            // Prepare the 'ConditionalWeakTable<<MAP_TYPE>, EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>>' signature
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
+                mapType,
+                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+
+            // Define the 'add_MapChanged' method as follows:
+            //
+            // [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+            // private static int add_MapChanged(void* thisPtr, void* handler, EventRegistrationToken* token)
+            MethodDefinition add_MapChangedMethod = new(
+                name: "add_MapChanged"u8,
+                attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
+                signature: MethodSignature.CreateStatic(
+                    returnType: module.CorLibTypeFactory.Int32,
+                    parameterTypes: [
+                        module.CorLibTypeFactory.Void.MakePointerType(),
+                        module.CorLibTypeFactory.Void.MakePointerType(),
+                        interopReferences.EventRegistrationToken.MakePointerType().Import(module)]))
+            {
+                CustomAttributes = { InteropCustomAttributeFactory.UnmanagedCallersOnly(interopReferences, module) }
+            };
+
+            // Jump labels
+            CilInstruction ldc_i4_e_pointer = new(Ldc_I4, unchecked((int)0x80004003));
+            CilInstruction nop_beforeTry = new(Nop);
+            CilInstruction ldarg_0_tryStart = new(Ldarg_0);
+            CilInstruction callvirt_catchHResult = new(Callvirt, interopReferences.Exceptionget_HResult.Import(module));
+            CilInstruction ldloc_2_returnHResult = new(Ldloc_2);
+
+            // Declare the local variables:
+            //   [0]: '<MAP_TYPE>' (the 'unboxedValue' object)
+            //   [1]: 'MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>' (the 'managedHandler' object)
+            //   [2]: 'int' (the 'HRESULT' to return)
+            CilLocalVariable loc_0_unboxedValue = new(mapType.Import(module));
+            CilLocalVariable loc_1_managedHandler = new(eventHandlerType.Import(module));
+            CilLocalVariable loc_2_hresult = new(module.CorLibTypeFactory.Int32);
+
+            // Create a method body for the 'add_MapChanged' method
+            add_MapChangedMethod.CilMethodBody = new CilMethodBody()
+            {
+                LocalVariables = { loc_0_unboxedValue, loc_1_managedHandler, loc_2_hresult },
+                Instructions =
+                {
+                    // Return 'E_POINTER' if either argument is 'null'
+                    { Ldarg_1 },
+                    { Ldc_I4_0 },
+                    { Conv_U },
+                    { Beq_S, ldc_i4_e_pointer.CreateLabel() },
+                    { Ldarg_2 },
+                    { Ldc_I4_0 },
+                    { Conv_U },
+                    { Bne_Un_S, nop_beforeTry.CreateLabel() },
+                    { ldc_i4_e_pointer },
+                    { Ret },
+                    { nop_beforeTry },
+
+                    // '.try' code
+                    { ldarg_0_tryStart },
+                    { Call, interopReferences.ComInterfaceDispatchGetInstance.MakeGenericInstanceMethod(mapType).Import(module) },
+                    { Stloc_0 },
+                    { Ldarg_1 },
+                    { Call, emitState.LookupTypeDefinition(eventHandlerType, "Marshaller").GetMethod("ConvertToManaged"u8) },
+                    { Stloc_1 },
+
+                    // *token = MapChangedTable.GetOrCreateValue(unboxedValue).AddEventHandler(managedHandler);
+                    { Ldarg_2 },
+                    { Call, get_MapChangedTableMethod },
+                    { Ldloc_0 },
+                    { Callvirt, interopReferences.ConditionalWeakTable2GetOrCreateValue(conditionalWeakTableType).Import(module) },
+                    { Ldloc_1 },
+                    { Callvirt, interopReferences.EventRegistrationTokenTableAddEventHandler(eventRegistrationTokenTableType).Import(module) },
+                    { Stobj, interopReferences.EventRegistrationToken.Import(module) },
+
+                    // unboxedValue.MapChanged += managedHandler;
+                    { Ldloc_0 },
+                    { Ldloc_1 },
+                    { Callvirt, interopReferences.IObservableMap2add_MapChanged(keyType, valueType).Import(module) },
+                    { Ldc_I4_0 },
+                    { Stloc_2 },
+                    { Leave_S, ldloc_2_returnHResult.CreateLabel() },
+
+                    // '.catch' code
+                    { callvirt_catchHResult },
+                    { Stloc_2 },
+                    { Leave_S, ldloc_2_returnHResult.CreateLabel() },
+
+                    // Return the 'HRESULT' from location [2]
+                    { ldloc_2_returnHResult },
+                    { Ret }
+                },
+                ExceptionHandlers =
+                {
+                    new CilExceptionHandler
+                    {
+                        HandlerType = CilExceptionHandlerType.Exception,
+                        TryStart = ldarg_0_tryStart.CreateLabel(),
+                        TryEnd = callvirt_catchHResult.CreateLabel(),
+                        HandlerStart = callvirt_catchHResult.CreateLabel(),
+                        HandlerEnd = ldloc_2_returnHResult.CreateLabel(),
+                        ExceptionType = interopReferences.Exception.Import(module)
+                    }
+                }
+            };
+
+            return add_MapChangedMethod;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MethodDefinition"/> for the <c>remove_MapChanged</c> export method.
+        /// </summary>
+        /// <param name="mapType">The <see cref="TypeSignature"/> for the map type.</param>
+        /// <param name="get_MapChangedTableMethod">The <see cref="MethodDefinition"/> to get the event token table.</param>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <param name="module">The interop module being built.</param>
+        public static MethodDefinition remove_MapChanged(
+            GenericInstanceTypeSignature mapType,
+            MethodDefinition get_MapChangedTableMethod,
+            InteropReferences interopReferences,
+            ModuleDefinition module)
+        {
+            TypeSignature keyType = mapType.TypeArguments[0];
+            TypeSignature valueType = mapType.TypeArguments[1];
+
+            // Prepare the 'MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>' signature
+            TypeSignature eventHandlerType = interopReferences.MapChangedEventHandler2.MakeGenericReferenceType(keyType, valueType);
+
+            // Prepare the 'EventRegistrationTokenTable<MapChangedEventHandler<KEY_TYPE>, <VALUE_TYPE>>' signature
+            TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
+
+            // Prepare the 'ConditionalWeakTable<<MAP_TYPE>, EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>>' signature
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
+                mapType,
+                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+
+            // Define the 'remove_MapChanged' method as follows:
+            //
+            // [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+            // private static int remove_MapChanged(void* thisPtr, EventRegistrationToken token)
+            MethodDefinition remove_MapChangedMethod = new(
+                name: "remove_MapChanged"u8,
+                attributes: MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static,
+                signature: MethodSignature.CreateStatic(
+                    returnType: module.CorLibTypeFactory.Int32,
+                    parameterTypes: [
+                        module.CorLibTypeFactory.Void.MakePointerType(),
+                        interopReferences.EventRegistrationToken.ToValueTypeSignature().Import(module)]))
+            {
+                CustomAttributes = { InteropCustomAttributeFactory.UnmanagedCallersOnly(interopReferences, module) }
+            };
+
+            // Jump labels
+            CilInstruction ldarg_0_tryStart = new(Ldarg_0);
+            CilInstruction ldc_i4_0_return0 = new(Ldc_I4_0);
+            CilInstruction callvirt_catchHResult = new(Callvirt, interopReferences.Exceptionget_HResult.Import(module));
+            CilInstruction ldloc_3_returnHResult = new(Ldloc_3);
+
+            // Declare the local variables:
+            //   [0]: '<MAP_TYPE>' (the 'unboxedValue' object)
+            //   [1]: 'EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>>' (the 'table' object)
+            //   [2]: 'MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>' (the 'managedHandler' object)
+            //   [3]: 'int' (the 'HRESULT' to return)
+            CilLocalVariable loc_0_unboxedValue = new(mapType.Import(module));
+            CilLocalVariable loc_1_table = new(eventRegistrationTokenTableType.Import(module));
+            CilLocalVariable loc_2_managedHandler = new(eventHandlerType.Import(module));
+            CilLocalVariable loc_3_hresult = new(module.CorLibTypeFactory.Int32);
+
+            // Create a method body for the 'add_MapChanged' method
+            remove_MapChangedMethod.CilMethodBody = new CilMethodBody()
+            {
+                LocalVariables = { loc_0_unboxedValue, loc_1_table, loc_2_managedHandler, loc_3_hresult },
+                Instructions =
+                {
+                    // '.try' code
+                    { ldarg_0_tryStart },
+                    { Call, interopReferences.ComInterfaceDispatchGetInstance.MakeGenericInstanceMethod(mapType).Import(module) },
+                    { Stloc_0 },
+
+                    // if (unboxedValue != null && MapChangedTable.TryGetValue(unboxedValue, out EventRegistrationTokenTable<MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>>> table))
+                    { Ldloc_0 },
+                    { Brfalse_S, ldc_i4_0_return0.CreateLabel() },
+                    { Call, get_MapChangedTableMethod },
+                    { Ldloc_0 },
+                    { Ldloca_S, loc_1_table },
+                    { Callvirt, interopReferences.ConditionalWeakTable2TryGetValue(conditionalWeakTableType).Import(module) },
+                    { Brfalse_S, ldc_i4_0_return0.CreateLabel() },
+
+                    // if (table.RemoveEventHandler(token, out MapChangedEventHandler<<KEY_TYPE>, <VALUE_TYPE>> managedHandler))
+                    { Ldloc_1 },
+                    { Ldarg_1 },
+                    { Ldloca_S, loc_2_managedHandler },
+                    { Callvirt, interopReferences.EventRegistrationTokenTableRemoveEventHandler(eventRegistrationTokenTableType).Import(module) },
+                    { Brfalse_S, ldc_i4_0_return0.CreateLabel() },
+
+                    // unboxedValue.MapChanged -= managedHandler;
+                    { Ldloc_0 },
+                    { Ldloc_2 },
+                    { Callvirt, interopReferences.IObservableMap2remove_MapChanged(keyType, valueType).Import(module) },
+
+                    // Return S_OK
+                    { ldc_i4_0_return0 },
+                    { Stloc_3 },
+                    { Leave_S, ldloc_3_returnHResult.CreateLabel() },
+
+                    // '.catch' code
+                    { callvirt_catchHResult },
+                    { Stloc_3 },
+                    { Leave_S, ldloc_3_returnHResult.CreateLabel() },
+
+                    // Return the 'HRESULT' from location [2]
+                    { ldloc_3_returnHResult },
+                    { Ret }
+                },
+                ExceptionHandlers =
+                {
+                    new CilExceptionHandler
+                    {
+                        HandlerType = CilExceptionHandlerType.Exception,
+                        TryStart = ldarg_0_tryStart.CreateLabel(),
+                        TryEnd = callvirt_catchHResult.CreateLabel(),
+                        HandlerStart = callvirt_catchHResult.CreateLabel(),
+                        HandlerEnd = ldloc_3_returnHResult.CreateLabel(),
+                        ExceptionType = interopReferences.Exception.Import(module)
+                    }
+                }
+            };
+
+            return remove_MapChangedMethod;
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IObservableVector1Impl.cs
@@ -46,9 +46,7 @@ internal partial class InteropMethodDefinitionFactory
             TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
 
             // Prepare the 'ConditionalWeakTable<<VECTOR_TYPE>, EventRegistrationTokenTable<VectorChangedEventHandler<<ELEMENT_TYPE>>>' signature
-            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
-                vectorType,
-                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(vectorType, eventRegistrationTokenTableType);
 
             // Define the 'add_VectorChanged' method as follows:
             //
@@ -174,9 +172,7 @@ internal partial class InteropMethodDefinitionFactory
             TypeSignature eventRegistrationTokenTableType = interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType);
 
             // Prepare the 'ConditionalWeakTable<<VECTOR_TYPE>, EventRegistrationTokenTable<VectorChangedEventHandler<<ELEMENT_TYPE>>>' signature
-            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(
-                vectorType,
-                interopReferences.EventRegistrationTokenTable1.MakeGenericReferenceType(eventHandlerType));
+            TypeSignature conditionalWeakTableType = interopReferences.ConditionalWeakTable2.MakeGenericReferenceType(vectorType, eventRegistrationTokenTableType);
 
             // Define the 'remove_VectorChanged' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -889,28 +889,9 @@ internal static partial class WellKnownTypeDefinitionFactory
         MethodSignature getRuntimeClassNameType = WellKnownTypeSignatureFactory.GetRuntimeClassNameImpl(interopReferences);
         MethodSignature getTrustLevelType = WellKnownTypeSignatureFactory.GetTrustLevelImpl(interopReferences);
 
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int>'
-        MethodSignature add_VectorChanged = new(
-            attributes: CallingConventionAttributes.Unmanaged,
-            returnType: new CustomModifierTypeSignature(
-                modifierType: interopReferences.CallConvMemberFunction,
-                isRequired: false,
-                baseType: module.CorLibTypeFactory.Int32),
-            parameterTypes: [
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.EventRegistrationToken.MakePointerType()]);
-
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int>'
-        MethodSignature remove_VectorChanged = new(
-            attributes: CallingConventionAttributes.Unmanaged,
-            returnType: new CustomModifierTypeSignature(
-                modifierType: interopReferences.CallConvMemberFunction,
-                isRequired: false,
-                baseType: module.CorLibTypeFactory.Int32),
-            parameterTypes: [
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
+        // Signatures for 'VectorChanged'
+        MethodSignature add_VectorChanged = WellKnownTypeSignatureFactory.add_EventHandler(interopReferences);
+        MethodSignature remove_VectorChanged = WellKnownTypeSignatureFactory.remove_EventHandler(interopReferences);
 
         // The vtable layout for 'IObservableVector`1<T>' looks like this:
         //
@@ -958,28 +939,9 @@ internal static partial class WellKnownTypeDefinitionFactory
         MethodSignature getRuntimeClassNameType = WellKnownTypeSignatureFactory.GetRuntimeClassNameImpl(interopReferences);
         MethodSignature getTrustLevelType = WellKnownTypeSignatureFactory.GetTrustLevelImpl(interopReferences);
 
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int>'
-        MethodSignature add_MapChanged = new(
-            attributes: CallingConventionAttributes.Unmanaged,
-            returnType: new CustomModifierTypeSignature(
-                modifierType: interopReferences.CallConvMemberFunction,
-                isRequired: false,
-                baseType: module.CorLibTypeFactory.Int32),
-            parameterTypes: [
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.EventRegistrationToken.MakePointerType()]);
-
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int>'
-        MethodSignature remove_MapChanged = new(
-            attributes: CallingConventionAttributes.Unmanaged,
-            returnType: new CustomModifierTypeSignature(
-                modifierType: interopReferences.CallConvMemberFunction,
-                isRequired: false,
-                baseType: module.CorLibTypeFactory.Int32),
-            parameterTypes: [
-                module.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
+        // Signatures for 'MapChanged'
+        MethodSignature add_MapChanged = WellKnownTypeSignatureFactory.add_EventHandler(interopReferences);
+        MethodSignature remove_MapChanged = WellKnownTypeSignatureFactory.remove_EventHandler(interopReferences);
 
         // The vtable layout for 'IObservableMap`2<K, V>' looks like this:
         //

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -704,7 +704,7 @@ internal static partial class WellKnownTypeDefinitionFactory
     }
 
     /// <summary>
-    /// Creates a new type definition for the vtable of an 'IKeyValuePair`2&lt;TKey, TValue&gt;' instantiation for some <see cref="System.Collections.Generic.KeyValuePair{TKey, TValue}"/> type.
+    /// Creates a new type definition for the vtable of an 'IKeyValuePair`2&lt;K, V&gt;' instantiation for some <see cref="System.Collections.Generic.KeyValuePair{TKey, TValue}"/> type.
     /// </summary>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="module">The module that will contain the type being created.</param>
@@ -930,6 +930,75 @@ internal static partial class WellKnownTypeDefinitionFactory
         vftblType.Fields.Add(new FieldDefinition("GetTrustLevel"u8, FieldAttributes.Public, getTrustLevelType.Import(module).MakeFunctionPointerType()));
         vftblType.Fields.Add(new FieldDefinition("add_VectorChanged"u8, FieldAttributes.Public, add_VectorChanged.Import(module).MakeFunctionPointerType()));
         vftblType.Fields.Add(new FieldDefinition("remove_VectorChanged"u8, FieldAttributes.Public, remove_VectorChanged.Import(module).MakeFunctionPointerType()));
+
+        return vftblType;
+    }
+
+    /// <summary>
+    /// Creates a new type definition for the vtable of an 'IObservableMap`2&lt;K, V&gt;' instantiation for some type.
+    /// </summary>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The module that will contain the type being created.</param>
+    /// <returns>The resulting <see cref="TypeDefinition"/> instance.</returns>
+    public static TypeDefinition IObservableMapVftbl(InteropReferences interopReferences, ModuleDefinition module)
+    {
+        TypeDefinition vftblType = new(
+            ns: null,
+            name: "<IObservableMapVftbl>"u8,
+            attributes: TypeAttributes.SequentialLayout | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            baseType: interopReferences.ValueType.Import(module));
+
+        // Get the 'IUnknown' signatures
+        MethodSignature queryInterfaceType = WellKnownTypeSignatureFactory.QueryInterfaceImpl(interopReferences);
+        MethodSignature addRefType = WellKnownTypeSignatureFactory.AddRefImpl(interopReferences);
+        MethodSignature releaseType = WellKnownTypeSignatureFactory.ReleaseImpl(interopReferences);
+
+        // Get the 'IInspectable' signatures
+        MethodSignature getIidsType = WellKnownTypeSignatureFactory.GetIidsImpl(interopReferences);
+        MethodSignature getRuntimeClassNameType = WellKnownTypeSignatureFactory.GetRuntimeClassNameImpl(interopReferences);
+        MethodSignature getTrustLevelType = WellKnownTypeSignatureFactory.GetTrustLevelImpl(interopReferences);
+
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int>'
+        MethodSignature add_MapChanged = new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: module.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.MakePointerType()]);
+
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int>'
+        MethodSignature remove_MapChanged = new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: module.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                module.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
+
+        // The vtable layout for 'IObservableMap`2<K, V>' looks like this:
+        //
+        // public delegate* unmanaged[MemberFunction]<void*, Guid*, void**, HRESULT> QueryInterface;
+        // public delegate* unmanaged[MemberFunction]<void*, uint> AddRef;
+        // public delegate* unmanaged[MemberFunction]<void*, uint> Release;
+        // public delegate* unmanaged[MemberFunction]<void*, uint*, Guid**, HRESULT> GetIids;
+        // public delegate* unmanaged[MemberFunction]<void*, HSTRING*, HRESULT> GetRuntimeClassName;
+        // public delegate* unmanaged[MemberFunction]<void*, TrustLevel*, HRESULT> GetTrustLevel;
+        // public delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int> add_MapChanged;
+        // public delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int> remove_MapChanged;
+        vftblType.Fields.Add(new FieldDefinition("QueryInterface"u8, FieldAttributes.Public, queryInterfaceType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("AddRef"u8, FieldAttributes.Public, addRefType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("Release"u8, FieldAttributes.Public, releaseType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetIids"u8, FieldAttributes.Public, getIidsType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetRuntimeClassName"u8, FieldAttributes.Public, getRuntimeClassNameType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("GetTrustLevel"u8, FieldAttributes.Public, getTrustLevelType.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("add_MapChanged"u8, FieldAttributes.Public, add_MapChanged.Import(module).MakeFunctionPointerType()));
+        vftblType.Fields.Add(new FieldDefinition("remove_MapChanged"u8, FieldAttributes.Public, remove_MapChanged.Import(module).MakeFunctionPointerType()));
 
         return vftblType;
     }

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
@@ -5,6 +5,8 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using WindowsRuntime.InteropGenerator.References;
 
+#pragma warning disable IDE1006
+
 namespace WindowsRuntime.InteropGenerator.Factories;
 
 /// <summary>

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
@@ -125,6 +125,45 @@ internal static class WellKnownTypeSignatureFactory
     }
 
     /// <summary>
+    /// Creates a type signature for the add accessor for some event.
+    /// </summary>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
+    public static MethodSignature add_EventHandler(InteropReferences interopReferences)
+    {
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, void*, EventRegistrationToken*, int>'
+        return new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: interopReferences.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.MakePointerType()]);
+    }
+
+    /// <summary>
+    /// Creates a type signature for the remove for some event.
+    /// </summary>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
+    public static MethodSignature remove_EventHandler(InteropReferences interopReferences)
+    {
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, EventRegistrationToken, int>'
+        return new(
+            attributes: CallingConventionAttributes.Unmanaged,
+            returnType: new CustomModifierTypeSignature(
+                modifierType: interopReferences.CallConvMemberFunction,
+                isRequired: false,
+                baseType: interopReferences.CorLibTypeFactory.Int32),
+            parameterTypes: [
+                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
+    }
+
+    /// <summary>
     /// Creates a type signature for the <c>Invoke</c> vtable entry for a delegate, taking objects for both parameters.
     /// </summary>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1390,6 +1390,15 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     factoryType: out TypeDefinition factoryType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.Methods(
+                    mapType: typeSignature,
+                    eventSourceFactoryType: factoryType,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    methodsType: out TypeDefinition methodsType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1440,6 +1440,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     marshallerType: out TypeDefinition marshallerType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.InterfaceImpl(
+                    mapType: typeSignature,
+                    mapMethodsType: methodsType,
+                    interopReferences: interopReferences,
+                    module: module,
+                    interfaceImplType: out TypeDefinition interfaceImplType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1424,6 +1424,14 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition comWrappersCallbackType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.ComWrappersMarshallerAttribute(
+                    mapType: typeSignature,
+                    nativeObjectType: nativeObjectType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition comWrappersMarshallerType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -342,6 +342,7 @@ internal partial class InteropGenerator
                         delegateType: typeSignature,
                         marshallerType: marshallerType,
                         interopReferences: interopReferences,
+                        emitState: emitState,
                         module: module,
                         eventSourceType: out _);
                 }
@@ -1381,6 +1382,14 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.EventSourceFactory(
+                    mapType: typeSignature,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    factoryType: out TypeDefinition factoryType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1009,6 +1009,7 @@ internal partial class InteropGenerator
                     dictionaryType: typeSignature,
                     vftblType: vftblType,
                     interopReferences: interopReferences,
+                    emitState: emitState,
                     module: module,
                     mapMethodsType: out TypeDefinition mapMethodsType);
 
@@ -1399,6 +1400,14 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     methodsType: out TypeDefinition methodsType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.NativeObject(
+                    mapType: typeSignature,
+                    mapMethodsType: methodsType,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    out TypeDefinition nativeObjectType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1447,6 +1447,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     interfaceImplType: out TypeDefinition interfaceImplType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.Proxy(
+                    mapType: typeSignature,
+                    mapComWrappersMarshallerAttributeType: comWrappersMarshallerType,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition proxyType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1392,6 +1392,15 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
+                InteropTypeDefinitionBuilder.IObservableMap2.ImplType(
+                    mapType: typeSignature,
+                    get_IidMethod: get_IidMethod,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    implType: out _);
+
                 InteropTypeDefinitionBuilder.IObservableMap2.EventSourceFactory(
                     mapType: typeSignature,
                     interopDefinitions: interopDefinitions,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1416,6 +1416,14 @@ internal partial class InteropGenerator
                     emitState: emitState,
                     module: module,
                     out TypeDefinition nativeObjectType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.ComWrappersCallbackType(
+                    mapType: typeSignature,
+                    nativeObjectType: nativeObjectType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    out TypeDefinition comWrappersCallbackType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -987,6 +987,14 @@ internal partial class InteropGenerator
                     module: module,
                     get_IidMethod: out MethodDefinition get_IidMethod);
 
+                InteropTypeDefinitionBuilder.IDictionary2.Interface(
+                    dictionaryType: typeSignature,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    emitState: emitState,
+                    module: module,
+                    interfaceType: out _);
+
                 InteropTypeDefinitionBuilder.IDictionary2.Vftbl(
                     dictionaryType: typeSignature,
                     interopDefinitions: interopDefinitions,

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1454,6 +1454,13 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition proxyType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.TypeMapAttributes(
+                    mapType: typeSignature,
+                    proxyType: proxyType,
+                    interfaceImplType: interfaceImplType,
+                    interopReferences: interopReferences,
+                    module: module);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -106,6 +106,11 @@ internal partial class InteropGenerator
 
         args.Token.ThrowIfCancellationRequested();
 
+        // Emit interop types for 'IObservableMap<>' types
+        DefineIObservableMapTypes(args, discoveryState, emitState, interopDefinitions, interopReferences, module);
+
+        args.Token.ThrowIfCancellationRequested();
+
         // Emit interop types for SZ array types
         DefineSzArrayTypes(args, discoveryState, interopDefinitions, interopReferences, module);
 
@@ -1343,6 +1348,43 @@ internal partial class InteropGenerator
             catch (Exception e) when (!e.IsWellKnown)
             {
                 throw WellKnownInteropExceptions.IObservableVectorTypeCodeGenerationError(typeSignature, e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Defines the interop types for <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> types.
+    /// </summary>
+    /// <param name="args"><inheritdoc cref="Emit" path="/param[@name='args']/node()"/></param>
+    /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
+    /// <param name="emitState">The emit state for this invocation.</param>
+    /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
+    /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+    /// <param name="module">The interop module being built.</param>
+    private static void DefineIObservableMapTypes(
+        InteropGeneratorArgs args,
+        InteropGeneratorDiscoveryState discoveryState,
+        InteropGeneratorEmitState emitState,
+        InteropDefinitions interopDefinitions,
+        InteropReferences interopReferences,
+        ModuleDefinition module)
+    {
+        foreach (GenericInstanceTypeSignature typeSignature in discoveryState.IObservableMap2Types)
+        {
+            args.Token.ThrowIfCancellationRequested();
+
+            try
+            {
+                InteropTypeDefinitionBuilder.IObservableMap2.IID(
+                    mapType: typeSignature,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    module: module,
+                    get_IidMethod: out MethodDefinition get_IidMethod);
+            }
+            catch (Exception e) when (!e.IsWellKnown)
+            {
+                throw WellKnownInteropExceptions.IObservableMapTypeCodeGenerationError(typeSignature, e);
             }
         }
     }

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1432,6 +1432,14 @@ internal partial class InteropGenerator
                     interopReferences: interopReferences,
                     module: module,
                     out TypeDefinition comWrappersMarshallerType);
+
+                InteropTypeDefinitionBuilder.IObservableMap2.Marshaller(
+                    mapType: typeSignature,
+                    mapComWrappersCallbackType: comWrappersMarshallerType,
+                    get_IidMethod: get_IidMethod,
+                    interopReferences: interopReferences,
+                    module: module,
+                    marshallerType: out TypeDefinition marshallerType);
             }
             catch (Exception e) when (!e.IsWellKnown)
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1679,6 +1679,7 @@ internal partial class InteropGenerator
             module.TopLevelTypes.Add(interopDefinitions.IKeyValuePairVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IKeyValuePairInterfaceEntries);
             module.TopLevelTypes.Add(interopDefinitions.IObservableVectorVftbl);
+            module.TopLevelTypes.Add(interopDefinitions.IObservableMapVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IMapChangedEventArgsVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IReferenceArrayVftbl);
             module.TopLevelTypes.Add(interopDefinitions.IReferenceArrayInterfaceEntries);

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -338,6 +338,9 @@ internal partial class InteropGenerator
                 }
                 else if (SignatureComparer.IgnoreVersion.Equals(typeSignature.GenericType, interopReferences.MapChangedEventHandler2))
                 {
+                    // We need the marshaller type for the 'IObservableMap<K, V>' implementation
+                    emitState.TrackTypeDefinition(marshallerType, typeSignature, "Marshaller");
+
                     InteropTypeDefinitionBuilder.EventSource.MapChangedEventHandler2(
                         delegateType: typeSignature,
                         marshallerType: marshallerType,

--- a/src/WinRT.Interop.Generator/Generation/InteropGeneratorDiscoveryState.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGeneratorDiscoveryState.cs
@@ -124,7 +124,7 @@ internal sealed class InteropGeneratorDiscoveryState
     public IReadOnlyCollection<GenericInstanceTypeSignature> IObservableVector1Types => (IReadOnlyCollection<GenericInstanceTypeSignature>)_iobservableVector1Types.Keys;
 
     /// <summary>
-    /// Gets all <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;</c> types.
+    /// Gets all <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> types.
     /// </summary>
     public IReadOnlyCollection<GenericInstanceTypeSignature> IObservableMap2Types => (IReadOnlyCollection<GenericInstanceTypeSignature>)_iobservableMap2Types.Keys;
 
@@ -270,9 +270,9 @@ internal sealed class InteropGeneratorDiscoveryState
     }
 
     /// <summary>
-    /// Tracks a <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;</c> type.
+    /// Tracks a <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> type.
     /// </summary>
-    /// <param name="mapType">The <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;</c> type.</param>
+    /// <param name="mapType">The <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> type.</param>
     public void TrackIObservableMap2Type(GenericInstanceTypeSignature mapType)
     {
         ThrowIfReadOnly();

--- a/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
+++ b/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
@@ -139,6 +139,11 @@ internal sealed class InteropDefinitions
     public TypeDefinition IObservableVectorVftbl => field ??= WellKnownTypeDefinitionFactory.IObservableVectorVftbl(_interopReferences, _interopModule);
 
     /// <summary>
+    /// Gets the <see cref="TypeDefinition"/> for the <c>IObservableMapVftbl</c> type.
+    /// </summary>
+    public TypeDefinition IObservableMapVftbl => field ??= WellKnownTypeDefinitionFactory.IObservableMapVftbl(_interopReferences, _interopModule);
+
+    /// <summary>
     /// Gets the <see cref="TypeDefinition"/> for the <c>IReferenceArrayVftbl</c> type.
     /// </summary>
     public TypeDefinition IReferenceArrayVftbl => field ??= WellKnownTypeDefinitionFactory.ReferenceArrayVftbl(_interopReferences, _interopModule);

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -462,6 +462,11 @@ internal sealed class InteropReferences
     public TypeReference IObservableVectorMethodsImpl1 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "IObservableVectorMethodsImpl`1"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.IObservableMapMethodsImpl&lt;TKey, TValue&gt;</c>.
+    /// </summary>
+    public TypeReference IObservableMapMethodsImpl2 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "IObservableMapMethodsImpl`2"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.InteropServices.IMapChangedEventArgsImpl&lt;K&gt;</c>.
     /// </summary>
     public TypeReference IMapChangedEventArgsImpl1 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "IMapChangedEventArgsImpl`1"u8);
@@ -2831,7 +2836,26 @@ internal sealed class InteropReferences
             .MakeGenericReferenceType(elementType)
             .ToTypeDefOrRef()
             .CreateMemberReference("VectorChanged"u8, MethodSignature.CreateInstance(
-                returnType: new GenericParameterSignature(GenericParameterType.Type, 0),
+                returnType: VectorChangedEventHandler1EventSource.MakeGenericReferenceType(new GenericParameterSignature(GenericParameterType.Type, 0)),
+                parameterTypes: [
+                    WindowsRuntimeObject.ToReferenceTypeSignature(),
+                    WindowsRuntimeObjectReference.ToReferenceTypeSignature()]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;.MapChanged</c>'s getter.
+    /// </summary>
+    /// <param name="keyType">The type of keys.</param>
+    /// <param name="valueType">The type of values.</param>
+    public MemberReference IObservableMapMethodsImpl2MapChanged(TypeSignature keyType, TypeSignature valueType)
+    {
+        return IObservableMapMethodsImpl2
+            .MakeGenericReferenceType(keyType, valueType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("MapChanged"u8, MethodSignature.CreateInstance(
+                returnType: MapChangedEventHandler2EventSource.MakeGenericReferenceType(
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    new GenericParameterSignature(GenericParameterType.Type, 1)),
                 parameterTypes: [
                     WindowsRuntimeObject.ToReferenceTypeSignature(),
                     WindowsRuntimeObjectReference.ToReferenceTypeSignature()]));

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -692,7 +692,7 @@ internal sealed class InteropReferences
     public TypeReference IObservableVector1 => field ??= _windowsSdkProjectionModule.CreateTypeReference("Windows.Foundation.Collections"u8, "IObservableVector`1"u8);
 
     /// <summary>
-    /// Gets the <see cref="TypeReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;</c>.
+    /// Gets the <see cref="TypeReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c>.
     /// </summary>
     public TypeReference IObservableMap2 => field ??= _windowsSdkProjectionModule.CreateTypeReference("Windows.Foundation.Collections"u8, "IObservableMap`2"u8);
 

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -2848,6 +2848,40 @@ internal sealed class InteropReferences
     }
 
     /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;.MapChanged</c>'s adder.
+    /// </summary>
+    /// <param name="keyType">The type of keys.</param>
+    /// <param name="valueType">The type of values.</param>
+    public MemberReference IObservableMap2add_MapChanged(TypeSignature keyType, TypeSignature valueType)
+    {
+        return IObservableMap2
+            .MakeGenericReferenceType(keyType, valueType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("add_MapChanged"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [MapChangedEventHandler2.MakeGenericReferenceType(
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    new GenericParameterSignature(GenericParameterType.Type, 1))]));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K,V&gt;.MapChanged</c>'s remover.
+    /// </summary>
+    /// <param name="keyType">The type of keys.</param>
+    /// <param name="valueType">The type of values.</param>
+    public MemberReference IObservableMap2remove_MapChanged(TypeSignature keyType, TypeSignature valueType)
+    {
+        return IObservableMap2
+            .MakeGenericReferenceType(keyType, valueType)
+            .ToTypeDefOrRef()
+            .CreateMemberReference("remove_MapChanged"u8, MethodSignature.CreateInstance(
+                returnType: _corLibTypeFactory.Void,
+                parameterTypes: [MapChangedEventHandler2.MakeGenericReferenceType(
+                    new GenericParameterSignature(GenericParameterType.Type, 0),
+                    new GenericParameterSignature(GenericParameterType.Type, 1))]));
+    }
+
+    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;.MapChanged</c>'s getter.
     /// </summary>
     /// <param name="keyType">The type of keys.</param>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -557,6 +557,11 @@ internal sealed class InteropReferences
     public TypeReference WindowsRuntimeObservableVector6 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeObservableVector`6"u8);
 
     /// <summary>
+    /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.WindowsRuntimeObservableMap&lt;TKey, TValue, ...&gt;</c>.
+    /// </summary>
+    public TypeReference WindowsRuntimeObservableMap7 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeObservableMap`7"u8);
+
+    /// <summary>
     /// Gets the <see cref="TypeReference"/> for <c>WindowsRuntime.WindowsRuntimeMapChangedEventArgs&lt;TKey, ...&gt;</c>.
     /// </summary>
     public TypeReference WindowsRuntimeMapChangedEventArgs2 => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime"u8, "WindowsRuntimeMapChangedEventArgs`2"u8);

--- a/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableMap{TKey, TValue}.cs
+++ b/src/WinRT.Runtime2/Collections/WindowsRuntimeObservableMap{TKey, TValue}.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Windows.Foundation.Collections;
+using WindowsRuntime.InteropServices;
+
+#pragma warning disable CA1816
+
+namespace WindowsRuntime;
+
+/// <summary>
+/// The implementation of all projected Windows Runtime <see cref="IObservableMap{K, V}"/> types.
+/// </summary>
+/// <typeparam name="TKey">The type of keys in the observable map.</typeparam>
+/// <typeparam name="TValue">The type of values in the observable map.</typeparam>
+/// <typeparam name="TIIterable">The <c>Windows.Foundation.Collections.IIterable&lt;T&gt;</c> interface type.</typeparam>
+/// <typeparam name="TIIterableMethods">The <c>Windows.Foundation.Collections.IIterable&lt;T&gt;</c> implementation type.</typeparam>
+/// <typeparam name="TIMap">The <c>Windows.Foundation.Collections.IMap&lt;K, V&gt;</c> interface type.</typeparam>
+/// <typeparam name="TIMapMethods">The <c>Windows.Foundation.Collections.IMap&lt;K, V&gt;</c> implementation type.</typeparam>
+/// <typeparam name="TIObservableMapMethods">The <c>Windows.Foundation.Collections.IObservableMap&lt;K, V&gt;</c> implementation type.</typeparam>
+/// <remarks>
+/// This type should only be used as a base type by generated generic instantiations.
+/// </remarks>
+/// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1"/>
+[Obsolete("This type is an implementation detail, and it's only meant to be consumed by 'cswinrtgen'")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class WindowsRuntimeObservableMap<
+    TKey,
+    TValue,
+    TIIterable,
+    TIIterableMethods,
+    TIMap,
+    TIMapMethods,
+    TIObservableMapMethods> : WindowsRuntimeObject,
+    IObservableMap<TKey, TValue>,
+    IDictionary<TKey, TValue>,
+    IReadOnlyDictionary<TKey, TValue>,
+    IWindowsRuntimeInterface<IObservableMap<TKey, TValue>>,
+    IWindowsRuntimeInterface<IDictionary<TKey, TValue>>,
+    IWindowsRuntimeInterface<IEnumerable<KeyValuePair<TKey, TValue>>>
+    where TIIterable : IWindowsRuntimeInterface
+    where TIIterableMethods : IIterableMethodsImpl<KeyValuePair<TKey, TValue>>
+    where TIMap : IWindowsRuntimeInterface
+    where TIMapMethods : IMapMethodsImpl<TKey, TValue>
+    where TIObservableMapMethods : IObservableMapMethodsImpl<TKey, TValue>
+{
+    /// <inheritdoc cref="WindowsRuntimeDictionary{TKey, TValue, TIIterable, TIIterableMethods, TIMapMethods}._keys"/>
+    private DictionaryKeyCollection<TKey, TValue>? _keys;
+
+    /// <inheritdoc cref="WindowsRuntimeDictionary{TKey, TValue, TIIterable, TIIterableMethods, TIMapMethods}._values"/>
+    private DictionaryValueCollection<TKey, TValue>? _values;
+
+    /// <summary>
+    /// Creates a <see cref="WindowsRuntimeObservableMap{TKey, TValue, TIIterable, TIIterableMethods, TIMap, TIMapMethods, TIObservableMapMethods}"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="nativeObjectReference">The inner Windows Runtime object reference to wrap in the current instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="nativeObjectReference"/> is <see langword="null"/>.</exception>
+    protected WindowsRuntimeObservableMap(WindowsRuntimeObjectReference nativeObjectReference)
+        : base(nativeObjectReference)
+    {
+    }
+
+    /// <summary>
+    /// Gets the lazy-loaded, cached object reference for <c>Windows.Foundation.Collections.IMap&lt;K, V&gt;</c> for the current object.
+    /// </summary>
+    private WindowsRuntimeObjectReference IMapObjectReference
+    {
+        get
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WindowsRuntimeObjectReference InitializeIMapObjectReference()
+            {
+                _ = Interlocked.CompareExchange(
+                    location1: ref field,
+                    value: NativeObjectReference.As(in TIMap.IID),
+                    comparand: null);
+
+                return field;
+            }
+
+            return field ?? InitializeIMapObjectReference();
+        }
+    }
+
+    /// <inheritdoc cref="WindowsRuntimeReadOnlyList{T, TIIterable, TIEnumerableMethods, TIReadOnlyListMethods}.IIterableObjectReference"/>
+    private WindowsRuntimeObjectReference IIterableObjectReference
+    {
+        get
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WindowsRuntimeObjectReference InitializeIIterableObjectReference()
+            {
+                _ = Interlocked.CompareExchange(
+                    location1: ref field,
+                    value: NativeObjectReference.As(in TIIterable.IID),
+                    comparand: null);
+
+                return field;
+            }
+
+            return field ?? InitializeIIterableObjectReference();
+        }
+    }
+
+    /// <inheritdoc/>
+    public event MapChangedEventHandler<TKey, TValue>? MapChanged
+    {
+        add => TIObservableMapMethods.MapChanged(this, NativeObjectReference).Subscribe(value);
+        remove => TIObservableMapMethods.MapChanged(this, NativeObjectReference).Unsubscribe(value);
+    }
+
+    /// <inheritdoc/>
+    protected internal sealed override bool HasUnwrappableNativeObjectReference => true;
+
+    /// <inheritdoc/>
+    public ICollection<TKey> Keys => _keys ??= new DictionaryKeyCollection<TKey, TValue>(this);
+
+    /// <inheritdoc/>
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+    /// <inheritdoc/>
+    public ICollection<TValue> Values => _values ??= new DictionaryValueCollection<TKey, TValue>(this);
+
+    /// <inheritdoc/>
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+    /// <inheritdoc/>
+    public int Count => IReadOnlyDictionaryMethods.Count(NativeObjectReference);
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public TValue this[TKey key]
+    {
+        get => IDictionaryMethods<TKey, TValue>.Item<TIMapMethods>(NativeObjectReference, key);
+        set => IDictionaryMethods<TKey, TValue>.Item<TIMapMethods>(NativeObjectReference, key, value);
+    }
+
+    /// <inheritdoc/>
+    public void Add(TKey key, TValue value)
+    {
+        IDictionaryMethods<TKey, TValue>.Add<TIMapMethods>(NativeObjectReference, key, value);
+    }
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key)
+    {
+        return IDictionaryMethods<TKey, TValue>.ContainsKey<TIMapMethods>(NativeObjectReference, key);
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        return IDictionaryMethods<TKey, TValue>.Remove<TIMapMethods>(NativeObjectReference, key);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+    {
+        return IDictionaryMethods<TKey, TValue>.TryGetValue<TIMapMethods>(NativeObjectReference, key, out value);
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        IMapMethods.Clear(NativeObjectReference);
+    }
+
+    /// <inheritdoc/>
+    public void Add(KeyValuePair<TKey, TValue> item)
+    {
+        IDictionaryMethods<TKey, TValue>.Add<TIMapMethods>(NativeObjectReference, item.Key, item.Value);
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+    {
+        return IDictionaryMethods<TKey, TValue>.Contains<TIMapMethods>(NativeObjectReference, item);
+    }
+
+    /// <inheritdoc/>
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+    {
+        IDictionaryMethods<TKey, TValue>.CopyTo<TIMapMethods, TIIterableMethods>(
+            thisIMapReference: NativeObjectReference,
+            thisIIterableReference: IIterableObjectReference,
+            array: array,
+            arrayIndex: arrayIndex);
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+    {
+        return IDictionaryMethods<TKey, TValue>.Remove<TIMapMethods>(NativeObjectReference, item.Key);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+        return TIIterableMethods.First(IIterableObjectReference);
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IObservableMap<TKey, TValue>>.GetInterface()
+    {
+        return NativeObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IDictionary<TKey, TValue>>.GetInterface()
+    {
+        return IMapObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    WindowsRuntimeObjectReferenceValue IWindowsRuntimeInterface<IEnumerable<KeyValuePair<TKey, TValue>>>.GetInterface()
+    {
+        return IIterableObjectReference.AsValue();
+    }
+
+    /// <inheritdoc/>
+    protected sealed override bool IsOverridableInterface(in Guid iid)
+    {
+        return false;
+    }
+}

--- a/src/WinRT.Runtime2/InteropServices/Collections/IObservableMapMethodsImpl{TKey, TValue}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Collections/IObservableMapMethodsImpl{TKey, TValue}.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace WindowsRuntime.InteropServices;
+
+/// <summary>
+/// An interface for implementations of <see cref="Windows.Foundation.Collections.IObservableMap{K, V}"/> types.
+/// </summary>
+/// <typeparam name="TKey">The type of keys in the observable map.</typeparam>
+/// <typeparam name="TValue">The type of values in the observable map.</typeparam>
+/// <remarks>
+/// This type should only be used by generated code.
+/// </remarks>
+[Obsolete("This type is an implementation detail, and it's only meant to be consumed by 'cswinrtgen'")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IObservableMapMethodsImpl<TKey, TValue>
+{
+    /// <summary>
+    /// Returns the <see cref="EventSource{T}"/> instance associated with <see cref="Windows.Foundation.Collections.IObservableMap{K, V}.MapChanged"/>.
+    /// </summary>
+    /// <param name="thisObject">The <see cref="WindowsRuntimeObject"/> instance to use.</param>
+    /// <param name="thisReference">The <see cref="WindowsRuntimeObjectReference"/> instance to use to invoke the native method.</param>
+    /// <returns>The <see cref="EventSource{T}"/> instance associated with <see cref="Windows.Foundation.Collections.IObservableMap{K, V}.MapChanged"/>.</returns>
+    /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.mapchanged"/>
+    static abstract MapChangedEventHandlerEventSource<TKey, TValue> MapChanged(WindowsRuntimeObject thisObject, WindowsRuntimeObjectReference thisReference);
+}


### PR DESCRIPTION
This PR updates cswinrtgen to emit code for `IObservableMap<K, V>` types.
Also includes some WinRT.Runtime tweaks in related supporting code.