### PR TITLE
Use interopReferences.* instead of CorLibTypeFactory

### DIFF
--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.Delegate.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.Delegate.cs
@@ -158,9 +158,9 @@ internal partial class InteropTypeDefinitionBuilder
             if (isSenderReferenceType)
             {
                 GetOrCreateVftbl(
-                    senderType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                    senderType: interopReferences.Void.MakePointerType(),
                     argsType: argsType.GetAbiType(interopReferences),
-                    displaySenderType: interopReferences.CorLibTypeFactory.Object,
+                    displaySenderType: interopReferences.Object,
                     displayArgsType: argsType,
                     interopReferences: interopReferences,
                     emitState: emitState,
@@ -171,9 +171,9 @@ internal partial class InteropTypeDefinitionBuilder
             {
                 GetOrCreateVftbl(
                     senderType: senderType.GetAbiType(interopReferences),
-                    argsType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                    argsType: interopReferences.Void.MakePointerType(),
                     displaySenderType: senderType,
-                    displayArgsType: interopReferences.CorLibTypeFactory.Object,
+                    displayArgsType: interopReferences.Object,
                     interopReferences: interopReferences,
                     emitState: emitState,
                     module: module,

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -59,7 +59,7 @@ internal partial class InteropTypeDefinitionBuilder
                 comparer: SignatureComparer.IgnoreVersion,
                 parameterTypes: [
                     interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    interopReferences.CorLibTypeFactory.Int32])!;
+                    interopReferences.Int32])!;
 
             // Create the 'MapChanged' method
             MethodDefinition mapChangedMethod = new(
@@ -134,7 +134,7 @@ internal partial class InteropTypeDefinitionBuilder
                 comparer: SignatureComparer.IgnoreVersion,
                 parameterTypes: [
                     interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    interopReferences.CorLibTypeFactory.Int32])!;
+                    interopReferences.Int32])!;
 
             // Define the 'Create' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -58,7 +58,7 @@ internal partial class InteropTypeDefinitionBuilder
                 comparer: SignatureComparer.IgnoreVersion,
                 parameterTypes: [
                     interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                    interopReferences.CorLibTypeFactory.Int32])!;
+                    interopReferences.Int32])!;
 
             // Create the 'VectorChanged' method
             MethodDefinition vectorChangedMethod = new(
@@ -131,7 +131,7 @@ internal partial class InteropTypeDefinitionBuilder
             MethodDefinition eventSourceConstructor = emitState.LookupTypeDefinition(handlerType, "EventSource").GetConstructor(
                 comparer: SignatureComparer.IgnoreVersion,
                 parameterTypes: [
-                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.CorLibTypeFactory.Int32])!;
+                    interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(), interopReferences.Int32])!;
 
             // Define the 'Create' method as follows:
             //

--- a/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
@@ -171,19 +171,19 @@ internal static class WindowsRuntimeExtensions
         public bool IsFundamentalWindowsRuntimeType(InteropReferences interopReferences)
         {
             // Check all fundamental primitive types
-            if (SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Boolean) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.String) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Single) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Double) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.UInt16) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.UInt32) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.UInt64) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Int16) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Int32) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Int64) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Char) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Byte) ||
-                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.CorLibTypeFactory.Object))
+            if (SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Boolean) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.String) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Single) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Double) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.UInt16) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.UInt32) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.UInt64) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Int16) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Int32) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Int64) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Char) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Byte) ||
+                SignatureComparer.IgnoreVersion.Equals(type, interopReferences.Object))
             {
                 return true;
             }
@@ -615,7 +615,7 @@ internal static class WindowsRuntimeExtensions
             // types, as well as 'KeyValuePair<,>', which also maps to 'void*', since it's an interface.
             if (type is GenericInstanceTypeSignature)
             {
-                return interopReferences.CorLibTypeFactory.Void.MakePointerType();
+                return interopReferences.Void.MakePointerType();
             }
 
             TypeDefinition typeDefinition = type.Resolve()!;
