### PR TITLE
Clear shared state after COM object creation

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
@@ -292,7 +292,7 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
             // make sure that those fields are always 'null' before any following calls. This is necessary because
             // we cannot guarantee callers will always go through this overload to set them correctly. In particular,
             // the 'WeakReference<T>' callback might use this 'ComWrappers' instance externally, and if any of these
-            // fields were set it would causes issues. See additional notes below for this in 'CreateObject'.
+            // fields were set it would cause issues. See additional notes below for this in 'CreateObject'.
             ObjectComWrappersCallback = null;
             UnsealedObjectComWrappersCallback = null;
             CreateObjectTargetInterfacePointer = null;


### PR DESCRIPTION
Wrap the GetOrCreateObjectForComInstance call in a try/finally and always reset the shared state fields (ObjectComWrappersCallback, UnsealedObjectComWrappersCallback, CreateObjectTargetInterfacePointer) to null. This ensures those fields are cleared even on exceptions so subsequent calls or external callbacks (e.g. from a WeakReference<T>) won't observe stale state and cause incorrect behavior.