### PR TITLE
Update code writers to emit locally-cached event sources

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.EventSource.cs
@@ -169,19 +169,10 @@ internal partial class InteropTypeDefinitionBuilder
 
             module.TopLevelTypes.Add(eventSourceType);
 
-            // Check whether we also need to pass a target index for the event (otherwise we'll only have a single parameter)
-            bool requiresIndexParameter = baseEventSource_ctor.Signature is MethodSignature { ParameterTypes.Count: 2 };
-
-            // Prepare the parameter types as requested. These are not constant because for some well-known event source types (e.g.
-            // for 'IObservableVector<T>'), the event index is hardcoded in the base type (to simplify the code and for efficiency).
-            TypeSignature[] parameterTypes = requiresIndexParameter
-                ? [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.Int32]
-                : [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature()];
-
             // Define the constructor:
             //
-            // public <EVENT_SOURCE_TYPE>(<PARAMETER_TYPES>)
-            //     : base(<PARAMETERS>)
+            // public <EVENT_SOURCE_TYPE>(WindowsRuntimeObjectReference nativeObjectReference, int index)
+            //     : base(nativeObjectReference, index)
             // {
             // }
             //
@@ -189,7 +180,9 @@ internal partial class InteropTypeDefinitionBuilder
             MethodDefinition ctor = MethodDefinition.CreateConstructor(
                 corLibTypeFactory: interopReferences.CorLibTypeFactory,
                 constructorMethod: baseEventSource_ctor,
-                parameterTypes: parameterTypes);
+                parameterTypes: [
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                    interopReferences.Int32]);
 
             eventSourceType.Methods.Add(ctor);
 

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -57,7 +57,9 @@ internal partial class InteropTypeDefinitionBuilder
             // Get the constructor for the generic event source type
             MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
                 comparer: SignatureComparer.IgnoreVersion,
-                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature()])!;
+                parameterTypes: [
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                    interopReferences.CorLibTypeFactory.Int32])!;
 
             // Create the 'MapChanged' method
             MethodDefinition mapChangedMethod = new(
@@ -70,6 +72,7 @@ internal partial class InteropTypeDefinitionBuilder
                 CilInstructions =
                 {
                     { Ldarg_0 },
+                    { Ldc_I4_6 },
                     { Newobj, eventSourceConstructor },
                     { Ret }
                 }
@@ -129,7 +132,9 @@ internal partial class InteropTypeDefinitionBuilder
             // Get the constructor for the generic event source type (same as above)
             MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
                 comparer: SignatureComparer.IgnoreVersion,
-                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature()])!;
+                parameterTypes: [
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                    interopReferences.CorLibTypeFactory.Int32])!;
 
             // Define the 'Create' method as follows:
             //
@@ -146,6 +151,7 @@ internal partial class InteropTypeDefinitionBuilder
                 CilInstructions =
                 {
                     { Ldarg_2 },
+                    { Ldc_I4_6 },
                     { Newobj, eventSourceConstructor },
                     { Ret }
                 }

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -56,7 +56,9 @@ internal partial class InteropTypeDefinitionBuilder
             // Get the constructor for the generic event source type
             MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
                 comparer: SignatureComparer.IgnoreVersion,
-                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature()])!;
+                parameterTypes: [
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
+                    interopReferences.CorLibTypeFactory.Int32])!;
 
             // Create the 'VectorChanged' method
             MethodDefinition vectorChangedMethod = new(
@@ -69,6 +71,7 @@ internal partial class InteropTypeDefinitionBuilder
                 CilInstructions =
                 {
                     { Ldarg_0 },
+                    { Ldc_I4_6 },
                     { Newobj, eventSourceConstructor },
                     { Ret }
                 }
@@ -127,7 +130,8 @@ internal partial class InteropTypeDefinitionBuilder
             // Get the constructor for the generic event source type (same as above)
             MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
                 comparer: SignatureComparer.IgnoreVersion,
-                parameterTypes: [interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature()])!;
+                parameterTypes: [
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.CorLibTypeFactory.Int32])!;
 
             // Define the 'Create' method as follows:
             //
@@ -144,6 +148,7 @@ internal partial class InteropTypeDefinitionBuilder
                 CilInstructions =
                 {
                     { Ldarg_2 },
+                    { Ldc_I4_6 },
                     { Newobj, eventSourceConstructor },
                     { Ret }
                 }

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -3625,7 +3625,7 @@ internal sealed class InteropReferences
             .ToTypeDefOrRef()
             .CreateConstructorReference(
                 corLibTypeFactory: _corLibTypeFactory,
-                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature()]);
+                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
     }
 
     /// <summary>