@@ -670,7 +670,7 @@ internal static class WindowsRuntimeExtensions
             }
 
             // For all other cases (e.g. interfaces, classes, delegates, etc.), the ABI type is always a pointer
-            return interopReferences.CorLibTypeFactory.Void.MakePointerType();
+            return interopReferences.Void.MakePointerType();
         }
 
         /// <summary>

--- a/src/WinRT.Interop.Generator/Factories/InteropCustomAttributeFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropCustomAttributeFactory.cs
@@ -181,7 +181,7 @@ internal static class InteropCustomAttributeFactory
         return new(interopReferences.TypeMapAttributeWindowsRuntimeComWrappersTypeMapGroup_ctor_TrimTarget, new CustomAttributeSignature(
             fixedArguments: [
                 new CustomAttributeArgument(
-                    argumentType: interopReferences.CorLibTypeFactory.String,
+                    argumentType: interopReferences.String,
                     value: value),
                 new CustomAttributeArgument(
                     argumentType: interopReferences.Type.ToReferenceTypeSignature(),
@@ -236,7 +236,7 @@ internal static class InteropCustomAttributeFactory
         return new(interopReferences.TypeMapAttributeWindowsRuntimeMetadataTypeMapGroup_ctor_TrimTarget, new CustomAttributeSignature(
             fixedArguments: [
                 new CustomAttributeArgument(
-                    argumentType: interopReferences.CorLibTypeFactory.String,
+                    argumentType: interopReferences.String,
                     value: value),
                 new CustomAttributeArgument(
                     argumentType: interopReferences.Type.ToReferenceTypeSignature(),

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IMapMethods.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IMapMethods.cs
@@ -60,7 +60,7 @@ internal partial class InteropMethodDefinitionFactory
             //   [2]: 'bool' (for 'result')
             CilLocalVariable loc_0_thisValue = new(interopReferences.WindowsRuntimeObjectReferenceValue.ToValueTypeSignature());
             CilLocalVariable loc_1_thisPtr = new(interopReferences.Void.MakePointerType());
-            CilLocalVariable loc_2_result = new(interopReferences.CorLibTypeFactory.Boolean);
+            CilLocalVariable loc_2_result = new(interopReferences.Boolean);
 
             // Jump labels
             CilInstruction nop_try_this = new(Nop);

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IMapViewMethods.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IMapViewMethods.cs
@@ -58,7 +58,7 @@ internal partial class InteropMethodDefinitionFactory
             //   [2]: 'bool' (for 'result')
             CilLocalVariable loc_0_thisValue = new(interopReferences.WindowsRuntimeObjectReferenceValue.ToValueTypeSignature());
             CilLocalVariable loc_1_thisPtr = new(interopReferences.Void.MakePointerType());
-            CilLocalVariable loc_2_result = new(interopReferences.CorLibTypeFactory.Boolean);
+            CilLocalVariable loc_2_result = new(interopReferences.Boolean);
 
             // Jump labels
             CilInstruction nop_try_this = new(Nop);

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IVectorMethods.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IVectorMethods.cs
@@ -203,7 +203,7 @@ internal partial class InteropMethodDefinitionFactory
                     parameterTypes: [
                         interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
                         elementType,
-                        interopReferences.CorLibTypeFactory.UInt32.MakeByReferenceType()]))
+                        interopReferences.UInt32.MakeByReferenceType()]))
             {
                 NoInlining = true,
                 CilOutParameterIndices = [3]
@@ -216,8 +216,8 @@ internal partial class InteropMethodDefinitionFactory
             //   [3]: 'bool' (for the return value)
             CilLocalVariable loc_0_thisValue = new(interopReferences.WindowsRuntimeObjectReferenceValue.ToValueTypeSignature());
             CilLocalVariable loc_1_thisPtr = new(interopReferences.Void.MakePointerType());
-            CilLocalVariable loc_2_pinnedIndex = new(interopReferences.CorLibTypeFactory.UInt32.MakeByReferenceType().MakePinnedType());
-            CilLocalVariable loc_3_result = new(interopReferences.CorLibTypeFactory.Boolean);
+            CilLocalVariable loc_2_pinnedIndex = new(interopReferences.UInt32.MakeByReferenceType().MakePinnedType());
+            CilLocalVariable loc_3_result = new(interopReferences.Boolean);
 
             // Jump labels
             CilInstruction nop_try_this = new(Nop);
@@ -333,7 +333,7 @@ internal partial class InteropMethodDefinitionFactory
                     returnType: interopReferences.Void,
                     parameterTypes: [
                         interopReferences.WindowsRuntimeObjectReference.ToReferenceTypeSignature(),
-                        interopReferences.CorLibTypeFactory.UInt32,
+                        interopReferences.UInt32,
                         elementType]))
             { NoInlining = true };
 

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -103,8 +103,8 @@ internal static partial class WellKnownTypeDefinitionFactory
         return DelegateVftbl(
             ns: null,
             name: "<DelegateVftbl>"u8,
-            senderType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-            argsType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+            senderType: interopReferences.Void.MakePointerType(),
+            argsType: interopReferences.Void.MakePointerType(),
             interopReferences: interopReferences);
     }
 
@@ -185,10 +185,10 @@ internal static partial class WellKnownTypeDefinitionFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
 
         // The vtable layout for 'IReference<T>' looks like this:
         //
@@ -365,7 +365,7 @@ internal static partial class WellKnownTypeDefinitionFactory
         return IReadOnlyList1Vftbl(
             ns: null,
             name: "<IReadOnlyList1Vftbl>"u8,
-            elementType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+            elementType: interopReferences.Void.MakePointerType(),
             interopReferences: interopReferences);
     }
 
