### PR TITLE
Rename `IgnoreAccessChecksTo` to `IgnoresAccessChecksTo`

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/IgnoresAccessChecksToBuilder.cs
+++ b/src/WinRT.Interop.Generator/Builders/IgnoresAccessChecksToBuilder.cs
@@ -10,9 +10,9 @@ using WindowsRuntime.InteropGenerator.References;
 namespace WindowsRuntime.InteropGenerator.Builders;
 
 /// <summary>
-/// A builder for the <c>[IgnoreAccessChecksTo]</c> uses.
+/// A builder for the <c>[IgnoresAccessChecksTo]</c> uses.
 /// </summary>
-internal static partial class IgnoreAccessChecksToBuilder
+internal static partial class IgnoresAccessChecksToBuilder
 {
     /// <summary>
     /// Defines all assembly attributes for target modules using the Windows TFM.
@@ -38,7 +38,7 @@ internal static partial class IgnoreAccessChecksToBuilder
             string assemblyName = Path.GetFileNameWithoutExtension(assemblyModule.Name!);
 
             // Create the attribute and add it to the assembly
-            module.Assembly!.CustomAttributes.Add(InteropCustomAttributeFactory.IgnoreAccessChecksTo(assemblyName, interopDefinitions, module));
+            module.Assembly!.CustomAttributes.Add(InteropCustomAttributeFactory.IgnoresAccessChecksTo(assemblyName, interopDefinitions, module));
         }
     }
 }

--- a/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
+++ b/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
@@ -164,11 +164,11 @@ internal static class WellKnownInteropExceptions
     }
 
     /// <summary>
-    /// Failed to define the <c>[IgnoreAccessChecksTo]</c> attributes
+    /// Failed to define the <c>[IgnoresAccessChecksTo]</c> attributes
     /// </summary>
-    public static Exception DefineIgnoreAccessChecksToAttributesError(Exception exception)
+    public static Exception DefineIgnoresAccessChecksToAttributesError(Exception exception)
     {
-        return Exception(19, "Failed to generate the '[IgnoreAccessChecksTo]' attribute definition and annotations.", exception);
+        return Exception(19, "Failed to generate the '[IgnoresAccessChecksTo]' attribute definition and annotations.", exception);
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/Factories/InteropCustomAttributeFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropCustomAttributeFactory.cs
@@ -72,23 +72,23 @@ internal static class InteropCustomAttributeFactory
     }
 
     /// <summary>
-    /// Creates a new custom attribute value for <c>IgnoreAccessChecksToAttribute</c>.
+    /// Creates a new custom attribute value for <c>IgnoresAccessChecksToAttribute</c>.
     /// </summary>
     /// <param name="assemblyName">The target assemby name.</param>
     /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
     /// <param name="module">The module that the attribute will be used from.</param>
     /// <returns>The resulting <see cref="CustomAttribute"/> instance.</returns>
