### PR TITLE
Move stub exe generation to MSBuild task with multi-stub support

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -464,11 +464,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                        Defaults to $(UseUwpTools).
       Platform       - Target platform (arm64, x64, x86). Defaults to the resolved
                        platform from $(Platform) / $(PlatformTarget).
+      SourceText     - Inline C source code for the stub. When set, this text is
+                       written to a .c file and compiled. Takes precedence over
+                       SourceFile and the default source template.
+      SourceFile     - Path to a custom .c source file for the stub. When set, it
+                       is copied and compiled. Takes precedence over the default
+                       source template, but is overridden by SourceText.
 
     Example:
       <ItemGroup>
         <CsWinRTStubExe Include="MyApp.Console" OutputType="Exe" />
         <CsWinRTStubExe Include="MyApp.Windowed" OutputType="WinExe" />
+        <CsWinRTStubExe Include="MyApp.Custom" SourceFile="src\CustomStub.c" />
       </ItemGroup>
     ============================================================
   -->

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -436,11 +436,43 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <!--
-    Produces a stub .exe for the application, if requested. This target is only executed when publishing, and
-    it's injected right after Native AOT invokes MSVC to produce the final binary, and before gathering all
-    publish artifacts. It's important for this target to run right after that, so that we can make sure that
-    the resulting stub .exe is gathered by the following MSIX packaging steps, which need to include it too.
+    ============================================================
+                        _CsWinRTGenerateStubExe
+
+    Produces one or more stub .exe files for the application, if requested.
+
+    A "stub .exe" is a small native executable whose only job is to call into
+    a method exported from a companion .dll produced by the Native AOT toolchain.
+    This is needed when the project is compiled as a shared library (NativeLib=Shared)
+    and still needs a standard .exe entry point.
+
+    This target is only executed when publishing, and it's injected right after
+    Native AOT invokes MSVC to produce the final binary, and before gathering all
+    publish artifacts. It's important for this target to run right after that, so
+    that we can make sure that the resulting stub .exe files are gathered by the
+    following MSIX packaging steps, which need to include them too.
+
+    Users can define additional stubs by adding items to the 'CsWinRTStubExe' item
+    group before this target runs. Each item's identity is the output binary name
+    (without the .exe extension), and the following optional metadata can be set:
+
+      OutputType     - 'WinExe' for /SUBSYSTEM:WINDOWS, anything else for CONSOLE.
+                       Defaults to the project's $(OutputType).
+      Win32Manifest  - Path to a Win32 manifest file to embed. If empty, manifest
+                       generation is suppressed. Defaults to the project's $(Win32Manifest).
+      AppContainer   - 'true' to set /APPCONTAINER for UWP apps.
+                       Defaults to $(UseUwpTools).
+      Platform       - Target platform (arm64, x64, x86). Defaults to the resolved
+                       platform from $(Platform) / $(PlatformTarget).
+
+    Example:
+      <ItemGroup>
+        <CsWinRTStubExe Include="MyApp.Console" OutputType="Exe" />
+        <CsWinRTStubExe Include="MyApp.Windowed" OutputType="WinExe" />
+      </ItemGroup>
+    ============================================================
   -->
+  <UsingTask Condition="'$(CsWinRTGeneratorTasksOverriden2)' != 'true'" TaskName="GenerateCsWinRTStubExes" AssemblyFile="$(CsWinRTGenTasksAssembly)" />
   <Target
     Name="_CsWinRTGenerateStubExe"
     DependsOnTargets="PrepareForPublish"
@@ -448,42 +480,36 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     BeforeTargets="ComputeLinkedFilesToPublish"
     Condition="'$(_CsWinRTEnableStubExeGeneration)' == 'true' AND '$(PublishAot)' == 'true'">
     <PropertyGroup>
-    
-      <!-- Prepare the generated files directory -->
+
+      <!-- Prepare the intermediate output directory for stub .exe generation -->
       <_StubExeFolderName>StubExe</_StubExeFolderName>
       <_StubExeGeneratedFilesDir Condition="'$(_StubExeGeneratedFilesDir)' == '' AND '$(GeneratedFilesDir)' != ''">$(GeneratedFilesDir)\$(_StubExeFolderName)\</_StubExeGeneratedFilesDir>
       <_StubExeGeneratedFilesDir Condition="'$(_StubExeGeneratedFilesDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'Generated Files', '$(_StubExeFolderName)'))</_StubExeGeneratedFilesDir>
-    
+
       <!-- The path of the .lib file produced by the Native AOT toolchain, which we need for the linker -->
       <_StubExeNativeLibraryPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath), $(AssemblyName).lib))</_StubExeNativeLibraryPath>
-    
-      <!-- Prepare the path of the .c file with the stub .exe source we need to compile -->
-      <_StubExeSourceFileName>$(AssemblyName).c</_StubExeSourceFileName>
-      <_StubExeSourceFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeSourceFileName)))</_StubExeSourceFilePath>
 
-      <!-- Get the path to the source in the NuGet package -->
+      <!-- Get the path to the .c source template in the NuGet package -->
       <_StubExeOriginalSourceFilePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), 'sources', 'StubExe.c'))</_StubExeOriginalSourceFilePath>
-    
-      <!-- Prepare the output path of the resulting stub .exe -->
-      <_StubExeBinaryFileName>$(AssemblyName).exe</_StubExeBinaryFileName>
-      <_StubExeBinaryOutputFilePath>$([System.IO.Path]::Combine($(_StubExeGeneratedFilesDir), $(_StubExeBinaryFileName)))</_StubExeBinaryOutputFilePath>
-      <_StubExeBinaryDestinationFilePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath), $(_StubExeBinaryFileName)))</_StubExeBinaryDestinationFilePath>
 
-      <!-- Get the target platform (we either use 'Platform', if set and not 'AnyCPU', or fallback to 'PlatformTarget' ) -->
+      <!-- The destination directory for the compiled stub .exe files (the native output directory) -->
+      <_StubExeDestinationDir>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(NativeOutputPath)))</_StubExeDestinationDir>
+
+      <!-- Get the target platform (we either use 'Platform', if set and not 'AnyCPU', or fallback to 'PlatformTarget') -->
       <_StubExePlatform Condition="'$(_StubExePlatform)' == '' AND '$(Platform)' != '' AND '$(Platform)' != 'AnyCPU'">$(Platform)</_StubExePlatform>
       <_StubExePlatform Condition="'$(_StubExePlatform)' == '' AND '$(PlatformTarget)' != ''">$(PlatformTarget)</_StubExePlatform>
 
+      <!-- Resolve the Win32 manifest path for the default stub, if specified -->
       <_StubExeWin32ManifestPath Condition="'$(Win32Manifest)' != ''">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(Win32Manifest)))</_StubExeWin32ManifestPath>
     </PropertyGroup>
-    
-    <!-- This whole target might take a minute (and it might fail), so notify the user to help debug issues -->
-    <Message Text="Generating stub .exe" />
 
-    <!-- Ensure the folder exists, or writing to the source file will fail -->
-    <MakeDir Directories="$(_StubExeGeneratedFilesDir)"/>
-      
-    <!-- Write the stub .exe source -->
-    <Copy SourceFiles="$(_StubExeOriginalSourceFilePath)" DestinationFiles="$(_StubExeSourceFilePath)" />
+    <!--
+      If the user hasn't defined any CsWinRTStubExe items, add the default one
+      matching the original single-stub behavior (named after the assembly).
+    -->
+    <ItemGroup Condition="'@(CsWinRTStubExe)' == ''">
+      <CsWinRTStubExe Include="$(AssemblyName)" />
+    </ItemGroup>
 
     <!--
       Get the path of 'cl.exe' from the Native AOT tooling, which finds the install folder for MSVC already.
@@ -491,22 +517,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <PropertyGroup>
       <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(CsWinRTUseEnvironmentalTools)' == 'true'">cl</_ClExeFilePath>
-      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(_CppToolsDirectory)' != ''">"$([System.IO.Path]::Combine($(_CppToolsDirectory), 'cl.exe'))"</_ClExeFilePath>
+      <_ClExeFilePath Condition="'$(_ClExeFilePath)' == '' AND '$(_CppToolsDirectory)' != ''">$([System.IO.Path]::Combine($(_CppToolsDirectory), 'cl.exe'))</_ClExeFilePath>
     </PropertyGroup>
 
-    <!-- Fail if we can't find any 'cl.exe' -->
-    <Error
-      Condition="'$(_ClExeFilePath)' == ''"
-      Text="Failed to find 'cl.exe', which is needed to compile the project in the current configuration. Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
-
-    <!-- Get the path to the include directories, if not using the environmental tools -->
+    <!-- Resolve MSVC and Windows SDK include/lib paths when not using the environmental tools -->
     <PropertyGroup Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'">
 
       <!-- Find the 'include' folder in the MSVC install folder -->
       <_MsvcCurrentVersionInstallDirectory>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($(_CppToolsDirectory), '..', '..', '..'))))</_MsvcCurrentVersionInstallDirectory>
       <_MsvcIncludePath>$([System.IO.Path]::Combine($(_MsvcCurrentVersionInstallDirectory), 'include'))</_MsvcIncludePath>
       <_MsvcLibPath>$([System.IO.Path]::Combine($(_MsvcCurrentVersionInstallDirectory), 'lib', '$(_StubExePlatform)'))</_MsvcLibPath>
-      <_MsvcLibWildcardPath>$([System.IO.Path]::Combine($(_MsvcLibPath), '*.lib'))</_MsvcLibWildcardPath>
 
       <!-- Also get the root for the Windows SDK headers -->
       <_WindowsSdk10InstallDirectory Condition="'$(_WindowsSdk10InstallDirectory)' == '' AND '$(WindowsSdkPath)' != ''">$(WindowsSdkPath)</_WindowsSdk10InstallDirectory>
@@ -519,141 +539,44 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_WindowsSdkLibPath Condition="'$(EffectiveTargetPlatformVersion)' != ''">$([System.IO.Path]::Combine($(_WindowsSdk10InstallDirectory), 'Lib', '$(EffectiveTargetPlatformVersion)'))</_WindowsSdkLibPath>
       <_WindowsSdk-ucrt-LibPath>$([System.IO.Path]::Combine($(_WindowsSdkLibPath), 'ucrt', '$(_StubExePlatform)'))</_WindowsSdk-ucrt-LibPath>
       <_WindowsSdk-um-LibPath>$([System.IO.Path]::Combine($(_WindowsSdkLibPath), 'um', '$(_StubExePlatform)'))</_WindowsSdk-um-LibPath>
-      <_WindowsSdk-ucrt-LibWildcardPath>$([System.IO.Path]::Combine($(_WindowsSdk-ucrt-LibPath), '*.lib'))</_WindowsSdk-ucrt-LibWildcardPath>
-      <_WindowsSdk-um-LibWildcardPath>$([System.IO.Path]::Combine($(_WindowsSdk-um-LibPath), '*.lib'))</_WindowsSdk-um-LibWildcardPath>
+
+      <!-- Additional PATH for Windows SDK build tools (mt.exe, rc.exe) that aren't alongside link.exe -->
+      <_StubExeAdditionalPath Condition="'$(WindowsSDKBuildToolsBinVersionedArchFolder)' != ''">$(PATH);$(WindowsSDKBuildToolsBinVersionedArchFolder)</_StubExeAdditionalPath>
     </PropertyGroup>
 
-    <!-- We can't find some of the additional include folders -->
-    <Error
-      Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true' AND ('$(_MsvcIncludePath)' == '' OR !Exists('$(_MsvcIncludePath)') OR '$(_WindowsSdkIncludePath)' == '' OR !Exists('$(_WindowsSdkIncludePath)'))"
-      Text="Failed to find the paths for the include folders to pass to MSVC, which are needed to compile the project in the current configuration. Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
-    
-    <!-- Error on unsupported platforms -->
-    <Error
-      Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true' AND '$(_StubExePlatform)' != 'arm64' AND '$(_StubExePlatform)' != 'x64' AND '$(_StubExePlatform)' != 'x86'"
-      Text="Invalid platform selected to invoke MSVC. Make sure to set 'Platform' to either 'arm64', 'x64', or 'x86'. Alternatively, try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session." />
+    <!-- Ensure the intermediate output directory exists -->
+    <MakeDir Directories="$(_StubExeGeneratedFilesDir)"/>
 
