### PR TITLE
Fix `HasOrInheritsAttribute` loop condition in cswinrtgen

### DIFF
--- a/src/WinRT.Interop.Generator/Extensions/TypeDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/TypeDefinitionExtensions.cs
@@ -31,7 +31,7 @@ internal static class TypeDefinitionExtensions
         {
             for (
                 TypeDefinition? currentType = type;
-                currentType is not null && !SignatureComparer.IgnoreVersion.Equals(currentType.BaseType, corLibTypeFactory.Object);
+                currentType is not null && !SignatureComparer.IgnoreVersion.Equals(currentType, corLibTypeFactory.Object);
                 currentType = currentType.BaseType?.Resolve())
             {
                 if (currentType.HasCustomAttribute(attributeType))


### PR DESCRIPTION
This fixes the `EventState` filtering as well, as this method was only used there so far.