### PR TITLE
Fix covariant expansion for recursive type definitions in 'cswinrtgen'

### DIFF
--- a/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
+++ b/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using WindowsRuntime.InteropGenerator.Errors;
@@ -180,7 +181,7 @@ internal static partial class InteropTypeDiscovery
             // - 'IEnumerable<IEnumerable<object>>'
             // - 'IEnumerable<IEnumerable>'
             // - 'IEnumerable<IDisposable>'
-            foreach (TypeSignature covariantInterfaceSignature in WindowsRuntimeTypeAnalyzer.EnumerateCovarianceExpandedInterfaceTypes(interfaceSignature, interopReferences))
+            foreach (TypeSignature covariantInterfaceSignature in WindowsRuntimeTypeAnalyzer.EnumerateCovarianceExpandedInterfaceTypes(interfaceSignature, interopReferences).Concat([interfaceSignature]))
             {
                 // Check for projected Windows Runtime interfaces first. We want to explicitly ignore
                 // '[exclusiveto]' interfaces too, which might still show up as part of the covariant

--- a/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
+++ b/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
@@ -113,7 +113,9 @@ internal static class WindowsRuntimeTypeAnalyzer
                 yield break;
             }
 
-            // First return the current constructed interface too, as it's a valid generic instantiation
+            // First return the current constructed interface too, as it's a valid generic instantiation.
+            // Even if callers are already checking the original input interface as well, this item is
+            // still needed, as it might result in additional combinations when used in a recursive call.
             yield return interfaceType;
 
             // Next, gather all combinations from interfaces implemented by the element type


### PR DESCRIPTION
Title. Review PR with **whitespaces off**.