### PR TITLE
Add authoring analyzers for [ApiContract] and [ContractVersion]

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -17,3 +17,6 @@ CSWINRT2007 | WindowsRuntime.SourceGenerator | Error | Indexer type not found fo
 CSWINRT2008 | WindowsRuntime.SourceGenerator | Error | Static indexer for '[GeneratedCustomPropertyProvider]'
 CSWINRT2009 | WindowsRuntime.SourceGenerator | Warning | Cast to '[ComImport]' type not supported
 CSWINRT2010 | WindowsRuntime.SourceGenerator | Warning | API contract enum type with enum cases
+CSWINRT2011 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for version-only constructor
+CSWINRT2012 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for contract-type constructor
+CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' contract type argument

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -20,3 +20,4 @@ CSWINRT2010 | WindowsRuntime.SourceGenerator | Warning | API contract enum type 
 CSWINRT2011 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for version-only constructor
 CSWINRT2012 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for contract-type constructor
 CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' contract type argument
+CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missing 'ContractVersionAttribute'

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -21,3 +21,4 @@ CSWINRT2011 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersio
 CSWINRT2012 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for contract-type constructor
 CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' contract type argument
 CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missing 'ContractVersionAttribute'
+CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing 'ContractVersionAttribute'

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -16,3 +16,4 @@ CSWINRT2006 | WindowsRuntime.SourceGenerator | Error | Property name not found f
 CSWINRT2007 | WindowsRuntime.SourceGenerator | Error | Indexer type not found for '[GeneratedCustomPropertyProvider]'
 CSWINRT2008 | WindowsRuntime.SourceGenerator | Error | Static indexer for '[GeneratedCustomPropertyProvider]'
 CSWINRT2009 | WindowsRuntime.SourceGenerator | Warning | Cast to '[ComImport]' type not supported
+CSWINRT2010 | WindowsRuntime.SourceGenerator | Warning | API contract enum type with enum cases

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -23,3 +23,4 @@ CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersio
 CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missing 'ContractVersionAttribute'
 CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing version metadata
 CSWINRT2016 | WindowsRuntime.SourceGenerator | Warning | Public authored type missing 'ContractVersionAttribute'
+CSWINRT2017 | WindowsRuntime.SourceGenerator | Warning | Public authored type mixing '[ContractVersion]' and '[Version]'

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -22,3 +22,4 @@ CSWINRT2012 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersio
 CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' contract type argument
 CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missing 'ContractVersionAttribute'
 CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing version metadata
+CSWINRT2016 | WindowsRuntime.SourceGenerator | Warning | Public authored type missing 'ContractVersionAttribute'

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -21,4 +21,4 @@ CSWINRT2011 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersio
 CSWINRT2012 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' target for contract-type constructor
 CSWINRT2013 | WindowsRuntime.SourceGenerator | Warning | Invalid 'ContractVersionAttribute' contract type argument
 CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missing 'ContractVersionAttribute'
-CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing 'ContractVersionAttribute'
+CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing version metadata

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ApiContractTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ApiContractTypeRequiresContractVersionAnalyzer.cs
@@ -58,13 +58,8 @@ public sealed class ApiContractTypeRequiresContractVersionAnalyzer : DiagnosticA
                 }
 
                 // Check whether any '[ContractVersion]' attribute using a version-only constructor is applied
