### PR TITLE
Optimize IsReferenceToManagedObject and add Unsafe variant

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Marshalling/WindowsRuntimeDelegateMarshaller.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/WindowsRuntimeDelegateMarshaller.cs
@@ -74,7 +74,7 @@ public static unsafe class WindowsRuntimeDelegateMarshaller
 
         // If the value is a CCW we recognize, unwrap it (and assume it's a 'Delegate' instance).
         // We use 'ComInterfaceDispatch' directly as we also need a fast type cast on the result.
-        if (WindowsRuntimeMarshal.IsReferenceToManagedObject(value))
+        if (WindowsRuntimeComWrappersMarshal.IsReferenceToManagedObjectUnsafe(value))
         {
             return ComWrappers.ComInterfaceDispatch.GetInstance<Delegate>((ComWrappers.ComInterfaceDispatch*)value);
         }

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappersMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappersMarshal.cs
@@ -174,6 +174,24 @@ public static unsafe class WindowsRuntimeComWrappersMarshal
     }
 
     /// <summary>
+    /// Checks whether a pointer to a COM object is actually a reference to a CCW produced for a managed object that was marshalled to native code.
+    /// </summary>
+    /// <param name="externalComObject">The external COM object to check.</param>
+    /// <returns>Whether <paramref name="externalComObject"/> refers to a CCW for a managed object, rather than a native COM object.</returns>
+    /// <remarks>
+    /// This method is the same as <see cref="WindowsRuntimeMarshal.IsReferenceToManagedObject"/>, but without performing a
+    /// <see langword="null"/> check on <paramref name="externalComObject"/>. Callers should validate the input pointers.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsReferenceToManagedObjectUnsafe(void* externalComObject)
+    {
+        IUnknownVftbl* unknownVftbl = (IUnknownVftbl*)*(void***)externalComObject;
+        IUnknownVftbl* runtimeVftbl = (IUnknownVftbl*)IUnknownImpl.Vtable;
+
+        return unknownVftbl->QueryInterface == runtimeVftbl->QueryInterface;
+    }
+
+    /// <summary>
     /// Attempts to extract a <see cref="WindowsRuntimeObjectReference"/> from the specified object.
     /// </summary>
     /// <param name="value">The object to attempt to unwrap.</param>

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappersMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappersMarshal.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 
-#pragma warning disable CS1573
+#pragma warning disable CS1573, CS8909
 
 namespace WindowsRuntime.InteropServices;
 

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
@@ -74,7 +74,7 @@ public static unsafe class WindowsRuntimeMarshal
     public static bool TryGetManagedObject(void* externalComObject, [NotNullWhen(true)] out object? result)
     {
         // If the input pointer is a reference to a managed object, we can resolve the original managed object
-        if (externalComObject is not null && IsReferenceToManagedObject(externalComObject))
+        if (externalComObject is not null && WindowsRuntimeComWrappersMarshal.IsReferenceToManagedObjectUnsafe(externalComObject))
         {
             result = ComWrappers.ComInterfaceDispatch.GetInstance<object>((ComWrappers.ComInterfaceDispatch*)externalComObject);
 

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using WindowsRuntime.InteropServices.Marshalling;
 
-#pragma warning disable CS8909
-
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>
@@ -59,10 +57,7 @@ public static unsafe class WindowsRuntimeMarshal
     {
         ArgumentNullException.ThrowIfNull(externalComObject);
 
-        IUnknownVftbl* unknownVftbl = (IUnknownVftbl*)*(void***)externalComObject;
-        IUnknownVftbl* runtimeVftbl = (IUnknownVftbl*)IUnknownImpl.Vtable;
-
-        return unknownVftbl->QueryInterface == runtimeVftbl->QueryInterface;
+        return WindowsRuntimeComWrappersMarshal.IsReferenceToManagedObjectUnsafe(externalComObject);
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
@@ -62,10 +62,7 @@ public static unsafe class WindowsRuntimeMarshal
         IUnknownVftbl* unknownVftbl = (IUnknownVftbl*)*(void***)externalComObject;
         IUnknownVftbl* runtimeVftbl = (IUnknownVftbl*)IUnknownImpl.Vtable;
 
-        return
-            unknownVftbl->QueryInterface == runtimeVftbl->QueryInterface &&
-            unknownVftbl->AddRef == runtimeVftbl->AddRef &&
-            unknownVftbl->Release == runtimeVftbl->Release;
+        return unknownVftbl->QueryInterface == runtimeVftbl->QueryInterface;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Optimize `IsReferenceToManagedObject` to only compare the `QueryInterface` slot in the vtable, and introduce a new `IsReferenceToManagedObjectUnsafe` helper on `WindowsRuntimeComWrappersMarshal` that skips the `null` check on the input pointer.

## Motivation

`IsReferenceToManagedObject` is on the hot path for marshalling, and we can make it cheaper:

- All CCWs produced by `WindowsRuntimeComWrappers` share the same `IUnknownImpl` vtable instance, so checking the `QueryInterface` slot is sufficient to identify a managed CCW. The additional comparisons on `AddRef` and `Release` were redundant.
- Internal callers (e.g. `WindowsRuntimeDelegateMarshaller`) already validate their input pointers, so they don't need the extra `null` check that the public `WindowsRuntimeMarshal.IsReferenceToManagedObject` API performs. Exposing an `Unsafe` variant lets these callers skip that branch.

## Changes

- **`src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappersMarshal.cs`**: add `IsReferenceToManagedObjectUnsafe` helper that performs the vtable check without a `null` guard, marked `AggressiveInlining`.
- **`src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs`**: simplify `IsReferenceToManagedObject` to only compare the `QueryInterface` slot, and route `TryGetManagedObject` through the new `Unsafe` helper after its own `null` check.
- **`src/WinRT.Runtime2/InteropServices/Marshalling/WindowsRuntimeDelegateMarshaller.cs`**: switch to `IsReferenceToManagedObjectUnsafe` since the input pointer is already validated.
