### PR TITLE
Remove AD0001 analyzer warning suppression

### DIFF
--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -29,13 +29,6 @@
     <Features>strict</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <!--
-      Workaround for: "CSC(0,0): Error AD0001: Analyzer 'ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer' threw
-      an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type
-      'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.NonErrorNamedTypeSymbol' to type 'Microsoft.CodeAnalysis.IMethodSymbol'.'.".
-    -->
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
-
     <!-- Workaround for some methods not being fully implemented yet -->
     <NoWarn>$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Eliminates the workaround for the AD0001 analyzer warning related to ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer, as it is no longer needed.