### PR TITLE
Fix 'MapChangedEventHandlerEventSource<K,V>' base '.ctor' call in 'cswinrtinteropgen'

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
@@ -123,10 +123,13 @@ internal partial class InteropTypeDefinitionBuilder
             ModuleDefinition module,
             out TypeDefinition eventSourceType)
         {
+            TypeSignature keyType = delegateType.TypeArguments[0];
+            TypeSignature valueType = delegateType.TypeArguments[1];
+
             DerivedEventSource(
                 delegateType: delegateType,
                 baseEventSourceType: interopReferences.MapChangedEventHandler2EventSource,
-                baseEventSource_ctor: interopReferences.MapChangedEventHandler2EventSource_ctor,
+                baseEventSource_ctor: interopReferences.MapChangedEventHandler2EventSource_ctor(keyType, valueType),
                 marshallerType: marshallerType,
                 interopReferences: interopReferences,
                 module: module,

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -2303,13 +2303,6 @@ internal sealed class InteropReferences
     public MemberReference WindowsRuntimeComWrappersMarshallerAttribute_ctor => field ??= WindowsRuntimeComWrappersMarshallerAttribute.CreateConstructorReference(_corLibTypeFactory);
 
     /// <summary>
-    /// Gets the <see cref="MemberReference"/> for <see cref="MapChangedEventHandler2EventSource"/>'s constructor.
-    /// </summary>
-    public MemberReference MapChangedEventHandler2EventSource_ctor => field ??= MapChangedEventHandler2EventSource.CreateConstructorReference(
-        corLibTypeFactory: _corLibTypeFactory,
-        parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
-
-    /// <summary>
     /// Gets the <see cref="MemberReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersMarshallerAttribute.GetOrCreateComInterfaceForObject(object)</c>.
     /// </summary>
     public MemberReference WindowsRuntimeComWrappersMarshallerAttributeGetOrCreateComInterfaceForObject => field ??= WindowsRuntimeComWrappersMarshallerAttribute
@@ -3625,6 +3618,20 @@ internal sealed class InteropReferences
                 parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
     }
 
+    /// <summary>
+    /// Gets the <see cref="MemberReference"/> for <see cref="MapChangedEventHandler2EventSource"/>'s constructor.
+    /// </summary>
+    /// <param name="keyType">The type of keys in the observable map.</param>
+    /// <param name="valueType">The type of values in the observable map.</param>
+    public MemberReference MapChangedEventHandler2EventSource_ctor(TypeSignature keyType, TypeSignature valueType)
+    {
+        return MapChangedEventHandler2EventSource
+            .MakeGenericReferenceType(keyType, valueType)
+            .ToTypeDefOrRef()
+            .CreateConstructorReference(
+                corLibTypeFactory: _corLibTypeFactory,
+                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
+    }
 
     /// <summary>
     /// Gets the <see cref="MemberReference"/> for the <c>.ctor</c> method of a given nullable value type.


### PR DESCRIPTION
Update InteropReferences to expose MapChangedEventHandler2EventSource_ctor(keyType, valueType) which builds a generic MapChangedEventHandler2EventSource reference and returns its constructor MemberReference. Adjust InteropTypeDefinitionBuilder to extract the delegate's key/value TypeArguments and pass them into the new ctor helper. Removes the previous non-generic ctor property.

TLDR, fixes this thing:

<img width="1509" height="281" alt="image" src="https://github.com/user-attachments/assets/51f87e30-39e5-4cfc-8234-933c4d48d004" />