-                foreach (AttributeData attribute in typeSymbol.GetAttributes())
+                foreach (AttributeData attribute in typeSymbol.GetAttributes(contractVersionAttributeType))
                 {
-                    if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, contractVersionAttributeType))
-                    {
-                        continue;
-                    }
-
                     // The version-only constructors are '(uint)' and '(string, uint)'.
                     // The contract-type constructor is '(Type, uint)', which we want to ignore here.
                     if (attribute.AttributeConstructor?.Parameters is [{ Type.SpecialType: SpecialType.System_UInt32 or SpecialType.System_String }, ..])

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ApiContractTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ApiContractTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that validates that <c>[ApiContract]</c> enum types declare their contract version using <c>[ContractVersion]</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ApiContractTypeRequiresContractVersionAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.ApiContractTypeMissingContractVersion];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute") is not { } apiContractAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[ContractVersion]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ContractVersionAttribute") is not { } contractVersionAttributeType)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only enum types can be valid API contract types
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Enum } typeSymbol)
+                {
+                    return;
+                }
+
+                // Immediately bail if the type is not an API contract type
+                if (!typeSymbol.HasAttributeWithType(apiContractAttributeType))
+                {
+                    return;
+                }
+
+                // Check whether any '[ContractVersion]' attribute using a version-only constructor is applied
+                foreach (AttributeData attribute in typeSymbol.GetAttributes())
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, contractVersionAttributeType))
+                    {
+                        continue;
+                    }
+
+                    // The version-only constructors are '(uint)' and '(string, uint)'.
+                    // The contract-type constructor is '(Type, uint)', which we want to ignore here.
+                    if (attribute.AttributeConstructor?.Parameters is [{ Type.SpecialType: SpecialType.System_UInt32 or SpecialType.System_String }, ..])
+                    {
+                        return;
+                    }
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ApiContractTypeMissingContractVersion,
+                    typeSymbol.Locations.FirstOrDefault(),
+                    typeSymbol));
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeMixedVersioningAttributesAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeMixedVersioningAttributesAnalyzer.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that reports when a public authored type has both a <c>[ContractVersion]</c>
+/// and a <c>[Version]</c> attribute applied. Public types in a Windows Runtime component should
+/// use only one of these two versioning schemes, applied consistently across the public API surface.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PublicTypeMixedVersioningAttributesAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.PublicTypeMixedVersioningAttributes];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ContractVersion]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ContractVersionAttribute") is not { } contractVersionAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[Version]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.VersionAttribute") is not { } versionAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol (used to skip API contract types, which are validated by a different analyzer)
+            INamedTypeSymbol? apiContractAttributeType = context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute");
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only consider top-level public types
+                if (context.Symbol is not INamedTypeSymbol { DeclaredAccessibility: Accessibility.Public, ContainingType: null } typeSymbol)
+                {
+                    return;
+                }
+
+                // Skip API contract types: those use '[ContractVersion]' with the version-only constructors
+                // to declare their own contract version, which is a different scenario from this analyzer.
+                if (apiContractAttributeType is not null &&
+                    typeSymbol is { TypeKind: TypeKind.Enum } &&
+                    typeSymbol.HasAttributeWithType(apiContractAttributeType))
+                {
+                    return;
+                }
+
+                // Only report if both '[ContractVersion]' and '[Version]' are applied to the type
+                if (!typeSymbol.HasAttributeWithType(contractVersionAttributeType) ||
+                    !typeSymbol.HasAttributeWithType(versionAttributeType))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.PublicTypeMixedVersioningAttributes,
+                    typeSymbol.Locations.FirstOrDefault(),
+                    typeSymbol));
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
@@ -42,10 +42,8 @@ public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyz
 
             context.RegisterSymbolAction(context =>
             {
-                INamedTypeSymbol typeSymbol = (INamedTypeSymbol)context.Symbol;
-
                 // Only consider top-level public types
-                if (typeSymbol is not { DeclaredAccessibility: Accessibility.Public, ContainingType: null })
+                if (context.Symbol is not INamedTypeSymbol { DeclaredAccessibility: Accessibility.Public, ContainingType: null } typeSymbol)
                 {
                     return;
                 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that reports when a public authored type is missing a <c>[ContractVersion]</c> attribute.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.PublicTypeMissingContractVersion];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ContractVersion]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ContractVersionAttribute") is not { } contractVersionAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol (used to skip API contract types, which are validated by a different analyzer)
+            INamedTypeSymbol? apiContractAttributeType = context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute");
+
+            context.RegisterSymbolAction(context =>
+            {
+                INamedTypeSymbol typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+                // Only consider top-level public types
+                if (typeSymbol is not { DeclaredAccessibility: Accessibility.Public, ContainingType: null })
+                {
+                    return;
+                }
+
+                // Skip API contract types: those are handled by 'ApiContractTypeRequiresContractVersionAnalyzer'
+                if (apiContractAttributeType is not null &&
+                    typeSymbol is { TypeKind: TypeKind.Enum } &&
+                    typeSymbol.HasAttributeWithType(apiContractAttributeType))
+                {
+                    return;
+                }
+
+                // Skip if any '[ContractVersion]' attribute is already applied (validity of the
+                // specific constructor used is reported by the other 'ContractVersion' analyzers)
+                if (typeSymbol.HasAttributeWithType(contractVersionAttributeType))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.PublicTypeMissingContractVersion,
+                    typeSymbol.Locations.FirstOrDefault(),
+                    typeSymbol));
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that reports when a public authored type is missing a <c>[ContractVersion]</c> attribute,
+/// but at least one other public type in the same compilation does have one applied. This enforces a consistent
+/// versioning scheme across the public API surface of a Windows Runtime component.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.PublicTypeMissingContractVersion];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ContractVersion]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ContractVersionAttribute") is not { } contractVersionAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol (used to skip API contract types, which use '[ContractVersion]'
+            // with the version-only constructors to declare their own contract version, not as an association).
+            INamedTypeSymbol? apiContractAttributeType = context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute");
+
+            // Shared state across symbol actions: collect public types missing '[ContractVersion]' and track
+            // whether at least one public type in the compilation does have a '[ContractVersion]' applied.
+            ConcurrentBag<INamedTypeSymbol> typesMissingContractVersion = [];
+            int anyTypeHasContractVersion = 0;
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only consider top-level public types
+                if (context.Symbol is not INamedTypeSymbol { DeclaredAccessibility: Accessibility.Public, ContainingType: null } typeSymbol)
+                {
+                    return;
+                }
+
+                // Skip API contract types: those use '[ContractVersion]' with a different semantics
+                // (declaring their own contract version, not associating with another contract).
+                if (apiContractAttributeType is not null &&
+                    typeSymbol is { TypeKind: TypeKind.Enum } &&
+                    typeSymbol.HasAttributeWithType(apiContractAttributeType))
+                {
+                    return;
+                }
+
+                if (typeSymbol.HasAttributeWithType(contractVersionAttributeType))
+                {
+                    _ = Interlocked.Exchange(ref anyTypeHasContractVersion, 1);
+                }
+                else
+                {
+                    typesMissingContractVersion.Add(typeSymbol);
+                }
+            }, SymbolKind.NamedType);
+
+            context.RegisterCompilationEndAction(context =>
+            {
+                // Only report if at least one public type does have a '[ContractVersion]' applied: the
+                // analyzer specifically targets components that have opted into contract versioning, but
+                // are inconsistently applying it across the public API surface.
+                if (Volatile.Read(ref anyTypeHasContractVersion) == 0)
+                {
+                    return;
+                }
+
+                // Sort by source location for deterministic diagnostic reporting order
+                foreach (INamedTypeSymbol typeSymbol in typesMissingContractVersion
+                    .OrderBy(static t => t.Locations.FirstOrDefault()?.SourceTree?.FilePath, StringComparer.Ordinal)
+                    .ThenBy(static t => t.Locations.FirstOrDefault()?.SourceSpan.Start ?? 0))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.PublicTypeMissingContractVersion,
+                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol));
+                }
+            });
+        });
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresVersioningAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/PublicTypeRequiresVersioningAnalyzer.cs
@@ -9,13 +9,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace WindowsRuntime.SourceGenerator.Diagnostics;
 
 /// <summary>
-/// A diagnostic analyzer that reports when a public authored type is missing a <c>[ContractVersion]</c> attribute.
+/// A diagnostic analyzer that reports when a public authored type is missing version metadata
+/// (i.e. is missing both a <c>[ContractVersion]</c> and a <c>[Version]</c> attribute).
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyzer
+public sealed class PublicTypeRequiresVersioningAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.PublicTypeMissingContractVersion];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.PublicTypeMissingVersioning];
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -37,6 +38,10 @@ public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyz
                 return;
             }
 
+            // Get the '[Version]' symbol (used to also accept '[Version]' as valid version metadata,
+            // as an alternative to '[ContractVersion]' for declaring the version of a public type).
+            INamedTypeSymbol? versionAttributeType = context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.VersionAttribute");
+
             // Get the '[ApiContract]' symbol (used to skip API contract types, which are validated by a different analyzer)
             INamedTypeSymbol? apiContractAttributeType = context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute");
 
@@ -57,14 +62,21 @@ public sealed class PublicTypeRequiresContractVersionAnalyzer : DiagnosticAnalyz
                 }
 
                 // Skip if any '[ContractVersion]' attribute is already applied (validity of the
-                // specific constructor used is reported by the other 'ContractVersion' analyzers)
+                // specific constructor used is reported by the other 'ContractVersion' analyzers).
                 if (typeSymbol.HasAttributeWithType(contractVersionAttributeType))
                 {
                     return;
                 }
 
+                // Skip if any '[Version]' attribute is applied: '[Version]' is an alternative versioning
+                // metadata that also satisfies the requirement of declaring a version for the type.
+                if (versionAttributeType is not null && typeSymbol.HasAttributeWithType(versionAttributeType))
+                {
+                    return;
+                }
+
                 context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.PublicTypeMissingContractVersion,
