### PR TITLE
Fix reference path in nuget scenarios and fix extra references

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.CsWinRTGen.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.CsWinRTGen.targets
@@ -151,20 +151,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Outputs="$(_CsWinRTGeneratorInteropAssemblyPath)"
     Condition="'$(CsWinRTGenerateInteropAssembly2)' == 'true'">
 
-    <ItemGroup>
-        <!--
-          Filter the reference assemblies to ones where the implementation
-          and reference assembly are different as is with our projection DLLs.
-          This also avoids passing the same DLLs in both such as with .NET Core
-          assemblies.
-         -->
-        <_ReferenceAssemblyPaths Include="@(ReferencePathWithRefAssemblies)" />
-        <_ReferenceAssemblyPaths Remove="@(ReferencePath)" />
-    </ItemGroup>
-
     <!-- Invoke 'cswinrtinteropgen' -->
     <RunCsWinRTInteropGenerator
-      ReferenceAssemblyPaths="@(_ReferenceAssemblyPaths)"
+      ReferenceAssemblyPaths="@(ReferencePathWithRefAssemblies)"
       ImplementationAssemblyPaths="@(ReferencePath)"      
       OutputAssemblyPath="@(IntermediateAssembly)"
       WinRTProjectionAssemblyPath="$(_CsWinRTGeneratorMergedProjectionAssemblyPath)"

--- a/src/Projections/Windows/Windows.csproj
+++ b/src/Projections/Windows/Windows.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj" />
+    <ProjectReference Include="..\..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\WinRT.Runtime2\WinRT.Runtime.csproj" />
     <ProjectReference Include="..\..\cswinrt\cswinrt.vcxproj" />
   </ItemGroup>


### PR DESCRIPTION
- In NuGet scenarios, we were not passing any reference assemblies.  Given we already have filtering for projection assemblies based on attribute in cswinrtgen, passing ReferencePathWithRefAssemblies without attempting to do any pre-filtering.
- Mark WinRT.Generator.Tasks to not reference assembly to avoid inner loop builds picking that up as a ref in cswinrtgen