### PR TITLE
Handle COM disconnect errors when cancelling WinRT async operations

### DIFF
--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -296,6 +296,7 @@ namespace System
     {
         private const int RPC_E_DISCONNECTED = unchecked((int)0x80010108);
         private const int RPC_S_SERVER_UNAVAILABLE = unchecked((int)0x800706BA);
+        private const int JSCRIPT_E_CANTEXECUTE = unchecked((int)0x89020001);
 
         private readonly CancellationToken _ct;
         private readonly CancellationTokenRegistration _asyncInfoRegistration;
@@ -329,7 +330,7 @@ namespace System
                         }
                         catch (Exception e) when (
                             e is COMException comException &&
-                            comException.HResult is RPC_E_DISCONNECTED or RPC_S_SERVER_UNAVAILABLE)
+                            comException.HResult is RPC_E_DISCONNECTED or RPC_S_SERVER_UNAVAILABLE or JSCRIPT_E_CANTEXECUTE)
                         {
                             // In the event of the async action/operation failing because it belonged to some COM server
                             // that was disconnected, handle the failure gracefully and do nothing here. We don't want to

--- a/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
+++ b/src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs
@@ -294,6 +294,9 @@ namespace System
 #endif
     sealed class AsyncInfoToTaskBridge<TResult, TProgress> : TaskCompletionSource<TResult>
     {
+        private const int RPC_E_DISCONNECTED = unchecked((int)0x80010108);
+        private const int RPC_S_SERVER_UNAVAILABLE = unchecked((int)0x800706BA);
+
         private readonly CancellationToken _ct;
         private readonly CancellationTokenRegistration _asyncInfoRegistration;
         private readonly CancellationTokenRegistration _registration;
@@ -316,7 +319,27 @@ namespace System
                 // Handle Exception from Cancel() if the token is already canceled.
                 try
                 {
-                    _asyncInfoRegistration = this._ct.Register(static ai => ((IAsyncInfo)ai).Cancel(), asyncInfo);
+                    _asyncInfoRegistration = this._ct.Register(static ai =>
+                    {
+                        IAsyncInfo asyncInfo = (IAsyncInfo)ai;
+
+                        try
+                        {
+                            asyncInfo.Cancel();
+                        }
+                        catch (Exception e) when (
+                            e is COMException comException &&
+                            comException.HResult is RPC_E_DISCONNECTED or RPC_S_SERVER_UNAVAILABLE)
+                        {
+                            // In the event of the async action/operation failing because it belonged to some COM server
+                            // that was disconnected, handle the failure gracefully and do nothing here. We don't want to
+                            // crash the entire process because of this. In this case, the task being returned to the
+                            // callers will already be marked as canceled, so this way they can properly handle things.
+                            // If they then tried to call any other methods on another object from the same COM server,
+                            // that would likely also fail in the same way, but once again at least they'll be able to
+                            // handle that as needed.
+                        }
+                    }, asyncInfo);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary

Handle COM disconnect errors gracefully when cancelling a WinRT async action/operation via the cancellation callback in `AsyncInfoToTaskBridge<TResult, TProgress>`, instead of letting the exception propagate and crash the process.

## Motivation

When awaiting a WinRT async API such as:

```csharp
await SomeWinRTAPIAsync().AsTask(token);
```

if the underlying object lives in a COM server that has died (gets disconnected), cancelling `token` would invoke `IAsyncInfo.Cancel()` from inside a `CancellationToken` callback. That call would then fail with `RPC_E_DISCONNECTED` (or related HRESULTs). The exception would propagate out of the cancellation callback and be re-thrown by `CancellationTokenSource.Cancel()` on whichever thread invoked it (often a thread pool thread), bringing down the entire app.

The pre-existing `try`/`catch` around the registration only protected the rare path where the token was already cancelled at registration time, not the typical case where cancellation happens later.

## Changes

- **`src/cswinrt/strings/additions/Windows.Foundation/Windows.Foundation.cs`**: in `AsyncInfoToTaskBridge<TResult, TProgress>`, wrap the `IAsyncInfo.Cancel()` invocation inside the cancellation callback with a `try`/`catch` filter that swallows `COMException` failures with `HRESULT` of `RPC_E_DISCONNECTED`, `RPC_S_SERVER_UNAVAILABLE`, or `JSCRIPT_E_CANTEXECUTE`. The task is still marked as cancelled by the other registration, so awaiters can handle the cancellation as usual without the process being torn down.
