### PR TITLE
Set deterministic MVID for generated impl modules

### DIFF
--- a/src/WinRT.Impl.Generator/Generation/ImplGenerator.cs
+++ b/src/WinRT.Impl.Generator/Generation/ImplGenerator.cs
@@ -29,6 +29,11 @@ namespace WindowsRuntime.ImplGenerator.Generation;
 internal static partial class ImplGenerator
 {
     /// <summary>
+    /// An IID used to produce MVID values for new implementation assemblies.
+    /// </summary>
+    private static readonly Guid ImplGeneratorMvidSalt = new("5A79C752-B558-4FFC-9465-25029F160117");
+
+    /// <summary>
     /// The set of well known attribute types to copy over to the generated assemblies.
     /// </summary>
     private static readonly FrozenSet<string> WellKnownAttributeTypes =
@@ -245,8 +250,13 @@ internal static partial class ImplGenerator
     {
         try
         {
-            // Create the impl module and its containing assembly
-            ModuleDefinition implModule = new(outputModule.Name, runtimeContext.RuntimeCorLib!.ToAssemblyReference());
+            // Create the impl module, with a deterministic MVID
+            ModuleDefinition implModule = new(outputModule.Name, runtimeContext.RuntimeCorLib!.ToAssemblyReference())
+            {
+                Mvid = MvidGenerator.CreateMvid(outputModule.Mvid, ImplGeneratorMvidSalt)
+            };
+
+            // Create its containing assembly as well and add the module to it
             AssemblyDefinition implAssembly = new(outputModule.Assembly?.Name, outputModule.Assembly?.Version ?? new Version(0, 0, 0, 0))
             {
                 Modules = { implModule }

--- a/src/WinRT.Impl.Generator/Helpers/MvidGenerator.cs
+++ b/src/WinRT.Impl.Generator/Helpers/MvidGenerator.cs
@@ -30,12 +30,7 @@ internal static class MvidGenerator
         // Hash the two IIDs together (the order matters)
         _ = SHA1.HashData(input, hash);
 
-        // Take first 16 bytes and set UUID v5 version and variant bits
-        Span<byte> result = hash[..16];
-        result[6] = (byte)((result[6] & 0x0F) | 0x50);
-        result[8] = (byte)((result[8] & 0x3F) | 0x80);
-
-        // Construct the resulting IID from the hashed data
-        return new(result, bigEndian: true);
+        // Create the final MVID from the first 16 bytes of the hash
+        return new(hash[..16]);
     }
 }

--- a/src/WinRT.Impl.Generator/Helpers/MvidGenerator.cs
+++ b/src/WinRT.Impl.Generator/Helpers/MvidGenerator.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace WindowsRuntime.ImplGenerator;
+
+/// <summary>
+/// A generator for MVIDs for .NET modules.
+/// </summary>
+internal static class MvidGenerator
+{
+    /// <summary>
+    /// Generates a deterministic MVID based on two input IIDs.
+    /// </summary>
+    /// <param name="left">The first IID to combine.</param>
+    /// <param name="right">The second IID to combine.</param>
+    /// <returns>The resulting MVID.</returns>
+    public static Guid CreateMvid(Guid left, Guid right)
+    {
+        Span<byte> input = stackalloc byte[32];
+
+        // Write the two IIDs in sequence
+        _ = left.TryWriteBytes(input, bigEndian: true, out _);
+        _ = right.TryWriteBytes(input[16..], bigEndian: true, out _);
+
+        Span<byte> hash = stackalloc byte[SHA1.HashSizeInBytes];
+
+        // Hash the two IIDs together (the order matters)
+        _ = SHA1.HashData(input, hash);
+
+        // Take first 16 bytes and set UUID v5 version and variant bits
+        Span<byte> result = hash[..16];
+        result[6] = (byte)((result[6] & 0x0F) | 0x50);
+        result[8] = (byte)((result[8] & 0x3F) | 0x80);
+
+        // Construct the resulting IID from the hashed data
+        return new(result, bigEndian: true);
+    }
+}


### PR DESCRIPTION
## Summary

Add deterministic MVID generation for impl assemblies produced by `cswinrtimplgen.exe`, so that repeated builds with the same input produce byte-identical output modules.

## Motivation

The impl generator creates new `ModuleDefinition` instances for forwarder assemblies, and AsmResolver assigns a random MVID to each new module by default. This means every build produces a different binary even when the input hasn't changed, which breaks build caching and complicates reproducibility. By deriving the MVID deterministically from the input module's MVID and a fixed salt GUID (via SHA1), we ensure the output is stable across builds.

## Changes

- **`src/WinRT.Impl.Generator/Helpers/MvidGenerator.cs`**: new helper that combines two GUIDs (input MVID + salt) via SHA1 to produce a deterministic MVID
- **`src/WinRT.Impl.Generator/Generation/ImplGenerator.cs`**: use `MvidGenerator.CreateMvid` to set a deterministic MVID on each generated impl module instead of relying on the random default
