### PR TITLE
Fix extra '%' in code_writers.h class format string

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -9279,7 +9279,7 @@ return MarshalInspectable<%>.FromAbi(thisPtr);
         auto gc_pressure_amount = get_gc_pressure_amount(type);
 
         w.write(R"(
-%%%%% %class %%
+%%%% %class %%
 {
 %
 %


### PR DESCRIPTION
## Summary

Fix an extra `%` format-string character in `code_writers.h` that was left behind due to a bad merge.

## Motivation

PRs #2353 and #2350 both removed a `%` character from the same format string in the `write_class` code path. When the second PR was merged, git diff incorrectly treated the overlapping change as identical and dropped a second `%` that should have remained, breaking the class declaration output from the code writer.

## Changes

- **`src/cswinrt/code_writers.h`**: Remove the extra `%` in the runtime class format string (`%%%%%` → `%%%%`), restoring the correct number of format placeholders.
