### PR TITLE
Make Matrix.s_identity readonly

### DIFF
--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media/Microsoft.UI.Xaml.Media.Matrix.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media/Microsoft.UI.Xaml.Media.Matrix.cs
@@ -6,7 +6,7 @@ namespace Microsoft.UI.Xaml.Media
     partial struct Matrix : IFormattable
     {
         // the transform is identity by default
-        private static Matrix s_identity = CreateIdentity();
+        private static readonly Matrix s_identity = CreateIdentity();
 
         public static Matrix Identity
         {

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media/Windows.UI.Xaml.Media.Matrix.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media/Windows.UI.Xaml.Media.Matrix.cs
@@ -6,7 +6,7 @@ namespace Windows.UI.Xaml.Media
     partial struct Matrix : IFormattable
     {
         // the transform is identity by default
-        private static Matrix s_identity = CreateIdentity();
+        private static readonly Matrix s_identity = CreateIdentity();
 
         public static Matrix Identity
         {


### PR DESCRIPTION
Mark the static s_identity field as readonly in the Matrix partial structs for both Microsoft.UI.Xaml.Media and Windows.UI.Xaml.Media. This enforces immutability of the identity matrix (created via CreateIdentity), preventing accidental reassignment and clarifying intent; no behavioral changes expected.