@@ -445,7 +445,7 @@ internal static partial class WellKnownTypeDefinitionFactory
         return IList1Vftbl(
             ns: null,
             name: "<IList1Vftbl>"u8,
-            elementType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+            elementType: interopReferences.Void.MakePointerType(),
             interopReferences: interopReferences);
     }
 
@@ -550,8 +550,8 @@ internal static partial class WellKnownTypeDefinitionFactory
         return IReadOnlyDictionary2Vftbl(
             ns: null,
             name: "<IReadOnlyDictionary2Vftbl>"u8,
-            keyType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-            valueType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+            keyType: interopReferences.Void.MakePointerType(),
+            valueType: interopReferences.Void.MakePointerType(),
             interopReferences: interopReferences);
     }
 
@@ -633,8 +633,8 @@ internal static partial class WellKnownTypeDefinitionFactory
         return IDictionary2Vftbl(
             ns: null,
             name: "<IDictionary2Vftbl>"u8,
-            keyType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-            valueType: interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+            keyType: interopReferences.Void.MakePointerType(),
+            valueType: interopReferences.Void.MakePointerType(),
             interopReferences: interopReferences);
     }
 
@@ -740,10 +740,10 @@ internal static partial class WellKnownTypeDefinitionFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType()]);
 
         // The vtable layout for 'IKeyValuePair`2<Key, Value>' looks like this:
         //
@@ -987,8 +987,8 @@ internal static partial class WellKnownTypeDefinitionFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
-            parameterTypes: [interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                baseType: interopReferences.Int32),
+            parameterTypes: [interopReferences.Void.MakePointerType()]);
 
         // The vtable layout for 'IAsyncActionWithProgress`1<TProgress>' looks like this:
         //

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
@@ -27,11 +27,11 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 interopReferences.Guid.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -47,8 +47,8 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.UInt32),
-            parameterTypes: [interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                baseType: interopReferences.UInt32),
+            parameterTypes: [interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -64,8 +64,8 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.UInt32),
-            parameterTypes: [interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                baseType: interopReferences.UInt32),
+            parameterTypes: [interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -81,10 +81,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32.MakePointerType(),
                 interopReferences.Guid.MakePointerType().MakePointerType()]);
     }
 
