### PR TITLE
Fix callback types for 'IObservable*<...>' types in 'cswinrtinteropgen'

### DIFF
--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Emit.cs
@@ -1517,7 +1517,7 @@ internal partial class InteropGenerator
 
                 InteropTypeDefinitionBuilder.Marshaller(
                     typeSignature: typeSignature,
-                    interfaceComWrappersCallbackType: comWrappersMarshallerType,
+                    interfaceComWrappersCallbackType: comWrappersCallbackType,
                     get_IidMethod: get_IidMethod,
                     interopReferences: interopReferences,
                     emitState: emitState,
@@ -1635,7 +1635,7 @@ internal partial class InteropGenerator
 
                 InteropTypeDefinitionBuilder.Marshaller(
                     typeSignature: typeSignature,
-                    interfaceComWrappersCallbackType: comWrappersMarshallerType,
+                    interfaceComWrappersCallbackType: comWrappersCallbackType,
                     get_IidMethod: get_IidMethod,
                     interopReferences: interopReferences,
                     emitState: emitState,


### PR DESCRIPTION
Correct the argument passed to InteropTypeDefinitionBuilder.Marshaller: replace comWrappersMarshallerType with comWrappersCallbackType for the interfaceComWrappersCallbackType parameter. This fixes two occurrences so the marshaller receives the intended callback type instead of the marshaller type, preventing incorrect generated interop code.