+                    DiagnosticDescriptors.PublicTypeMissingVersioning,
                     typeSymbol.Locations.FirstOrDefault(),
                     typeSymbol));
             }, SymbolKind.NamedType);

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidApiContractEnumTypeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidApiContractEnumTypeAnalyzer.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that validates that <c>[ApiContract]</c> enum types do not define any enum cases.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ValidApiContractEnumTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.ApiContractEnumWithCases];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute") is not { } attributeType)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only enum types can be annotated with '[ApiContract]'
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Enum } typeSymbol)
+                {
+                    return;
+                }
+
+                // Immediately bail if the type doesn't have the attribute
+                if (!typeSymbol.HasAttributeWithType(attributeType))
+                {
+                    return;
+                }
+
+                // Warn if the enum defines any enum cases (i.e. any fields other than the implicit value field)
+                if (typeSymbol.GetMembers().Any(static member => member is IFieldSymbol { IsConst: true }))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.ApiContractEnumWithCases,
+                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that validates applications of <c>[ContractVersion]</c> attributes.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
+        DiagnosticDescriptors.ContractVersionAttributeRequiresApiContractTarget,
+        DiagnosticDescriptors.ContractVersionAttributeNotAllowedOnApiContractTarget,
+        DiagnosticDescriptors.ContractVersionAttributeInvalidContractTypeArgument];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[ContractVersion]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ContractVersionAttribute") is not { } contractVersionAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[ApiContract]' symbol
+            if (context.Compilation.GetTypeByMetadataName("Windows.Foundation.Metadata.ApiContractAttribute") is not { } apiContractAttributeType)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                if (context.Symbol is not INamedTypeSymbol typeSymbol)
+                {
+                    return;
+                }
+
+                bool isApiContractType = IsApiContractType(typeSymbol, apiContractAttributeType);
+
+                foreach (AttributeData attribute in typeSymbol.GetAttributes())
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, contractVersionAttributeType))
+                    {
+                        continue;
+                    }
+
+                    if (attribute.AttributeConstructor is not { } constructor)
+                    {
+                        continue;
+                    }
+
+                    ImmutableArray<IParameterSymbol> parameters = constructor.Parameters;
+
+                    // Identify the constructor by its first parameter type:
+                    //   - 'ContractVersionAttribute(uint)'
+                    //   - 'ContractVersionAttribute(string, uint)'
+                    //   - 'ContractVersionAttribute(Type, uint)'
+                    bool isVersionOnlyConstructor = parameters is
+                        [{ Type.SpecialType: SpecialType.System_UInt32 }] or
+                        [{ Type.SpecialType: SpecialType.System_String }, _];
+
+                    bool isContractTypeConstructor = parameters is
+                        [{ Type: INamedTypeSymbol { MetadataName: "Type", ContainingNamespace.Name: "System" } }, _];
+
+                    if (isVersionOnlyConstructor)
+                    {
+                        // The version-only constructors must be applied to API contract types
+                        if (!isApiContractType)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.ContractVersionAttributeRequiresApiContractTarget,
+                                GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
+                                typeSymbol));
+                        }
+                    }
+                    else if (isContractTypeConstructor)
+                    {
+                        // The contract-type constructor must NOT be applied to API contract types
+                        if (isApiContractType)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.ContractVersionAttributeNotAllowedOnApiContractTarget,
+                                GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
+                                typeSymbol));
+                        }
+
+                        // The contract type argument must be a valid API contract type
+                        if (attribute.ConstructorArguments is [{ Value: INamedTypeSymbol contractTypeArgument }, ..] &&
+                            !IsApiContractType(contractTypeArgument, apiContractAttributeType))
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.ContractVersionAttributeInvalidContractTypeArgument,
+                                GetAttributeArgumentLocation(attribute, argumentIndex: 0, context.CancellationToken)
+                                    ?? GetAttributeLocation(attribute, context.CancellationToken)
+                                    ?? typeSymbol.Locations.FirstOrDefault(),
+                                typeSymbol,
+                                contractTypeArgument));
+                        }
+                    }
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    /// <summary>
+    /// Checks whether a type is a valid API contract type (an enum type annotated with <c>[ApiContract]</c>).
+    /// </summary>
+    /// <param name="typeSymbol">The type symbol to check.</param>
+    /// <param name="apiContractAttributeType">The <c>[ApiContract]</c> attribute symbol.</param>
+    /// <returns>Whether <paramref name="typeSymbol"/> is a valid API contract type.</returns>
+    private static bool IsApiContractType(INamedTypeSymbol typeSymbol, INamedTypeSymbol apiContractAttributeType)
+    {
+        return typeSymbol is { TypeKind: TypeKind.Enum } && typeSymbol.HasAttributeWithType(apiContractAttributeType);
+    }
+
+    /// <summary>
+    /// Gets the location of the syntax node where an attribute is applied.
+    /// </summary>
+    /// <param name="attribute">The attribute to locate.</param>
+    /// <param name="cancellationToken">The cancellation token to use.</param>
+    /// <returns>The location of the attribute application, or <see langword="null"/> if it cannot be determined.</returns>
+    private static Location? GetAttributeLocation(AttributeData attribute, CancellationToken cancellationToken)
+    {
+        return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation();
+    }
+
+    /// <summary>
+    /// Gets the location of a specific positional argument of an attribute application.
+    /// </summary>
+    /// <param name="attribute">The attribute to locate.</param>
+    /// <param name="argumentIndex">The index of the positional argument.</param>
+    /// <param name="cancellationToken">The cancellation token to use.</param>
+    /// <returns>The location of the argument, or <see langword="null"/> if it cannot be determined.</returns>
+    private static Location? GetAttributeArgumentLocation(AttributeData attribute, int argumentIndex, CancellationToken cancellationToken)
+    {
+        return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is AttributeSyntax { ArgumentList.Arguments: { } arguments } && argumentIndex < arguments.Count
+            ? arguments[argumentIndex].GetLocation()
+            : null;
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
@@ -59,6 +59,7 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
 
                 foreach (AttributeData attribute in typeSymbol.GetAttributes())
                 {
+                    // We can have multiple '[ContractVersion]' uses, so we need to iterate and check each of them
                     if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, contractVersionAttributeType))
                     {
                         continue;
@@ -82,20 +83,17 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
                     bool isContractTypeConstructor = parameters is
                         [{ Type: INamedTypeSymbol { MetadataName: "Type", ContainingNamespace.Name: "System" } }, _];
 
-                    if (isVersionOnlyConstructor)
+                    // The version-only constructors must be applied to API contract types
+                    if (isVersionOnlyConstructor && !isApiContractType)
                     {
-                        // The version-only constructors must be applied to API contract types
-                        if (!isApiContractType)
-                        {
-                            context.ReportDiagnostic(Diagnostic.Create(
-                                DiagnosticDescriptors.ContractVersionAttributeRequiresApiContractTarget,
-                                GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
-                                typeSymbol));
-                        }
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.ContractVersionAttributeRequiresApiContractTarget,
+                            GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
+                            typeSymbol));
                     }
                     else if (isContractTypeConstructor)
                     {
-                        // The contract-type constructor must NOT be applied to API contract types
+                        // The contract-type constructor must not be applied to API contract types
                         if (isApiContractType)
                         {
                             context.ReportDiagnostic(Diagnostic.Create(

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace WindowsRuntime.SourceGenerator.Diagnostics;
@@ -88,7 +86,7 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.ContractVersionAttributeRequiresApiContractTarget,
-                            GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
+                            attribute.GetLocation(context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
                             typeSymbol));
                     }
                     else if (isContractTypeConstructor)
@@ -98,7 +96,7 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
                         {
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.ContractVersionAttributeNotAllowedOnApiContractTarget,
-                                GetAttributeLocation(attribute, context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
+                                attribute.GetLocation(context.CancellationToken) ?? typeSymbol.Locations.FirstOrDefault(),
                                 typeSymbol));
                         }
 
@@ -108,8 +106,8 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
                         {
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.ContractVersionAttributeInvalidContractTypeArgument,
-                                GetAttributeArgumentLocation(attribute, argumentIndex: 0, context.CancellationToken)
-                                    ?? GetAttributeLocation(attribute, context.CancellationToken)
+                                attribute.GetArgumentLocation(argumentIndex: 0, context.CancellationToken)
+                                    ?? attribute.GetLocation(context.CancellationToken)
                                     ?? typeSymbol.Locations.FirstOrDefault(),
                                 typeSymbol,
                                 contractTypeArgument));
