### PR TITLE
Skip IsOverridableInterface and HasUnwrappableNativeObjectReference overrides in reference assemblies

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9126,25 +9126,16 @@ public static unsafe class %Marshaller
 
     void write_custom_query_interface_impl(writer& w, TypeDef const& type)
     {
+        if (settings.reference_projection)
+        {
+            return;
+        }
 
         bool has_base_class = !std::holds_alternative<object_type>(get_type_semantics(type.Extends()));
         separator s{ w, " || " };
         w.write(R"(
-%protected override bool IsOverridableInterface(in Guid iid) => %%;
+protected override bool IsOverridableInterface(in Guid iid) => %%;
 )",
-            bind([&](writer& w)
-            {
-                if (settings.reference_projection)
-                {
-                     w.write(R"(
-[Obsolete(WindowsRuntimeConstants.PrivateImplementationDetailObsoleteMessage,
-    DiagnosticId = WindowsRuntimeConstants.PrivateImplementationDetailObsoleteDiagnosticId,
-    UrlFormat = WindowsRuntimeConstants.CsWinRTDiagnosticsUrlFormat)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-)");
-                     return;
-                }
-            }),
             bind_each([&](writer& w, InterfaceImpl const& iface)
             {
                 if (has_attribute(iface, "Windows.Foundation.Metadata", "OverridableAttribute"))
@@ -9303,14 +9294,10 @@ GC.RemoveMemoryPressure(%);
             {
                 if (settings.reference_projection)
                 {
-                    w.write(R"(
-[Obsolete(WindowsRuntimeConstants.PrivateImplementationDetailObsoleteMessage,
-    DiagnosticId = WindowsRuntimeConstants.PrivateImplementationDetailObsoleteDiagnosticId,
-    UrlFormat = WindowsRuntimeConstants.CsWinRTDiagnosticsUrlFormat)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-protected override bool HasUnwrappableNativeObjectReference => throw null;)");
+                    return;
                 }
-                else if (!type.Flags().Sealed())
+
+                if (!type.Flags().Sealed())
                 {
                     w.write(R"(
 protected override bool HasUnwrappableNativeObjectReference => GetType() == typeof(%);)",


### PR DESCRIPTION
## Summary

Stops emitting the two private implementation detail method overrides from \\WindowsRuntimeObject\\ (\\IsOverridableInterface\\ and \\HasUnwrappableNativeObjectReference\\) in reference projection assemblies. These methods are internal implementation details that are not needed in reference assemblies.

## Changes

In \\write_custom_query_interface_impl\\ (\\src/cswinrt/code_writers.h\\):

- Added an early \\eturn\\ guard when \\settings.reference_projection\\ is true, so no \\IsOverridableInterface\\ override is emitted.
- Removed the reference assembly branch that previously emitted a stub with \\[Obsolete]\\ and \\[EditorBrowsable(Never)]\\ attributes.
- Simplified the remaining write to only include the format placeholder for the method body (no longer needs the leading attributes placeholder).

In the class template for \\HasUnwrappableNativeObjectReference\\:

- Replaced the reference assembly branch (which emitted a \\	hrow null\\ stub with \\[Obsolete]\\ and \\[EditorBrowsable(Never)]\\ attributes) with an early \\eturn\\.
- Implementation assembly logic for both sealed and unsealed types remains unchanged.