### PR TITLE
Handle COM disconnect errors when cancelling WinRT async operations (3.0)

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TProgress}.cs
+++ b/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TProgress}.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
-#pragma warning disable IDE0010
+#pragma warning disable IDE0010, IDE0055
 
 namespace WindowsRuntime.InteropServices;
 
@@ -85,7 +86,10 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
         {
             _asyncInfo.Cancel();
         }
-        catch
+        catch (Exception e) when (e is COMException { HResult:
+            WellKnownErrorCodes.RPC_E_DISCONNECTED or
+            WellKnownErrorCodes.RPC_S_SERVER_UNAVAILABLE or
+            WellKnownErrorCodes.JSCRIPT_E_CANTEXECUTE })
         {
             // The native 'Cancel' call failed (e.g. the COM server hosting the async
             // operation has been disconnected). Swallow the exception here so it doesn't
@@ -94,6 +98,11 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
             // it (often a thread pool thread), potentially crashing the process. The task
             // has already been marked as canceled above, so awaiters will observe the
             // cancellation as expected.
+            //
+            // Note that we're intentionally only handling well-known exceptions due to "valid"
+            // infrastructure issues that can happen normally (e.g. a COM server disconnecting).
+            // We are not handling all exceptions, as that could hide legitimate bugs. The set of
+            // 'HRESULT'-s should be kept in sync with 'ExceptionDispatchInfoExtensions.ThrowAsync'.
         }
     }
 

--- a/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TProgress}.cs
+++ b/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TProgress}.cs
@@ -26,14 +26,14 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
     private readonly CancellationToken _cancellationToken;
 
     /// <summary>
-    /// The cancellation registration from <see cref="_cancellationToken"/> canceling this <see cref="TaskCompletionSource"/> instance.
+    /// The <see cref="IAsyncInfo"/> instance to cancel when <see cref="_cancellationToken"/> is canceled.
     /// </summary>
-    private readonly CancellationTokenRegistration _registration;
+    private readonly IAsyncInfo? _asyncInfo;
 
     /// <summary>
-    /// The cancellation registration from <see cref="_cancellationToken"/> canceling the input <see cref="IAsyncInfo"/> instance.
+    /// The cancellation registration that handles cancellation of <see cref="_cancellationToken"/>.
     /// </summary>
-    private readonly CancellationTokenRegistration _asyncInfoRegistration;
+    private readonly CancellationTokenRegistration _registration;
 
     /// <summary>
     /// Creates a new <see cref="AsyncInfoTaskCompletionSource{TProgress}"/> instance with the specified parameters.
@@ -46,28 +46,19 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
 
         if (_cancellationToken.CanBeCanceled)
         {
-            // Register the cancellation from the input cancellation token
+            _asyncInfo = asyncInfo;
+
+            // Register a single callback that cancels the underlying 'IAsyncInfo' and then
+            // completes the task. We handle both responsibilities (forwarding the cancellation
+            // to native and completing the task) inside one callback so that any exception
+            // thrown by 'IAsyncInfo.Cancel()' (e.g. 'RPC_E_DISCONNECTED' if the backing COM
+            // server has died) is observed and used to fault the task, rather than escaping
+            // out of the cancellation callback. If the exception escaped, it would be re-thrown
+            // from 'CancellationTokenSource.Cancel()' on whichever thread invoked it (often a
+            // thread pool thread), potentially crashing the process.
             _registration = _cancellationToken.Register(
-                callback: static (@this, ct) => Unsafe.As<TaskCompletionSource>(@this!).TrySetCanceled(ct),
+                callback: static @this => Unsafe.As<AsyncInfoTaskCompletionSource<TProgress>>(@this!).OnCancellation(),
                 state: this);
-
-            // Register the cancellation from the async object as well
-            try
-            {
-                _asyncInfoRegistration = _cancellationToken.Register(
-                    callback: static asyncInfo => Unsafe.As<IAsyncInfo>(asyncInfo!).Cancel(),
-                    state: asyncInfo);
-            }
-            catch (Exception ex)
-            {
-                // Handle exceptions from 'Cancel' if the token is already canceled
-                if (!Task.IsFaulted)
-                {
-                    Debug.Fail($"Expected base task to already be faulted, but found it in state '{Task.Status}'.");
-
-                    _ = TrySetException(ex);
-                }
-            }
         }
 
         // If we're already completed, unregister everything again.
