### PR TITLE
Add missing custom-mapped and manually-projected type checks to 'cswinrtgen'

### DIFF
--- a/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
@@ -151,7 +151,18 @@ internal static class WindowsRuntimeExtensions
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.TimeSpan) ||
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.DateTimeOffset) ||
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Exception) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Type);
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Type) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Uri) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Matrix3x2) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Matrix4x4) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Plane) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Quaternion) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Vector2) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Vector3) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Vector4) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.DataErrorsChangedEventArgs) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.PropertyChangedEventArgs) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.NotifyCollectionChangedEventArgs);
         }
 
         /// <summary>
@@ -169,7 +180,8 @@ internal static class WindowsRuntimeExtensions
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.AsyncStatus) ||
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Point) ||
                 SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Rect) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Size);
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Size) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.EventRegistrationToken);
         }
 
         /// <summary>

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -89,6 +89,15 @@ internal sealed class InteropReferences
         publicKeyOrToken: WellKnownPublicKeyTokens.SystemMemory);
 
     /// <summary>
+    /// Gets the <see cref="AssemblyReference"/> for <c>System.Numerics.Vectors.dll</c>.
+    /// </summary>
+    public AssemblyReference SystemNumericsVectors => field ??= new AssemblyReference(
+        name: "System.Numerics.Vectors"u8,
+        version: new Version(10, 0, 0, 0),
+        publicKey: false,
+        publicKeyOrToken: WellKnownPublicKeyTokens.SystemNumericsVectors);
+
+    /// <summary>
     /// Gets the <see cref="AssemblyReference"/> for <c>WinRT.Projection.dll</c>.
     /// </summary>
     public AssemblyReference WinRTProjection => field ??= new AssemblyReference(
@@ -273,6 +282,46 @@ internal sealed class InteropReferences
     public TypeReference DateTimeOffset => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "DateTimeOffset"u8);
 
     /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Uri"/>.
+    /// </summary>
+    public TypeReference Uri => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "Uri"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Matrix3x2"/>.
+    /// </summary>
+    public TypeReference Matrix3x2 => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Matrix3x2"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Matrix4x4"/>.
+    /// </summary>
+    public TypeReference Matrix4x4 => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Matrix4x4"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Plane"/>.
+    /// </summary>
+    public TypeReference Plane => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Plane"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Quaternion"/>.
+    /// </summary>
+    public TypeReference Quaternion => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Quaternion"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Vector2"/>.
+    /// </summary>
+    public TypeReference Vector2 => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Vector2"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Vector3"/>.
+    /// </summary>
+    public TypeReference Vector3 => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Vector3"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Numerics.Vector4"/>.
+    /// </summary>
+    public TypeReference Vector4 => field ??= SystemNumericsVectors.CreateTypeReference("System.Numerics"u8, "Vector4"u8);
+
+    /// <summary>
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.IServiceProvider"/>.
     /// </summary>
     public TypeReference IServiceProvider => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System"u8, "IServiceProvider"u8);
@@ -386,6 +435,11 @@ internal sealed class InteropReferences
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.ComponentModel.PropertyChangedEventArgs"/>.
     /// </summary>
     public TypeReference PropertyChangedEventArgs => field ??= SystemObjectModel.CreateTypeReference("System.ComponentModel"u8, "PropertyChangedEventArgs"u8);
+
+    /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.ComponentModel.DataErrorsChangedEventArgs"/>.
+    /// </summary>
+    public TypeReference DataErrorsChangedEventArgs => field ??= SystemObjectModel.CreateTypeReference("System.ComponentModel"u8, "DataErrorsChangedEventArgs"u8);
 
     /// <summary>
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.MemoryExtensions"/>.

--- a/src/WinRT.Interop.Generator/References/WellKnownPublicKeyTokens.cs
+++ b/src/WinRT.Interop.Generator/References/WellKnownPublicKeyTokens.cs
@@ -22,4 +22,9 @@ internal static class WellKnownPublicKeyTokens
     /// The public key data for <c>System.Runtime.InteropServices.dll</c>.
     /// </summary>
     public static readonly byte[] SystemRuntimeInteropServices = [0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A];
+
+    /// <summary>
+    /// The public key data for <c>System.Numerics.Vectors.dll</c>.
+    /// </summary>
+    public static readonly byte[] SystemNumericsVectors = [0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A];
 }


### PR DESCRIPTION
Title. Adds a bunch of missing custom-mapped and manually-projected types to 'cswinrtgen'.