@@ -101,10 +101,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -120,9 +120,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 interopReferences.TrustLevel.MakePointerType()]);
     }
 
@@ -139,10 +139,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 interopReferences.EventRegistrationToken.MakePointerType()]);
     }
 
@@ -159,9 +159,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 interopReferences.EventRegistrationToken.ToValueTypeSignature()]);
     }
 
@@ -178,10 +178,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -197,10 +197,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -216,10 +216,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -240,9 +240,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 senderType,
                 argsType]);
     }
@@ -260,10 +260,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -279,10 +279,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Boolean.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Boolean.MakePointerType()]);
     }
 
     /// <summary>
@@ -298,12 +298,12 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32,
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32.MakePointerType()]);
     }
 
     /// <summary>
@@ -319,10 +319,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -339,10 +339,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32,
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
                 elementType.MakePointerType()]);
     }
 
@@ -359,10 +359,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32.MakePointerType()]);
     }
 
     /// <summary>
@@ -379,11 +379,11 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 elementType,
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType()]);
+                interopReferences.UInt32.MakePointerType()]);
     }
 
     /// <summary>
@@ -400,12 +400,12 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32,
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
                 elementType.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType()]);
+                interopReferences.UInt32.MakePointerType()]);
     }
 
     /// <summary>
@@ -444,10 +444,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -464,12 +464,12 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 elementType,
-                interopReferences.CorLibTypeFactory.UInt32.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Boolean.MakePointerType()]);
+                interopReferences.UInt32.MakePointerType(),
+                interopReferences.Boolean.MakePointerType()]);
     }
 
     /// <summary>
@@ -486,10 +486,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32,
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
                 elementType]);
     }
 
@@ -519,10 +519,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32]);
     }
 
     /// <summary>
@@ -539,9 +539,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 elementType]);
     }
 
@@ -558,8 +558,8 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
-            parameterTypes: [interopReferences.CorLibTypeFactory.Void.MakePointerType()]);
+                baseType: interopReferences.Int32),
+            parameterTypes: [interopReferences.Void.MakePointerType()]);
     }
 
     /// <summary>
@@ -601,10 +601,10 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.UInt32,
+                interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
                 elementType.MakePointerType()]);
     }
 
@@ -626,9 +626,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 keyType,
                 valueType.MakePointerType()]);
     }
@@ -658,11 +658,11 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 keyType,
-                interopReferences.CorLibTypeFactory.Boolean.MakePointerType()]);
+                interopReferences.Boolean.MakePointerType()]);
     }
 
     /// <summary>
@@ -678,11 +678,11 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType(),
-                interopReferences.CorLibTypeFactory.Void.MakePointerType().MakePointerType()]);
+                interopReferences.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType(),
+                interopReferences.Void.MakePointerType().MakePointerType()]);
     }
 
     /// <summary>
@@ -751,12 +751,12 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 keyType,
                 valueType,
-                interopReferences.CorLibTypeFactory.Boolean.MakePointerType()]);
+                interopReferences.Boolean.MakePointerType()]);
     }
 
     /// <summary>
@@ -773,9 +773,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 keyType]);
     }
 
@@ -802,9 +802,9 @@ internal static class WellKnownTypeSignatureFactory
             returnType: new CustomModifierTypeSignature(
                 modifierType: interopReferences.CallConvMemberFunction,
                 isRequired: false,
-                baseType: interopReferences.CorLibTypeFactory.Int32),
+                baseType: interopReferences.Int32),
             parameterTypes: [
-                interopReferences.CorLibTypeFactory.Void.MakePointerType(),
+                interopReferences.Void.MakePointerType(),
                 interopReferences.CollectionChange.MakePointerType()]);
     }
 

--- a/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
+++ b/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
@@ -143,7 +143,7 @@ internal static class WindowsRuntimeTypeAnalyzer
             // Lastly, make sure to also always track 'object' as a base type. This would be
             // skipped for element types being interfaces, as they have no base type. However,
             // with respect to variant conversions, 'object' is always a valid covariant type.