@@ -75,6 +66,34 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
         if (Task.IsCompleted)
         {
             Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Cancels the underlying <see cref="IAsyncInfo"/> and completes the task accordingly.
+    /// </summary>
+    private void OnCancellation()
+    {
+        Debug.Assert(_asyncInfo is not null);
+
+        // Mark the task as canceled first, so that the 'Canceled' status wins over any
+        // failure from the native 'Cancel' call below. This matches the original ordering
+        // (where the cancellation registration ran before the 'IAsyncInfo.Cancel' one).
+        _ = TrySetCanceled(_cancellationToken);
+
+        try
+        {
+            _asyncInfo.Cancel();
+        }
+        catch
+        {
+            // The native 'Cancel' call failed (e.g. the COM server hosting the async
+            // operation has been disconnected). Swallow the exception here so it doesn't
+            // propagate out of the cancellation callback, which would otherwise be
+            // re-thrown by 'CancellationTokenSource.Cancel()' on whichever thread invoked
+            // it (often a thread pool thread), potentially crashing the process. The task
+            // has already been marked as canceled above, so awaiters will observe the
+            // cancellation as expected.
         }
     }
 
@@ -177,6 +196,5 @@ internal sealed class AsyncInfoTaskCompletionSource<TProgress> : TaskCompletionS
     private void Dispose()
     {
         _registration.Dispose();
-        _asyncInfoRegistration.Dispose();
     }
 }

--- a/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TResult, TProgress}.cs
+++ b/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TResult, TProgress}.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
-#pragma warning disable IDE0010
+#pragma warning disable IDE0010, IDE0055
 
 namespace WindowsRuntime.InteropServices;
 
@@ -69,7 +70,10 @@ internal sealed class AsyncInfoTaskCompletionSource<TResult, TProgress> : TaskCo
         {
             _asyncInfo.Cancel();
         }
-        catch
+        catch (Exception e) when (e is COMException { HResult:
+            WellKnownErrorCodes.RPC_E_DISCONNECTED or
+            WellKnownErrorCodes.RPC_S_SERVER_UNAVAILABLE or
+            WellKnownErrorCodes.JSCRIPT_E_CANTEXECUTE })
         {
         }
     }

--- a/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TResult, TProgress}.cs
+++ b/src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TResult, TProgress}.cs
@@ -24,11 +24,11 @@ internal sealed class AsyncInfoTaskCompletionSource<TResult, TProgress> : TaskCo
     /// <inheritdoc cref="AsyncInfoTaskCompletionSource{TProgress}._cancellationToken"/>
     private readonly CancellationToken _cancellationToken;
 
+    /// <inheritdoc cref="AsyncInfoTaskCompletionSource{TProgress}._asyncInfo"/>
+    private readonly IAsyncInfo? _asyncInfo;
+
     /// <inheritdoc cref="AsyncInfoTaskCompletionSource{TProgress}._registration"/>
     private readonly CancellationTokenRegistration _registration;
-
-    /// <inheritdoc cref="AsyncInfoTaskCompletionSource{TProgress}._asyncInfoRegistration"/>
-    private readonly CancellationTokenRegistration _asyncInfoRegistration;
 
     /// <summary>
     /// Creates a new <see cref="AsyncInfoTaskCompletionSource{TResult, TProgress}"/> instance with the specified parameters.
