### PR TITLE
Hide 'IWindowsRuntimeInterface<T>' in 'WinRT.Runtime.dll'

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/IWindowsRuntimeInterface{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/IWindowsRuntimeInterface{T}.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.ComponentModel;
+
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>
@@ -15,6 +18,10 @@ namespace WindowsRuntime.InteropServices;
 /// The <typeparamref name="T"/> type must refer to a projected Windows Runtime interface.
 /// </para>
 /// </remarks>
+[Obsolete(WindowsRuntimeConstants.PrivateImplementationDetailObsoleteMessage,
+    DiagnosticId = WindowsRuntimeConstants.PrivateImplementationDetailObsoleteDiagnosticId,
+    UrlFormat = WindowsRuntimeConstants.CsWinRTDiagnosticsUrlFormat)]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public interface IWindowsRuntimeInterface<T>
     where T : class
 {


### PR DESCRIPTION
Mark IWindowsRuntimeInterface<T> as a private implementation detail by adding an [Obsolete] attribute (using WindowsRuntimeConstants for message, diagnostic id and URL) and [EditorBrowsable(EditorBrowsableState.Never)] to hide it from IntelliSense. Also added required using directives for System and System.ComponentModel.