### PR TITLE
Avoid '[GeneratedComInterface]' lookups for failed IDIC casts if possible

### DIFF
--- a/src/WinRT.Runtime2/WindowsRuntimeObject.cs
+++ b/src/WinRT.Runtime2/WindowsRuntimeObject.cs
@@ -716,7 +716,7 @@ public abstract unsafe class WindowsRuntimeObject :
     /// Looks up whether the input interface type is implemented for an <see cref="IDynamicInterfaceCastable"/> cast.
     /// </summary>
     /// <param name="interfaceType">The input interface type.</param>
-    /// <param name="castResult">The resulting <see cref="GeneratedComInterfaceCastResult"/> value, if the cast is successful.</param>
+    /// <param name="castResult">The resulting <see cref="DynamicInterfaceCastableResult"/> value, if the cast is successful.</param>
     /// <returns>A <see cref="CustomQueryInterfaceResult"/> value representing the result of this dynamic cast lookup operation.</returns>
     /// <remarks>
     /// When successful, this method will cache a <see cref="DynamicInterfaceCastableResult"/> value into <see cref="TypeHandleCache"/>.


### PR DESCRIPTION
This pull request refactors the casting logic for Windows Runtime objects to improve clarity and consistency in handling interface cast results. The changes replace boolean return values with a more descriptive `CustomQueryInterfaceResult` enum, unify error handling, and add trim-friendly feature checks. These updates make the casting process more robust and easier to maintain.

Improvements to casting logic and error handling:

* Changed the return type of `LookupDynamicInterfaceCastableImplementationInfo` and `LookupGeneratedVTableInfo` from `bool` to `CustomQueryInterfaceResult`, enabling more granular handling of cast outcomes and improving code readability. [[1]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L712-R732) [[2]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L800-R808)
* Updated the `TryGetCastResult` method to use the new enum values and added a unified failure handling label for clearer control flow. [[1]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L669-R694) [[2]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8R705)

Feature switch and trim-friendliness:

* Added explicit checks for the `EnableIDynamicInterfaceCastableSupport` feature switch in both `LookupDynamicInterfaceCastableImplementationInfo` and `LookupGeneratedVTableInfo`, ensuring methods return `CustomQueryInterfaceResult.Failed` when the feature is disabled. This supports better trimming and reliability. [[1]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L712-R732) [[2]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8R820-R825)

Consistent error propagation:

* Updated all failure paths in `LookupDynamicInterfaceCastableImplementationInfo` to return appropriate `CustomQueryInterfaceResult` values (`Failed` or `NotHandled`), rather than just `false`. [[1]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L734-R742) [[2]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L756-R764) [[3]](diffhunk://#diff-f182728302e2bf6c9d379493daea5c1c8cc2085a1177316af88fbb508d0d40f8L767-R775)

Return value semantics:

* Modified documentation comments to reflect the new return type (`CustomQueryInterfaceResult`) and clarified the meaning of each return value for interface cast operations.