@@ -3640,7 +3640,7 @@ internal sealed class InteropReferences
             .ToTypeDefOrRef()
             .CreateConstructorReference(
                 corLibTypeFactory: _corLibTypeFactory,
-                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature()]);
+                parameterTypes: [WindowsRuntimeObjectReference.ToReferenceTypeSignature(), _corLibTypeFactory.Int32]);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/MapChangedEventHandlerEventSource{K, V}.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/MapChangedEventHandlerEventSource{K, V}.cs
@@ -21,8 +21,8 @@ namespace ABI.Windows.Foundation.Collections;
 public abstract unsafe class MapChangedEventHandlerEventSource<K, V> : EventSource<MapChangedEventHandler<K, V>>
 {
     /// <inheritdoc cref="EventSource{T}.EventSource"/>
-    protected MapChangedEventHandlerEventSource(WindowsRuntimeObjectReference nativeObjectReference)
-        : base(nativeObjectReference, index: 6)
+    protected MapChangedEventHandlerEventSource(WindowsRuntimeObjectReference nativeObjectReference, int index)
+        : base(nativeObjectReference, index)
     {
     }
 

--- a/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/VectorChangedEventHandlerEventSource{T}.cs
+++ b/src/WinRT.Runtime2/ABI/Windows.Foundation/Collections/VectorChangedEventHandlerEventSource{T}.cs
@@ -20,8 +20,8 @@ namespace ABI.Windows.Foundation.Collections;
 public abstract unsafe class VectorChangedEventHandlerEventSource<T> : EventSource<VectorChangedEventHandler<T>>
 {
     /// <inheritdoc cref="EventSource{T}.EventSource"/>
-    protected VectorChangedEventHandlerEventSource(WindowsRuntimeObjectReference nativeObjectReference)
-        : base(nativeObjectReference, index: 6)
+    protected VectorChangedEventHandlerEventSource(WindowsRuntimeObjectReference nativeObjectReference, int index)
+        : base(nativeObjectReference, index)
     {
     }
 

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -3010,21 +3010,6 @@ private WindowsRuntimeObjectReference %
                         auto vtable_index = get_vmethod_index(add.Parent(), add) + 6;
                         bool is_generic_event = std::holds_alternative<generic_type_instance>(event_semantics);
 
-                        // MapChangedEventHandler and VectorChangedEventHandler event sources have a hardcoded
-                        // vtable index in their constructor, so they only take a WindowsRuntimeObjectReference
-                        // parameter (no int index). We need to track this to emit the correct constructor call.
-                        bool is_collection_changed_event = false;
-                        if (is_generic_event)
-                        {
-                            auto& gti = std::get<generic_type_instance>(event_semantics);
-                            if (gti.generic_type.TypeNamespace() == "Windows.Foundation.Collections" &&
-                                (gti.generic_type.TypeName() == "MapChangedEventHandler`2" ||
-                                 gti.generic_type.TypeName() == "VectorChangedEventHandler`1"))
-                            {
-                                is_collection_changed_event = true;
-                            }
-                        }
-
                         // ICommand.CanExecuteChanged has a type mismatch: the .NET event type is EventHandler (non-generic),
                         // but the WinRT type is EventHandler<object>. Use the non-generic EventHandlerEventSource which has
                         // Subscribe(EventHandler), matching the .NET event type after the fixup in write_event.
@@ -3062,33 +3047,19 @@ private % _eventSource_%
                             event_source_field_name,
                             [&](writer& w) {
                                 if (is_generic_event) {
-                                    if (is_collection_changed_event) {
-                                        w.write(R"(
-        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
-        [return: UnsafeAccessorType("%, WinRT.Interop")]
-        static extern object ctor(WindowsRuntimeObjectReference nativeObjectReference);
-)",
-                                            bind<write_interop_dll_type_name>(event_semantics, typedef_name_type::EventSource));
-                                    } else {
-                                        w.write(R"(
+                                    w.write(R"(
         [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
         [return: UnsafeAccessorType("%, WinRT.Interop")]
         static extern object ctor(WindowsRuntimeObjectReference nativeObjectReference, int index);
 )",
-                                            bind<write_interop_dll_type_name>(event_semantics, typedef_name_type::EventSource));
-                                    }
+                                        bind<write_interop_dll_type_name>(event_semantics, typedef_name_type::EventSource));
                                 }
                             },
                             event_source_type,
                             [&](writer& w) {
                                 if (is_generic_event) {
-                                    if (is_collection_changed_event) {
-                                        w.write("Unsafe.As<%>(ctor(%))",
-                                            event_source_type, objref_name);
-                                    } else {
-                                        w.write("Unsafe.As<%>(ctor(%, %))",
-                                            event_source_type, objref_name, vtable_index);
-                                    }
+                                    w.write("Unsafe.As<%>(ctor(%, %))",
+                                        event_source_type, objref_name, vtable_index);
                                 } else {
                                     w.write("new %(%, %)",
                                         event_source_type, objref_name, vtable_index);


### PR DESCRIPTION
This pull request introduces significant improvements to event handling in the code generation logic for WinRT projected classes, specifically around event source field management and event subscription/unsubscription. The changes focus on generating lazy-loaded event source properties, streamlining event wiring, and handling private and explicit interface events more robustly.

Event Source Property Generation:

* Added `write_class_event_sources_definition` to generate lazy-loaded, inline-cached event source properties for each event in implemented interfaces, including proper handling for generic events and exclusive interfaces.
* Integrated event source property generation into the class code generation pipeline, ensuring event source fields are available for event wiring.

Event Subscription/Unsubscription Logic:

* Updated `write_event` to support an `inline_event_source_field` parameter, enabling direct subscription/unsubscription via the generated event source property when appropriate.
* Modified event add/remove logic to use the inline event source field when specified, falling back to static method calls otherwise. [[1]](diffhunk://#diff-1a17c03ba21494327d0afbdc3f744decb8090d807bfcb5e557a3263b2d4e0f7bL2176-R2188) [[2]](diffhunk://#diff-1a17c03ba21494327d0afbdc3f744decb8090d807bfcb5e557a3263b2d4e0f7bL2188-R2211)

Private and Explicit Interface Event Handling:

* Enhanced `write_class_event` to generate explicit event implementations for private and overridable events, using the new event source property naming scheme for private interface events.
* Cleaned up unused parameters in `write_class_event` for clarity and maintainability.