### PR TITLE
Add manually-projected ApiContractAttribute to WinRT.Runtime

### DIFF
--- a/src/WinRT.Runtime2/Windows.Foundation/FoundationContract.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/FoundationContract.cs
@@ -11,5 +11,6 @@ namespace Windows.Foundation;
 /// <remarks>
 /// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
 /// </remarks>
+[ApiContract]
 [ContractVersion(262144u)]
 public enum FoundationContract;

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ApiContractAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ApiContractAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Versioning;
+using WindowsRuntime;
+
+namespace Windows.Foundation.Metadata;
+
+/// <summary>
+/// Specifies that the type represents an API contract.
+/// </summary>
+/// <remarks>
+/// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
+/// </remarks>
+[WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
+[AttributeUsage(AttributeTargets.Enum, AllowMultiple = false)]
+[SupportedOSPlatform("Windows10.0.10240.0")]
+[ContractVersion(typeof(FoundationContract), 65536u)]
+public sealed class ApiContractAttribute : Attribute;

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ApiContractAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ApiContractAttribute.cs
@@ -10,9 +10,6 @@ namespace Windows.Foundation.Metadata;
 /// <summary>
 /// Specifies that the type represents an API contract.
 /// </summary>
-/// <remarks>
-/// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
-/// </remarks>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [AttributeUsage(AttributeTargets.Enum, AllowMultiple = false)]
 [SupportedOSPlatform("Windows10.0.10240.0")]

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
@@ -12,9 +12,6 @@ namespace Windows.Foundation.Metadata;
 /// <summary>
 /// Indicates the version of the API contract.
 /// </summary>
-/// <remarks>
-/// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
-/// </remarks>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
 [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
 [SupportedOSPlatform("Windows10.0.10240.0")]

--- a/src/WinRT.Runtime2/Windows.Foundation/UniversalApiContract.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/UniversalApiContract.cs
@@ -11,5 +11,6 @@ namespace Windows.Foundation;
 /// <remarks>
 /// This type is required for ABI projection of the value types and delegates, but marshalling it is not supported.
 /// </remarks>
+[ApiContract]
 [ContractVersion(1245184u)]
 public enum UniversalApiContract;

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -885,6 +885,7 @@ namespace cswinrt
             },
             { "Windows.Foundation.Metadata",
                 {
+                    { "ApiContractAttribute", "Windows.Foundation.Metadata", "ApiContractAttribute"},
                     { "AttributeTargets", "System", "AttributeTargets" },
                     { "AttributeUsageAttribute", "System", "AttributeUsageAttribute" },
                     { "ContractVersionAttribute", "Windows.Foundation.Metadata", "ContractVersionAttribute"},


### PR DESCRIPTION
## Summary

Add `ApiContractAttribute` as a manually-projected type in `WinRT.Runtime`, and update the code generator to skip it.

## Motivation

The `[ApiContract]` attribute (`Windows.Foundation.Metadata.ApiContractAttribute`) marks enum types that represent API contracts (e.g. `FoundationContract`, `UniversalApiContract`). Since these contract enums are already manually projected in `WinRT.Runtime`, the attribute that decorates them should also be manually projected for consistency and correctness. This also allows the existing contract enums to be properly annotated with `[ApiContract]`.

## Changes

- **`src/WinRT.Runtime2/Windows.Foundation/Metadata/ApiContractAttribute.cs`**: new manually-projected `ApiContractAttribute` type, following the same pattern as `ContractVersionAttribute`
- **`src/WinRT.Runtime2/Windows.Foundation/FoundationContract.cs`**: add `[ApiContract]` attribute
- **`src/WinRT.Runtime2/Windows.Foundation/UniversalApiContract.cs`**: add `[ApiContract]` attribute
- **`src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs`**: remove unnecessary marshalling remark (consistent with new attribute style)
- **`src/cswinrt/helpers.h`**: add `ApiContractAttribute` to the mapped types table so the code generator skips generating a duplicate projection