-    <!-- Prepare the arguments for MSVC -->
+    <!-- Invoke the task to generate all stub .exe files -->
+    <GenerateCsWinRTStubExes
+      StubExes="@(CsWinRTStubExe)"
+      SourceFilePath="$(_StubExeOriginalSourceFilePath)"
+      NativeLibraryPath="$(_StubExeNativeLibraryPath)"
+      IntermediateOutputDirectory="$(_StubExeGeneratedFilesDir)"
+      DestinationDirectory="$(_StubExeDestinationDir)"
+      ClExePath="$(_ClExeFilePath)"
+      UseEnvironmentalTools="$(CsWinRTUseEnvironmentalTools)"
+      MsvcIncludePath="$(_MsvcIncludePath)"
+      MsvcLibPath="$(_MsvcLibPath)"
+      WindowsSdkUcrtIncludePath="$(_WindowsSdk-ucrt-IncludePath)"
+      WindowsSdkUmIncludePath="$(_WindowsSdk-um-IncludePath)"
+      WindowsSdkUcrtLibPath="$(_WindowsSdk-ucrt-LibPath)"
+      WindowsSdkUmLibPath="$(_WindowsSdk-um-LibPath)"
+      AdditionalPath="$(_StubExeAdditionalPath)"
+      IsDebugConfiguration="$([MSBuild]::ValueOrDefault('$(Configuration)', '') == 'Debug')"
+      ControlFlowGuard="$([MSBuild]::ValueOrDefault('$(ControlFlowGuard)', '') == 'Guard')"
+      CETCompat="$(CETCompat)"
+      DefaultOutputType="$(OutputType)"
+      DefaultWin32Manifest="$(_StubExeWin32ManifestPath)"
+      DefaultAppContainer="$(UseUwpTools)"
+      DefaultPlatform="$(_StubExePlatform)"
+      CopyBuildOutputToPublishDirectory="$(CopyBuildOutputToPublishDirectory)">
+      <Output TaskParameter="GeneratedStubExes" ItemName="_GeneratedStubExes" />
+    </GenerateCsWinRTStubExes>
+
+    <!-- Mark all generated stub .exe files as publish artifacts (so they're gathered by the PRI/MSIX tools) -->
     <ItemGroup>
-
-      <!-- If not using the environmental tools, manually pass the paths to the required libs -->
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_MsvcLibWildcardPath)"' />
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_WindowsSdk-ucrt-LibWildcardPath)"' />
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='"$(_WindowsSdk-um-LibWildcardPath)"' />
-
-      <!-- Hide the copyright banner, to reduce visual clutter (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) -->
-      <_StubExeMsvcArgs Include="/nologo" />
-
-      <!-- If not using the environmental tools, also pass the paths to the necessary include folders -->
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_MsvcIncludePath)"' />
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_WindowsSdk-ucrt-IncludePath)"' />
-      <_StubExeMsvcArgs Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true'" Include='/I "$(_WindowsSdk-um-IncludePath)"' />
-
-      <!--
-        Configure the binary to statically link the C runtime library (https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library).
-        This library (UCRT) has the implementation of all standard C runtime methods, like 'printf'. We want to actually link it dynamically, so we
-        will opt-in that individual library below. The dynamically linked version ships in the OS as 'ucrt.dll'. This matches the behavior of
-        Native AOT as well, which links UCRT dynamically, and VCRUNTIME140 (the MSVC-specific part of the C runtime) statically. The latter is much
-        smaller in size, so it does not matter. Dynamically linking UCRT reduces the size from 98 KB to 20 KB. The reason why we're not configuring
-        libraries to be dynamically linked, and then just having an opt-out for VCRUNTIME140, is that doing so causes a linker warning.
-      -->
-      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/MTd" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/MT" />
-
-      <!-- Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed) -->
-      <_StubExeMsvcArgs Include="/O2" />
-
-      <!-- Denote the start of the sequence of linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax) -->
-      <_StubExeMsvcArgs Include="/link" />
-
-      <!-- Hide the copyright banner for the linker as well -->
-      <_StubExeMsvcArgs Include="/NOLOGO" />
-
-      <!-- Embed a manifest if Win32Manifest is specified. (https://learn.microsoft.com/cpp/build/reference/manifest-create-side-by-side-assembly-manifest) -->
-      <_StubExeMsvcArgs Include="/MANIFEST:NO" Condition="'$(_StubExeWin32ManifestPath)'==''" />
-      <_StubExeMsvcArgs Include="/MANIFEST:EMBED /MANIFESTINPUT:$(_StubExeWin32ManifestPath)" Condition="'$(_StubExeWin32ManifestPath)'!=''" />
-
-      <!--
-        Change the behavior for UCRT to be dynamically linked (the default would be to statically link it, due to '/MT[d]').
-        See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library.
-        Also see: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries.
-      -->
-      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/NODEFAULTLIB:libucrtd.lib" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/NODEFAULTLIB:libucrt.lib" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' == 'Debug'" Include="/DEFAULTLIB:ucrtd.lib" />
-      <_StubExeMsvcArgs Condition="'$(Configuration)' != 'Debug'" Include="/DEFAULTLIB:ucrt.lib" />
-
-      <!-- Skip generating additional code for incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally) -->
-      <_StubExeMsvcArgs Include="/INCREMENTAL:NO" />
-
-      <!-- Enable COMDAT folding and remove unreferenced code (https://learn.microsoft.com/cpp/build/reference/opt-optimizations) -->
-      <_StubExeMsvcArgs Include="/OPT:ICF" />
-      <_StubExeMsvcArgs Include="/OPT:REF" />
-
-      <!--
-        Set the bit for AppContainer, for UWP apps (https://learn.microsoft.com/cpp/build/reference/appcontainer-windows-store-app).
-        This is not strictly needed on new Windows versions, but doing so matches the behavior of .NET Native as well.
-      -->
-      <_StubExeMsvcArgs Condition="'$(UseUwpTools)' == 'true'" Include="/APPCONTAINER" />
-
-      <!-- Set the right subsystem type, to match the project type (https://learn.microsoft.com/cpp/build/reference/subsystem-specify-subsystem) -->
-      <_StubExeMsvcArgs Condition="'$(OutputType)' == 'WinExe'" Include="/SUBSYSTEM:WINDOWS" />
-      <_StubExeMsvcArgs Condition="'$(OutputType)' != 'WinExe'" Include="/SUBSYSTEM:CONSOLE" />
-
-      <!--
-        Always set 'wmainCRTStartup' as the entry point (https://learn.microsoft.com/cpp/build/reference/entry-entry-point-symbol).
-        This matches what Native AOT does, and it allows us to always use 'wmain' for all application types, including 'WinExe'.
-      -->
-      <_StubExeMsvcArgs Include="/ENTRY:wmainCRTStartup" />
-
-      <!-- Enable CFG, if requested (https://learn.microsoft.com/cpp/build/reference/guard-enable-control-flow-guard) -->
-      <_StubExeMsvcArgs Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
-
-      <!-- Configure the CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat) -->
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(_StubExePlatform)' == 'x64'" Include="/CETCOMPAT" />
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' == 'false' and '$(_StubExePlatform)' == 'x64'" Include="/CETCOMPAT:NO" />
-
-      <!--
-        Enable EH continuation metadata if CET is not disabled and CFG is enabled, to match what Native AOT does.
-        See: https://learn.microsoft.com/cpp/build/reference/guard-enable-eh-continuation-metadata.
-      -->
-      <_StubExeMsvcArgs Condition="'$(CETCompat)' != 'false' and '$(_StubExePlatform)' == 'x64' and '$(ControlFlowGuard)' == 'Guard'" Include="/guard:ehcont"/>
-    </ItemGroup>
-
-    <!-- Combine all arguments, separated by a space (also, using a property makes it easier to inspect them, for debugging) -->
-    <PropertyGroup>
-      <_StubExeMsvcArgsText>@(_StubExeMsvcArgs, ' ')</_StubExeMsvcArgsText>
-    </PropertyGroup>
-    
-    <!--
-      Remove the broken .exe, if present (see https://github.com/dotnet/runtime/issues/111313). We want to do this before
-      compiling the binary, to ensure users won't ever see the wrong one in the publish folder and use that by accident.
-    -->
-    <Delete Files="$(_StubExeBinaryDestinationFilePath)" />
-
-    <!-- Add WindowsSDKBuildToolsBinVersionedArchFolder to the path if we're not using environmental tools since mt.exe and rc.exe aren't alongside link.exe. -->
-    <PropertyGroup Condition="'$(CsWinRTUseEnvironmentalTools)' != 'true' and '$(WindowsSDKBuildToolsBinVersionedArchFolder)'!=''">
-      <_StubExeAdditionalPath>$(PATH);$(WindowsSDKBuildToolsBinVersionedArchFolder)</_StubExeAdditionalPath>
-      <_StubExeEnvVars>PATH=$(_StubExeAdditionalPath.Replace(';','%3B'))</_StubExeEnvVars>
-    </PropertyGroup>
-    
-    <!-- Invoke MSVC to produce the native executable -->
-    <Exec
-      Command='$(_ClExeFilePath) "$(_StubExeSourceFilePath)" "$(_StubExeNativeLibraryPath)" $(_StubExeMsvcArgsText)'
-      ConsoleToMsBuild="true"
-      WorkingDirectory="$(_StubExeGeneratedFilesDir)"
-      EnvironmentVariables="$(_StubExeEnvVars)">
-    </Exec>
-    
-    <!-- Copy the resulting executable to the native directory -->
-    <Copy SourceFiles="$(_StubExeBinaryOutputFilePath)" DestinationFiles="$(_StubExeBinaryDestinationFilePath)" />
-
-    <!-- Also mark the stub .exe as being part of the published items (so it's gathered by the PRI/MSIX tools) -->
-    <ItemGroup>
-      <ResolvedFileToPublish Include="$(_StubExeBinaryDestinationFilePath)" Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
-        <RelativePath>$(_StubExeBinaryFileName)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_GeneratedStubExes)" />
     </ItemGroup>
   </Target>
 

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -506,6 +506,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <!-- Resolve the Win32 manifest path for the default stub, if specified -->
       <_StubExeWin32ManifestPath Condition="'$(Win32Manifest)' != ''">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(Win32Manifest)))</_StubExeWin32ManifestPath>
+
+      <!--
+        Normalize the MSVC toggles into 'true'/'false' values that can be passed to the boolean task parameters.
+        These have to be computed as separate properties, as MSBuild only supports comparisons in conditions.
+      -->
+      <_StubExeIsDebugConfiguration>false</_StubExeIsDebugConfiguration>
+      <_StubExeIsDebugConfiguration Condition="'$(Configuration)' == 'Debug'">true</_StubExeIsDebugConfiguration>
+      <_StubExeControlFlowGuard>false</_StubExeControlFlowGuard>
+      <_StubExeControlFlowGuard Condition="'$(ControlFlowGuard)' == 'Guard'">true</_StubExeControlFlowGuard>
+      <_StubExeCETCompat>true</_StubExeCETCompat>
+      <_StubExeCETCompat Condition="'$(CETCompat)' == 'false'">false</_StubExeCETCompat>
+      <_StubExeAppContainer>false</_StubExeAppContainer>
+      <_StubExeAppContainer Condition="'$(UseUwpTools)' == 'true'">true</_StubExeAppContainer>
     </PropertyGroup>
 
     <!--
@@ -568,12 +581,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       WindowsSdkUcrtLibPath="$(_WindowsSdk-ucrt-LibPath)"
       WindowsSdkUmLibPath="$(_WindowsSdk-um-LibPath)"
       AdditionalPath="$(_StubExeAdditionalPath)"
-      IsDebugConfiguration="$([MSBuild]::ValueOrDefault('$(Configuration)', '') == 'Debug')"
-      ControlFlowGuard="$([MSBuild]::ValueOrDefault('$(ControlFlowGuard)', '') == 'Guard')"
-      CETCompat="$([MSBuild]::ValueOrDefault('$(CETCompat)', '') != 'false')"
+      IsDebugConfiguration="$(_StubExeIsDebugConfiguration)"
+      ControlFlowGuard="$(_StubExeControlFlowGuard)"
+      CETCompat="$(_StubExeCETCompat)"
       DefaultOutputType="$(OutputType)"
       DefaultWin32Manifest="$(_StubExeWin32ManifestPath)"
-      DefaultAppContainer="$(UseUwpTools)"
+      DefaultAppContainer="$(_StubExeAppContainer)"
       DefaultPlatform="$(_StubExePlatform)"
       CopyBuildOutputToPublishDirectory="$(CopyBuildOutputToPublishDirectory)">
       <Output TaskParameter="GeneratedStubExes" ItemName="_GeneratedStubExes" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -557,7 +557,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Invoke the task to generate all stub .exe files -->
     <GenerateCsWinRTStubExes
       StubExes="@(CsWinRTStubExe)"
-      SourceFilePath="$(_StubExeOriginalSourceFilePath)"
+      DefaultSourceFilePath="$(_StubExeOriginalSourceFilePath)"
       NativeLibraryPath="$(_StubExeNativeLibraryPath)"
       IntermediateOutputDirectory="$(_StubExeGeneratedFilesDir)"
       DestinationDirectory="$(_StubExeDestinationDir)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -476,6 +476,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CsWinRTStubExe Include="MyApp.Windowed" OutputType="WinExe" />
         <CsWinRTStubExe Include="MyApp.Custom" SourceFile="src\CustomStub.c" />
       </ItemGroup>
+
+    When no items are defined, a single default stub named after the assembly is
+    added, with 'AppContainer' set based on whether the app runs in an app container
+    (i.e. whether $(UseUwpTools) or $(WindowsAppContainer) is 'true').
     ============================================================
   -->
   <UsingTask Condition="'$(CsWinRTGeneratorTasksOverriden2)' != 'true'" TaskName="GenerateCsWinRTStubExes" AssemblyFile="$(CsWinRTGenTasksAssembly)" />
@@ -519,9 +523,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_StubExeCETCompat>true</_StubExeCETCompat>
       <_StubExeCETCompat Condition="'$(CETCompat)' == 'false'">false</_StubExeCETCompat>
 
-      <!-- Resolve the 'AppContainer' setting for the default stub (see the item group below) -->
+      <!--
+        Resolve the 'AppContainer' setting for the default stub (see the item group below). This is
+        enabled for UWP apps ('UseUwpTools'), as well as for any other app that opts into running in
+        an app container ('WindowsAppContainer'), which is what MSIX packaging (.wapproj) projects set
+        for packaged Win32 apps. Both cases require the '/APPCONTAINER' bit to be set on the stub .exe.
+      -->
       <_StubExeDefaultAppContainer>false</_StubExeDefaultAppContainer>
-      <_StubExeDefaultAppContainer Condition="'$(UseUwpTools)' == 'true'">true</_StubExeDefaultAppContainer>
+      <_StubExeDefaultAppContainer Condition="'$(UseUwpTools)' == 'true' OR '$(WindowsAppContainer)' == 'true'">true</_StubExeDefaultAppContainer>
     </PropertyGroup>
 
     <!--

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -572,7 +572,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AdditionalPath="$(_StubExeAdditionalPath)"
       IsDebugConfiguration="$([MSBuild]::ValueOrDefault('$(Configuration)', '') == 'Debug')"
       ControlFlowGuard="$([MSBuild]::ValueOrDefault('$(ControlFlowGuard)', '') == 'Guard')"
-      CETCompat="$(CETCompat)"
+      CETCompat="$([MSBuild]::ValueOrDefault('$(CETCompat)', '') != 'false')"
       DefaultOutputType="$(OutputType)"
       DefaultWin32Manifest="$(_StubExeWin32ManifestPath)"
       DefaultAppContainer="$(UseUwpTools)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -460,8 +460,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                        Defaults to the project's $(OutputType).
       Win32Manifest  - Path to a Win32 manifest file to embed. If empty, manifest
                        generation is suppressed. Defaults to the project's $(Win32Manifest).
-      AppContainer   - 'true' to set /APPCONTAINER for UWP apps.
-                       Defaults to $(UseUwpTools).
+      AppContainer   - 'true' to set /APPCONTAINER, for apps running in an app container.
+                       This is a per-stub setting, so stubs with different values are
+                       compiled separately. Defaults to 'false'.
       SourceText     - Inline C source code for the stub. When set, this text is
                        written to a .c file and compiled. Takes precedence over
                        SourceFile and the default source template.
@@ -517,8 +518,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_StubExeControlFlowGuard Condition="'$(ControlFlowGuard)' == 'Guard'">true</_StubExeControlFlowGuard>
       <_StubExeCETCompat>true</_StubExeCETCompat>
       <_StubExeCETCompat Condition="'$(CETCompat)' == 'false'">false</_StubExeCETCompat>
-      <_StubExeAppContainer>false</_StubExeAppContainer>
-      <_StubExeAppContainer Condition="'$(UseUwpTools)' == 'true'">true</_StubExeAppContainer>
+
+      <!-- Resolve the 'AppContainer' setting for the default stub (see the item group below) -->
+      <_StubExeDefaultAppContainer>false</_StubExeDefaultAppContainer>
+      <_StubExeDefaultAppContainer Condition="'$(UseUwpTools)' == 'true'">true</_StubExeDefaultAppContainer>
     </PropertyGroup>
 
     <!--
@@ -526,7 +529,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       matching the original single-stub behavior (named after the assembly).
     -->
     <ItemGroup Condition="'@(CsWinRTStubExe)' == ''">
-      <CsWinRTStubExe Include="$(AssemblyName)" />
+      <CsWinRTStubExe Include="$(AssemblyName)" AppContainer="$(_StubExeDefaultAppContainer)" />
     </ItemGroup>
 
     <!--
@@ -586,7 +589,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       CETCompat="$(_StubExeCETCompat)"
       DefaultOutputType="$(OutputType)"
       DefaultWin32Manifest="$(_StubExeWin32ManifestPath)"
-      DefaultAppContainer="$(_StubExeAppContainer)"
       DefaultPlatform="$(_StubExePlatform)"
       CopyBuildOutputToPublishDirectory="$(CopyBuildOutputToPublishDirectory)">
       <Output TaskParameter="GeneratedStubExes" ItemName="_GeneratedStubExes" />

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -462,8 +462,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                        generation is suppressed. Defaults to the project's $(Win32Manifest).
       AppContainer   - 'true' to set /APPCONTAINER for UWP apps.
                        Defaults to $(UseUwpTools).
-      Platform       - Target platform (arm64, x64, x86). Defaults to the resolved
-                       platform from $(Platform) / $(PlatformTarget).
       SourceText     - Inline C source code for the stub. When set, this text is
                        written to a .c file and compiled. Takes precedence over
                        SourceFile and the default source template.
@@ -548,7 +546,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_WindowsSdk-um-LibPath>$([System.IO.Path]::Combine($(_WindowsSdkLibPath), 'um', '$(_StubExePlatform)'))</_WindowsSdk-um-LibPath>
 
       <!-- Additional PATH for Windows SDK build tools (mt.exe, rc.exe) that aren't alongside link.exe -->
-      <_StubExeAdditionalPath Condition="'$(WindowsSDKBuildToolsBinVersionedArchFolder)' != ''">$(PATH);$(WindowsSDKBuildToolsBinVersionedArchFolder)</_StubExeAdditionalPath>
+      <_StubExeAdditionalPath Condition="'$(WindowsSDKBuildToolsBinVersionedArchFolder)' != ''">$(WindowsSDKBuildToolsBinVersionedArchFolder)</_StubExeAdditionalPath>
     </PropertyGroup>
 
     <!-- Ensure the intermediate output directory exists -->

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -62,6 +62,23 @@ namespace Microsoft.NET.Build.Tasks;
 ///       Defaults to <see cref="DefaultPlatform"/>.
 ///     </description>
 ///   </item>
+///   <item>
+///     <term><c>SourceText</c></term>
+///     <description>
+///       Inline C source code to use for this stub. When set, the text is written
+///       to a <c>.c</c> file in the intermediate directory and compiled. Takes
+///       precedence over <c>SourceFile</c> and the default <see cref="SourceFilePath"/>.
+///     </description>
+///   </item>
+///   <item>
+///     <term><c>SourceFile</c></term>
+///     <description>
+///       Path to a custom <c>.c</c> source file to use for this stub. When set,
+///       the file is copied to the intermediate directory and compiled. Takes
+///       precedence over the default <see cref="SourceFilePath"/>, but is
+///       overridden by <c>SourceText</c> if both are specified.
+///     </description>
+///   </item>
 /// </list>
 /// </remarks>
 public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
@@ -72,16 +89,20 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <remarks>
     /// <para>
     /// The item identity (<c>Include</c>) is the stub name (used as the output <c>.exe</c> filename).
-    /// Supported metadata: <c>OutputType</c>, <c>Win32Manifest</c>, <c>AppContainer</c>, <c>Platform</c>.
+    /// Supported metadata: <c>OutputType</c>, <c>Win32Manifest</c>, <c>AppContainer</c>, <c>Platform</c>,
+    /// <c>SourceText</c>, <c>SourceFile</c>.
     /// </para>
     /// </remarks>
     [Required]
     public ITaskItem[]? StubExes { get; set; }
 
     /// <summary>
-    /// Gets or sets the path to the <c>.c</c> source file used for building the stub executable.
+    /// Gets or sets the path to the default <c>.c</c> source file used for building stub executables.
     /// </summary>
-    [Required]
+    /// <remarks>
+    /// This is used as a fallback when a stub item does not specify <c>SourceText</c> or <c>SourceFile</c>
+    /// metadata. If all items provide their own source, this property can be left empty.
+    /// </remarks>
     public string? SourceFilePath { get; set; }
 
     /// <summary>
@@ -242,13 +263,6 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        if (string.IsNullOrEmpty(SourceFilePath) || !File.Exists(SourceFilePath))
-        {
-            Log.LogError("The stub .exe source file '{0}' does not exist.", SourceFilePath);
-
-            return false;
-        }
-
         if (string.IsNullOrEmpty(NativeLibraryPath) || !File.Exists(NativeLibraryPath))
         {
             Log.LogError("The native library '{0}' does not exist.", NativeLibraryPath);
@@ -323,6 +337,8 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
         bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
         string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
+        string sourceText = stubExe.GetMetadata("SourceText");
+        string sourceFile = stubExe.GetMetadata("SourceFile");
 
         // Validate the platform
         if (!UseEnvironmentalTools &&
@@ -352,8 +368,45 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         // Ensure the intermediate directory exists
         Directory.CreateDirectory(stubIntermediateDir);
 
-        // Copy the .c source template into the working directory with the stub-specific name
-        File.Copy(SourceFilePath!, sourceFilePath, overwrite: true);
+        // Resolve the source for this stub:
+        //   1. SourceText metadata: write inline text to the .c file
+        //   2. SourceFile metadata: copy the specified file
+        //   3. Default SourceFilePath: copy the default template from the NuGet package
+        if (!string.IsNullOrEmpty(sourceText))
+        {
+            File.WriteAllText(sourceFilePath, sourceText);
+        }
+        else if (!string.IsNullOrEmpty(sourceFile))
+        {
+            if (!File.Exists(sourceFile))
+            {
+                Log.LogError("The source file '{0}' specified for stub '{1}' does not exist.", sourceFile, stubName);
+
+                return false;
+            }
+
+            File.Copy(sourceFile, sourceFilePath, overwrite: true);
+        }
+        else if (!string.IsNullOrEmpty(SourceFilePath))
+        {
+            if (!File.Exists(SourceFilePath))
+            {
+                Log.LogError("The default stub .exe source file '{0}' does not exist.", SourceFilePath);
+
+                return false;
+            }
+
+            File.Copy(SourceFilePath, sourceFilePath, overwrite: true);
+        }
+        else
+        {
+            Log.LogError(
+                "No source was specified for stub '{0}'. Set 'SourceText' or 'SourceFile' metadata on the item, " +
+                "or provide a default source file via the 'SourceFilePath' task parameter.",
+                stubName);
+
+            return false;
+        }
 
         // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)
         if (File.Exists(binaryDestinationFilePath))

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -253,6 +253,32 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <inheritdoc/>
     public override bool Execute()
     {
+        if (!ValidateParameters())
+        {
+            return false;
+        }
+
+        List<ITaskItem> generatedItems = new();
+
+        foreach (ITaskItem stubExe in StubExes!)
+        {
+            if (!GenerateStubExe(stubExe, generatedItems))
+            {
+                return false;
+            }
+        }
+
+        GeneratedStubExes = generatedItems.ToArray();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates all task parameters and input items upfront, before any compilation begins.
+    /// </summary>
+    /// <returns><see langword="true"/> if all parameters and items are valid; otherwise, <see langword="false"/>.</returns>
+    private bool ValidateParameters()
+    {
         if (StubExes is not { Length: > 0 })
         {
             Log.LogError("No stub executables were specified.");
@@ -304,40 +330,30 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             }
         }
 
-        List<ITaskItem> generatedItems = new();
-
+        // Validate each input item
         foreach (ITaskItem stubExe in StubExes)
         {
-            if (!GenerateStubExe(stubExe, generatedItems))
+            if (!ValidateStubExeItem(stubExe))
             {
                 return false;
             }
         }
 
-        GeneratedStubExes = generatedItems.ToArray();
-
         return true;
     }
 
     /// <summary>
-    /// Generates a single stub <c>.exe</c> for the given item.
+    /// Validates a single <see cref="ITaskItem"/> describing a stub to generate.
     /// </summary>
-    /// <param name="stubExe">The <see cref="ITaskItem"/> describing the stub to generate.</param>
-    /// <param name="generatedItems">The list to add generated output items to.</param>
-    /// <returns><see langword="true"/> if the stub was generated successfully; otherwise, <see langword="false"/>.</returns>
-    private bool GenerateStubExe(ITaskItem stubExe, List<ITaskItem> generatedItems)
+    /// <param name="stubExe">The item to validate.</param>
+    /// <returns><see langword="true"/> if the item is valid; otherwise, <see langword="false"/>.</returns>
+    private bool ValidateStubExeItem(ITaskItem stubExe)
     {
         string stubName = stubExe.ItemSpec;
 
-        // Resolve per-stub metadata, falling back to defaults
-        string outputType = GetMetadataOrDefault(stubExe, "OutputType", DefaultOutputType ?? "Exe");
-        string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
-        bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
-        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
-        string sourceText = stubExe.GetMetadata("SourceText");
-        string sourceFile = stubExe.GetMetadata("SourceFile");
-
         // Validate the platform
+        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
+
         if (!UseEnvironmentalTools &&
             !string.Equals(platform, "arm64", StringComparison.OrdinalIgnoreCase) &&
             !string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase) &&
@@ -352,6 +368,63 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             return false;
         }
 
+        // Validate the source: one of SourceText, SourceFile, or DefaultSourceFilePath must be available
+        string sourceText = stubExe.GetMetadata("SourceText");
+        string sourceFile = stubExe.GetMetadata("SourceFile");
+
+        if (!string.IsNullOrEmpty(sourceText))
+        {
+            // Inline source text is always valid
+        }
+        else if (!string.IsNullOrEmpty(sourceFile))
+        {
+            if (!File.Exists(sourceFile))
+            {
+                Log.LogError("The source file '{0}' specified for stub '{1}' does not exist.", sourceFile, stubName);
+
+                return false;
+            }
+        }
+        else if (!string.IsNullOrEmpty(DefaultSourceFilePath))
+        {
+            if (!File.Exists(DefaultSourceFilePath))
+            {
+                Log.LogError("The default stub .exe source file '{0}' does not exist.", DefaultSourceFilePath);
+
+                return false;
+            }
+        }
+        else
+        {
+            Log.LogError(
+                "No source was specified for stub '{0}'. Set 'SourceText' or 'SourceFile' metadata on the item, " +
+                "or provide a default source file via the 'DefaultSourceFilePath' task parameter.",
+                stubName);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Generates a single stub <c>.exe</c> for the given item.
+    /// </summary>
+    /// <param name="stubExe">The <see cref="ITaskItem"/> describing the stub to generate (must be pre-validated).</param>
+    /// <param name="generatedItems">The list to add generated output items to.</param>
+    /// <returns><see langword="true"/> if the stub was generated successfully; otherwise, <see langword="false"/>.</returns>
+    private bool GenerateStubExe(ITaskItem stubExe, List<ITaskItem> generatedItems)
+    {
+        string stubName = stubExe.ItemSpec;
+
+        // Resolve per-stub metadata, falling back to defaults
+        string outputType = GetMetadataOrDefault(stubExe, "OutputType", DefaultOutputType ?? "Exe");
+        string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
+        bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
+        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
+        string sourceText = stubExe.GetMetadata("SourceText");
+        string sourceFile = stubExe.GetMetadata("SourceFile");
+
         // Prepare paths for the intermediate working directory for this stub
         string stubIntermediateDir = Path.Combine(IntermediateOutputDirectory!, stubName);
         string sourceFileName = stubName + ".c";
@@ -365,44 +438,18 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         // Ensure the intermediate directory exists
         Directory.CreateDirectory(stubIntermediateDir);
 
-        // Resolve the source for this stub:
-        //   1. SourceText metadata: write inline text to the .c file
-        //   2. SourceFile metadata: copy the specified file
-        //   3. Default DefaultSourceFilePath: copy the default template from the NuGet package
+        // Write the source for this stub (priority: SourceText > SourceFile > DefaultSourceFilePath)
         if (!string.IsNullOrEmpty(sourceText))
         {
             File.WriteAllText(sourceFilePath, sourceText);
         }
         else if (!string.IsNullOrEmpty(sourceFile))
         {
-            if (!File.Exists(sourceFile))
-            {
-                Log.LogError("The source file '{0}' specified for stub '{1}' does not exist.", sourceFile, stubName);
-
-                return false;
-            }
-
             File.Copy(sourceFile, sourceFilePath, overwrite: true);
-        }
-        else if (!string.IsNullOrEmpty(DefaultSourceFilePath))
-        {
-            if (!File.Exists(DefaultSourceFilePath))
-            {
-                Log.LogError("The default stub .exe source file '{0}' does not exist.", DefaultSourceFilePath);
-
-                return false;
-            }
-
-            File.Copy(DefaultSourceFilePath, sourceFilePath, overwrite: true);
         }
         else
         {
-            Log.LogError(
-                "No source was specified for stub '{0}'. Set 'SourceText' or 'SourceFile' metadata on the item, " +
-                "or provide a default source file via the 'DefaultSourceFilePath' task parameter.",
-                stubName);
-
-            return false;
+            File.Copy(DefaultSourceFilePath!, sourceFilePath, overwrite: true);
         }
 
         // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tasks;
 ///     <description>
 ///       Inline C source code to use for this stub. When set, the text is written
 ///       to a <c>.c</c> file in the intermediate directory and compiled. Takes
-///       precedence over <c>SourceFile</c> and the default <see cref="SourceFilePath"/>.
+///       precedence over <c>SourceFile</c> and the default <see cref="DefaultSourceFilePath"/>.
 ///     </description>
 ///   </item>
 ///   <item>
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Build.Tasks;
 ///     <description>
 ///       Path to a custom <c>.c</c> source file to use for this stub. When set,
 ///       the file is copied to the intermediate directory and compiled. Takes
-///       precedence over the default <see cref="SourceFilePath"/>, but is
+///       precedence over the default <see cref="DefaultSourceFilePath"/>, but is
 ///       overridden by <c>SourceText</c> if both are specified.
 ///     </description>
 ///   </item>
@@ -103,7 +103,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// This is used as a fallback when a stub item does not specify <c>SourceText</c> or <c>SourceFile</c>
     /// metadata. If all items provide their own source, this property can be left empty.
     /// </remarks>
-    public string? SourceFilePath { get; set; }
+    public string? DefaultSourceFilePath { get; set; }
 
     /// <summary>
     /// Gets or sets the path to the <c>.lib</c> file produced by the Native AOT toolchain,
@@ -371,7 +371,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         // Resolve the source for this stub:
         //   1. SourceText metadata: write inline text to the .c file
         //   2. SourceFile metadata: copy the specified file
-        //   3. Default SourceFilePath: copy the default template from the NuGet package
+        //   3. Default DefaultSourceFilePath: copy the default template from the NuGet package
         if (!string.IsNullOrEmpty(sourceText))
         {
             File.WriteAllText(sourceFilePath, sourceText);
@@ -387,22 +387,22 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
 
             File.Copy(sourceFile, sourceFilePath, overwrite: true);
         }
-        else if (!string.IsNullOrEmpty(SourceFilePath))
+        else if (!string.IsNullOrEmpty(DefaultSourceFilePath))
         {
-            if (!File.Exists(SourceFilePath))
+            if (!File.Exists(DefaultSourceFilePath))
             {
-                Log.LogError("The default stub .exe source file '{0}' does not exist.", SourceFilePath);
+                Log.LogError("The default stub .exe source file '{0}' does not exist.", DefaultSourceFilePath);
 
                 return false;
             }
 
-            File.Copy(SourceFilePath, sourceFilePath, overwrite: true);
+            File.Copy(DefaultSourceFilePath, sourceFilePath, overwrite: true);
         }
         else
         {
             Log.LogError(
                 "No source was specified for stub '{0}'. Set 'SourceText' or 'SourceFile' metadata on the item, " +
-                "or provide a default source file via the 'SourceFilePath' task parameter.",
+                "or provide a default source file via the 'DefaultSourceFilePath' task parameter.",
                 stubName);
 
             return false;

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -205,16 +205,13 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     public bool ControlFlowGuard { get; set; }
 
     /// <summary>
-    /// Gets or sets the CET compatibility mode.
+    /// Gets or sets whether CET shadow stack compatibility is enabled.
     /// </summary>
     /// <remarks>
-    /// <para>Maps to the <c>CETCompat</c> MSBuild property.</para>
-    /// <list type="bullet">
-    ///   <item>Empty or non-<c>"false"</c>: CET shadow stack is enabled (for x64).</item>
-    ///   <item><c>"false"</c>: CET shadow stack is disabled.</item>
-    /// </list>
+    /// When <see langword="true"/> (the default), the <c>/CETCOMPAT</c> linker flag is set for x64 targets.
+    /// Maps to the <c>CETCompat</c> MSBuild property.
     /// </remarks>
-    public string? CETCompat { get; set; }
+    public bool CETCompat { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the default output type for stubs that don't specify one.
@@ -561,7 +558,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         }
 
         // Configure CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat)
-        bool cetEnabled = !string.Equals(CETCompat, "false", StringComparison.OrdinalIgnoreCase);
+        bool cetEnabled = CETCompat;
         bool isX64 = string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase);
 
         if (isX64)

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -255,7 +255,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        List<ITaskItem> generatedItems = new();
+        List<ITaskItem> generatedItems = [];
 
         foreach (ITaskItem stubExe in StubExes!)
         {
@@ -265,7 +265,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             }
         }
 
-        GeneratedStubExes = generatedItems.ToArray();
+        GeneratedStubExes = [.. generatedItems];
 
         return true;
     }

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -1,0 +1,666 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks;
+
+/// <summary>
+/// An MSBuild task that generates one or more stub <c>.exe</c> files by invoking MSVC (<c>cl.exe</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A "stub <c>.exe</c>" is a small native executable whose only job is to call into a method
+/// exported from a companion <c>.dll</c> produced by the Native AOT toolchain. This is needed
+/// when the project is compiled as a shared library (i.e. <c>NativeLib=Shared</c>), and the
+/// application still needs a standard <c>.exe</c> entry point.
+/// </para>
+/// <para>
+/// Each item in <see cref="StubExes"/> describes one stub to generate. The item identity
+/// (<c>Include</c>) is used as the output binary name (i.e. <c>{Identity}.exe</c>), and
+/// optional metadata controls per-stub behavior:
+/// </para>
+/// <list type="table">
+///   <listheader>
+///     <term>Metadata</term>
+///     <description>Description</description>
+///   </listheader>
+///   <item>
+///     <term><c>OutputType</c></term>
+///     <description>
+///       The output type for the stub, controlling the PE subsystem.
+///       <c>WinExe</c> produces a <c>/SUBSYSTEM:WINDOWS</c> binary;
+///       any other value (including <c>Exe</c>) produces <c>/SUBSYSTEM:CONSOLE</c>.
+///       Defaults to the project's <c>OutputType</c> (see <see cref="DefaultOutputType"/>).
+///     </description>
+///   </item>
+///   <item>
+///     <term><c>Win32Manifest</c></term>
+///     <description>
+///       Path to a Win32 manifest file to embed into the stub <c>.exe</c>.
+///       If empty, the stub is produced with <c>/MANIFEST:NO</c>.
+///       Defaults to the project's <c>Win32Manifest</c> (see <see cref="DefaultWin32Manifest"/>).
+///     </description>
+///   </item>
+///   <item>
+///     <term><c>AppContainer</c></term>
+///     <description>
+///       Whether to set the <c>/APPCONTAINER</c> linker flag, for UWP apps.
+///       Defaults to <see cref="DefaultAppContainer"/>.
+///     </description>
+///   </item>
+///   <item>
+///     <term><c>Platform</c></term>
+///     <description>
+///       The target platform (<c>x64</c>, <c>x86</c>, or <c>arm64</c>).
+///       Defaults to <see cref="DefaultPlatform"/>.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
+{
+    /// <summary>
+    /// Gets or sets the collection of stub executables to generate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The item identity (<c>Include</c>) is the stub name (used as the output <c>.exe</c> filename).
+    /// Supported metadata: <c>OutputType</c>, <c>Win32Manifest</c>, <c>AppContainer</c>, <c>Platform</c>.
+    /// </para>
+    /// </remarks>
+    [Required]
+    public ITaskItem[]? StubExes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the <c>.c</c> source file used for building the stub executable.
+    /// </summary>
+    [Required]
+    public string? SourceFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the <c>.lib</c> file produced by the Native AOT toolchain,
+    /// which the linker needs to resolve the managed entry point import.
+    /// </summary>
+    [Required]
+    public string? NativeLibraryPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the intermediate output directory where generated files are placed.
+    /// </summary>
+    [Required]
+    public string? IntermediateOutputDirectory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the destination directory for the compiled stub <c>.exe</c> files
+    /// (typically the native output directory alongside the AOT-compiled <c>.dll</c>).
+    /// </summary>
+    [Required]
+    public string? DestinationDirectory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the MSVC compiler (<c>cl.exe</c>).
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="UseEnvironmentalTools"/> is <see langword="true"/>, this can be just <c>"cl"</c>
+    /// (resolved from the environment <c>PATH</c>). Otherwise, it should be the full path to <c>cl.exe</c>
+    /// from the Native AOT tooling's <c>_CppToolsDirectory</c>.
+    /// </remarks>
+    [Required]
+    public string? ClExePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether environmental tools are being used (i.e. building from a VS Developer Command Prompt).
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="true"/>, the task does not need to manually resolve MSVC and Windows SDK include/lib
+    /// paths, because they are already available on the <c>PATH</c> and in environment variables.
+    /// </remarks>
+    public bool UseEnvironmentalTools { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the MSVC include directory.
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? MsvcIncludePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the MSVC lib directory (architecture-specific).
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? MsvcLibPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the Windows SDK UCRT include directory.
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? WindowsSdkUcrtIncludePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the Windows SDK UM include directory.
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? WindowsSdkUmIncludePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the Windows SDK UCRT lib directory (architecture-specific).
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? WindowsSdkUcrtLibPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the Windows SDK UM lib directory (architecture-specific).
+    /// </summary>
+    /// <remarks>Only used when <see cref="UseEnvironmentalTools"/> is <see langword="false"/>.</remarks>
+    public string? WindowsSdkUmLibPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional directories to prepend to the <c>PATH</c> when invoking <c>cl.exe</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is used when not using environmental tools and the Windows SDK build tools directory
+    /// (containing <c>mt.exe</c> and <c>rc.exe</c>) is not already on the <c>PATH</c>.
+    /// </remarks>
+    public string? AdditionalPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the build configuration is <c>Debug</c>.
+    /// </summary>
+    /// <remarks>
+    /// This controls whether the debug or release variants of the C runtime libraries are linked.
+    /// </remarks>
+    public bool IsDebugConfiguration { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether Control Flow Guard (CFG) is enabled.
+    /// </summary>
+    /// <remarks>Maps to the <c>ControlFlowGuard</c> MSBuild property (value <c>"Guard"</c>).</remarks>
+    public bool ControlFlowGuard { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CET compatibility mode.
+    /// </summary>
+    /// <remarks>
+    /// <para>Maps to the <c>CETCompat</c> MSBuild property.</para>
+    /// <list type="bullet">
+    ///   <item>Empty or non-<c>"false"</c>: CET shadow stack is enabled (for x64).</item>
+    ///   <item><c>"false"</c>: CET shadow stack is disabled.</item>
+    /// </list>
+    /// </remarks>
+    public string? CETCompat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default output type for stubs that don't specify one.
+    /// </summary>
+    /// <remarks>Falls back to the project's <c>OutputType</c>.</remarks>
+    public string? DefaultOutputType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default Win32 manifest path for stubs that don't specify one.
+    /// </summary>
+    public string? DefaultWin32Manifest { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default <c>AppContainer</c> value for stubs that don't specify one.
+    /// </summary>
+    public bool DefaultAppContainer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default platform for stubs that don't specify one.
+    /// </summary>
+    public string? DefaultPlatform { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to include generated stub <c>.exe</c> files in the publish output.
+    /// </summary>
+    /// <remarks>Maps to <c>CopyBuildOutputToPublishDirectory</c>.</remarks>
+    public bool CopyBuildOutputToPublishDirectory { get; set; } = true;
+
+    /// <summary>
+    /// Returns the list of generated stub <c>.exe</c> items to be included in <c>ResolvedFileToPublish</c>.
+    /// </summary>
+    /// <remarks>
+    /// Each output item has <c>RelativePath</c> and <c>CopyToPublishDirectory</c> metadata set,
+    /// so the calling target can merge them directly into <c>ResolvedFileToPublish</c>.
+    /// </remarks>
+    [Output]
+    public ITaskItem[]? GeneratedStubExes { get; set; }
+
+    /// <inheritdoc/>
+    public override bool Execute()
+    {
+        if (StubExes is not { Length: > 0 })
+        {
+            Log.LogError("No stub executables were specified.");
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(SourceFilePath) || !File.Exists(SourceFilePath))
+        {
+            Log.LogError("The stub .exe source file '{0}' does not exist.", SourceFilePath);
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(NativeLibraryPath) || !File.Exists(NativeLibraryPath))
+        {
+            Log.LogError("The native library '{0}' does not exist.", NativeLibraryPath);
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(IntermediateOutputDirectory))
+        {
+            Log.LogError("The intermediate output directory was not specified.");
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(DestinationDirectory))
+        {
+            Log.LogError("The destination directory was not specified.");
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(ClExePath))
+        {
+            Log.LogError(
+                "Failed to find 'cl.exe', which is needed to compile stub executables. " +
+                "Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.");
+
+            return false;
+        }
+
+        // Validate MSVC/SDK paths when not using environmental tools
+        if (!UseEnvironmentalTools)
+        {
+            if (string.IsNullOrEmpty(MsvcIncludePath) || !Directory.Exists(MsvcIncludePath) ||
+                string.IsNullOrEmpty(WindowsSdkUcrtIncludePath) || !Directory.Exists(WindowsSdkUcrtIncludePath))
+            {
+                Log.LogError(
+                    "Failed to find the paths for the include folders to pass to MSVC, which are needed to compile stub executables. " +
+                    "Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.");
+
+                return false;
+            }
+        }
+
+        List<ITaskItem> generatedItems = new();
+
+        foreach (ITaskItem stubExe in StubExes)
+        {
+            if (!GenerateStubExe(stubExe, generatedItems))
+            {
+                return false;
+            }
+        }
+
+        GeneratedStubExes = generatedItems.ToArray();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Generates a single stub <c>.exe</c> for the given item.
+    /// </summary>
+    /// <param name="stubExe">The <see cref="ITaskItem"/> describing the stub to generate.</param>
+    /// <param name="generatedItems">The list to add generated output items to.</param>
+    /// <returns><see langword="true"/> if the stub was generated successfully; otherwise, <see langword="false"/>.</returns>
+    private bool GenerateStubExe(ITaskItem stubExe, List<ITaskItem> generatedItems)
+    {
+        string stubName = stubExe.ItemSpec;
+
+        // Resolve per-stub metadata, falling back to defaults
+        string outputType = GetMetadataOrDefault(stubExe, "OutputType", DefaultOutputType ?? "Exe");
+        string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
+        bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
+        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
+
+        // Validate the platform
+        if (!UseEnvironmentalTools &&
+            !string.Equals(platform, "arm64", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(platform, "x86", StringComparison.OrdinalIgnoreCase))
+        {
+            Log.LogError(
+                "Invalid platform '{0}' for stub '{1}'. Make sure to set 'Platform' to either 'arm64', 'x64', or 'x86'. " +
+                "Alternatively, try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.",
+                platform,
+                stubName);
+
+            return false;
+        }
+
+        // Prepare paths for the intermediate working directory for this stub
+        string stubIntermediateDir = Path.Combine(IntermediateOutputDirectory!, stubName);
+        string sourceFileName = stubName + ".c";
+        string sourceFilePath = Path.Combine(stubIntermediateDir, sourceFileName);
+        string binaryFileName = stubName + ".exe";
+        string binaryOutputFilePath = Path.Combine(stubIntermediateDir, binaryFileName);
+        string binaryDestinationFilePath = Path.Combine(DestinationDirectory!, binaryFileName);
+
+        Log.LogMessage(MessageImportance.Normal, "Generating stub .exe '{0}'", stubName);
+
+        // Ensure the intermediate directory exists
+        Directory.CreateDirectory(stubIntermediateDir);
+
+        // Copy the .c source template into the working directory with the stub-specific name
+        File.Copy(SourceFilePath!, sourceFilePath, overwrite: true);
+
+        // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)
+        if (File.Exists(binaryDestinationFilePath))
+        {
+            File.Delete(binaryDestinationFilePath);
+        }
+
+        // Build the MSVC command-line arguments
+        string arguments = BuildMsvcArguments(
+            sourceFilePath: sourceFilePath,
+            platform: platform,
+            outputType: outputType,
+            win32Manifest: win32Manifest,
+            appContainer: appContainer);
+
+        // Invoke cl.exe
+        if (!InvokeCompiler(arguments, stubIntermediateDir, stubName))
+        {
+            return false;
+        }
+
+        // Copy the resulting executable to the native output directory
+        if (!File.Exists(binaryOutputFilePath))
+        {
+            Log.LogError("The stub .exe '{0}' was not produced by the compiler.", binaryOutputFilePath);
+
+            return false;
+        }
+
+        File.Copy(binaryOutputFilePath, binaryDestinationFilePath, overwrite: true);
+
+        // If publishing, add to the output items
+        if (CopyBuildOutputToPublishDirectory)
+        {
+            TaskItem outputItem = new(binaryDestinationFilePath);
+
+            outputItem.SetMetadata("RelativePath", binaryFileName);
+            outputItem.SetMetadata("CopyToPublishDirectory", "PreserveNewest");
+
+            generatedItems.Add(outputItem);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the full MSVC command-line arguments string for compiling a single stub <c>.exe</c>.
+    /// </summary>
+    /// <param name="sourceFilePath">The path to the <c>.c</c> source file.</param>
+    /// <param name="platform">The target platform.</param>
+    /// <param name="outputType">The output type (<c>WinExe</c> or <c>Exe</c>).</param>
+    /// <param name="win32Manifest">The optional Win32 manifest path.</param>
+    /// <param name="appContainer">Whether to enable <c>/APPCONTAINER</c>.</param>
+    /// <returns>The formatted arguments string.</returns>
+    private string BuildMsvcArguments(
+        string sourceFilePath,
+        string platform,
+        string outputType,
+        string win32Manifest,
+        bool appContainer)
+    {
+        StringBuilder args = new();
+
+        // Hide the copyright banner (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp)
+        args.Append("/nologo ");
+
+        // If not using environmental tools, pass the paths to the required include folders
+        if (!UseEnvironmentalTools)
+        {
+            AppendQuoted(args, "/I", MsvcIncludePath!);
+            AppendQuoted(args, "/I", WindowsSdkUcrtIncludePath!);
+            AppendQuoted(args, "/I", WindowsSdkUmIncludePath!);
+        }
+
+        // Configure the C runtime library linking behavior:
+        //   - Statically link the MSVC-specific runtime (VCRUNTIME140), which is small.
+        //   - Dynamically link UCRT (the OS-provided C runtime), matching Native AOT behavior.
+        //   We start with /MT[d] for static linking, then override the UCRT portion below.
+        // See: https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library
+        args.Append(IsDebugConfiguration ? "/MTd " : "/MT ");
+
+        // Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed)
+        args.Append("/O2 ");
+
+        // Source file and native library
+        AppendQuotedPath(args, sourceFilePath);
+        AppendQuotedPath(args, NativeLibraryPath!);
+
+        // If not using environmental tools, pass the paths to the required lib folders
+        if (!UseEnvironmentalTools)
+        {
+            AppendQuotedWildcard(args, MsvcLibPath!);
+            AppendQuotedWildcard(args, WindowsSdkUcrtLibPath!);
+            AppendQuotedWildcard(args, WindowsSdkUmLibPath!);
+        }
+
+        // Start linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax)
+        args.Append("/link ");
+
+        // Hide the copyright banner for the linker
+        args.Append("/NOLOGO ");
+
+        // Embed a manifest if specified, otherwise suppress manifest generation.
+        // See: https://learn.microsoft.com/cpp/build/reference/manifest-create-side-by-side-assembly-manifest
+        if (!string.IsNullOrEmpty(win32Manifest))
+        {
+            args.AppendFormat("/MANIFEST:EMBED /MANIFESTINPUT:{0} ", win32Manifest);
+        }
+        else
+        {
+            args.Append("/MANIFEST:NO ");
+        }
+
+        // Switch UCRT from static to dynamic linking to reduce binary size (~98 KB → ~20 KB).
+        // See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library
+        // See: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries
+        if (IsDebugConfiguration)
+        {
+            args.Append("/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib ");
+        }
+        else
+        {
+            args.Append("/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib ");
+        }
+
+        // Skip incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally)
+        args.Append("/INCREMENTAL:NO ");
+
+        // Enable COMDAT folding and unreferenced code removal (https://learn.microsoft.com/cpp/build/reference/opt-optimizations)
+        args.Append("/OPT:ICF /OPT:REF ");
+
+        // Set the AppContainer bit for UWP apps (https://learn.microsoft.com/cpp/build/reference/appcontainer-windows-store-app)
+        if (appContainer)
+        {
+            args.Append("/APPCONTAINER ");
+        }
+
+        // Set the subsystem type (https://learn.microsoft.com/cpp/build/reference/subsystem-specify-subsystem)
+        args.Append(string.Equals(outputType, "WinExe", StringComparison.OrdinalIgnoreCase)
+            ? "/SUBSYSTEM:WINDOWS "
+            : "/SUBSYSTEM:CONSOLE ");
+
+        // Always use 'wmainCRTStartup' as the entry point, matching Native AOT behavior.
+        // This allows using 'wmain' for all application types, including WinExe.
+        // See: https://learn.microsoft.com/cpp/build/reference/entry-entry-point-symbol
+        args.Append("/ENTRY:wmainCRTStartup ");
+
+        // Enable CFG if requested (https://learn.microsoft.com/cpp/build/reference/guard-enable-control-flow-guard)
+        if (ControlFlowGuard)
+        {
+            args.Append("/guard:cf ");
+        }
+
+        // Configure CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat)
+        bool cetEnabled = !string.Equals(CETCompat, "false", StringComparison.OrdinalIgnoreCase);
+        bool isX64 = string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase);
+
+        if (isX64)
+        {
+            args.Append(cetEnabled ? "/CETCOMPAT " : "/CETCOMPAT:NO ");
+        }
+
+        // Enable EH continuation metadata if CET is enabled and CFG is active, matching Native AOT.
+        // See: https://learn.microsoft.com/cpp/build/reference/guard-enable-eh-continuation-metadata
+        if (cetEnabled && isX64 && ControlFlowGuard)
+        {
+            args.Append("/guard:ehcont ");
+        }
+
+        return args.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Invokes <c>cl.exe</c> with the given arguments.
+    /// </summary>
+    /// <param name="arguments">The command-line arguments.</param>
+    /// <param name="workingDirectory">The working directory for the process.</param>
+    /// <param name="stubName">The name of the stub being compiled (for diagnostics).</param>
+    /// <returns><see langword="true"/> if the compiler exited successfully; otherwise, <see langword="false"/>.</returns>
+    private bool InvokeCompiler(string arguments, string workingDirectory, string stubName)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = ClExePath!,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        // Add extra directories to the PATH if needed (e.g. for mt.exe and rc.exe)
+        if (!string.IsNullOrEmpty(AdditionalPath))
+        {
+            string currentPath = startInfo.EnvironmentVariables.ContainsKey("PATH")
+                ? startInfo.EnvironmentVariables["PATH"]!
+                : "";
+
+            startInfo.EnvironmentVariables["PATH"] = currentPath + ";" + AdditionalPath;
+        }
+
+        try
+        {
+            using Process? process = Process.Start(startInfo);
+
+            if (process is null)
+            {
+                Log.LogError("Failed to start cl.exe for stub '{0}'.", stubName);
+
+                return false;
+            }
+
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+
+            process.WaitForExit();
+
+            // Log compiler output
+            if (!string.IsNullOrWhiteSpace(stdout))
+            {
+                Log.LogMessage(MessageImportance.Normal, stdout.TrimEnd());
+            }
+
+            if (!string.IsNullOrWhiteSpace(stderr))
+            {
+                Log.LogWarning("{0}", stderr.TrimEnd());
+            }
+
+            if (process.ExitCode != 0)
+            {
+                Log.LogError("cl.exe failed for stub '{0}' with exit code {1}.", stubName, process.ExitCode);
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            Log.LogError("Failed to invoke cl.exe for stub '{0}': {1}", stubName, e.Message);
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets a metadata value from an item, falling back to a default if the metadata is empty.
+    /// </summary>
+    /// <param name="item">The task item.</param>
+    /// <param name="metadataName">The metadata name.</param>
+    /// <param name="defaultValue">The default value if metadata is empty.</param>
+    /// <returns>The effective metadata value.</returns>
+    private static string GetMetadataOrDefault(ITaskItem item, string metadataName, string defaultValue)
+    {
+        string value = item.GetMetadata(metadataName);
+
+        return string.IsNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    /// <summary>
+    /// Gets a boolean metadata value from an item, falling back to a default if the metadata is empty.
+    /// </summary>
+    /// <param name="item">The task item.</param>
+    /// <param name="metadataName">The metadata name.</param>
+    /// <param name="defaultValue">The default value if metadata is empty.</param>
+    /// <returns>The effective boolean value.</returns>
+    private static bool GetBooleanMetadataOrDefault(ITaskItem item, string metadataName, bool defaultValue)
+    {
+        string value = item.GetMetadata(metadataName);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return defaultValue;
+        }
+
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Appends a quoted path argument to the string builder (e.g. <c>"C:\path\file.c" </c>).
+    /// </summary>
+    /// <param name="args">The string builder.</param>
+    /// <param name="path">The path to quote.</param>
+    private static void AppendQuotedPath(StringBuilder args, string path)
+    {
+        args.Append('"').Append(path).Append("\" ");
+    }
+
+    /// <summary>
+    /// Appends a quoted argument with a flag prefix (e.g. <c>/I "C:\include" </c>).
+    /// </summary>
+    /// <param name="args">The string builder.</param>
+    /// <param name="flag">The compiler flag.</param>
+    /// <param name="path">The path to quote.</param>
+    private static void AppendQuoted(StringBuilder args, string flag, string path)
+    {
+        args.Append(flag).Append(" \"").Append(path).Append("\" ");
+    }
+
+    /// <summary>
+    /// Appends a quoted wildcard lib path (e.g. <c>"C:\lib\*.lib" </c>).
+    /// </summary>
+    /// <param name="args">The string builder.</param>
+    /// <param name="libDir">The library directory path.</param>
+    private static void AppendQuotedWildcard(StringBuilder args, string libDir)
+    {
+        args.Append('"').Append(Path.Combine(libDir, "*.lib")).Append("\" ");
+    }
+}

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -695,6 +695,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             StringBuilder stdoutBuilder = new();
             StringBuilder stderrBuilder = new();
 
+            // Handle receiving stdio lines
             process.OutputDataReceived += (_, e) =>
             {
                 if (e.Data is not null)
@@ -703,6 +704,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
                 }
             };
 
+            // Handle receiving stderr lines
             process.ErrorDataReceived += (_, e) =>
             {
                 if (e.Data is not null)
@@ -711,6 +713,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
                 }
             };
 
+            // Start reading asynchronously and then block until the process completes
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
             process.WaitForExit();

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -53,13 +53,6 @@ namespace Microsoft.NET.Build.Tasks;
 ///     </description>
 ///   </item>
 ///   <item>
-///     <term><c>Platform</c></term>
-///     <description>
-///       The target platform (<c>x64</c>, <c>x86</c>, or <c>arm64</c>).
-///       Defaults to <see cref="DefaultPlatform"/>.
-///     </description>
-///   </item>
-///   <item>
 ///     <term><c>SourceText</c></term>
 ///     <description>
 ///       Inline C source code to use for this stub. When set, the text is written
@@ -86,7 +79,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <remarks>
     /// <para>
     /// The item identity (<c>Include</c>) is the stub name (used as the output <c>.exe</c> filename).
-    /// Supported metadata: <c>OutputType</c>, <c>Win32Manifest</c>, <c>AppContainer</c>, <c>Platform</c>,
+    /// Supported metadata: <c>OutputType</c>, <c>Win32Manifest</c>, <c>AppContainer</c>,
     /// <c>SourceText</c>, <c>SourceFile</c>.
     /// </para>
     /// </remarks>
@@ -179,11 +172,13 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     public string? WindowsSdkUmLibPath { get; set; }
 
     /// <summary>
-    /// Gets or sets additional directories to prepend to the <c>PATH</c> when invoking <c>cl.exe</c>.
+    /// Gets or sets an additional <c>PATH</c> fragment to append when invoking <c>cl.exe</c>.
     /// </summary>
     /// <remarks>
     /// This is used when not using environmental tools and the Windows SDK build tools directory
-    /// (containing <c>mt.exe</c> and <c>rc.exe</c>) is not already on the <c>PATH</c>.
+    /// (containing <c>mt.exe</c> and <c>rc.exe</c>) is not already on the <c>PATH</c>. The value is
+    /// appended to the existing <c>PATH</c> and may contain one or more semicolon-separated directories.
+    /// Callers should not include the current <c>PATH</c> (for example, via <c>$(PATH)</c>) in this value.
     /// </remarks>
     public string? AdditionalPath { get; set; }
 
@@ -227,8 +222,12 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     public bool DefaultAppContainer { get; set; }
 
     /// <summary>
-    /// Gets or sets the default platform for stubs that don't specify one.
+    /// Gets or sets the target platform for all stubs.
     /// </summary>
+    /// <remarks>
+    /// The platform controls architecture-specific linker flags such as <c>/CETCOMPAT</c>.
+    /// Valid values are <c>arm64</c>, <c>x64</c>, and <c>x86</c>.
+    /// </remarks>
     public string? DefaultPlatform { get; set; }
 
     /// <summary>
@@ -317,11 +316,30 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         if (!UseEnvironmentalTools)
         {
             if (string.IsNullOrEmpty(MsvcIncludePath) || !Directory.Exists(MsvcIncludePath) ||
-                string.IsNullOrEmpty(WindowsSdkUcrtIncludePath) || !Directory.Exists(WindowsSdkUcrtIncludePath))
+                string.IsNullOrEmpty(WindowsSdkUcrtIncludePath) || !Directory.Exists(WindowsSdkUcrtIncludePath) ||
+                string.IsNullOrEmpty(WindowsSdkUmIncludePath) || !Directory.Exists(WindowsSdkUmIncludePath) ||
+                string.IsNullOrEmpty(MsvcLibPath) || !Directory.Exists(MsvcLibPath) ||
+                string.IsNullOrEmpty(WindowsSdkUcrtLibPath) || !Directory.Exists(WindowsSdkUcrtLibPath) ||
+                string.IsNullOrEmpty(WindowsSdkUmLibPath) || !Directory.Exists(WindowsSdkUmLibPath))
             {
                 Log.LogError(
-                    "Failed to find the paths for the include folders to pass to MSVC, which are needed to compile stub executables. " +
+                    "Failed to find the paths for the include and library folders to pass to MSVC, which are needed to compile stub executables. " +
                     "Try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.");
+
+                return false;
+            }
+
+            // Validate the platform when not using environmental tools
+            string platform = DefaultPlatform ?? "";
+
+            if (!string.Equals(platform, "arm64", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(platform, "x86", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.LogError(
+                    "Invalid platform '{0}'. Make sure to set 'Platform' to either 'arm64', 'x64', or 'x86'. " +
+                    "Alternatively, try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.",
+                    platform);
 
                 return false;
             }
@@ -348,18 +366,13 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     {
         string stubName = stubExe.ItemSpec;
 
-        // Validate the platform
-        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
-
-        if (!UseEnvironmentalTools &&
-            !string.Equals(platform, "arm64", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(platform, "x64", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(platform, "x86", StringComparison.OrdinalIgnoreCase))
+        // Validate that the stub name is a simple file name (no path separators, no '..' traversal, no invalid chars)
+        if (string.IsNullOrEmpty(stubName) ||
+            stubName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            stubName.Contains(".."))
         {
             Log.LogError(
-                "Invalid platform '{0}' for stub '{1}'. Make sure to set 'Platform' to either 'arm64', 'x64', or 'x86'. " +
-                "Alternatively, try setting 'CsWinRTUseEnvironmentalTools' and building from a Visual Studio Developer Command Prompt (or PowerShell) session.",
-                platform,
+                "Invalid stub name '{0}'. The stub name must be a simple file name without path separators or invalid characters.",
                 stubName);
 
             return false;
@@ -418,9 +431,15 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         string outputType = GetMetadataOrDefault(stubExe, "OutputType", DefaultOutputType ?? "Exe");
         string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
         bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
-        string platform = GetMetadataOrDefault(stubExe, "Platform", DefaultPlatform ?? "");
+        string platform = DefaultPlatform ?? "";
         string sourceText = stubExe.GetMetadata("SourceText");
         string sourceFile = stubExe.GetMetadata("SourceFile");
+
+        // Resolve manifest path to full path so it works regardless of working directory
+        if (!string.IsNullOrEmpty(win32Manifest))
+        {
+            win32Manifest = Path.GetFullPath(win32Manifest);
+        }
 
         // Prepare paths for the intermediate working directory for this stub
         string stubIntermediateDir = Path.Combine(IntermediateOutputDirectory!, stubName);
@@ -432,27 +451,37 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
 
         Log.LogMessage(MessageImportance.Normal, "Generating stub .exe '{0}'", stubName);
 
-        // Ensure the intermediate directory exists
-        Directory.CreateDirectory(stubIntermediateDir);
+        try
+        {
+            // Ensure the intermediate and destination directories exist
+            Directory.CreateDirectory(stubIntermediateDir);
+            Directory.CreateDirectory(DestinationDirectory!);
 
-        // Write the source for this stub (priority: SourceText > SourceFile > DefaultSourceFilePath)
-        if (!string.IsNullOrEmpty(sourceText))
-        {
-            File.WriteAllText(sourceFilePath, sourceText);
-        }
-        else if (!string.IsNullOrEmpty(sourceFile))
-        {
-            File.Copy(sourceFile, sourceFilePath, overwrite: true);
-        }
-        else
-        {
-            File.Copy(DefaultSourceFilePath!, sourceFilePath, overwrite: true);
-        }
+            // Write the source for this stub (priority: SourceText > SourceFile > DefaultSourceFilePath)
+            if (!string.IsNullOrEmpty(sourceText))
+            {
+                File.WriteAllText(sourceFilePath, sourceText);
+            }
+            else if (!string.IsNullOrEmpty(sourceFile))
+            {
+                File.Copy(sourceFile, sourceFilePath, overwrite: true);
+            }
+            else
+            {
+                File.Copy(DefaultSourceFilePath!, sourceFilePath, overwrite: true);
+            }
 
-        // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)
-        if (File.Exists(binaryDestinationFilePath))
+            // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)
+            if (File.Exists(binaryDestinationFilePath))
+            {
+                File.Delete(binaryDestinationFilePath);
+            }
+        }
+        catch (Exception ex)
         {
-            File.Delete(binaryDestinationFilePath);
+            Log.LogError("Failed to prepare files for stub .exe '{0}': {1}", stubName, ex.Message);
+
+            return false;
         }
 
         // Build the MSVC command-line arguments
@@ -554,7 +583,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         // See: https://learn.microsoft.com/cpp/build/reference/manifest-create-side-by-side-assembly-manifest
         if (!string.IsNullOrEmpty(win32Manifest))
         {
-            args.AppendFormat("/MANIFEST:EMBED /MANIFESTINPUT:{0} ", win32Manifest);
+            args.Append("/MANIFEST:EMBED /MANIFESTINPUT:\"").Append(win32Manifest).Append("\" ");
         }
         else
         {
@@ -661,20 +690,43 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
                 return false;
             }
 
-            string stdout = process.StandardOutput.ReadToEnd();
-            string stderr = process.StandardError.ReadToEnd();
+            // Read stdout and stderr concurrently to avoid deadlocks from full pipe buffers.
+            // See: https://learn.microsoft.com/dotnet/api/system.diagnostics.process.standardoutput#remarks
+            StringBuilder stdoutBuilder = new();
+            StringBuilder stderrBuilder = new();
 
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    stdoutBuilder.AppendLine(e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    stderrBuilder.AppendLine(e.Data);
+                }
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
             process.WaitForExit();
 
+            string stdout = stdoutBuilder.ToString().TrimEnd();
+            string stderr = stderrBuilder.ToString().TrimEnd();
+
             // Log compiler output
-            if (!string.IsNullOrWhiteSpace(stdout))
+            if (stdout.Length > 0)
             {
-                Log.LogMessage(MessageImportance.Normal, stdout.TrimEnd());
+                Log.LogMessage(MessageImportance.Normal, stdout);
             }
 
-            if (!string.IsNullOrWhiteSpace(stderr))
+            if (stderr.Length > 0)
             {
-                Log.LogWarning("{0}", stderr.TrimEnd());
+                Log.LogWarning("{0}", stderr);
             }
 
             if (process.ExitCode != 0)

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Text;

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -442,20 +442,20 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         }
 
         // Prepare paths for the intermediate working directory for this stub
-        string stubIntermediateDir = Path.Combine(IntermediateOutputDirectory!, stubName);
+        string stubIntermediateDir = Path.Combine(IntermediateOutputDirectory, stubName);
         string sourceFileName = stubName + ".c";
         string sourceFilePath = Path.Combine(stubIntermediateDir, sourceFileName);
         string binaryFileName = stubName + ".exe";
         string binaryOutputFilePath = Path.Combine(stubIntermediateDir, binaryFileName);
-        string binaryDestinationFilePath = Path.Combine(DestinationDirectory!, binaryFileName);
+        string binaryDestinationFilePath = Path.Combine(DestinationDirectory, binaryFileName);
 
         Log.LogMessage(MessageImportance.Normal, "Generating stub .exe '{0}'", stubName);
 
         try
         {
             // Ensure the intermediate and destination directories exist
-            Directory.CreateDirectory(stubIntermediateDir);
-            Directory.CreateDirectory(DestinationDirectory!);
+            _ = Directory.CreateDirectory(stubIntermediateDir);
+            _ = Directory.CreateDirectory(DestinationDirectory);
 
             // Write the source for this stub (priority: SourceText > SourceFile > DefaultSourceFilePath)
             if (!string.IsNullOrEmpty(sourceText))
@@ -468,7 +468,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             }
             else
             {
-                File.Copy(DefaultSourceFilePath!, sourceFilePath, overwrite: true);
+                File.Copy(DefaultSourceFilePath, sourceFilePath, overwrite: true);
             }
 
             // Delete any previously-generated broken .exe in the destination (see https://github.com/dotnet/runtime/issues/111313)
@@ -541,7 +541,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         StringBuilder args = new();
 
         // Hide the copyright banner (https://learn.microsoft.com/cpp/build/reference/nologo-suppress-startup-banner-c-cpp)
-        args.Append("/nologo ");
+        _ = args.Append("/nologo ");
 
         // If not using environmental tools, pass the paths to the required include folders
         if (!UseEnvironmentalTools)
@@ -556,10 +556,10 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         //   - Dynamically link UCRT (the OS-provided C runtime), matching Native AOT behavior.
         //   We start with /MT[d] for static linking, then override the UCRT portion below.
         // See: https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library
-        args.Append(IsDebugConfiguration ? "/MTd " : "/MT ");
+        _ = args.Append(IsDebugConfiguration ? "/MTd " : "/MT ");
 
         // Optimize for speed (https://learn.microsoft.com/cpp/build/reference/o1-o2-minimize-size-maximize-speed)
-        args.Append("/O2 ");
+        _ = args.Append("/O2 ");
 
         // Source file and native library
         AppendQuotedPath(args, sourceFilePath);
@@ -574,60 +574,50 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         }
 
         // Start linker options (https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax)
-        args.Append("/link ");
+        _ = args.Append("/link ");
 
         // Hide the copyright banner for the linker
-        args.Append("/NOLOGO ");
+        _ = args.Append("/NOLOGO ");
 
         // Embed a manifest if specified, otherwise suppress manifest generation.
         // See: https://learn.microsoft.com/cpp/build/reference/manifest-create-side-by-side-assembly-manifest
-        if (!string.IsNullOrEmpty(win32Manifest))
-        {
-            args.Append("/MANIFEST:EMBED /MANIFESTINPUT:\"").Append(win32Manifest).Append("\" ");
-        }
-        else
-        {
-            args.Append("/MANIFEST:NO ");
-        }
+        _ = args.Append(string.IsNullOrEmpty(win32Manifest)
+            ? "/MANIFEST:NO "
+            : $"/MANIFEST:EMBED /MANIFESTINPUT:\"{win32Manifest}\" ");
 
         // Switch UCRT from static to dynamic linking to reduce binary size (~98 KB → ~20 KB).
         // See: https://learn.microsoft.com/cpp/build/reference/defaultlib-specify-default-library
         // See: https://learn.microsoft.com/cpp/build/reference/nodefaultlib-ignore-libraries
-        if (IsDebugConfiguration)
-        {
-            args.Append("/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib ");
-        }
-        else
-        {
-            args.Append("/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib ");
-        }
+        _ = args.Append(IsDebugConfiguration
+            ? "/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib "
+            : "/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib ");
 
         // Skip incremental linking (https://learn.microsoft.com/cpp/build/reference/incremental-link-incrementally)
-        args.Append("/INCREMENTAL:NO ");
+        _ = args.Append("/INCREMENTAL:NO ");
 
         // Enable COMDAT folding and unreferenced code removal (https://learn.microsoft.com/cpp/build/reference/opt-optimizations)
-        args.Append("/OPT:ICF /OPT:REF ");
+        _ = args.Append("/OPT:ICF /OPT:REF ");
 
         // Set the AppContainer bit for UWP apps (https://learn.microsoft.com/cpp/build/reference/appcontainer-windows-store-app)
         if (appContainer)
         {
-            args.Append("/APPCONTAINER ");
+            _ = args.Append("/APPCONTAINER ");
         }
 
         // Set the subsystem type (https://learn.microsoft.com/cpp/build/reference/subsystem-specify-subsystem)
-        args.Append(string.Equals(outputType, "WinExe", StringComparison.OrdinalIgnoreCase)
+        _ = args.Append(string.Equals(outputType, "WinExe", StringComparison.OrdinalIgnoreCase)
             ? "/SUBSYSTEM:WINDOWS "
             : "/SUBSYSTEM:CONSOLE ");
 
         // Always use 'wmainCRTStartup' as the entry point, matching Native AOT behavior.
         // This allows using 'wmain' for all application types, including WinExe.
         // See: https://learn.microsoft.com/cpp/build/reference/entry-entry-point-symbol
-        args.Append("/ENTRY:wmainCRTStartup ");
+        _ = args.Append("/ENTRY:wmainCRTStartup ");
 
         // Enable CFG if requested (https://learn.microsoft.com/cpp/build/reference/guard-enable-control-flow-guard)
         if (ControlFlowGuard)
         {
-            args.Append("/guard:cf ");
+            _ = args.Append("/guard:cf ");
         }
 
         // Configure CET shadow stack compatibility (https://learn.microsoft.com/cpp/build/reference/cetcompat)
@@ -636,14 +626,14 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
 
         if (isX64)
         {
-            args.Append(cetEnabled ? "/CETCOMPAT " : "/CETCOMPAT:NO ");
+            _ = args.Append(cetEnabled ? "/CETCOMPAT " : "/CETCOMPAT:NO ");
         }
 
         // Enable EH continuation metadata if CET is enabled and CFG is active, matching Native AOT.
         // See: https://learn.microsoft.com/cpp/build/reference/guard-enable-eh-continuation-metadata
         if (cetEnabled && isX64 && ControlFlowGuard)
         {
-            args.Append("/guard:ehcont ");
+            _ = args.Append("/guard:ehcont ");
         }
 
         return args.ToString().TrimEnd();
@@ -660,7 +650,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     {
         ProcessStartInfo startInfo = new()
         {
-            FileName = ClExePath!,
+            FileName = ClExePath,
             Arguments = arguments,
             WorkingDirectory = workingDirectory,
             UseShellExecute = false,
@@ -673,7 +663,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
         if (!string.IsNullOrEmpty(AdditionalPath))
         {
             string currentPath = startInfo.EnvironmentVariables.ContainsKey("PATH")
-                ? startInfo.EnvironmentVariables["PATH"]!
+                ? startInfo.EnvironmentVariables["PATH"]
                 : "";
 
             startInfo.EnvironmentVariables["PATH"] = currentPath + ";" + AdditionalPath;
@@ -700,7 +690,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             {
                 if (e.Data is not null)
                 {
-                    stdoutBuilder.AppendLine(e.Data);
+                    _ = stdoutBuilder.AppendLine(e.Data);
                 }
             };
 
@@ -709,7 +699,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             {
                 if (e.Data is not null)
                 {
-                    stderrBuilder.AppendLine(e.Data);
+                    _ = stderrBuilder.AppendLine(e.Data);
                 }
             };
 
@@ -774,12 +764,9 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     {
         string value = item.GetMetadata(metadataName);
 
-        if (string.IsNullOrEmpty(value))
-        {
-            return defaultValue;
-        }
-
-        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        return string.IsNullOrEmpty(value)
+            ? defaultValue
+            : string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -789,7 +776,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <param name="path">The path to quote.</param>
     private static void AppendQuotedPath(StringBuilder args, string path)
     {
-        args.Append('"').Append(path).Append("\" ");
+        _ = args.Append('"').Append(path).Append("\" ");
     }
 
     /// <summary>
@@ -800,7 +787,7 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <param name="path">The path to quote.</param>
     private static void AppendQuoted(StringBuilder args, string flag, string path)
     {
-        args.Append(flag).Append(" \"").Append(path).Append("\" ");
+        _ = args.Append(flag).Append(" \"").Append(path).Append("\" ");
     }
 
     /// <summary>
@@ -810,6 +797,6 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// <param name="libDir">The library directory path.</param>
     private static void AppendQuotedWildcard(StringBuilder args, string libDir)
     {
-        args.Append('"').Append(Path.Combine(libDir, "*.lib")).Append("\" ");
+        _ = args.Append('"').Append(Path.Combine(libDir, "*.lib")).Append("\" ");
     }
 }

--- a/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
+++ b/src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs
@@ -48,8 +48,9 @@ namespace Microsoft.NET.Build.Tasks;
 ///   <item>
 ///     <term><c>AppContainer</c></term>
 ///     <description>
-///       Whether to set the <c>/APPCONTAINER</c> linker flag, for UWP apps.
-///       Defaults to <see cref="DefaultAppContainer"/>.
+///       Whether to set the <c>/APPCONTAINER</c> linker flag, for apps running in an app container.
+///       This is a per-stub setting, so stubs with different values are compiled separately.
+///       Defaults to <see langword="false"/>.
 ///     </description>
 ///   </item>
 ///   <item>
@@ -215,11 +216,6 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     /// Gets or sets the default Win32 manifest path for stubs that don't specify one.
     /// </summary>
     public string? DefaultWin32Manifest { get; set; }
-
-    /// <summary>
-    /// Gets or sets the default <c>AppContainer</c> value for stubs that don't specify one.
-    /// </summary>
-    public bool DefaultAppContainer { get; set; }
 
     /// <summary>
     /// Gets or sets the target platform for all stubs.
@@ -414,6 +410,17 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
             return false;
         }
 
+        // Validate the 'AppContainer' metadata, which controls a per-stub linker flag
+        if (!TryGetBooleanMetadata(stubExe, "AppContainer", out _))
+        {
+            Log.LogError(
+                "Invalid 'AppContainer' metadata value '{0}' for stub '{1}'. The value must be either 'true' or 'false'.",
+                stubExe.GetMetadata("AppContainer"),
+                stubName);
+
+            return false;
+        }
+
         return true;
     }
 
@@ -427,13 +434,15 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     {
         string stubName = stubExe.ItemSpec;
 
-        // Resolve per-stub metadata, falling back to defaults
+        // Resolve per-stub metadata, falling back to defaults (the metadata has already
+        // been validated at this point, so parsing the boolean values cannot fail here)
         string outputType = GetMetadataOrDefault(stubExe, "OutputType", DefaultOutputType ?? "Exe");
         string win32Manifest = GetMetadataOrDefault(stubExe, "Win32Manifest", DefaultWin32Manifest ?? "");
-        bool appContainer = GetBooleanMetadataOrDefault(stubExe, "AppContainer", DefaultAppContainer);
         string platform = DefaultPlatform ?? "";
         string sourceText = stubExe.GetMetadata("SourceText");
         string sourceFile = stubExe.GetMetadata("SourceFile");
+
+        _ = TryGetBooleanMetadata(stubExe, "AppContainer", out bool appContainer);
 
         // Resolve manifest path to full path so it works regardless of working directory
         if (!string.IsNullOrEmpty(win32Manifest))
@@ -754,19 +763,27 @@ public sealed class GenerateCsWinRTStubExes : Microsoft.Build.Utilities.Task
     }
 
     /// <summary>
-    /// Gets a boolean metadata value from an item, falling back to a default if the metadata is empty.
+    /// Tries to get a boolean metadata value from an item.
     /// </summary>
     /// <param name="item">The task item.</param>
     /// <param name="metadataName">The metadata name.</param>
-    /// <param name="defaultValue">The default value if metadata is empty.</param>
-    /// <returns>The effective boolean value.</returns>
-    private static bool GetBooleanMetadataOrDefault(ITaskItem item, string metadataName, bool defaultValue)
+    /// <param name="value">The resulting value, which is <see langword="false"/> if the metadata is not set.</param>
+    /// <returns>
+    /// <see langword="true"/> if the metadata is either not set or set to a valid boolean value;
+    /// <see langword="false"/> if it is set to a value that could not be parsed.
+    /// </returns>
+    private static bool TryGetBooleanMetadata(ITaskItem item, string metadataName, out bool value)
     {
-        string value = item.GetMetadata(metadataName);
+        string metadataValue = item.GetMetadata(metadataName);
 
-        return string.IsNullOrEmpty(value)
-            ? defaultValue
-            : string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(metadataValue))
+        {
+            value = false;
+
+            return true;
+        }
+
+        return bool.TryParse(metadataValue, out value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Move the inline MSVC compilation logic from the `_CsWinRTGenerateStubExe` MSBuild target into a new `GenerateCsWinRTStubExes` MSBuild task, and add support for generating multiple stub `.exe` files with per-item customization.

## Motivation

The existing `_CsWinRTGenerateStubExe` target can only generate a single stub `.exe`. Users who need multiple stubs (e.g. with different subsystems like Windows vs Console) are forced to copy the entire target and maintain it locally, which is error-prone and hard to keep in sync with CsWinRT updates. By moving the logic into a proper MSBuild task that accepts a collection of items, users can declaratively specify all the stubs they need.

## Changes

- **`src/WinRT.Generator.Tasks/GenerateCsWinRTStubExes.cs`**: new MSBuild task that generates one or more stub `.exe` files by invoking MSVC. Takes a `StubExes` item group as input, with optional per-item metadata:
  - `OutputType`: controls PE subsystem (`WinExe` for WINDOWS, else CONSOLE)
  - `Win32Manifest`: path to manifest to embed
  - `AppContainer`: whether to set `/APPCONTAINER`
  - `Platform`: target platform (arm64, x64, x86)
  - `SourceText`: inline C source code for the stub
  - `SourceFile`: path to a custom `.c` source file
- **`nuget/Microsoft.Windows.CsWinRT.targets`**: refactored `_CsWinRTGenerateStubExe` target to use the new task. Adds `UsingTask` registration, documents the `CsWinRTStubExe` item schema with usage examples, and handles `ResolvedFileToPublish` for all generated stubs. When no `CsWinRTStubExe` items are defined, a default item named after the assembly is added, preserving backward compatibility.

### Usage example

```xml
<ItemGroup>
  <CsWinRTStubExe Include="MyApp.Console" OutputType="Exe" />
  <CsWinRTStubExe Include="MyApp.Windowed" OutputType="WinExe" />
  <CsWinRTStubExe Include="MyApp.Custom" SourceFile="src\CustomStub.c" />
</ItemGroup>
```
