### PR TITLE
Fix overridable properties

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -624,6 +624,9 @@ namespace TestComponentCSharp
             overridable Int32 WarningOverridableProperty;
             // see https://github.com/microsoft/cppwinrt/issues/782
             //overridable event Windows.Foundation.EventHandler<Int32> WarningOverridableEvent;
+            Int32 CallOverridablePropertyGetter();
+            void CallOverridablePropertySetter(Int32 value);
+            void CallOverridableMethod();
         }
     }
 

--- a/src/Tests/TestComponentCSharp/WarningClass.cpp
+++ b/src/Tests/TestComponentCSharp/WarningClass.cpp
@@ -41,6 +41,18 @@ namespace winrt::TestComponentCSharp::implementation
     void WarningClass::WarningOverridableProperty(int32_t value)
     {
     }
+    int32_t WarningClass::CallOverridablePropertyGetter()
+    {
+        return overridable().WarningOverridableProperty();
+    }
+    void WarningClass::CallOverridablePropertySetter(int32_t value)
+    {
+        overridable().WarningOverridableProperty(value);
+    }
+    void WarningClass::CallOverridableMethod()
+    {
+        overridable().WarningOverridableMethod();
+    }
     //winrt::event_token WarningClass::WarningOverridableEvent(Windows::Foundation::EventHandler<int32_t> const& handler)
     //{
     //    return {};

--- a/src/Tests/TestComponentCSharp/WarningClass.h
+++ b/src/Tests/TestComponentCSharp/WarningClass.h
@@ -18,6 +18,9 @@ namespace winrt::TestComponentCSharp::implementation
         void WarningOverridableMethod();
         int32_t WarningOverridableProperty();
         void WarningOverridableProperty(int32_t value);
+        int32_t CallOverridablePropertyGetter();
+        void CallOverridablePropertySetter(int32_t value);
+        void CallOverridableMethod();
         //winrt::event_token WarningOverridableEvent(Windows::Foundation::EventHandler<int32_t> const& handler);
         //void WarningOverridableEvent(winrt::event_token const& token) noexcept;
         int32_t WarningInterfacePropertySetter();

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3553,7 +3553,6 @@ namespace UnitTest
         }
 #endif
 
-#if NET
         [Fact]
         public void TestOverridable()
         {
@@ -3586,7 +3585,6 @@ namespace UnitTest
                 MethodWasCalled = true;
             }
         }
-#endif
 
         [Fact]
         public void TestObjectFunctions()

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3553,6 +3553,7 @@ namespace UnitTest
         }
 #endif
 
+#if NET
         [Fact]
         public void TestOverridable()
         {
@@ -3585,6 +3586,7 @@ namespace UnitTest
                 MethodWasCalled = true;
             }
         }
+#endif
 
         [Fact]
         public void TestObjectFunctions()

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3554,6 +3554,39 @@ namespace UnitTest
 #endif
 
         [Fact]
+        public void TestOverridable()
+        {
+            var obj = new OverridableTestClass();
+
+            // Test overridable property round-trip through native overrides interface
+            Assert.Equal(42, obj.CallOverridablePropertyGetter());
+            obj.CallOverridablePropertySetter(99);
+            Assert.Equal(99, obj.CallOverridablePropertyGetter());
+
+            // Test overridable method round-trip through native overrides interface
+            Assert.False(obj.MethodWasCalled);
+            obj.CallOverridableMethod();
+            Assert.True(obj.MethodWasCalled);
+        }
+
+        class OverridableTestClass : WarningClass
+        {
+            private int _value = 42;
+            public bool MethodWasCalled { get; private set; }
+
+            protected override int WarningOverridableProperty
+            {
+                get => _value;
+                set => _value = value;
+            }
+
+            protected override void WarningOverridableMethod()
+            {
+                MethodWasCalled = true;
+            }
+        }
+
+        [Fact]
         public void TestObjectFunctions()
         {
             CustomEquals first = new()

--- a/src/WinRT.Runtime/ComWrappersSupport.net5.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.net5.cs
@@ -482,8 +482,9 @@ namespace WinRT
                 // pointer can be retained and used.  This is determined by the
                 // IsAggregated and PreventReleaseOnDispose properties on IObjectReference.
                 objRef.IsAggregated = true;
-                // In WinUI scenario don't release inner
-                objRef.PreventReleaseOnDispose = referenceTracker != default;
+                // In aggregation scenarios, inner is passed to .NET and it manages
+                // its release when the RCW goes away, so don't release it.
+                objRef.PreventReleaseOnDispose = true;
             }
             else
             {

--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -3395,15 +3395,22 @@ private % AsInternal(InterfaceTag<%> _) => % ?? Make_%();
                             if (getter || base_getter)
                             {
                                 w.write("%get => %; ", base_getter_platform_attribute, bind([&](writer& w) {
-                                    if (call_static_method)
+                                    if (is_private)
                                     {
-                                        auto iface = base_getter ? getter_property_iface : prop.Parent();
-                                        w.write("%", bind<write_abi_get_property_static_method_call>(iface, prop,
-                                            w.write_temp("%", bind<write_objref_type_name>(iface))));
+                                        if (call_static_method)
+                                        {
+                                            auto iface = base_getter ? getter_property_iface : prop.Parent();
+                                            w.write("%", bind<write_abi_get_property_static_method_call>(iface, prop,
+                                                w.write_temp("%", bind<write_objref_type_name>(iface))));
+                                        }
+                                        else
+                                        {
+                                            w.write("%.%", target, prop.Name());
+                                        }
                                     }
                                     else
                                     {
-                                        w.write("%%", is_private ? target + "." : "", prop.Name());
+                                        w.write("%", prop.Name());
                                     }
                                     }));
                             }
@@ -3413,14 +3420,21 @@ private % AsInternal(InterfaceTag<%> _) => % ?? Make_%();
                             if (setter)
                             {
                                 w.write("set => %;", bind([&](writer& w) {
-                                    if (call_static_method)
+                                    if (is_private)
                                     {
-                                        w.write("%", bind<write_abi_set_property_static_method_call>(prop.Parent(), prop,
-                                            w.write_temp("%", bind<write_objref_type_name>(prop.Parent()))));
+                                        if (call_static_method)
+                                        {
+                                            w.write("%", bind<write_abi_set_property_static_method_call>(prop.Parent(), prop,
+                                                w.write_temp("%", bind<write_objref_type_name>(prop.Parent()))));
+                                        }
+                                        else
+                                        {
+                                            w.write("%.% = value", target, prop.Name());
+                                        }
                                     }
                                     else
                                     {
-                                        w.write("%% = value", is_private ? target + "." : "", prop.Name());
+                                        w.write("% = value", prop.Name());
                                     }
                                     }));
                             }


### PR DESCRIPTION
Overridable properties were missing the logic overridable methods had to have the explicit interface implementations call the virtual override property / method rather than directly calling the static methods class.  This addresses that allowing to override properties similar to methods.  Also addressing reference counting in non reference tracker aggregated scenarios.

Fixes #2145 