@@ -129,30 +127,5 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
     private static bool IsApiContractType(INamedTypeSymbol typeSymbol, INamedTypeSymbol apiContractAttributeType)
     {
         return typeSymbol is { TypeKind: TypeKind.Enum } && typeSymbol.HasAttributeWithType(apiContractAttributeType);
-    }
-
-    /// <summary>
-    /// Gets the location of the syntax node where an attribute is applied.
-    /// </summary>
-    /// <param name="attribute">The attribute to locate.</param>
-    /// <param name="cancellationToken">The cancellation token to use.</param>
-    /// <returns>The location of the attribute application, or <see langword="null"/> if it cannot be determined.</returns>
-    private static Location? GetAttributeLocation(AttributeData attribute, CancellationToken cancellationToken)
-    {
-        return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation();
-    }
-
-    /// <summary>
-    /// Gets the location of a specific positional argument of an attribute application.
-    /// </summary>
-    /// <param name="attribute">The attribute to locate.</param>
-    /// <param name="argumentIndex">The index of the positional argument.</param>
-    /// <param name="cancellationToken">The cancellation token to use.</param>
-    /// <returns>The location of the argument, or <see langword="null"/> if it cannot be determined.</returns>
-    private static Location? GetAttributeArgumentLocation(AttributeData attribute, int argumentIndex, CancellationToken cancellationToken)
-    {
-        return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is AttributeSyntax { ArgumentList.Arguments: { } arguments } && argumentIndex < arguments.Count
-            ? arguments[argumentIndex].GetLocation()
-            : null;
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ValidContractVersionAttributeAnalyzer.cs
@@ -55,14 +55,9 @@ public sealed class ValidContractVersionAttributeAnalyzer : DiagnosticAnalyzer
 
                 bool isApiContractType = IsApiContractType(typeSymbol, apiContractAttributeType);
 
-                foreach (AttributeData attribute in typeSymbol.GetAttributes())
+                foreach (AttributeData attribute in typeSymbol.GetAttributes(contractVersionAttributeType))
                 {
                     // We can have multiple '[ContractVersion]' uses, so we need to iterate and check each of them
-                    if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, contractVersionAttributeType))
-                    {
-                        continue;
-                    }
-
                     if (attribute.AttributeConstructor is not { } constructor)
                     {
                         continue;

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -139,4 +139,17 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Types used in cast operations must not be '[ComImport]' interfaces, as they are not compatible with Windows Runtime objects marshalled by CsWinRT.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an <c>[ApiContract]</c> enum type that defines enum cases.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ApiContractEnumWithCases = new(
+        id: "CSWINRT2010",
+        title: "API contract enum type with enum cases",
+        messageFormat: """The type '{0}' is annotated with '[ApiContract]', but it defines one or more enum cases. API contract types are represented by empty struct types in the Windows Runtime type system, and as such defining any enum cases is invalid. The enum cases will be ignored when generating the resulting .winmd file.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Enum types annotated with '[ApiContract]' must not define any enum cases, as API contract types are represented by empty struct types in the Windows Runtime type system. Any enum cases will be ignored when generating the resulting .winmd file.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -191,4 +191,17 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The contract type argument of '[ContractVersion]' must be a valid API contract type (an enum type annotated with '[ApiContract]').",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an <c>[ApiContract]</c> enum type that is missing a <c>[ContractVersion]</c> attribute.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ApiContractTypeMissingContractVersion = new(
+        id: "CSWINRT2014",
+        title: "API contract type missing 'ContractVersionAttribute'",
+        messageFormat: """The type '{0}' is annotated with '[ApiContract]', but it does not have a '[ContractVersion]' attribute applied to it. API contract types must declare their contract version using one of the version-only constructors of '[ContractVersion]'.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Enum types annotated with '[ApiContract]' must also have a '[ContractVersion]' attribute applied to them, using one of the version-only constructors, to declare the contract version of the API contract.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -204,4 +204,17 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Enum types annotated with '[ApiContract]' must also have a '[ContractVersion]' attribute applied to them, using one of the version-only constructors, to declare the contract version of the API contract.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a public authored type missing a <c>[ContractVersion]</c> attribute.
+    /// </summary>
+    public static readonly DiagnosticDescriptor PublicTypeMissingContractVersion = new(
+        id: "CSWINRT2015",
+        title: "Public authored type missing 'ContractVersionAttribute'",
+        messageFormat: """The type '{0}' is publicly exposed in a Windows Runtime component, but it does not have a '[ContractVersion]' attribute applied to it. Public types should declare their associated API contract using '[ContractVersion(typeof(SomeContract), version)]' so that consumers can target a specific contract version.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Public types in a Windows Runtime component should declare their associated API contract using '[ContractVersion(typeof(SomeContract), version)]', so that consumers can target a specific contract version.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -152,4 +152,43 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Enum types annotated with '[ApiContract]' must not define any enum cases, as API contract types are represented by empty struct types in the Windows Runtime type system. Any enum cases will be ignored when generating the resulting .winmd file.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[ContractVersion]</c> attribute using the version-only constructors on a non-API contract type.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ContractVersionAttributeRequiresApiContractTarget = new(
+        id: "CSWINRT2011",
+        title: "Invalid 'ContractVersionAttribute' target for version-only constructor",
+        messageFormat: """The type '{0}' is annotated with '[ContractVersion]' using a constructor that only specifies the contract version, but '{0}' is not an API contract type (an enum type annotated with '[ApiContract]'). These constructors only apply to API contract types and are used to specify the contract version of that API contract.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The 'ContractVersionAttribute' constructors taking only the contract version (or the contract name and version) only apply to API contract types (enum types annotated with '[ApiContract]'), and are used to specify the contract version of that API contract.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[ContractVersion]</c> attribute using the contract-type constructor on an API contract type.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ContractVersionAttributeNotAllowedOnApiContractTarget = new(
+        id: "CSWINRT2012",
+        title: "Invalid 'ContractVersionAttribute' target for contract-type constructor",
+        messageFormat: """The type '{0}' is annotated with '[ContractVersion]' using the constructor that takes a contract type and version, but '{0}' is itself an API contract type. This constructor is used to associate a non-contract type with an API contract; use the constructor that only takes the contract version instead.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The 'ContractVersionAttribute' constructor taking a contract type and version cannot be applied to API contract types, as it is meant to associate a non-contract type with an API contract.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[ContractVersion]</c> attribute whose contract type argument is not a valid API contract type.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ContractVersionAttributeInvalidContractTypeArgument = new(
+        id: "CSWINRT2013",
+        title: "Invalid 'ContractVersionAttribute' contract type argument",
+        messageFormat: """The 'ContractVersionAttribute' applied to '{0}' specifies '{1}' as the contract type, but '{1}' is not a valid API contract type (an enum type annotated with '[ApiContract]')""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The contract type argument of '[ContractVersion]' must be a valid API contract type (an enum type annotated with '[ApiContract]').",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -217,4 +217,18 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Public types in a Windows Runtime component should declare their version using either '[ContractVersion(typeof(SomeContract), version)]' (to associate with an API contract) or '[Version(version)]' (to specify a Windows Runtime version), so that consumers can target a specific version.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a public authored type missing a <c>[ContractVersion]</c> attribute when at least one other public type in the same component has one applied.
+    /// </summary>
+    public static readonly DiagnosticDescriptor PublicTypeMissingContractVersion = new(
+        id: "CSWINRT2016",
+        title: "Public authored type missing 'ContractVersionAttribute'",
+        messageFormat: """The type '{0}' is publicly exposed in a Windows Runtime component that uses '[ContractVersion]' on at least one other public type, but '{0}' itself does not have a '[ContractVersion]' attribute applied. Public types in a component using contract versioning should consistently declare their associated API contract using '[ContractVersion(typeof(SomeContract), version)]'.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Public types in a Windows Runtime component should use a consistent versioning scheme. If at least one public type uses '[ContractVersion]', all other public types should also use '[ContractVersion]' to declare their associated API contract.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -206,15 +206,15 @@ internal static partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a public authored type missing a <c>[ContractVersion]</c> attribute.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a public authored type missing version metadata (either <c>[ContractVersion]</c> or <c>[Version]</c>).
     /// </summary>
-    public static readonly DiagnosticDescriptor PublicTypeMissingContractVersion = new(
+    public static readonly DiagnosticDescriptor PublicTypeMissingVersioning = new(
         id: "CSWINRT2015",
-        title: "Public authored type missing 'ContractVersionAttribute'",
-        messageFormat: """The type '{0}' is publicly exposed in a Windows Runtime component, but it does not have a '[ContractVersion]' attribute applied to it. Public types should declare their associated API contract using '[ContractVersion(typeof(SomeContract), version)]' so that consumers can target a specific contract version.""",
+        title: "Public authored type missing version metadata",
+        messageFormat: """The type '{0}' is publicly exposed in a Windows Runtime component, but it does not have either a '[ContractVersion]' or a '[Version]' attribute applied to it. Public types should declare their associated API contract version using '[ContractVersion(typeof(SomeContract), version)]', or specify a Windows Runtime version using '[Version(version)]', so that consumers can target a specific version.""",
         category: "WindowsRuntime.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        description: "Public types in a Windows Runtime component should declare their associated API contract using '[ContractVersion(typeof(SomeContract), version)]', so that consumers can target a specific contract version.",
+        description: "Public types in a Windows Runtime component should declare their version using either '[ContractVersion(typeof(SomeContract), version)]' (to associate with an API contract) or '[Version(version)]' (to specify a Windows Runtime version), so that consumers can target a specific version.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -231,4 +231,17 @@ internal static partial class DiagnosticDescriptors
         description: "Public types in a Windows Runtime component should use a consistent versioning scheme. If at least one public type uses '[ContractVersion]', all other public types should also use '[ContractVersion]' to declare their associated API contract.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT",
         customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a public authored type that has both a <c>[ContractVersion]</c> and a <c>[Version]</c> attribute applied.
+    /// </summary>
+    public static readonly DiagnosticDescriptor PublicTypeMixedVersioningAttributes = new(
+        id: "CSWINRT2017",
+        title: "Public authored type mixing '[ContractVersion]' and '[Version]'",
+        messageFormat: """The type '{0}' is publicly exposed in a Windows Runtime component and has both a '[ContractVersion]' and a '[Version]' attribute applied. Public types in a component should not mix two different versioning schemes; pick one of '[ContractVersion]' (to associate with an API contract) or '[Version]' (to specify a Windows Runtime version), and apply it consistently.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Public types in a Windows Runtime component should not mix '[ContractVersion]' and '[Version]', as these represent two different versioning schemes. Pick one and apply it consistently across the public API surface of the component.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Extensions/AttributeDataExtensions.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Extensions/AttributeDataExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+#pragma warning disable CS1734
+
+namespace WindowsRuntime.SourceGenerator;
+
+/// <summary>
+/// Extensions for <see cref="AttributeData"/>.
+/// </summary>
+internal static class AttributeDataExtensions
+{
+    /// <param name="attribute">The input <see cref="AttributeData"/> instance.</param>
+    extension(AttributeData attribute)
+    {
+        /// <summary>
+        /// Gets the location of the syntax node where the attribute is applied.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to use.</param>
+        /// <returns>The location of the attribute application, or <see langword="null"/> if it cannot be determined.</returns>
+        public Location? GetLocation(CancellationToken cancellationToken)
+        {
+            return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation();
+        }
+
+        /// <summary>
+        /// Gets the location of a specific positional argument of the attribute application.
+        /// </summary>
+        /// <param name="argumentIndex">The index of the positional argument.</param>
+        /// <param name="cancellationToken">The cancellation token to use.</param>
+        /// <returns>The location of the argument, or <see langword="null"/> if it cannot be determined.</returns>
+        public Location? GetArgumentLocation(int argumentIndex, CancellationToken cancellationToken)
+        {
+            return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is AttributeSyntax { ArgumentList.Arguments: { } arguments } && argumentIndex < arguments.Count
+                ? arguments[argumentIndex].GetLocation()
+                : null;
+        }
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Extensions/ISymbolExtensions.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Extensions/ISymbolExtensions.cs
@@ -69,6 +69,22 @@ internal static class ISymbolExtensions
         }
 
         /// <summary>
+        /// Gets all attributes applied to a symbol with a specified type.
+        /// </summary>
+        /// <param name="typeSymbol">The <see cref="INamedTypeSymbol"/> instance for the attribute type to look for.</param>
+        /// <returns>The sequence of attributes applied to <paramref name="symbol"/> with the specified type.</returns>
+        public IEnumerable<AttributeData> GetAttributes(INamedTypeSymbol typeSymbol)
+        {
+            foreach (AttributeData attribute in symbol.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, typeSymbol))
+                {
+                    yield return attribute;
+                }
+            }
+        }
+
+        /// <summary>
         /// Checks whether a given symbol is accessible from the assembly of a given compilation (including eg. through nested types).
         /// </summary>
         /// <param name="compilation">The <see cref="Compilation"/> instance currently in use.</param>

--- a/src/Tests/AuthoringTest/AuthoringTest.csproj
+++ b/src/Tests/AuthoringTest/AuthoringTest.csproj
@@ -30,6 +30,14 @@
           location it is assigned to."		  
     -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0067;CS0282;IL2087</WarningsNotAsErrors>
+
+    <!--
+      Suppress 'CSWINRT2016' (public type missing '[ContractVersion]' when at least one other public
+      type has it) in the authoring test project: the test surface intentionally exercises all the
+      various combinations of versioning attributes (with and without '[ContractVersion]', with
+      '[Version]', mixed, etc.), so the consistency analyzer is expected to fire here.
+    -->
+    <NoWarn>$(NoWarn);CSWINRT2016</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -2285,6 +2285,7 @@ namespace AuthoringTest
 
         // Contract versioning
         [Windows.Foundation.Metadata.ApiContract]
+        [Windows.Foundation.Metadata.ContractVersion(1u)]
         public enum AnotherNamespaceContract { }
 
         [Windows.Foundation.Metadata.ContractVersion(typeof(AnotherNamespaceContract), 1u)]

--- a/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
+++ b/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
@@ -59,11 +59,13 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
     /// <param name="expectedDiagnostics">The list of expected diagnostic for the test (used as alternative to the markdown syntax).</param>
     /// <param name="allowUnsafeBlocks">Whether to enable unsafe blocks.</param>
     /// <param name="languageVersion">The language version to use to run the test.</param>
+    /// <param name="isCsWinRTComponent">Whether to set the <c>"CsWinRTComponent"</c> MSBuild property to <see langword="true"/>.</param>
     public static Task VerifyAnalyzerAsync(
         string source,
         ReadOnlySpan<DiagnosticResult> expectedDiagnostics = default,
         bool allowUnsafeBlocks = true,
-        LanguageVersion languageVersion = LanguageVersion.CSharp14)
+        LanguageVersion languageVersion = LanguageVersion.CSharp14,
+        bool isCsWinRTComponent = false)
     {
         CSharpAnalyzerTest<TAnalyzer> test = new(allowUnsafeBlocks, languageVersion) { TestCode = source };
 
@@ -72,6 +74,16 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(CoreApplication).Assembly.Location));
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Button).Assembly.Location));
         test.TestState.ExpectedDiagnostics.AddRange([.. expectedDiagnostics]);
