### PR TITLE
Fixes to CsWinRTResolveWindowsMetadata

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -185,15 +185,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <!-- From the Windows SDK projection binary referenced, determine the folder with the WinMDs in the targeting pack -->
-  <Target Name="CsWinRTResolveWindowsMetadata" BeforeTargets="BeforeCompile" AfterTargets="ResolveReferences" Condition="'$(CsWinRTWindowsMetadata)' == ''">
-      <ItemGroup>
-        <_WindowsSdkProjectionFolder Include="@(ReferencePath->'%(RootDir)%(Directory)..\..\winmd\')" Condition="'%(ReferencePath.FileName)%(ReferencePath.Extension)' == 'Microsoft.Windows.SDK.NET.dll'" />
-      </ItemGroup>
-      <PropertyGroup>
-        <CsWinRTWindowsMetadata>@(_WindowsSdkProjectionFolder)</CsWinRTWindowsMetadata>
-        <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
-        <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(EffectiveTargetPlatformVersion)</CsWinRTWindowsMetadata>
-      </PropertyGroup>
+  <Target Name="CsWinRTResolveWindowsMetadata" BeforeTargets="BeforeCompile" AfterTargets="ResolveReferences" Condition="'$(CsWinRTResolveWindowsMetadata)' != 'false' AND '$(CsWinRTWindowsMetadata)' == ''">
+    <!-- Based on the Windows SDK projection profile used, the winmds are in a different folder. -->
+    <PropertyGroup>
+      <_CsWinRTMetadataSubFolder>windows</_CsWinRTMetadataSubFolder>
+      <_CsWinRTMetadataSubFolder Condition="'$(CsWinRTUseWindowsUIXamlProjections)' == 'true'">xaml</_CsWinRTMetadataSubFolder>
+    </PropertyGroup>
+      
+    <ItemGroup>
+      <_WindowsSdkProjectionFolder Include="@(ReferencePath->'%(RootDir)%(Directory)..\..\winmd\$(_CsWinRTMetadataSubFolder)\')" Condition="'%(ReferencePath.FileName)%(ReferencePath.Extension)' == 'Microsoft.Windows.SDK.NET.dll'" />
+    </ItemGroup>
+      
+    <PropertyGroup>
+      <CsWinRTWindowsMetadata>@(_WindowsSdkProjectionFolder)</CsWinRTWindowsMetadata>
+      <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(WindowsSDKVersion.TrimEnd('\'))</CsWinRTWindowsMetadata>
+      <CsWinRTWindowsMetadata Condition="'$(CsWinRTWindowsMetadata)' == ''">$(EffectiveTargetPlatformVersion)</CsWinRTWindowsMetadata>
+    </PropertyGroup>
   </Target>
 
   <Target Name="CsWinRTPrepareProjection" DependsOnTargets="$(CsWinRTPrepareProjectionDependsOn)" Outputs="$(CsWinRTGeneratedFilesDir)">


### PR DESCRIPTION
- The SDK pipeline needs a way to disable this target given it provides its own WinMDs.  So added CsWinRTResolveWindowsMetadata property check.
- We also need to distribute the set of winmds respective to both of the projections we ship (the Windows profile and the xaml profile).  So based on which one is being used, we need to choose the right one.  Added logic to handle that.