### PR TITLE
Skip generating unused events in 'Methods' types

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -8715,7 +8715,24 @@ private IObjectReference % => __% ?? Make__%();
         // Skip generating event members for exclusive interfaces whose events are now
         // inlined in the RCW class. This is safe because the interface and its Methods
         // type are internal, so no other type can reference these event methods.
-        bool skip_exclusive_events = is_exclusive_to(iface) && !settings.public_exclusiveto;
+        // Only do this for instance interfaces (listed in InterfaceImpl on the class),
+        // not for statics interfaces (referenced via StaticAttribute), whose events
+        // are never inlined and still go through the Methods type.
+        bool skip_exclusive_events = false;
+        if (is_exclusive_to(iface) && !settings.public_exclusiveto)
+        {
+            auto class_type = get_exclusive_to_type(iface);
+            for (auto&& ii : class_type.InterfaceImpl())
+            {
+                for_typedef(w, get_type_semantics(ii.Interface()), [&](TypeDef const& impl_iface)
+                {
+                    if (interfaces_equal(impl_iface, iface))
+                    {
+                        skip_exclusive_events = true;
+                    }
+                });
+            }
+        }
 
         auto members = w.write_temp("%", [&](writer& w) {
             if (!fast_abi_class_val.has_value() || (!fast_abi_class_val.value().contains_other_interface(iface) && !interfaces_equal(fast_abi_class_val.value().default_interface, iface))) {


### PR DESCRIPTION
This pull request refines how static ABI class members are generated for exclusive interfaces in `src/cswinrt/code_writers.h`, specifically improving the handling of event members. The key change is that event members for exclusive interfaces are now inlined in the RCW class, and the code avoids generating redundant event methods in the static ABI class. This prevents unnecessary code and ensures correctness for internal-only interfaces.

Event handling and code generation improvements:

* Added a `skip_events` parameter to `write_static_abi_class_members`, allowing selective omission of event members when generating static ABI class members.
* Updated the event member generation logic to respect the `skip_events` flag, so event members are not written when requested. [[1]](diffhunk://#diff-1a17c03ba21494327d0afbdc3f744decb8090d807bfcb5e557a3263b2d4e0f7bR6893-R6894) [[2]](diffhunk://#diff-1a17c03ba21494327d0afbdc3f744decb8090d807bfcb5e557a3263b2d4e0f7bR6919)

Exclusive interface handling:

* Introduced logic to skip generating event members for exclusive interfaces whose events are now inlined in the RCW class, with comments explaining the rationale and safety of this approach.
* Modified the code to omit generating the empty Methods type entirely if all members were skipped (e.g., for exclusive interfaces with only events).
* Ensured that event members for other interfaces (not exclusive) are still generated as before, preserving backward compatibility.