+
+        // Configure the desired MSBuild properties via a global analyzer config file
+        if (isCsWinRTComponent)
+        {
+            test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+                is_global = true
+
+                build_property.CsWinRTComponent = true
+                """));
+        }
 
         return test.RunAsync(CancellationToken.None);
     }

--- a/src/Tests/SourceGenerator2Test/Test_ApiContractTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_ApiContractTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<ApiContractTypeRequiresContractVersionAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="ApiContractTypeRequiresContractVersionAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_ApiContractTypeRequiresContractVersionAnalyzer
+{
+    [TestMethod]
+    public async Task ApiContractEnum_WithVersionOnlyConstructor_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_WithNameAndVersionConstructor_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion("OtherContract", 1u)]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NonApiContractEnum_DoesNotWarn()
+    {
+        const string source = """
+            public enum MyEnum
+            {
+                A,
+                B
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_NoContractVersion_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum {|CSWINRT2014:MyContract|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_OnlyContractTypeConstructor_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(typeof(MyContract), 1u)]
+            public enum {|CSWINRT2014:MyContract|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_PublicTypeMixedVersioningAttributesAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_PublicTypeMixedVersioningAttributesAnalyzer.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<PublicTypeMixedVersioningAttributesAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="PublicTypeMixedVersioningAttributesAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_PublicTypeMixedVersioningAttributesAnalyzer
+{
+    [TestMethod]
+    public async Task PublicClass_NoVersioning_DoesNotWarn()
+    {
+        const string source = """
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_OnlyContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_OnlyVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [Version(1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_WithContractVersionAndVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            [Version(1u)]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task InternalClass_WithBothAttributes_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            internal sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NestedPublicClass_WithBothAttributes_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class Outer
+            {
+                [ContractVersion(typeof(MyContract), 1u)]
+                [Version(1u)]
+                public sealed class Nested;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_WithBothAttributes_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_WithBothAttributes_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public sealed class {|CSWINRT2017:MyClass|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicInterface_WithBothAttributes_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public interface {|CSWINRT2017:IMyInterface|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicStruct_WithBothAttributes_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public struct {|CSWINRT2017:MyStruct|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicEnum_WithBothAttributes_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public enum {|CSWINRT2017:MyEnum|}
+            {
+                A,
+                B
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicDelegate_WithBothAttributes_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
+            public delegate void {|CSWINRT2017:MyDelegate|}();
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<PublicTypeRequiresContractVersionAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="PublicTypeRequiresContractVersionAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
+{
+    [TestMethod]
+    public async Task PublicClass_WithContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task InternalClass_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            internal sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NestedPublicClass_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class Outer
+            {
+                public sealed class Nested;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            public sealed class {|CSWINRT2015:MyClass|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicInterface_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            public interface {|CSWINRT2015:IMyInterface|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicStruct_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            public struct {|CSWINRT2015:MyStruct|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicEnum_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            public enum {|CSWINRT2015:MyEnum|}
+            {
+                A,
+                B
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicDelegate_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            public delegate void {|CSWINRT2015:MyDelegate|}();
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresContractVersionAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresContractVersionAnalyzer.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<PublicTypeRequiresContractVersionAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="PublicTypeRequiresContractVersionAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
+{
+    [TestMethod]
+    public async Task NoPublicTypes_DoesNotWarn()
+    {
+        const string source = """
+            internal sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task SinglePublicType_WithContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task SinglePublicType_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task AllPublicTypes_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            public sealed class MyClass1;
+
+            public sealed class MyClass2;
+
+            public interface IMyInterface;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task AllPublicTypes_WithContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass2;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public interface IMyInterface;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task MixedPublicTypes_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            public sealed class MyClass2;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnum_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            [ApiContract]
+            public enum MyOtherContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NestedPublicType_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class Outer
+            {
+                public sealed class Nested;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task InternalType_WithoutContractVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            internal sealed class MyClass2;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task MixedPublicTypes_WithoutContractVersion_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            public sealed class {|CSWINRT2016:MyClass2|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicTypeWithVersionOnly_OtherTypeWithContractVersion_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            [Version(1u)]
+            public sealed class {|CSWINRT2016:MyClass2|};
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task MultiplePublicTypes_WithoutContractVersion_AllWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass1;
+
+            public sealed class {|CSWINRT2016:MyClass2|};
+
+            public interface {|CSWINRT2016:IMyInterface|};
+
+            public struct {|CSWINRT2016:MyStruct|};
+
+            public enum {|CSWINRT2016:MyEnum|}
+            {
+                A,
+                B
+            }
+
+            public delegate void {|CSWINRT2016:MyDelegate|}();
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresVersioningAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_PublicTypeRequiresVersioningAnalyzer.cs
@@ -7,13 +7,13 @@ using WindowsRuntime.SourceGenerator.Tests.Helpers;
 
 namespace WindowsRuntime.SourceGenerator.Tests;
 
-using VerifyCS = CSharpAnalyzerTest<PublicTypeRequiresContractVersionAnalyzer>;
+using VerifyCS = CSharpAnalyzerTest<PublicTypeRequiresVersioningAnalyzer>;
 
 /// <summary>
-/// Tests for <see cref="PublicTypeRequiresContractVersionAnalyzer"/>.
+/// Tests for <see cref="PublicTypeRequiresVersioningAnalyzer"/>.
 /// </summary>
 [TestClass]
-public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
+public sealed class Test_PublicTypeRequiresVersioningAnalyzer
 {
     [TestMethod]
     public async Task PublicClass_WithContractVersion_DoesNotWarn()
@@ -26,6 +26,37 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
             public enum MyContract;
 
             [ContractVersion(typeof(MyContract), 1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_WithVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [Version(1u)]
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task PublicClass_WithBothContractVersionAndVersion_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [Version(1u)]
             public sealed class MyClass;
             """;
 
@@ -46,7 +77,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task InternalClass_WithoutContractVersion_DoesNotWarn()
+    public async Task InternalClass_WithoutVersioning_DoesNotWarn()
     {
         const string source = """
             internal sealed class MyClass;
@@ -56,7 +87,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task NestedPublicClass_WithoutContractVersion_DoesNotWarn()
+    public async Task NestedPublicClass_WithoutVersioning_DoesNotWarn()
     {
         const string source = """
             using Windows.Foundation.Metadata;
@@ -86,7 +117,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task PublicClass_WithoutContractVersion_Warns()
+    public async Task PublicClass_WithoutVersioning_Warns()
     {
         const string source = """
             public sealed class {|CSWINRT2015:MyClass|};
@@ -96,7 +127,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task PublicInterface_WithoutContractVersion_Warns()
+    public async Task PublicInterface_WithoutVersioning_Warns()
     {
         const string source = """
             public interface {|CSWINRT2015:IMyInterface|};
@@ -106,7 +137,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task PublicStruct_WithoutContractVersion_Warns()
+    public async Task PublicStruct_WithoutVersioning_Warns()
     {
         const string source = """
             public struct {|CSWINRT2015:MyStruct|};
@@ -116,7 +147,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task PublicEnum_WithoutContractVersion_Warns()
+    public async Task PublicEnum_WithoutVersioning_Warns()
     {
         const string source = """
             public enum {|CSWINRT2015:MyEnum|}
@@ -130,7 +161,7 @@ public sealed class Test_PublicTypeRequiresContractVersionAnalyzer
     }
 
     [TestMethod]
-    public async Task PublicDelegate_WithoutContractVersion_Warns()
+    public async Task PublicDelegate_WithoutVersioning_Warns()
     {
         const string source = """
             public delegate void {|CSWINRT2015:MyDelegate|}();

--- a/src/Tests/SourceGenerator2Test/Test_ValidApiContractEnumTypeAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_ValidApiContractEnumTypeAnalyzer.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<ValidApiContractEnumTypeAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="ValidApiContractEnumTypeAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_ValidApiContractEnumTypeAnalyzer
+{
+    [TestMethod]
+    public async Task EmptyApiContractEnum_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task EnumWithCases_NoApiContract_DoesNotWarn()
+    {
+        const string source = """
+            public enum MyEnum
+            {
+                A,
+                B,
+                C
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnumWithCases_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract
+            {
+                A
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnumWithCases_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum {|CSWINRT2010:MyContract|}
+            {
+                A,
+                B
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ApiContractEnumWithSingleCase_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum {|CSWINRT2010:MyContract|}
+            {
+                Version1
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_ValidContractVersionAttributeAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_ValidContractVersionAttributeAnalyzer.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<ValidContractVersionAttributeAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="ValidContractVersionAttributeAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_ValidContractVersionAttributeAnalyzer
+{
+    [TestMethod]
+    public async Task VersionOnlyConstructor_OnApiContractType_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion(1u)]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractNameAndVersionConstructor_OnApiContractType_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            [ContractVersion("MyContractName", 1u)]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractTypeConstructor_WithValidContract_OnNonContractType_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            public class MyType;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task InvalidUsage_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum MyContract;
+
+            [ContractVersion(1u)]
+            public class NotAContract;
+
+            [ContractVersion(typeof(MyContract), 1u)]
+            [ApiContract]
+            public enum AlsoAContract;
+
+            [ContractVersion(typeof(NotAContract), 1u)]
+            public class TypeWithBadContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task VersionOnlyConstructor_OnNonContractType_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [{|CSWINRT2011:ContractVersion(1u)|}]
+            public class MyType;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task VersionOnlyConstructor_OnEnumWithoutApiContract_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [{|CSWINRT2011:ContractVersion(1u)|}]
+            public enum MyEnum;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractNameAndVersionConstructor_OnNonContractType_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [{|CSWINRT2011:ContractVersion("MyContractName", 1u)|}]
+            public class MyType;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractTypeConstructor_OnApiContractType_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            [ApiContract]
+            public enum OtherContract;
+
+            [ApiContract]
+            [{|CSWINRT2012:ContractVersion(typeof(OtherContract), 1u)|}]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractTypeConstructor_WithNonContractTypeArgument_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            public class NotAContract;
+
+            [ContractVersion({|CSWINRT2013:typeof(NotAContract)|}, 1u)]
+            public class MyType;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractTypeConstructor_WithEnumWithoutApiContractArgument_Warns()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            public enum NotAContract;
+
+            [ContractVersion({|CSWINRT2013:typeof(NotAContract)|}, 1u)]
+            public class MyType;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ContractTypeConstructor_OnApiContractType_WithNonContractTypeArgument_WarnsBoth()
+    {
+        const string source = """
+            using Windows.Foundation.Metadata;
+
+            public class NotAContract;
+
+            [ApiContract]
+            [{|CSWINRT2012:ContractVersion({|CSWINRT2013:typeof(NotAContract)|}, 1u)|}]
+            public enum MyContract;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
@@ -13,7 +13,16 @@ namespace Windows.Foundation.Metadata;
 /// Indicates the version of the API contract.
 /// </summary>
 [WindowsRuntimeMetadata("Windows.Foundation.FoundationContract")]
-[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+[AttributeUsage(
+    AttributeTargets.Delegate |
+    AttributeTargets.Enum |
+    AttributeTargets.Event |
+    AttributeTargets.Field |
+    AttributeTargets.Interface |
+    AttributeTargets.Method |
+    AttributeTargets.Property |
+    AttributeTargets.Class |
+    AttributeTargets.Struct, AllowMultiple = true)]
 [SupportedOSPlatform("Windows10.0.10240.0")]
 [ContractVersion(typeof(FoundationContract), 65536u)]
 public sealed class ContractVersionAttribute : Attribute
@@ -22,6 +31,9 @@ public sealed class ContractVersionAttribute : Attribute
     /// Creates a new <see cref="ContractVersionAttribute"/> instance with the specified parameters.
     /// </summary>
     /// <param name="version">The version of the API contract.</param>
+    /// <remarks>
+    /// This constructor applies to a type with the <see cref="ApiContractAttribute"/> and specifies the contract version of that API contract.
+    /// </remarks>
     public ContractVersionAttribute(uint version)
     {
     }
@@ -31,7 +43,10 @@ public sealed class ContractVersionAttribute : Attribute
     /// </summary>
     /// <param name="contract">The type to associate with the API contract.</param>
     /// <param name="version">The version of the API contract.</param>
-    public ContractVersionAttribute(Type contract, uint version)
+    /// <remarks>
+    /// This constructor applies to a type with the <see cref="ApiContractAttribute"/> and specifies the contract version of that API contract.
+    /// </remarks>
+    public ContractVersionAttribute(string contract, uint version)
     {
     }
 
@@ -40,7 +55,11 @@ public sealed class ContractVersionAttribute : Attribute
     /// </summary>
     /// <param name="contract">The type to associate with the API contract.</param>
     /// <param name="version">The version of the API contract.</param>
-    public ContractVersionAttribute(string contract, uint version)
+    /// <remarks>
+    /// This constructor applies to any type that does not have the <see cref="ApiContractAttribute"/> and
+    /// indicates the API contract version in which this type was added to the specified API contract.
+    /// </remarks>
+    public ContractVersionAttribute(Type contract, uint version)
     {
     }
 }


### PR DESCRIPTION
## Summary

Adds a set of new Roslyn diagnostic analyzers in the `WinRT.SourceGenerator2` project that validate Windows Runtime component authoring usage of `[ApiContract]`, `[ContractVersion]`, and `[Version]`. Also introduces small reusable extension helpers and refines the public surface of `ContractVersionAttribute`.

All new analyzers are scoped to component-authoring scenarios (`CsWinRTComponent = true`) and are skipped otherwise.

## Motivation

Authoring Windows Runtime components in C# has a number of WinMD-level constraints that are easy to get wrong silently — invalid `[ApiContract]` enum cases, mismatched `[ContractVersion]` constructor usage, missing version metadata, mixed versioning schemes across the public API surface, etc. These analyzers surface those issues at edit/build time with actionable diagnostics, rather than producing a malformed `.winmd` that fails (or worse, succeeds with wrong metadata) downstream.

## Changes

### New diagnostics (`CSWINRT2010`–`CSWINRT2017`)

- **`CSWINRT2010` — `ValidApiContractEnumTypeAnalyzer`** (Warning): warns when an `[ApiContract]` enum defines enum cases. API contract types are represented as empty struct types in WinRT and any enum cases are ignored when generating the `.winmd`.
- **`CSWINRT2011` / `CSWINRT2012` / `CSWINRT2013` — `ValidContractVersionAttributeAnalyzer`** (Warning): validates `[ContractVersion]` applications:
  - `2011`: the `(uint)` and `(string, uint)` constructors must target an API contract type.
  - `2012`: the `(Type, uint)` constructor must not target an API contract type.
  - `2013`: the `Type` argument of the `(Type, uint)` constructor must itself be a valid API contract type.
- **`CSWINRT2014` — `ApiContractTypeRequiresContractVersionAnalyzer`** (Warning): every `[ApiContract]` enum must declare its contract version using a version-only constructor of `[ContractVersion]`.
- **`CSWINRT2015` — `PublicTypeRequiresVersioningAnalyzer`** (Info): public top-level types in a component should declare their version using either `[ContractVersion(typeof(SomeContract), version)]` (to associate with an API contract) or `[Version(version)]` (to specify a Windows Runtime version). Skips API contract enums (covered by `CSWINRT2014`) and types that already have either attribute applied.
- **`CSWINRT2016` — `PublicTypeRequiresContractVersionAnalyzer`** (Warning): if at least one public type in the component uses `[ContractVersion]`, then all other public types should also use `[ContractVersion]` for consistency. Whole-compilation analysis (collects candidates during symbol analysis, then reports during the compilation end action). Skips API contract enums.
- **`CSWINRT2017` — `PublicTypeMixedVersioningAttributesAnalyzer`** (Warning): public types should not mix `[ContractVersion]` and `[Version]` on the same type — pick one versioning scheme and apply it consistently. Skips API contract enums.

### Files

- **`src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/`**: new analyzers `ValidApiContractEnumTypeAnalyzer`, `ValidContractVersionAttributeAnalyzer`, `ApiContractTypeRequiresContractVersionAnalyzer`, `PublicTypeRequiresVersioningAnalyzer`, `PublicTypeRequiresContractVersionAnalyzer`, `PublicTypeMixedVersioningAttributesAnalyzer`.
- **`src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs`**: descriptors for `CSWINRT2010`–`CSWINRT2017`.
- **`src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md`**: release tracking entries for the new diagnostics.
- **`src/Authoring/WinRT.SourceGenerator2/Extensions/AttributeDataExtensions.cs`**: new `AttributeData.GetLocation(...)` and `AttributeData.GetArgumentLocation(int, ...)` extensions, factored out of the analyzer code.
- **`src/Authoring/WinRT.SourceGenerator2/Extensions/ISymbolExtensions.cs`**: new `ISymbol.GetAttributes(INamedTypeSymbol)` overload that yields only attributes of the specified type, eliminating the manual `foreach` + `SymbolEqualityComparer` filter pattern at call sites.
- **`src/WinRT.Runtime2/Windows.Foundation.Metadata/ContractVersionAttribute.cs`**: small API/doc tweaks aligned with the new analyzer expectations.
- **`src/Tests/SourceGenerator2Test/`**:
  - `Test_ValidApiContractEnumTypeAnalyzer.cs`, `Test_ValidContractVersionAttributeAnalyzer.cs`, `Test_ApiContractTypeRequiresContractVersionAnalyzer.cs`, `Test_PublicTypeRequiresVersioningAnalyzer.cs`, `Test_PublicTypeRequiresContractVersionAnalyzer.cs`, `Test_PublicTypeMixedVersioningAttributesAnalyzer.cs`.
  - `Helpers/CSharpAnalyzerTest{TAnalyzer}.cs`: extended `VerifyAnalyzerAsync` with an `isCsWinRTComponent` parameter that injects a `.globalconfig` setting `build_property.CsWinRTComponent = true` so the gated analyzers actually run under test.