### PR TITLE
Fix EventSourceCache leak and array marshaller allocation size

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Events/EventSourceState{T}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Events/EventSourceState{T}.cs
@@ -209,7 +209,7 @@ public abstract unsafe class EventSourceState<T> : IDisposable
         // ensures that no cache object is kept alive unnecessarily when no longer needed.
         if (thisPtr is not null)
         {
-            EventSourceCache.Remove(_thisPtr, _index, _weakReferenceToSelf);
+            EventSourceCache.Remove(thisPtr, _index, _weakReferenceToSelf);
         }
     }
 }

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/SzArrays/WindowsRuntimeManagedValueTypeArrayMarshaller{T, TAbi}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/SzArrays/WindowsRuntimeManagedValueTypeArrayMarshaller{T, TAbi}.cs
@@ -33,7 +33,7 @@ public static unsafe class WindowsRuntimeManagedValueTypeArrayMarshaller<T, TAbi
             return;
         }
 
-        TAbi* destination = (TAbi*)Marshal.AllocCoTaskMem(sizeof(T) * source.Length);
+        TAbi* destination = (TAbi*)Marshal.AllocCoTaskMem(sizeof(TAbi) * source.Length);
 
         int i = 0;
 

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/SzArrays/WindowsRuntimeUnmanagedValueTypeArrayMarshaller{T, TAbi}.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/SzArrays/WindowsRuntimeUnmanagedValueTypeArrayMarshaller{T, TAbi}.cs
@@ -33,7 +33,7 @@ public static unsafe class WindowsRuntimeUnmanagedValueTypeArrayMarshaller<T, TA
             return;
         }
 
-        TAbi* destination = (TAbi*)Marshal.AllocCoTaskMem(sizeof(T) * source.Length);
+        TAbi* destination = (TAbi*)Marshal.AllocCoTaskMem(sizeof(TAbi) * source.Length);
 
         try
         {


### PR DESCRIPTION
1. EventSourceState.OnDispose: pass local 'thisPtr' (not nulled field '_thisPtr') to EventSourceCache.Remove. The field is nulled on the preceding line, so the cache entry was never actually removed, leaking entries for the lifetime of the application.

2. Array marshallers: allocate using sizeof(TAbi) instead of sizeof(T). The destination buffer is indexed as TAbi*, so the allocation must match the ABI element size.