@@ -42,34 +42,35 @@ internal sealed class AsyncInfoTaskCompletionSource<TResult, TProgress> : TaskCo
         // The logic for this constructor should be kept in sync with the one without 'TResult'
         if (_cancellationToken.CanBeCanceled)
         {
-            // Register the cancellation from the input cancellation token
+            _asyncInfo = asyncInfo;
+
             _registration = _cancellationToken.Register(
-                callback: static (@this, ct) => Unsafe.As<TaskCompletionSource>(@this!).TrySetCanceled(ct),
+                callback: static @this => Unsafe.As<AsyncInfoTaskCompletionSource<TResult, TProgress>>(@this!).OnCancellation(),
                 state: this);
-
-            // Register the cancellation from the async object as well
-            try
-            {
-                _asyncInfoRegistration = _cancellationToken.Register(
-                    callback: static asyncInfo => Unsafe.As<IAsyncInfo>(asyncInfo!).Cancel(),
-                    state: asyncInfo);
-            }
-            catch (Exception ex)
-            {
-                // Handle exceptions from 'Cancel' if the token is already canceled
-                if (!Task.IsFaulted)
-                {
-                    Debug.Fail($"Expected base task to already be faulted, but found it in state '{Task.Status}'.");
-
-                    _ = TrySetException(ex);
-                }
-            }
         }
 
         // If we're already completed, unregister everything again
         if (Task.IsCompleted)
         {
             Dispose();
+        }
+    }
+
+    /// <inheritdoc cref="AsyncInfoTaskCompletionSource{TProgress}.OnCancellation"/>
+    private void OnCancellation()
+    {
+        Debug.Assert(_asyncInfo is not null);
+
+        _ = TrySetCanceled(_cancellationToken);
+
+        // Cancelling the underlying operation is a best-effort attempt, so ignore exceptions.
+        // See more details about this in 'AsyncInfoTaskCompletionSource<TProgress>.OnCancellation'.
+        try
+        {
+            _asyncInfo.Cancel();
+        }
+        catch
+        {
         }
     }
 
@@ -192,6 +193,5 @@ internal sealed class AsyncInfoTaskCompletionSource<TResult, TProgress> : TaskCo
     private void Dispose()
     {
         _registration.Dispose();
-        _asyncInfoRegistration.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Prevent app crashes when an `IAsyncInfo.Cancel()` call from the cancellation callback in `AsyncInfoTaskCompletionSource` fails because the backing COM server has been disconnected.

## Motivation

When awaiting a WinRT async API such as:

```csharp
await SomeWinRTAPIAsync().AsTask(token);
```

if the underlying object lives in a COM server that has died, cancelling `token` would invoke `IAsyncInfo.Cancel()` from inside a `CancellationToken` callback. That call would then fail with `RPC_E_DISCONNECTED` (or related HRESULTs). The exception would propagate out of the cancellation callback and be re-thrown by `CancellationTokenSource.Cancel()` on whichever thread invoked it (often a thread pool thread), tearing down the entire process.

The pre-existing `try`/`catch` around the cancellation registration only protected the rare path where the token was already cancelled at registration time, since `CancellationToken.Register(...)` only invokes the callback synchronously in that case. In the typical flow, where cancellation happens later, nothing was guarding the `Cancel()` call.

## Changes

- **`src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TProgress}.cs`**: collapsed the two cancellation registrations (one to mark the task cancelled, one to call `IAsyncInfo.Cancel()`) into a single `OnCancellation` callback. The callback first calls `TrySetCanceled(_cancellationToken)` to preserve the original ordering (so `Canceled` wins as the task state), then calls `IAsyncInfo.Cancel()` inside a `try`/`catch` that swallows any exception. This ensures no exception can escape the callback and crash the process.
- **`src/WinRT.Runtime2/InteropServices/AsyncInfo/TaskCompletionSources/AsyncInfoTaskCompletionSource{TResult, TProgress}.cs`**: same treatment for the generic `TResult` variant.
