### PR TITLE
Correct .winmd references count in log

### DIFF
--- a/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
@@ -40,7 +40,7 @@ internal static partial class ProjectionGenerator
         // Process all .winmd references and create the .rsp file for 'cswinrt.exe'
         try
         {
-            ConsoleApp.Log($"Processing {args.WinMDPaths.Length + 1} .winmd references");
+            ConsoleApp.Log($"Processing {args.WinMDPaths.Length} .winmd references");
 
             processingState = ProcessReferences(args);
         }


### PR DESCRIPTION
Fix an off-by-one error in ProjectionGenerator logging: report args.WinMDPaths.Length instead of args.WinMDPaths.Length + 1 so the logged number of .winmd references is accurate. Update is limited to ProjectionGenerator.cs.