### PR TITLE
Mark RestrictedErrorInfo as private implementation detail

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -14,6 +15,10 @@ namespace WindowsRuntime.InteropServices;
 /// Handles the <c>IRestrictedErrorInfo</c> infrastructure for .NET exceptions.
 /// </summary>
 /// <see href="https://learn.microsoft.com/windows/win32/api/restrictederrorinfo/nn-restrictederrorinfo-irestrictederrorinfo"/>.
+[Obsolete(WindowsRuntimeConstants.PrivateImplementationDetailObsoleteMessage,
+    DiagnosticId = WindowsRuntimeConstants.PrivateImplementationDetailObsoleteDiagnosticId,
+    UrlFormat = WindowsRuntimeConstants.CsWinRTDiagnosticsUrlFormat)]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static unsafe class RestrictedErrorInfo
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Move `RestrictedErrorInfo` to the `InteropServices/Exceptions/` subdirectory (alongside other exception-related infrastructure) and mark it as a private implementation detail.

## Motivation

`RestrictedErrorInfo` is internal projection plumbing for `IRestrictedErrorInfo` handling, not a public API meant for consumption. Marking it with `[Obsolete]` (using the `CSWINRT3001` private-implementation-detail diagnostic) and `[EditorBrowsable(Never)]` hides it from IntelliSense and produces a diagnostic if external code attempts to use it, consistent with how other internal projection helpers are surfaced. The move into `InteropServices/Exceptions/` also better reflects its role alongside other exception-related interop types.

## Changes

- **`src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs`** (renamed from `src/WinRT.Runtime2/InteropServices/RestrictedErrorInfo.cs`): moved file into the `Exceptions` subdirectory; added `[Obsolete]` (`CSWINRT3001`) and `[EditorBrowsable(EditorBrowsableState.Never)]` attributes marking the type as a private implementation detail.
