### PR TITLE
Minor tweaks to output messages for generators

### DIFF
--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.cs
@@ -91,7 +91,7 @@ internal static partial class InteropGenerator
         // exceptions that can reach that path to have our custom formatting implementation there.
         try
         {
-            ConsoleApp.Log($"Processing {args.ReferenceAssemblyPaths.Length + args.ImplementationAssemblyPaths.Length + 1} modules");
+            ConsoleApp.Log($"Processing {args.ReferenceAssemblyPaths.Length + args.ImplementationAssemblyPaths.Length + 1} module(s)");
 
             discoveryState = Discover(args);
         }

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
@@ -40,7 +40,7 @@ internal static partial class ProjectionGenerator
         // Process all .winmd references and create the .rsp file for 'cswinrt.exe'
         try
         {
-            ConsoleApp.Log($"Processing {args.WinMDPaths.Length} .winmd references");
+            ConsoleApp.Log($"Processing {args.WinMDPaths.Length} .winmd reference(s)");
 
             processingState = ProcessReferences(args);
         }
@@ -54,7 +54,7 @@ internal static partial class ProjectionGenerator
         // Invoke 'cswinrt.exe' to generate the projection sources
         try
         {
-            ConsoleApp.Log("Generating merged projection code");
+            ConsoleApp.Log("Generating projection code");
 
             GenerateSources(args, processingState);
         }
@@ -68,7 +68,7 @@ internal static partial class ProjectionGenerator
         // Invoke Roslyn to compile the generated sources into 'WinRT.Projection.dll'
         try
         {
-            ConsoleApp.Log("Compiling merged projection");
+            ConsoleApp.Log("Compiling projection code");
 
             Emit(args, processingState);
         }


### PR DESCRIPTION
Adjust console log text in InteropGenerator and ProjectionGenerator for clarity: use "module(s)" and ".winmd reference(s)" to handle singular/plural cases, and remove the word "merged" from projection generation and compilation messages to make it clearer. Also did the same in the interop generator for consistency.