### PR TITLE
Fix 'Interlocked' type references in 'cswinrtinteropgen'

### DIFF
--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -155,6 +155,16 @@ internal sealed class InteropReferences
         publicKeyOrToken: WellKnownPublicKeyTokens.SystemNumericsVectors).Import(_corLibTypeFactory.CorLibScope);
 
     /// <summary>
+    /// Gets the <see cref="AssemblyReference"/> for <c>System.Threading.dll</c>.
+    /// </summary>
+    /// <remarks><inheritdoc cref="SystemThreading" path="/remarks/node()"/></remarks>
+    public AssemblyReference SystemThreading => field ??= new AssemblyReference(
+        name: "System.Threading"u8,
+        version: new Version(10, 0, 0, 0),
+        publicKey: false,
+        publicKeyOrToken: WellKnownPublicKeyTokens.SystemThreading).Import(_corLibTypeFactory.CorLibScope);
+
+    /// <summary>
     /// Gets the <see cref="AssemblyReference"/> for <c>WinRT.Projection.dll</c>.
     /// </summary>
     /// <remarks><inheritdoc cref="SystemRuntimeInteropServices" path="/remarks/node()"/></remarks>
@@ -517,7 +527,7 @@ internal sealed class InteropReferences
     /// <summary>
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Threading.Interlocked"/>.
     /// </summary>
-    public TypeReference Interlocked => field ??= _corLibTypeFactory.CorLibScope.CreateTypeReference("System.Threading"u8, "Interlocked"u8);
+    public TypeReference Interlocked => field ??= SystemThreading.CreateTypeReference("System.Threading"u8, "Interlocked"u8);
 
     /// <summary>
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <see cref="System.Runtime.InteropServices.MemoryMarshal"/>.

--- a/src/WinRT.Interop.Generator/References/WellKnownPublicKeyTokens.cs
+++ b/src/WinRT.Interop.Generator/References/WellKnownPublicKeyTokens.cs
@@ -27,4 +27,9 @@ internal static class WellKnownPublicKeyTokens
     /// The public key data for <c>System.Numerics.Vectors.dll</c>.
     /// </summary>
     public static readonly byte[] SystemNumericsVectors = [0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A];
+
+    /// <summary>
+    /// The public key data for <c>System.Threading.dll</c>.
+    /// </summary>
+    public static readonly byte[] SystemThreading = [0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A];
 }


### PR DESCRIPTION
Introduce a SystemThreading AssemblyReference in InteropReferences (name: System.Threading, version 10.0.0.0, imported into CorLibScope) and switch the Interlocked TypeReference to be created from that reference. Also add a matching public key token byte array WellKnownPublicKeyTokens.SystemThreading. This centralizes the System.Threading reference and ensures the Interlocked type is resolved from the same assembly reference.