### PR TITLE
Fix typos and clarify comments

### DIFF
--- a/src/WinRT.Interop.Generator/Helpers/SignatureGenerator.cs
+++ b/src/WinRT.Interop.Generator/Helpers/SignatureGenerator.cs
@@ -139,7 +139,7 @@ internal static partial class SignatureGenerator
 
     /// <summary>
     /// Attempts to retrieve the IID for the specified type by checking the <see cref="System.Runtime.InteropServices.GuidAttribute"/>
-    /// attribute applied to it, if presen. The type is assumed to be some projected Windows Runtime interface or delegate type.
+    /// attribute applied to it, if present. The type is assumed to be some projected Windows Runtime interface or delegate type.
     /// </summary>
     /// <param name="type">The type descriptor to try to get the IID for.</param>
     /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>

--- a/src/WinRT.Interop.Generator/Helpers/TypeMapping.cs
+++ b/src/WinRT.Interop.Generator/Helpers/TypeMapping.cs
@@ -169,7 +169,7 @@ internal static class TypeMapping
     /// </summary>
     /// <param name="fullName">The full name of the type.</param>
     /// <param name="useWindowsUIXamlProjections">Whether to use <c>Windows.UI.Xaml</c> projections.</param>
-    /// <param name="signature">The resulting mapped type signatre, if found.</param>
+    /// <param name="signature">The resulting mapped type signature, if found.</param>
     /// <returns>Whether <paramref name="signature"/> was retrieved successfully.</returns>
     public static bool TryFindMappedTypeSignature(
         ReadOnlySpan<char> fullName,
@@ -200,7 +200,7 @@ internal static class TypeMapping
 
             // All entries here will always have a signature, if their corresponding entries
             // in the global table of type mappings also have signatures. If that's not the
-            // case, then it means an entry in the second lokup is just malformed
+            // case, then it means an entry in the second lookup is just malformed
             signature = mappedType.Signature!;
 
             return true;

--- a/src/WinRT.Interop.Generator/Visitors/AllSzArrayTypesVisitor.cs
+++ b/src/WinRT.Interop.Generator/Visitors/AllSzArrayTypesVisitor.cs
@@ -57,9 +57,9 @@ internal sealed class AllSzArrayTypesVisitor : ITypeSignatureVisitor<IEnumerable
     /// <inheritdoc/>
     public IEnumerable<SzArrayTypeSignature> VisitGenericInstanceType(GenericInstanceTypeSignature signature)
     {
-        // This will recursively visit all substituted arguments in an instantiated generic type signature. For
-        // instance, if it finds 'List<(string[], string, List<int[]>)>', it will give give back 'string[]' and
-        // also recurse on all other arguments, such that the 'int[]' type signature can also be discovered.
+        // This will recursively visit all substituted arguments in an instantiated generic type signature.
+        // For instance, if it finds 'List<(string[], string, List<int[]>)>', it will give back 'string[]'
+        // and recurse on all other arguments, such that the 'int[]' type signature can also be discovered.
         return signature.TypeArguments.SelectMany(static arg => arg.AcceptVisitor(Instance));
     }
 

--- a/src/WinRT.Runtime2/InteropServices/AsyncInfo/Adapters/UniversalTaskAdapter{TResult, TProgress}.IAsyncInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/AsyncInfo/Adapters/UniversalTaskAdapter{TResult, TProgress}.IAsyncInfo.cs
@@ -93,7 +93,7 @@ internal partial class UniversalTaskAdapter<
             conditionBitMask: STATE_STARTED,
             conditionFailed: out bool stateWasNotStarted);
 
-        // If the state was different than 'STATE_STARTED'
+        // If the state was 'STATE_STARTED' (i.e. the condition did not fail)
         if (!stateWasNotStarted)
         {
             _cancelTokenSource?.Cancel();

--- a/src/WinRT.Runtime2/InteropServices/Bindables/BindableIListMethods.cs
+++ b/src/WinRT.Runtime2/InteropServices/Bindables/BindableIListMethods.cs
@@ -188,7 +188,7 @@ internal static class BindableIListMethods
             ArgumentException.ThrowIndexOutOfArrayBounds();
         }
 
-        // We need to verify the index as we;
+        // Copy all items into the target array, at the specified starting offset
         for (int i = 0; i < sourceLength; i++)
         {
             array.SetValue(Item(thisReference, i), i + index);

--- a/src/WinRT.Runtime2/InteropServices/Collections/IReadOnlyDictionaryAdapterExtensions.cs
+++ b/src/WinRT.Runtime2/InteropServices/Collections/IReadOnlyDictionaryAdapterExtensions.cs
@@ -78,7 +78,7 @@ public static class IReadOnlyDictionaryAdapterExtensions
         /// <remarks>
         /// This overload can be used to avoid a <see cref="string"/> allocation on the caller side.
         /// </remarks>
-        /// /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey"/>
+        /// <see href="https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey"/>
         public static bool HasKey(IReadOnlyDictionary<string, TValue> dictionary, ReadOnlySpan<char> key)
         {
             // Same logic as in 'Lookup' above for trying to avoid materializing the 'string' key

--- a/src/WinRT.Runtime2/InteropServices/Collections/IReadOnlyListMethods{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Collections/IReadOnlyListMethods{T}.cs
@@ -30,7 +30,7 @@ public static class IReadOnlyListMethods<T>
         {
             // The native implementation will perform the bounds check, so we avoid doing an
             // extra native call just to get the size of the collection. If the call fails
-            // because the index is not valid, we translate the exception to the rigth one.
+            // because the index is not valid, we translate the exception to the right one.
             return TMethods.GetAt(thisReference, (uint)index);
         }
         catch (Exception e) when (e.HResult == WellKnownErrorCodes.E_BOUNDS)

--- a/src/WinRT.Runtime2/InteropServices/Events/EventRegistrationTokenTable{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Events/EventRegistrationTokenTable{T}.cs
@@ -102,7 +102,7 @@ public sealed class EventRegistrationTokenTable<T>
             do
             {
                 // Iterate on TryAdd, which allows skipping the extra lookup on
-                // the last iteration (as the handler is added rigth away instead).
+                // the last iteration (as the handler is added right away instead).
                 //
                 // We're doing this do-while loop here and incrementing 'm_low32Bits' on every failed insertion to work
                 // around one possible (theoretical) performance problem. Suppose the candidate token was somehow already


### PR DESCRIPTION
Corrects various typos and improves clarity in comments and XML docs across multiple files. Notable fixes: corrects misspellings (e.g. presen->present, signatre->signature, lokup->lookup, rigth->right), removes a duplicated word, fixes an extra XML-doc marker, and clarifies the UniversalTaskAdapter comment to accurately describe the STATE_STARTED condition. These changes improve readability and prevent misleading documentation without changing runtime behavior.