### PR TITLE
Remove StructLayout attribute from XAML structs

### DIFF
--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.KeyTime.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.KeyTime.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Media.Animation.KeyTime>")]
     [ABI.Microsoft.UI.Xaml.Media.Animation.KeyTimeComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct KeyTime : IEquatable<KeyTime>
     {
         public static KeyTime FromTimeSpan(TimeSpan timeSpan)

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Media.Animation.RepeatBehavior>")]
     [ABI.Microsoft.UI.Xaml.Media.Animation.RepeatBehaviorComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct RepeatBehavior : IFormattable, IEquatable<RepeatBehavior>
     {
         internal static bool IsFinite(double value)

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Media3D/Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml.Media.Media3D/Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml.Media.Media3D
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Media.Media3D.Matrix3D>")]
     [ABI.Microsoft.UI.Xaml.Media.Media3D.Matrix3DComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct Matrix3D : IFormattable, IEquatable<Matrix3D>
     {
         // Assuming this matrix has fourth column of 0,0,0,1 and isn't identity this function:

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.CornerRadius.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.CornerRadius.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.CornerRadius>")]
     [ABI.Microsoft.UI.Xaml.CornerRadiusComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct CornerRadius : IEquatable<CornerRadius>
     {
         private double _TopLeft;

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.Duration.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.Duration.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Duration>")]
     [ABI.Microsoft.UI.Xaml.DurationComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct Duration : IEquatable<Duration>
     {
         private readonly TimeSpan _timeSpan;

--- a/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
+++ b/src/cswinrt/strings/additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
@@ -8,7 +8,6 @@ namespace Microsoft.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.GridLength>")]
     [ABI.Microsoft.UI.Xaml.GridLengthComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct GridLength : IEquatable<GridLength>
     {
         private readonly double _unitValue;

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.KeyTime.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.KeyTime.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Media.Animation.KeyTime>")]
     [ABI.Windows.UI.Xaml.Media.Animation.KeyTimeComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct KeyTime : IEquatable<KeyTime>
     {
         public static KeyTime FromTimeSpan(TimeSpan timeSpan)

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Media.Animation.RepeatBehavior>")]
     [ABI.Windows.UI.Xaml.Media.Animation.RepeatBehaviorComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct RepeatBehavior : IFormattable, IEquatable<RepeatBehavior>
     {
         internal static bool IsFinite(double value)

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.Matrix3D.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.Matrix3D.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml.Media.Media3D
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Media.Media3D.Matrix3D>")]
     [ABI.Windows.UI.Xaml.Media.Media3D.Matrix3DComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct Matrix3D : IFormattable, IEquatable<Matrix3D>
     {
         // Assuming this matrix has fourth column of 0,0,0,1 and isn't identity this function:

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.CornerRadius.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.CornerRadius.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.CornerRadius>")]
     [ABI.Windows.UI.Xaml.CornerRadiusComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public struct CornerRadius : IEquatable<CornerRadius>
     {
         private double _TopLeft;

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.Duration.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.Duration.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Duration>")]
     [ABI.Windows.UI.Xaml.DurationComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct Duration : IEquatable<Duration>
     {
         private readonly TimeSpan _timeSpan;

--- a/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
+++ b/src/cswinrt/strings/additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.GridLength>")]
     [ABI.Windows.UI.Xaml.GridLengthComWrappersMarshaller]
 #endif
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct GridLength : IEquatable<GridLength>
     {
         private readonly double _unitValue;


### PR DESCRIPTION
Remove the redundant [StructLayout(LayoutKind.Sequential)] attribute from several value types in the cswinrt strings additions for Microsoft.UI.Xaml and Windows.UI.Xaml. Affected types include KeyTime, RepeatBehavior, Matrix3D, CornerRadius, Duration, and GridLength (in both Microsoft.UI.Xaml and Windows.UI.Xaml namespaces). This cleans up generated/added sources and makes the struct definitions consistent across these files.

Sequential layout is already the default for structs with unmanaged fields.
And if they have managed fields then the layout is always auto no matter what you say.