### PR TITLE
Remove IGlobalInterfaceTable IID entry in 'WinRT.Runtime.dll'

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/WellKnownWindowsInterfaceIIDs.g.cs
+++ b/src/WinRT.Runtime2/InteropServices/WellKnownWindowsInterfaceIIDs.g.cs
@@ -1135,31 +1135,6 @@ internal static class WellKnownWindowsInterfaceIIDs
         }
     }
 
-    /// <summary>The IID for <c>IGlobalInterfaceTable</c> (00000146-0000-0000-C000-000000000046).</summary>
-    public static ref readonly Guid IID_IGlobalInterfaceTable
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]   
-        get
-        {
-            ReadOnlySpan<byte> data =
-            [
-                0x46, 0x01, 0x00, 0x00,
-                0x00, 0x00,
-                0x00, 0x00,
-                0xC0,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x46
-            ];
-
-            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
-        }
-    }
-
     /// <summary>The IID for <c>EventHandler</c> (C50898F6-C536-5F47-8583-8B2C2438A13B).</summary>
     public static ref readonly Guid IID_EventHandler
     {

--- a/src/WinRT.Runtime2/InteropServices/WellKnownWindowsInterfaceIIDs.tt
+++ b/src/WinRT.Runtime2/InteropServices/WellKnownWindowsInterfaceIIDs.tt
@@ -62,7 +62,6 @@ var entries = new (string Name, string IID)[]
     ("UriRuntimeClassFactory", "44A9796F-723E-4FDF-A218-033E75B0C084"),
     ("INotifyDataErrorInfo", "0EE6C2CC-273E-567D-BC0A-1DD87EE51EBA"),
     ("ICommand", "E5AF3542-CA67-4081-995B-709DD13792DF"),
-    ("IGlobalInterfaceTable", "00000146-0000-0000-C000-000000000046"),
     ("EventHandler", "C50898F6-C536-5F47-8583-8B2C2438A13B"),
     ("IBindableIterable", "036D2C08-DF29-41AF-8AA2-D774BE62BA6F"),
     ("IBindableIterator", "6A1D6C07-076D-49F2-8314-F52C9C9A8331"),


### PR DESCRIPTION
Delete the IGlobalInterfaceTable IID from the generated IID list: remove its Guid property from WellKnownWindowsInterfaceIIDs.g.cs and remove the corresponding tuple from the WellKnownWindowsInterfaceIIDs.tt template so the IID is no longer generated.