### PR TITLE
Fix some missing releases in `*Methods` APIs

### DIFF
--- a/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
+++ b/src/WinRT.Runtime2/ABI/System/Collections.Specialized/INotifyCollectionChanged.cs
@@ -155,8 +155,6 @@ public static unsafe class INotifyCollectionChangedImpl
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
     private static HRESULT add_CollectionChanged(void* thisPtr, void* handler, EventRegistrationToken* token)
     {
-        *token = default;
-
         try
         {
             var unboxedValue = ComInterfaceDispatch.GetInstance<INotifyCollectionChanged>((ComInterfaceDispatch*)thisPtr);

--- a/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
+++ b/src/WinRT.Runtime2/ABI/System/IServiceProvider.cs
@@ -56,7 +56,14 @@ public static unsafe class IServiceProviderMethods
 
         RestrictedErrorInfo.ThrowExceptionForHR(hresult);
 
-        return WindowsRuntimeObjectMarshaller.ConvertToManaged(result);
+        try
+        {
+            return WindowsRuntimeObjectMarshaller.ConvertToManaged(result);
+        }
+        finally
+        {
+            WindowsRuntimeObjectMarshaller.Free(result);
+        }
     }
 }
 

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/IAsyncAction.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/IAsyncAction.cs
@@ -106,7 +106,14 @@ public static unsafe class IAsyncActionMethods
 
         RestrictedErrorInfo.ThrowExceptionForHR(hresult);
 
-        return AsyncActionCompletedHandlerMarshaller.ConvertToManaged(result);
+        try
+        {
+            return AsyncActionCompletedHandlerMarshaller.ConvertToManaged(result);
+        }
+        finally
+        {
+            WindowsRuntimeObjectMarshaller.Free(result);
+        }
     }
 
     /// <see cref="IAsyncAction.Completed"/>


### PR DESCRIPTION
Updated `IServiceProvider` and `IAsyncAction` marshaller methods to free unmanaged resources after conversion to managed objects. Also removed redundant token initialization in `INotifyCollectionChangedImpl`.