### PR TITLE
Handle CoIncrementMTAUsage failure in platform module

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimePlatformModule.cs
+++ b/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimePlatformModule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using WindowsRuntime.InteropServices.Marshalling;
 
@@ -30,7 +31,16 @@ internal sealed unsafe class WindowsRuntimePlatformModule
     {
         CO_MTA_USAGE_COOKIE mtaCookie;
 
-        WindowsRuntimeImports.CoIncrementMTAUsage(&mtaCookie).Assert();
+        HRESULT hresult = WindowsRuntimeImports.CoIncrementMTAUsage(&mtaCookie);
+
+        // If we failed to increment the MTA usage, we want to suppress the finalizer.
+        // We only need to run that if we actually have a cookie to use to decrement.
+        if (!WellKnownErrorCodes.Succeeded(hresult))
+        {
+            GC.SuppressFinalize(this);
+
+            Marshal.ThrowExceptionForHR(hresult);
+        }
 
         _mtaCookie = mtaCookie;
     }


### PR DESCRIPTION
This ensures the finalizer doesn't try to run and release a cookie that's not valid.