-            yield return genericInterfaceType.MakeGenericReferenceType(interopReferences.CorLibTypeFactory.Object);
+            yield return genericInterfaceType.MakeGenericReferenceType(interopReferences.Object);
 
             // We're closing this recursive sub-tree, so we can remove the current interface type
             _ = visitedTypes.Remove(interfaceType);

--- a/src/WinRT.Interop.Generator/Resolvers/InteropImplTypeResolver.cs
+++ b/src/WinRT.Interop.Generator/Resolvers/InteropImplTypeResolver.cs
@@ -56,7 +56,7 @@ internal static class InteropImplTypeResolver
         // For (non-generic) custom-mapped types, their ABI types are in 'WinRT.Runtime.dll', so we use those directly.
         // This also applies to all manually-projected interface types (e.g. 'IAsyncAction'), they have the same location.
         TypeReference typeReference = interopReferences.WindowsRuntimeModule.CreateTypeReference($"ABI.{type.Namespace}", $"{type.Name}Impl");
-        MemberReference get_VtableMethod = typeReference.CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(interopReferences.CorLibTypeFactory.IntPtr));
+        MemberReference get_VtableMethod = typeReference.CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(interopReferences.IntPtr));
 
         // For custom-mapped types, the IID is in 'WellKnownInterfaceIIDs' in 'WinRT.Runtime.dll'
         MemberReference get_IIDMethod = WellKnownInterfaceIIDs.get_IID(
@@ -88,7 +88,7 @@ internal static class InteropImplTypeResolver
         // Finally, we have the base scenario of simple non-generic projected Windows Runtime interface types.
         // Those will have the marshalling code in the right implementation projection .dll that we found above.
         TypeReference implTypeReference = projectionAssembly.CreateTypeReference($"ABI.{type.Namespace}", $"{type.Name}Impl");
-        MemberReference get_VtableMethod = implTypeReference.CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(interopReferences.CorLibTypeFactory.IntPtr));
+        MemberReference get_VtableMethod = implTypeReference.CreateMemberReference("get_Vtable"u8, MethodSignature.CreateStatic(interopReferences.IntPtr));
 
         // For normal projected types, the IID is in the generated 'InterfaceIIDs' type in the merged projection
         string get_IIDMethodName = $"get_IID_{type.FullName.Replace('.', '_')}";
@@ -164,7 +164,7 @@ internal static class InteropImplTypeResolver
         IMethodDefOrRef get_IIDMethod = interopReferences.WellKnownInterfaceIIDsget_IID_IPropertyValue;
         IMethodDefOrRef get_VtableMethod = interopReferences.IPropertyValueImpl.CreateMemberReference(
             memberName: $"get_{typeName}ArrayVtable",
-            signature: MethodSignature.CreateStatic(interopReferences.CorLibTypeFactory.IntPtr));
+            signature: MethodSignature.CreateStatic(interopReferences.IntPtr));
 
         // Return the pair of methods from the ABI type in 'WinRT.Runtime.dll'
         return (get_IIDMethod, get_VtableMethod);

--- a/src/WinRT.Interop.Generator/Resolvers/InteropMarshallerType.cs
+++ b/src/WinRT.Interop.Generator/Resolvers/InteropMarshallerType.cs
@@ -110,7 +110,7 @@ internal readonly ref struct InteropMarshallerType
             name: "UnboxToManaged"u8,
             signature: MethodSignature.CreateStatic(
                 returnType: returnType,
-                parameterTypes: [_interopReferences.CorLibTypeFactory.Void.MakePointerType()]));
+                parameterTypes: [_interopReferences.Void.MakePointerType()]));
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ internal readonly ref struct InteropMarshallerType
         return _marshallerType.GetMethodDefOrRef(
             name: "Dispose"u8,
             signature: MethodSignature.CreateStatic(
-                returnType: _interopReferences.CorLibTypeFactory.Void,
+                returnType: _interopReferences.Void,
                 parameterTypes: [_type.GetAbiType(_interopReferences)]));
     }
 }

