### PR TITLE
Change WindowsRuntimeObjectReference methods to internal

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Helpers.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Helpers.cs
@@ -55,7 +55,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <returns>The COM object pointer for the requested interface.</returns>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
     /// <exception cref="Exception">Thrown if the <c>QueryInterface</c> call fails for any reason.</exception>
-    public void* AsUnsafe(in Guid iid)
+    internal void* AsUnsafe(in Guid iid)
     {
         AsUnsafe(in iid, out void* pv);
 
@@ -69,13 +69,13 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <param name="ppv">The resulting COM object pointer to retrieve.</param>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
     /// <exception cref="Exception">Thrown if the <c>QueryInterface</c> call fails for any reason.</exception>
-    public void AsUnsafe(in Guid iid, out void* ppv)
+    internal void AsUnsafe(in Guid iid, out void* ppv)
     {
         TryAsNative(in iid, out ppv).Assert();
     }
 
     /// <inheritdoc cref="AsUnsafe(in Guid, out void*)"/>
-    public void AsUnsafe(in Guid iid, out nint ppv)
+    internal void AsUnsafe(in Guid iid, out nint ppv)
     {
         TryAsNative(in iid, out ppv).Assert();
     }
@@ -87,7 +87,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <param name="objectReference">The resulting <see cref="WindowsRuntimeObjectReference"/> instance for the requested interface.</param>
     /// <returns>Whether the requested interface was retrieved successfully.</returns>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
-    public bool TryAs(in Guid iid, [NotNullWhen(true)] out WindowsRuntimeObjectReference? objectReference)
+    internal bool TryAs(in Guid iid, [NotNullWhen(true)] out WindowsRuntimeObjectReference? objectReference)
     {
         HRESULT hresult = DerivedTryAsNative(in iid, out objectReference);
 
@@ -101,7 +101,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <param name="ppv">The resulting COM pointer for the requested interface.</param>
     /// <returns>Whether the requested interface was retrieved successfully.</returns>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
-    public bool TryAsUnsafe(in Guid iid, out void* ppv)
+    internal bool TryAsUnsafe(in Guid iid, out void* ppv)
     {
         HRESULT hresult = TryAsNative(in iid, out ppv);
 
@@ -109,7 +109,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     }
 
     /// <inheritdoc cref="TryAsUnsafe(in Guid, out void*)"/>
-    public bool TryAsUnsafe(in Guid iid, out nint ppv)
+    internal bool TryAsUnsafe(in Guid iid, out nint ppv)
     {
         HRESULT hresult = TryAsNative(in iid, out ppv);
 

--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Lifecycle.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Lifecycle.cs
@@ -99,7 +99,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// the current object. Callers must call <see cref="AddRefUnsafe"/> and <see cref="ReleaseUnsafe"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void* GetReferenceTrackerPtrUnsafe()
+    internal void* GetReferenceTrackerPtrUnsafe()
     {
         return _referenceTrackerPtr;
     }
@@ -109,7 +109,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// </summary>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance has been disposed.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AddRefUnsafe()
+    internal void AddRefUnsafe()
     {
         ObjectDisposedException.ThrowIf(!TryAddRefUnsafe(), this);
     }
@@ -119,7 +119,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// </summary>
     /// <returns>Whether the managed reference count has been increased successfully.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryAddRefUnsafe()
+    internal bool TryAddRefUnsafe()
     {
         bool success = true;
 
@@ -220,7 +220,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <remarks>
     /// Calls to <see cref="ReleaseUnsafe"/> should always exactly match calls to <see cref="AddRefUnsafe"/>.
     /// </remarks>
-    public void ReleaseUnsafe()
+    internal void ReleaseUnsafe()
     {
         // To release, we can simply do an interlocked decrement on the reference tracking
         // mask. Each caller is guaranteed to only call this method once (the contract states to only


### PR DESCRIPTION
Reduce the public surface of WindowsRuntimeObjectReference by changing several API access modifiers from public to internal. Updated AsUnsafe/TryAs/TryAsUnsafe overloads in WindowsRuntimeObjectReference.Helpers.cs and lifecycle methods (GetReferenceTrackerPtrUnsafe, AddRefUnsafe, TryAddRefUnsafe, ReleaseUnsafe) in WindowsRuntimeObjectReference.Lifecycle.cs. No behavioral changes intended — only visibility/encapsulation adjustments to restrict these unsafe/lifecycle operations to internal consumers.