-    public static CustomAttribute IgnoreAccessChecksTo(
+    public static CustomAttribute IgnoresAccessChecksTo(
         string assemblyName,
         InteropDefinitions interopDefinitions,
         ModuleDefinition module)
     {
         // Get the constructor taking 'assemblyName' as a string argument
-        MethodDefinition ctor = interopDefinitions.IgnoreAccessChecksToAttribute.GetConstructor(module.CorLibTypeFactory.String)!;
+        MethodDefinition ctor = interopDefinitions.IgnoresAccessChecksToAttribute.GetConstructor(module.CorLibTypeFactory.String)!;
 
         // Create the following attribute:
         //
-        // [IgnoreAccessChecksTo(<assemblyName>)]
+        // [IgnoresAccessChecksTo(<assemblyName>)]
         return new(ctor, new CustomAttributeSignature(new CustomAttributeArgument(
             argumentType: module.CorLibTypeFactory.String,
             value: assemblyName)));

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.IgnoreAccessChecksToAttribute.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.IgnoreAccessChecksToAttribute.cs
@@ -15,17 +15,17 @@ namespace WindowsRuntime.InteropGenerator.Factories;
 internal partial class WellKnownTypeDefinitionFactory
 {
     /// <summary>
-    /// Creates the <c>IgnoreAccessChecksToAttribute</c> type.
+    /// Creates the <c>IgnoresAccessChecksToAttribute</c> type.
     /// </summary>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="module">The module that will contain the type being created.</param>
-    /// <returns>The resulting <c>IgnoreAccessChecksToAttribute</c> type.</returns>
-    public static TypeDefinition IgnoreAccessChecksToAttribute(InteropReferences interopReferences, ModuleDefinition module)
+    /// <returns>The resulting <c>IgnoresAccessChecksToAttribute</c> type.</returns>
+    public static TypeDefinition IgnoresAccessChecksToAttribute(InteropReferences interopReferences, ModuleDefinition module)
     {
         // We're declaring a 'public sealed class' type
-        TypeDefinition ignoreAccessChecksToType = new(
+        TypeDefinition IgnoresAccessChecksToType = new(
             ns: "System.Runtime.CompilerServices"u8,
-            name: "IgnoreAccessChecksToAttribute"u8,
+            name: "IgnoresAccessChecksToAttribute"u8,
             attributes: TypeAttributes.Public | TypeAttributes.AutoLayout | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             baseType: interopReferences.Attribute.Import(module));
 
@@ -35,12 +35,12 @@ internal partial class WellKnownTypeDefinitionFactory
             attributes: FieldAttributes.Private | FieldAttributes.InitOnly,
             fieldType: module.CorLibTypeFactory.String);
 
-        ignoreAccessChecksToType.Fields.Add(assemblyNameField);
+        IgnoresAccessChecksToType.Fields.Add(assemblyNameField);
 
         // Define the constructor
         MethodDefinition ctor = MethodDefinition.CreateConstructor(module, module.CorLibTypeFactory.String);
 
-        ignoreAccessChecksToType.Methods.Add(ctor);
+        IgnoresAccessChecksToType.Methods.Add(ctor);
 
         _ = ctor.CilMethodBody!.Instructions.Insert(0, Ldarg_0);
         _ = ctor.CilMethodBody!.Instructions.Insert(1, Ldarg_1);
@@ -63,8 +63,8 @@ internal partial class WellKnownTypeDefinitionFactory
             GetMethod = get_AssemblyNameMethod
         };
 
-        ignoreAccessChecksToType.Properties.Add(assemblyNameProperty);
-        ignoreAccessChecksToType.Methods.Add(get_AssemblyNameMethod);
+        IgnoresAccessChecksToType.Properties.Add(assemblyNameProperty);
+        IgnoresAccessChecksToType.Methods.Add(get_AssemblyNameMethod);
 
         // Create a method body for the 'AssemblyName' property
         get_AssemblyNameMethod.CilMethodBody = new CilMethodBody()
@@ -78,12 +78,12 @@ internal partial class WellKnownTypeDefinitionFactory
         };
 
         // Also emit '[AttributeUsage]' on the type
-        ignoreAccessChecksToType.CustomAttributes.Add(InteropCustomAttributeFactory.AttributeUsage(
+        IgnoresAccessChecksToType.CustomAttributes.Add(InteropCustomAttributeFactory.AttributeUsage(
             attributeTargets: AttributeTargets.Assembly,
             allowMultiple: true,
             interopReferences: interopReferences,
             module: module));
 
-        return ignoreAccessChecksToType;
+        return IgnoresAccessChecksToType;
     }
 }

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -151,8 +151,8 @@ internal partial class InteropGenerator
 
         args.Token.ThrowIfCancellationRequested();
 
-        // Add all '[IgnoreAccessChecksTo]' attributes
-        DefineIgnoreAccessChecksToAttributes(discoveryState, interopDefinitions, module);
+        // Add all '[IgnoresAccessChecksTo]' attributes
+        DefineIgnoresAccessChecksToAttributes(discoveryState, interopDefinitions, module);
 
         args.Token.ThrowIfCancellationRequested();
 
@@ -2087,27 +2087,27 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Defines the <c>[IgnoreAccessChecksTo]</c> attribute, and applies it to the assembly for each input reference.
+    /// Defines the <c>[IgnoresAccessChecksTo]</c> attribute, and applies it to the assembly for each input reference.
     /// </summary>
     /// <param name="discoveryState"><inheritdoc cref="Emit" path="/param[@name='state']/node()"/></param>
     /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
     /// <param name="module">The interop module being built.</param>
-    private static void DefineIgnoreAccessChecksToAttributes(
+    private static void DefineIgnoresAccessChecksToAttributes(
         InteropGeneratorDiscoveryState discoveryState,
         InteropDefinitions interopDefinitions,
         ModuleDefinition module)
     {
         try
         {
-            // Emit the '[IgnoreAccessChecksTo]' type first
-            module.TopLevelTypes.Add(interopDefinitions.IgnoreAccessChecksToAttribute);
+            // Emit the '[IgnoresAccessChecksTo]' type first
+            module.TopLevelTypes.Add(interopDefinitions.IgnoresAccessChecksToAttribute);
 
-            // Next, emit all the '[IgnoreAccessChecksTo]' attributes for each type
-            IgnoreAccessChecksToBuilder.AssemblyAttributes(discoveryState.ModuleDefinitions.Values, interopDefinitions, module);
+            // Next, emit all the '[IgnoresAccessChecksTo]' attributes for each type
+            IgnoresAccessChecksToBuilder.AssemblyAttributes(discoveryState.ModuleDefinitions.Values, interopDefinitions, module);
         }
         catch (Exception e) when (!e.IsWellKnown)
         {
-            throw WellKnownInteropExceptions.DefineIgnoreAccessChecksToAttributesError(e);
+            throw WellKnownInteropExceptions.DefineIgnoresAccessChecksToAttributesError(e);
         }
     }
 

--- a/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
+++ b/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
@@ -41,9 +41,9 @@ internal sealed class InteropDefinitions
     }
 
     /// <summary>
-    /// Gets the <see cref="TypeDefinition"/> for the <c>IgnoreAccessChecksToAttribute</c> type.
+    /// Gets the <see cref="TypeDefinition"/> for the <c>IgnoresAccessChecksToAttribute</c> type.
     /// </summary>
-    public TypeDefinition IgnoreAccessChecksToAttribute => field ??= WellKnownTypeDefinitionFactory.IgnoreAccessChecksToAttribute(_interopReferences, _interopModule);
+    public TypeDefinition IgnoresAccessChecksToAttribute => field ??= WellKnownTypeDefinitionFactory.IgnoresAccessChecksToAttribute(_interopReferences, _interopModule);
 
     /// <summary>
     /// Gets the <see cref="TypeDefinition"/> for the <c>RvaFields</c> type.


### PR DESCRIPTION
The name is actually plural, we made a typo because I got confused by the builder type in the BCL which is singular 😆