--- a/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.NativeParameter.cs
+++ b/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.NativeParameter.cs
@@ -286,9 +286,9 @@ internal partial class InteropMethodRewriter
             //   [0]: 'ref char' (for the pinned 'string')
             //   [1]: 'HStringReference' (for 'hstringReference')
             //   [2]: 'int?' (for 'length')
-            CilLocalVariable loc_0_pinnedString = new(interopReferences.CorLibTypeFactory.Char.MakeByReferenceType().MakePinnedType());
+            CilLocalVariable loc_0_pinnedString = new(interopReferences.Char.MakeByReferenceType().MakePinnedType());
             CilLocalVariable loc_1_hstringReference = new(interopReferences.HStringReference.ToValueTypeSignature());
-            CilLocalVariable loc_2_length = new(interopReferences.Nullable1.MakeGenericValueType(interopReferences.CorLibTypeFactory.Int32));
+            CilLocalVariable loc_2_length = new(interopReferences.Nullable1.MakeGenericValueType(interopReferences.Int32));
 
             body.LocalVariables.Add(loc_0_pinnedString);
             body.LocalVariables.Add(loc_1_hstringReference);
@@ -328,7 +328,7 @@ internal partial class InteropMethodRewriter
                 new CilInstruction(Br_S, ldloca_s_getHStringReference.CreateLabel()),
                 ldarg_getLength,
                 new CilInstruction(Call, interopReferences.Stringget_Length),
-                new CilInstruction(Newobj, interopReferences.Nullable1_ctor(interopReferences.CorLibTypeFactory.Int32)),
+                new CilInstruction(Newobj, interopReferences.Nullable1_ctor(interopReferences.Int32)),
 
                 // HStringMarshaller.ConvertToUnmanagedUnsafe(p, length, out HStringReference hstringReference);
                 ldloca_s_getHStringReference,
@@ -381,7 +381,7 @@ internal partial class InteropMethodRewriter
             //   [0]: 'TypeReference' (for 'typeReference')
             //   [1]: 'ref byte' (for the pinned type reference)
             CilLocalVariable loc_0_typeReference = new(interopReferences.TypeReference.ToValueTypeSignature());
-            CilLocalVariable loc_1_pinnedTypeReference = new(interopReferences.CorLibTypeFactory.Byte.MakeByReferenceType().MakePinnedType());
+            CilLocalVariable loc_1_pinnedTypeReference = new(interopReferences.Byte.MakeByReferenceType().MakePinnedType());
 
             body.LocalVariables.Add(loc_0_typeReference);
             body.LocalVariables.Add(loc_1_pinnedTypeReference);


### PR DESCRIPTION
Replace occurrences of interopReferences.CorLibTypeFactory.* with the corresponding interopReferences.* primitive properties across the generator. Standardizes usage for Void, Object, Int32, Boolean, Char, Byte, UInt32, IntPtr, etc., and updates pointer/MakePointerType, nullable/pinned local variable types, and method signatures. Changes span builders, factories, helpers, resolvers and rewriters to unify primitive type lookups and ABI signatures.

Files updated: Builders/InteropTypeDefinitionBuilder.Delegate.cs, Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs, Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs, Extensions/WindowsRuntimeExtensions.cs, Factories/InteropCustomAttributeFactory.cs, Factories/InteropMethodDefinitionFactory.IMapMethods.cs, Factories/InteropMethodDefinitionFactory.IMapViewMethods.cs, Factories/InteropMethodDefinitionFactory.IVectorMethods.cs, Factories/WellKnownTypeDefinitionFactory.cs, Factories/WellKnownTypeSignatureFactory.cs, Helpers/WindowsRuntimeTypeAnalyzer.cs, Resolvers/InteropImplTypeResolver.cs, Resolvers/InteropMarshallerType.cs, Rewriters/InteropMethodRewriter.NativeParameter.cs.