### PR TITLE
Fix missing [SupportedOSPlatform] on projected members for newer SDK versions

### DIFF
--- a/src/cswinrt/PreviousPlatforms.linq
+++ b/src/cswinrt/PreviousPlatforms.linq
@@ -3,7 +3,7 @@
 // This script can be run periodically from within LINQPad (https://www.linqpad.net) 
 // to generate aggregate data for get_contract_platform in helpers.h
 
-var doc = XDocument.Load(@"C:\Program Files (x86)\Windows Kits\10\Platforms\UAP\10.0.19041.0\PreviousPlatforms.xml");
+var doc = XDocument.Load(@"C:\Program Files (x86)\Windows Kits\10\Platforms\UAP\10.0.26100.0\PreviousPlatforms.xml");
 
 XNamespace pp = "http://microsoft.com/schemas/Windows/SDK/PreviousPlatforms";
 

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -1190,7 +1190,7 @@ namespace cswinrt
             return v.contract_version < contract_version;
         });
 
-        if ((versionItr == std::end(versions)) || (versionItr->contract_version != contract_version))
+        if (versionItr == std::end(versions))
         {
             return {};
         }

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -955,6 +955,8 @@ namespace cswinrt
                     { 1, "10.0.17763.0" },
                     { 2, "10.0.18362.0" },
                     { 3, "10.0.19041.0" },
+                    { 4, "10.0.20348.0" },
+                    { 5, "10.0.22000.0" },
                 }
             },
             { "Windows.AI.MachineLearning.Preview.MachineLearningPreviewContract",
@@ -967,12 +969,16 @@ namespace cswinrt
                 {
                     { 1, "10.0.17763.0" },
                     { 2, "10.0.18362.0" },
+                    { 3, "10.0.20348.0" },
+                    { 4, "10.0.22621.0" },
                 }
             },
             { "Windows.ApplicationModel.Calls.CallsPhoneContract",
                 {
                     { 4, "10.0.17763.0" },
                     { 5, "10.0.18362.0" },
+                    { 6, "10.0.20348.0" },
+                    { 7, "10.0.22621.0" },
                 }
             },
             { "Windows.ApplicationModel.Calls.CallsVoipContract",
@@ -981,6 +987,7 @@ namespace cswinrt
                     { 2, "10.0.16299.0" },
                     { 3, "10.0.17134.0" },
                     { 4, "10.0.17763.0" },
+                    { 5, "10.0.26100.0" },
                 }
             },
             { "Windows.ApplicationModel.CommunicationBlocking.CommunicationBlockingContract",
@@ -1046,6 +1053,10 @@ namespace cswinrt
                     { 7, "10.0.17763.0" },
                     { 8, "10.0.18362.0" },
                     { 10, "10.0.19041.0" },
+                    { 12, "10.0.20348.0" },
+                    { 14, "10.0.22000.0" },
+                    { 15, "10.0.22621.0" },
+                    { 19, "10.0.26100.0" },
                 }
             },
             { "Windows.Foundation.VelocityIntegration.VelocityIntegrationContract",
@@ -1069,6 +1080,7 @@ namespace cswinrt
                 {
                     { 1, "10.0.10240.0" },
                     { 2, "10.0.17134.0" },
+                    { 3, "10.0.26100.0" },
                 }
             },
             { "Windows.Networking.Sockets.ControlChannelTriggerContract",
@@ -1079,6 +1091,9 @@ namespace cswinrt
             { "Windows.Security.Isolation.IsolatedWindowsEnvironmentContract",
                 {
                     { 1, "10.0.19041.0" },
+                    { 3, "10.0.20348.0" },
+                    { 4, "10.0.22621.0" },
+                    { 5, "10.0.26100.0" },
                 }
             },
             { "Windows.Services.Maps.GuidanceContract",
@@ -1107,11 +1122,18 @@ namespace cswinrt
             { "Windows.Storage.Provider.CloudFilesContract",
                 {
                     { 4, "10.0.19041.0" },
+                    { 6, "10.0.20348.0" },
+                    { 7, "10.0.22621.0" },
                 }
             },
             { "Windows.System.Profile.ProfileHardwareTokenContract",
                 {
                     { 1, "10.0.14393.0" },
+                }
+            },
+            { "Windows.System.Profile.ProfileRetailInfoContract",
+                {
+                    { 1, "10.0.20348.0" },
                 }
             },
             { "Windows.System.Profile.ProfileSharedModeContract",
@@ -1131,6 +1153,12 @@ namespace cswinrt
                     { 7, "10.0.19041.0" },
                 }
             },
+            { "Windows.UI.UIAutomation.UIAutomationContract",
+                {
+                    { 1, "10.0.20348.0" },
+                    { 2, "10.0.22000.0" },
+                }
+            },
             { "Windows.UI.ViewManagement.ViewManagementViewScalingContract",
                 {
                     { 1, "10.0.14393.0" },
@@ -1140,6 +1168,8 @@ namespace cswinrt
                 {
                     { 1, "10.0.17763.0" },
                     { 2, "10.0.18362.0" },
+                    { 3, "10.0.20348.0" },
+                    { 5, "10.0.22000.0" },
                 }
             },
         };


### PR DESCRIPTION
## Summary

Fixes \[SupportedOSPlatform]\ not being emitted on projected class members that require a newer OS version than their containing type.

## Root Cause

Two issues in \get_contract_platform()\ in \src/cswinrt/helpers.h\:

1. **Outdated contract-to-platform mapping table** — generated from the 10.0.19041.0 SDK, missing all contract versions introduced in later SDK releases (20348, 22000, 22621, 26100). When a contract version wasn't in the table, the function returned empty and the attribute was silently dropped.

2. **Exact-match requirement for contract versions** — the \PreviousPlatforms.xml\ only lists the *highest* contract version per platform release (e.g., \UniversalApiContract\ v19 for 10.0.26100.0). Intermediate versions like v16/v17/v18 (also introduced in 10.0.26100.0) had no exact table entry, so they also produced no attribute.

## Example

\AppExtensionCatalog\ (UAC v3 = 10.0.14393.0) implements \IAppExtensionCatalog2\ (UAC v17), which contains the \FindAll\ method. Before this fix, UAC v17 was not found in the table, so \FindAll\ got no \[SupportedOSPlatform]\ attribute despite requiring 10.0.26100.0.

## Changes

**Commit 1: Update contract-to-platform version mappings**
- Regenerated the \contract_mappings\ table from 10.0.26100.0 \PreviousPlatforms.xml\
- Added missing versions for \UniversalApiContract\ (v12/14/15/19), \IsolatedWindowsEnvironmentContract\, \CloudFilesContract\, and others
- Added 2 new contracts: \ProfileRetailInfoContract\, \UIAutomationContract\
- Updated \PreviousPlatforms.linq\ to reference the 26100 SDK

**Commit 2: Fix gap contract version lookup**
- Removed the exact-match requirement from the version lookup in \get_contract_platform()\
- \lower_bound\ already finds the correct platform for in-between versions (e.g., UAC v17 → 10.0.26100.0 via the v19 entry), since a version not present in a lower platform must have been introduced with the next higher one