### PR TITLE
Port WindowsRuntime.Internal.idl to C# in new WinRT.Internal project

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -211,7 +211,7 @@ steps:
       condition: and(succeeded(), and(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release')))
       continueOnError: True
       inputs:
-        SourceFolder: $(Build.SourcesDirectory)\src\_build\$(BuildPlatform)\$(BuildConfiguration)\cswinrt\bin
+        SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Internal\bin\$(BuildConfiguration)\net10.0-windows10.0.26100.1
         Contents: WindowsRuntime.Internal.winmd
         TargetFolder: $(StagingFolder)\native
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,20 +52,22 @@
   <PropertyGroup>
     <VersionNumber Condition="'$(VersionNumber)'==''">0.0.0.0</VersionNumber>
     <VersionString Condition="'$(VersionString)'==''">0.0.0-private.0</VersionString>
+
     <!--
-      Default 'AssemblyVersionNumber' to '3.0.0.0' (the WinRT.Runtime CsWinRT 3.0 baseline) so
+      Default 'AssemblyVersionNumber' to '3.0.0.0' (the 'WinRT.Runtime' CsWinRT 3.0 baseline) so
       that 'dotnet build' from the repo root works without explicit '/p:AssemblyVersionNumber=...'.
-      Official builds set this explicitly via the CsWinRT-Variables pipeline.
+      Official builds set this explicitly via the 'CsWinRT-Variables' pipeline.
     -->
     <AssemblyVersionNumber Condition="'$(AssemblyVersionNumber)' == ''">3.0.0.0</AssemblyVersionNumber>
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
     <BuildOutDir Condition="'$(BuildOutDir)'==''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)_build', '$(BuildPlatform)', '$(Configuration)'))</BuildOutDir>
+
     <!--
       Legacy 'cswinrt' (C++) build-output paths. These are kept defined so existing
       MSBuild infrastructure (e.g. the '$(CsWinRTExe)' argument still passed to the
       'RunCsWinRTMergedProjectionGenerator' MSBuild task) continues to resolve to a path
-      string. The .exe file itself is no longer required to exist or to be built — the C#
+      string. The .exe file itself is no longer required to exist or to be built. The C#
       'cswinrtprojectiongen.exe' tool only stores this value as metadata and never
       reads or executes the file. It will be removed entirely once the legacy 'cswinrt'
       project is dropped.
@@ -73,10 +75,11 @@
     <CsWinRTPath>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', 'cswinrt', 'bin'))</CsWinRTPath>
     <CsWinRTPath Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)_build', 'x86', '$(Configuration)', 'cswinrt', 'bin'))</CsWinRTPath>
     <CsWinRTExe>$(CsWinRTPath)cswinrt.exe</CsWinRTExe>
+
     <!--
       The 'WindowsRuntime.Internal.winmd' metadata used to bind the Windows SDK interop
-      interfaces (e.g. IPrintManagerInterop, IDragDropManagerInterop) is produced by the
-      managed 'WinRT.Internal' project, which targets the TFM below.
+      interfaces (e.g. 'IPrintManagerInterop', 'IDragDropManagerInterop') is produced by
+      the managed 'WinRT.Internal' project, which targets the TFM below.
     -->
     <CsWinRTInternalTargetFramework Condition="'$(CsWinRTInternalTargetFramework)' == ''">net10.0-windows10.0.26100.1</CsWinRTInternalTargetFramework>
     <CsWinRTInteropMetadata Condition="'$(CsWinRTInteropMetadata)' == ''">$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'WinRT.Internal', 'bin', '$(Configuration)', '$(CsWinRTInternalTargetFramework)', 'WindowsRuntime.Internal.winmd'))</CsWinRTInteropMetadata>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,13 +52,34 @@
   <PropertyGroup>
     <VersionNumber Condition="'$(VersionNumber)'==''">0.0.0.0</VersionNumber>
     <VersionString Condition="'$(VersionString)'==''">0.0.0-private.0</VersionString>
+    <!--
+      Default 'AssemblyVersionNumber' to '3.0.0.0' (the WinRT.Runtime CsWinRT 3.0 baseline) so
+      that 'dotnet build' from the repo root works without explicit '/p:AssemblyVersionNumber=...'.
+      Official builds set this explicitly via the CsWinRT-Variables pipeline.
+    -->
+    <AssemblyVersionNumber Condition="'$(AssemblyVersionNumber)' == ''">3.0.0.0</AssemblyVersionNumber>
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
     <BuildOutDir Condition="'$(BuildOutDir)'==''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)_build', '$(BuildPlatform)', '$(Configuration)'))</BuildOutDir>
+    <!--
+      Legacy 'cswinrt' (C++) build-output paths. These are kept defined so existing
+      MSBuild infrastructure (e.g. the '$(CsWinRTExe)' argument still passed to the
+      'RunCsWinRTMergedProjectionGenerator' MSBuild task) continues to resolve to a path
+      string. The .exe file itself is no longer required to exist or to be built — the C#
+      'cswinrtprojectiongen.exe' tool only stores this value as metadata and never
+      reads or executes the file. It will be removed entirely once the legacy 'cswinrt'
+      project is dropped.
+    -->
     <CsWinRTPath>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', 'cswinrt', 'bin'))</CsWinRTPath>
     <CsWinRTPath Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)_build', 'x86', '$(Configuration)', 'cswinrt', 'bin'))</CsWinRTPath>
     <CsWinRTExe>$(CsWinRTPath)cswinrt.exe</CsWinRTExe>
-    <CsWinRTInteropMetadata Condition="'$(CsWinRTInteropMetadata)' == ''">$(CsWinRTPath)WindowsRuntime.Internal.winmd</CsWinRTInteropMetadata>
+    <!--
+      The 'WindowsRuntime.Internal.winmd' metadata used to bind the Windows SDK interop
+      interfaces (e.g. IPrintManagerInterop, IDragDropManagerInterop) is produced by the
+      managed 'WinRT.Internal' project, which targets the TFM below.
+    -->
+    <CsWinRTInternalTargetFramework Condition="'$(CsWinRTInternalTargetFramework)' == ''">net10.0-windows10.0.26100.1</CsWinRTInternalTargetFramework>
+    <CsWinRTInteropMetadata Condition="'$(CsWinRTInteropMetadata)' == ''">$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'WinRT.Internal', 'bin', '$(Configuration)', '$(CsWinRTInternalTargetFramework)', 'WindowsRuntime.Internal.winmd'))</CsWinRTInteropMetadata>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj' or '$(MSBuildProjectExtension)' == '.wapproj'">

--- a/src/WinRT.Internal/HWND.cs
+++ b/src/WinRT.Internal/HWND.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// Windows Runtime metadata representation of the Win32 <c>HWND</c> type.
+/// </summary>
+/// <remarks>
+/// CsWinRT applies a custom mapping that projects <see cref="HWND"/> to <see cref="System.IntPtr"/>
+/// in generated C# code, so that interop methods on the runtime classes appear with normal handle
+/// parameters. The <see cref="unused"/> field exists only to give the struct a representable layout
+/// in the Windows Runtime type system.
+/// </remarks>
+public struct HWND
+{
+    /// <summary>
+    /// Reserved field. Not used by callers; the type is mapped to <see cref="System.IntPtr"/>
+    /// at the projection layer.
+    /// </summary>
+#pragma warning disable IDE1006 // Naming Styles
+    public int unused;
+#pragma warning restore IDE1006
+}

--- a/src/WinRT.Internal/HWND.cs
+++ b/src/WinRT.Internal/HWND.cs
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#pragma warning disable IDE1006
+
 namespace WindowsRuntime.Internal;
 
 /// <summary>
 /// Windows Runtime metadata representation of the Win32 <c>HWND</c> type.
 /// </summary>
 /// <remarks>
-/// CsWinRT applies a custom mapping that projects <see cref="HWND"/> to <see cref="System.IntPtr"/>
+/// CsWinRT applies a custom mapping that projects <see cref="HWND"/> to <see cref="nint"/>
 /// in generated C# code, so that interop methods on the runtime classes appear with normal handle
-/// parameters. The <see cref="unused"/> field exists only to give the struct a representable layout
+/// parameters. The <see cref="__Reserved"/> field exists only to give the struct a representable layout
 /// in the Windows Runtime type system.
 /// </remarks>
+/// <see href="https://learn.microsoft.com/windows/win32/winprog/windows-data-types"/>
 public struct HWND
 {
     /// <summary>
-    /// Reserved field. Not used by callers; the type is mapped to <see cref="System.IntPtr"/>
-    /// at the projection layer.
+    /// Reserved field. Not used by callers: the type is mapped to <see cref="nint"/> at the projection layer.
     /// </summary>
-#pragma warning disable IDE1006 // Naming Styles
-    public int unused;
-#pragma warning restore IDE1006
+    public int __Reserved;
 }

--- a/src/WinRT.Internal/IAccountsSettingsPaneInterop.cs
+++ b/src/WinRT.Internal/IAccountsSettingsPaneInterop.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.UI.ApplicationSettings;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving an <see cref="AccountsSettingsPane"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/accountssettingspaneinterop/">accountssettingspaneinterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("D3EE12AD-3865-4362-9746-B75A682DF0E6")]
+public interface IAccountsSettingsPaneInterop
+{
+    /// <summary>
+    /// Gets the <see cref="AccountsSettingsPane"/> associated with the specified window.
+    /// </summary>
+    AccountsSettingsPane GetForWindow(
+        HWND appWindow,
+        ref Guid riid);
+
+    /// <summary>
+    /// Shows the manage-accounts UI for the specified window.
+    /// </summary>
+    IAsyncAction ShowManageAccountsForWindowAsync(
+        HWND appWindow,
+        ref Guid riid);
+
+    /// <summary>
+    /// Shows the add-account UI for the specified window.
+    /// </summary>
+    IAsyncAction ShowAddAccountForWindowAsync(
+        HWND appWindow,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IDisplayInformationStaticsInterop.cs
+++ b/src/WinRT.Internal/IDisplayInformationStaticsInterop.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Graphics.Display;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving <see cref="DisplayInformation"/> bound to a Win32 window or monitor handle.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/windows.graphics.display.interop/">WindowsGraphicsDisplayInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("7449121C-382B-4705-8DA7-A795BA482013")]
+public interface IDisplayInformationStaticsInterop
+{
+    /// <summary>
+    /// Gets the <see cref="DisplayInformation"/> associated with the specified window.
+    /// </summary>
+    DisplayInformation GetForWindow(
+        HWND window,
+        ref Guid riid);
+
+    /// <summary>
+    /// Gets the <see cref="DisplayInformation"/> associated with the specified monitor.
+    /// </summary>
+    DisplayInformation GetForMonitor(
+        HWND monitor,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IDragDropManagerInterop.cs
+++ b/src/WinRT.Internal/IDragDropManagerInterop.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.ApplicationModel.DataTransfer.DragDrop.Core;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="CoreDragDropManager"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/dragdropinterop/">dragdropinterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("5AD8CBA7-4C01-4DAC-9074-827894292D63")]
+public interface IDragDropManagerInterop
+{
+    /// <summary>
+    /// Gets the <see cref="CoreDragDropManager"/> associated with the specified window.
+    /// </summary>
+    CoreDragDropManager GetForWindow(
+        HWND hwnd,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IInputPaneInterop.cs
+++ b/src/WinRT.Internal/IInputPaneInterop.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.ViewManagement;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving an <see cref="InputPane"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/inputpaneinterop/">inputpaneinterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("75CF2C57-9195-4931-8332-F0B409E916AF")]
+public interface IInputPaneInterop
+{
+    /// <summary>
+    /// Gets the <see cref="InputPane"/> associated with the specified window.
+    /// </summary>
+    InputPane GetForWindow(
+        HWND appWindow,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IPlayToManagerInterop.cs
+++ b/src/WinRT.Internal/IPlayToManagerInterop.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Media.PlayTo;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="PlayToManager"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/playtomanagerinterop/">PlayToManagerInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("24394699-1F2C-4EB3-8CD7-0EC1DA42A540")]
+public interface IPlayToManagerInterop
+{
+    /// <summary>
+    /// Gets the <see cref="PlayToManager"/> associated with the specified window.
+    /// </summary>
+    PlayToManager GetForWindow(
+        HWND appWindow,
+        ref Guid riid);
+
+    /// <summary>
+    /// Shows the Play To UI for the specified window.
+    /// </summary>
+    void ShowPlayToUIForWindow(
+        HWND appWindow);
+}

--- a/src/WinRT.Internal/IPrintManagerInterop.cs
+++ b/src/WinRT.Internal/IPrintManagerInterop.cs
@@ -15,7 +15,7 @@ namespace WindowsRuntime.Internal;
 /// See <see href="https://learn.microsoft.com/windows/win32/api/printmanagerinterop/">PrintManagerInterop.idl</see>.
 /// </remarks>
 [ProjectionInternal]
-[Guid("c5435a42-8d43-4e7b-a68a-ef311e392087")]
+[Guid("C5435A42-8D43-4E7B-A68A-EF311E392087")]
 public interface IPrintManagerInterop
 {
     /// <summary>

--- a/src/WinRT.Internal/IPrintManagerInterop.cs
+++ b/src/WinRT.Internal/IPrintManagerInterop.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Graphics.Printing;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="PrintManager"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/printmanagerinterop/">PrintManagerInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("c5435a42-8d43-4e7b-a68a-ef311e392087")]
+public interface IPrintManagerInterop
+{
+    /// <summary>
+    /// Gets the <see cref="PrintManager"/> associated with the specified window.
+    /// </summary>
+    PrintManager GetForWindow(
+        HWND appWindow,
+        ref Guid riid);
+
+    /// <summary>
+    /// Shows the print UI for the specified window.
+    /// </summary>
+    IAsyncOperation<bool> ShowPrintUIForWindowAsync(
+        HWND appWindow,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IRadialControllerConfigurationInterop.cs
+++ b/src/WinRT.Internal/IRadialControllerConfigurationInterop.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.Input;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="RadialControllerConfiguration"/> bound to a Win32 window.
+/// </summary>
+[ProjectionInternal]
+[Guid("787cdaac-3186-476d-87e4-b9374a7b9970")]
+public interface IRadialControllerConfigurationInterop
+{
+    /// <summary>
+    /// Gets the <see cref="RadialControllerConfiguration"/> associated with the specified window.
+    /// </summary>
+    RadialControllerConfiguration GetForWindow(
+        HWND hwnd,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IRadialControllerConfigurationInterop.cs
+++ b/src/WinRT.Internal/IRadialControllerConfigurationInterop.cs
@@ -11,7 +11,7 @@ namespace WindowsRuntime.Internal;
 /// COM interop interface for retrieving a <see cref="RadialControllerConfiguration"/> bound to a Win32 window.
 /// </summary>
 [ProjectionInternal]
-[Guid("787cdaac-3186-476d-87e4-b9374a7b9970")]
+[Guid("787CDAAC-3186-476D-87E4-B9374A7B9970")]
 public interface IRadialControllerConfigurationInterop
 {
     /// <summary>

--- a/src/WinRT.Internal/IRadialControllerIndependentInputSourceInterop.cs
+++ b/src/WinRT.Internal/IRadialControllerIndependentInputSourceInterop.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.Input.Core;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for creating a <see cref="RadialControllerIndependentInputSource"/> bound to a Win32 window.
+/// </summary>
+[ProjectionInternal]
+[Guid("3D577EFF-4CEE-11E6-B535-001BDC06AB3B")]
+public interface IRadialControllerIndependentInputSourceInterop
+{
+    /// <summary>
+    /// Creates a <see cref="RadialControllerIndependentInputSource"/> for the specified window.
+    /// </summary>
+    RadialControllerIndependentInputSource CreateForWindow(
+        HWND hwnd,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IRadialControllerInterop.cs
+++ b/src/WinRT.Internal/IRadialControllerInterop.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.Input;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for creating a <see cref="RadialController"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/radialcontrollerinterop/">RadialControllerInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("1B0535C9-57AD-45C1-9D79-AD5C34360513")]
+public interface IRadialControllerInterop
+{
+    /// <summary>
+    /// Creates a <see cref="RadialController"/> for the specified window.
+    /// </summary>
+    RadialController CreateForWindow(
+        HWND hwnd,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/ISpatialInteractionManagerInterop.cs
+++ b/src/WinRT.Internal/ISpatialInteractionManagerInterop.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.Input.Spatial;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="SpatialInteractionManager"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/spatialinteractionmanagerinterop/">SpatialInteractionManagerInterop.idl</see>.
+/// This interop interface is duplicated by <c>IHolographicSpaceInterop</c>, which has the same IID.
+/// </remarks>
+[ProjectionInternal]
+[Guid("5C4EE536-6A98-4B86-A170-587013D6FD4B")]
+public interface ISpatialInteractionManagerInterop
+{
+    /// <summary>
+    /// Gets the <see cref="SpatialInteractionManager"/> associated with the specified window.
+    /// </summary>
+    SpatialInteractionManager GetForWindow(
+        HWND window,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/ISystemMediaTransportControlsInterop.cs
+++ b/src/WinRT.Internal/ISystemMediaTransportControlsInterop.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Media;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving a <see cref="SystemMediaTransportControls"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/systemmediatransportcontrolsinterop/">SystemMediaTransportControlsInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("ddb0472d-c911-4a1f-86d9-dc3d71a95f5a")]
+public interface ISystemMediaTransportControlsInterop
+{
+    /// <summary>
+    /// Gets the <see cref="SystemMediaTransportControls"/> associated with the specified window.
+    /// </summary>
+    SystemMediaTransportControls GetForWindow(
+        HWND appWindow,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/ISystemMediaTransportControlsInterop.cs
+++ b/src/WinRT.Internal/ISystemMediaTransportControlsInterop.cs
@@ -14,7 +14,7 @@ namespace WindowsRuntime.Internal;
 /// See <see href="https://learn.microsoft.com/windows/win32/api/systemmediatransportcontrolsinterop/">SystemMediaTransportControlsInterop.idl</see>.
 /// </remarks>
 [ProjectionInternal]
-[Guid("ddb0472d-c911-4a1f-86d9-dc3d71a95f5a")]
+[Guid("DDB0472D-C911-4A1F-86D9-DC3D71A95F5A")]
 public interface ISystemMediaTransportControlsInterop
 {
     /// <summary>

--- a/src/WinRT.Internal/IUIViewSettingsInterop.cs
+++ b/src/WinRT.Internal/IUIViewSettingsInterop.cs
@@ -14,7 +14,7 @@ namespace WindowsRuntime.Internal;
 /// See <see href="https://learn.microsoft.com/windows/win32/api/uiviewsettingsinterop/">UIViewSettingsInterop.idl</see>.
 /// </remarks>
 [ProjectionInternal]
-[Guid("3694dbf9-8f68-44be-8ff5-195c98ede8a6")]
+[Guid("3694DBF9-8F68-44BE-8FF5-195C98EDE8A6")]
 public interface IUIViewSettingsInterop
 {
     /// <summary>

--- a/src/WinRT.Internal/IUIViewSettingsInterop.cs
+++ b/src/WinRT.Internal/IUIViewSettingsInterop.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.UI.ViewManagement;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for retrieving <see cref="UIViewSettings"/> bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/uiviewsettingsinterop/">UIViewSettingsInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("3694dbf9-8f68-44be-8ff5-195c98ede8a6")]
+public interface IUIViewSettingsInterop
+{
+    /// <summary>
+    /// Gets the <see cref="UIViewSettings"/> associated with the specified window.
+    /// </summary>
+    UIViewSettings GetForWindow(
+        HWND hwnd,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IUserConsentVerifierInterop.cs
+++ b/src/WinRT.Internal/IUserConsentVerifierInterop.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Security.Credentials.UI;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for requesting user consent verification bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/userconsentverifierinterop/">UserConsentVerifierInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("39E050C3-4E74-441A-8DC0-B81104DF949C")]
+public interface IUserConsentVerifierInterop
+{
+    /// <summary>
+    /// Asynchronously requests user consent verification for the specified window.
+    /// </summary>
+    IAsyncOperation<UserConsentVerificationResult> RequestVerificationForWindowAsync(
+        HWND appWindow,
+        string message,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/IWebAuthenticationCoreManagerInterop.cs
+++ b/src/WinRT.Internal/IWebAuthenticationCoreManagerInterop.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Security.Authentication.Web.Core;
+using Windows.Security.Credentials;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// COM interop interface for requesting web authentication tokens bound to a Win32 window.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/windows/win32/api/webauthenticationcoremanagerinterop/">WebAuthenticationCoreManagerInterop.idl</see>.
+/// </remarks>
+[ProjectionInternal]
+[Guid("F4B8E804-811E-4436-B69C-44CB67B72084")]
+public interface IWebAuthenticationCoreManagerInterop
+{
+    /// <summary>
+    /// Asynchronously requests a token for the specified window.
+    /// </summary>
+    IAsyncOperation<WebTokenRequestResult> RequestTokenForWindowAsync(
+        HWND appWindow,
+        WebTokenRequest request,
+        ref Guid riid);
+
+    /// <summary>
+    /// Asynchronously requests a token for the specified window using the specified web account.
+    /// </summary>
+    IAsyncOperation<WebTokenRequestResult> RequestTokenWithWebAccountForWindowAsync(
+        HWND appWindow,
+        WebTokenRequest request,
+        WebAccount webAccount,
+        ref Guid riid);
+}

--- a/src/WinRT.Internal/ProjectionInternalAttribute.cs
+++ b/src/WinRT.Internal/ProjectionInternalAttribute.cs
@@ -18,13 +18,13 @@ namespace WindowsRuntime.Internal;
 /// <para>
 /// This attribute is the C# counterpart of the Modern IDL 3.0 declaration:
 /// </para>
-/// <code>
+/// <code language="csharp">
 /// [attributeusage(target_interface)]
 /// [attributename("ProjectionInternal")]
-/// attribute ProjectionInternalAttribute { };
+/// attribute ProjectionInternalAttribute
+/// {
+/// };
 /// </code>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
-public sealed class ProjectionInternalAttribute : Attribute
-{
-}
+public sealed class ProjectionInternalAttribute : Attribute;

--- a/src/WinRT.Internal/ProjectionInternalAttribute.cs
+++ b/src/WinRT.Internal/ProjectionInternalAttribute.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace WindowsRuntime.Internal;
+
+/// <summary>
+/// Marks a Windows Runtime interface as having an "internal" projection in CsWinRT.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CsWinRT generates an <see langword="internal"/> projection for any interface marked with this
+/// attribute (rather than the default <see langword="public"/> projection). User-friendly wrappers
+/// over the internal projection are exposed via hand-authored extension methods (see e.g.
+/// <c>ComInteropExtensions</c>).
+/// </para>
+/// <para>
+/// This attribute is the C# counterpart of the Modern IDL 3.0 declaration:
+/// </para>
+/// <code>
+/// [attributeusage(target_interface)]
+/// [attributename("ProjectionInternal")]
+/// attribute ProjectionInternalAttribute { };
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
+public sealed class ProjectionInternalAttribute : Attribute
+{
+}

--- a/src/WinRT.Internal/ProjectionInternalAttribute.cs
+++ b/src/WinRT.Internal/ProjectionInternalAttribute.cs
@@ -10,21 +10,9 @@ namespace WindowsRuntime.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// CsWinRT generates an <see langword="internal"/> projection for any interface marked with this
-/// attribute (rather than the default <see langword="public"/> projection). User-friendly wrappers
-/// over the internal projection are exposed via hand-authored extension methods (see e.g.
-/// <c>ComInteropExtensions</c>).
-/// </para>
-/// <para>
-/// This attribute is the C# counterpart of the Modern IDL 3.0 declaration:
-/// </para>
-/// <code language="csharp">
-/// [attributeusage(target_interface)]
-/// [attributename("ProjectionInternal")]
-/// attribute ProjectionInternalAttribute
-/// {
-/// };
-/// </code>
+/// CsWinRT generates an <see langword="internal"/> projection for any interface marked with this attribute
+/// (rather than the default <see langword="public"/> projection). User-friendly wrappers over the internal
+/// projection are exposed via hand-authored extension methods (see e.g. <c>ComInteropExtensions</c>).
 /// </remarks>
 [AttributeUsage(AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 public sealed class ProjectionInternalAttribute : Attribute;

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -1,9 +1,54 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      Target a 'CsWinRT 3.0' Windows TFM (revision .1) so the .NET SDK selects the
+      'cswinrt3' Windows SDK projection reference assemblies (with '[WindowsRuntimeMetadata]'
+      attributes). The C# source files in this project reference Windows Runtime types
+      (e.g. 'Windows.UI.ApplicationSettings.AccountsSettingsPane') through those projections.
+    -->
+    <TargetFramework>net10.0-windows10.0.26100.1</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <!--
+      Pin the 'Microsoft.Windows.SDK.NET.Ref' package version so the .NET SDK adds an implicit
+      'FrameworkReference' to it (matching the cswinrt3 projections required by this project).
+    -->
+    <WindowsSdkPackageVersion>10.0.26100.85-preview</WindowsSdkPackageVersion>
     <Nullable>enable</Nullable>
+    <RootNamespace>WindowsRuntime.Internal</RootNamespace>
+    <AssemblyName>WinRT.Internal</AssemblyName>
+    <LangVersion>14.0</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--
+      This project contains hand-authored Windows Runtime metadata that is fed back into the
+      CsWinRT toolchain. CsWinRT's own per-project projection / interop generation should not
+      run on it (we are building CsWinRT itself), and no NuGet 'CsWinRT' package reference is
+      involved here.
+    -->
+    <CsWinRTEnabled>false</CsWinRTEnabled>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+    <CsWinRTGenerateInteropAssembly>false</CsWinRTGenerateInteropAssembly>
+    <CsWinRTGenerateInteropAssembly2>false</CsWinRTGenerateInteropAssembly2>
+
+    <!-- The produced .dll is just an intermediate artifact; only the generated .winmd is shipped. -->
+    <IsPackable>false</IsPackable>
+
+    <!-- Suppress XML doc warnings for parameters/return doc tags we omit on interop methods.
+         NETSDK1229 is also suppressed: this project intentionally targets the CsWinRT 3.0
+         preview Windows SDK projections to author Windows Runtime metadata, so the preview
+         warning is not actionable. -->
+    <NoWarn>$(NoWarn);1591;1701;1702;NETSDK1229</NoWarn>
   </PropertyGroup>
+
+  <!--
+    Reference the already-built 'WinRT.Runtime.dll' directly (cswinrt3 SDK projections depend on it)
+    so this project can compile without needing the 'Microsoft.Windows.CsWinRT' NuGet package.
+  -->
+  <ItemGroup>
+    <Reference Include="WinRT.Runtime">
+      <HintPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Runtime2', 'bin', '$(Configuration)', 'net10.0', 'WinRT.Runtime.dll'))</HintPath>
+    </Reference>
+  </ItemGroup>
 
 </Project>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -48,11 +48,12 @@
   <!--
     Reference the already-built 'WinRT.Runtime.dll' directly (cswinrt3 SDK projections depend on it)
     so this project can compile without needing the 'Microsoft.Windows.CsWinRT' NuGet package.
+    A 'ProjectReference' is used (rather than '<Reference HintPath="..." />' as in
+    WinRT.Sdk.Projection) so that 'dotnet build' on this project alone implicitly builds
+    WinRT.Runtime2 first. 'Private=false' keeps the .dll out of the bin output / publish set.
   -->
   <ItemGroup>
-    <Reference Include="WinRT.Runtime">
-      <HintPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Runtime2', 'bin', '$(Configuration)', 'net10.0', 'WinRT.Runtime.dll'))</HintPath>
-    </Reference>
+    <ProjectReference Include="..\WinRT.Runtime2\WinRT.Runtime.csproj" Private="false" />
   </ItemGroup>
 
   <!--

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -19,12 +19,6 @@
 
     <!-- Disable nullability annotations (not supported by the Windows Runtime type system yet) -->
     <Nullable>disable</Nullable>
- 
-    <!--
-      The assembly name must match the legacy 'WindowsRuntime.Internal' identity that the rest
-      of the CsWinRT toolchain (and downstream Windows Runtime metadata consumers) references.
-    -->
-    <AssemblyName>WindowsRuntime.Internal</AssemblyName>
 
     <!--
       This project contains hand-authored Windows Runtime metadata that is fed back into the

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 
@@ -60,13 +60,15 @@
   </ItemGroup>
 
   <!--
-    Build-order dependencies: 'WinRT.WinMD.Generator' ('cswinrtwinmdgen.exe', the tool we invoke)
-    and 'WinRT.Generator.Tasks' ('RunCsWinRTWinMDGenerator' MSBuild task). Neither contributes
-    a runtime reference to this project's compilation.
+    Build-order dependency: 'WinRT.WinMD.Generator' produces 'cswinrtwinmdgen.exe', which the
+    target below invokes directly via 'Exec' (no custom 'UsingTask'). This avoids the
+    'WinRT.Generator.Tasks.dll' file-lock contention that happens in Visual Studio when
+    the persistent MSBuild build server keeps a custom-task assembly loaded across
+    incremental builds (MSB3027 "The file is locked by MSBuild.exe (...)"). No build-time
+    dependency on 'WinRT.Generator.Tasks' is required for this project.
   -->
   <ItemGroup>
     <ProjectReference Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj" ReferenceOutputAssembly="false" OutputItemType="_CsWinRTToolReference" Private="false" />
-    <ProjectReference Include="..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj" ReferenceOutputAssembly="false" OutputItemType="_CsWinRTToolReference" Private="false" />
   </ItemGroup>
 
   <!--
@@ -78,45 +80,61 @@
     The '.winmd' is the actual artifact consumed by the CsWinRT toolchain, and
     the '.dll' itself is just an intermediate build artifact, which is not used.
 
-    'TaskFactory="TaskHostFactory"' loads the MSBuild task in a separate
-    'MSBuild.TaskHost' process. Without it, the main MSBuild build server keeps
-    'WinRT.Generator.Tasks.dll' loaded for the lifetime of the build session,
-    which prevents 'WinRT.Generator.Tasks' from being rebuilt on the next build
-    (or by the 'ProjectReference' triggering a fresh compile) and produces
-    'MSB3027 / file is locked' errors on incremental builds in Visual Studio.
+    The tool is invoked via '<Exec>' (not via the 'RunCsWinRTWinMDGenerator' MSBuild
+    task) so that the build doesn't depend on 'WinRT.Generator.Tasks.dll' being loaded
+    by the MSBuild engine — that DLL is the one that's prone to being locked across
+    incremental builds when the build server (in Visual Studio or 'dotnet build') keeps
+    a handle to the custom-task assembly. The tool's argument set is the same: we hand-
+    write a '.rsp' response file and pass it via the '@<file>' convention that
+    'ConsoleAppFramework' (and 'cswinrtwinmdgen.exe' itself) accepts.
     ============================================================
   -->
-  <UsingTask
-    TaskName="RunCsWinRTWinMDGenerator"
-    AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))"
-    TaskFactory="TaskHostFactory" />
   <Target
     Name="GenerateWindowsRuntimeInternalWinMD"
     AfterTargets="CoreCompile"
     Inputs="@(IntermediateAssembly);@(ReferencePathWithRefAssemblies)"
     Outputs="$(TargetDir)$(AssemblyName).winmd">
 
-    <!-- Setup the folder for the generator to invoke, and the target output folder for the produced '.winmd' -->
+    <!-- Setup the folder for the generator to invoke, the response file, and the target output folder for the produced '.winmd' -->
     <PropertyGroup>
-      <_CsWinRTWinMDGenToolsDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0'))</_CsWinRTWinMDGenToolsDirectory>
+      <_CsWinRTWinMDGenExePath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0', 'cswinrtwinmdgen.exe'))</_CsWinRTWinMDGenExePath>
       <_CsWinRTInternalWinMDOutputPath>$([MSBuild]::NormalizePath('$(TargetDir)', '$(AssemblyName).winmd'))</_CsWinRTInternalWinMDOutputPath>
+      <_CsWinRTInternalWinMDResponseFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'cswinrtwinmdgen.rsp'))</_CsWinRTInternalWinMDResponseFile>
     </PropertyGroup>
 
-    <!-- Manually invoke the '.winmd' generator task to produce the '.winmd' from this project -->
-    <RunCsWinRTWinMDGenerator
-      InputAssemblyPath="@(IntermediateAssembly)"
-      ReferenceAssemblyPaths="@(ReferencePathWithRefAssemblies)"
-      OutputWinmdPath="$(_CsWinRTInternalWinMDOutputPath)"
-      AssemblyVersion="$(AssemblyVersion)"
-      UseWindowsUIXamlProjections="false"
-      CsWinRTToolsDirectory="$(_CsWinRTWinMDGenToolsDirectory)"
-      CsWinRTToolsArchitecture="AnyCPU" />
+    <!--
+      Build the response file content (one 'argument value' per line). This matches the
+      format that 'WinMDGeneratorArgs.ParseFromResponseFile' expects. The reference assembly
+      list is comma-separated within a single line (matching 'GetStringArrayArgument').
+    -->
+    <PropertyGroup>
+      <_CsWinRTInternalWinMDInputAssemblyPath>@(IntermediateAssembly->'%(FullPath)')</_CsWinRTInternalWinMDInputAssemblyPath>
+      <_CsWinRTInternalWinMDReferenceAssemblyPaths>@(ReferencePathWithRefAssemblies->'%(FullPath)', ',')</_CsWinRTInternalWinMDReferenceAssemblyPaths>
+    </PropertyGroup>
 
-    <!-- Mark the generated '.winmd' file as a file write (for incremental builds) -->
     <ItemGroup>
+      <_CsWinRTInternalWinMDResponseLines Include="--input-assembly-path $(_CsWinRTInternalWinMDInputAssemblyPath)" />
+      <_CsWinRTInternalWinMDResponseLines Include="--reference-assembly-paths $(_CsWinRTInternalWinMDReferenceAssemblyPaths)" />
+      <_CsWinRTInternalWinMDResponseLines Include="--output-winmd-path $(_CsWinRTInternalWinMDOutputPath)" />
+      <_CsWinRTInternalWinMDResponseLines Include="--assembly-version $(AssemblyVersion)" />
+      <_CsWinRTInternalWinMDResponseLines Include="--use-windows-ui-xaml-projections false" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(_CsWinRTInternalWinMDResponseFile)"
+      Lines="@(_CsWinRTInternalWinMDResponseLines)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+
+    <!-- Invoke 'cswinrtwinmdgen.exe' with the response file. -->
+    <Exec
+      Command="&quot;$(_CsWinRTWinMDGenExePath)&quot; @&quot;$(_CsWinRTInternalWinMDResponseFile)&quot;"
+      WorkingDirectory="$(MSBuildProjectDirectory)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_CsWinRTInternalWinMDResponseFile)" />
       <FileWrites Include="$(_CsWinRTInternalWinMDOutputPath)" />
     </ItemGroup>
   </Target>
 
 </Project>
-

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -77,9 +77,16 @@
     'WindowsRuntime.Internal.winmd' from the compiled 'WindowsRuntime.Internal.dll'.
     The '.winmd' is the actual artifact consumed by the CsWinRT toolchain, and
     the '.dll' itself is just an intermediate build artifact, which is not used.
+
+    'TaskFactory="TaskHostFactory"' loads the MSBuild task in a separate
+    'MSBuild.TaskHost' process. Without it, the main MSBuild build server keeps
+    'WinRT.Generator.Tasks.dll' loaded for the lifetime of the build session,
+    which prevents 'WinRT.Generator.Tasks' from being rebuilt on the next build
+    (or by the 'ProjectReference' triggering a fresh compile) and produces
+    'MSB3027 / file is locked' errors on incremental builds in Visual Studio.
     ============================================================
   -->
-  <UsingTask TaskName="RunCsWinRTWinMDGenerator" AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" />
+  <UsingTask TaskName="RunCsWinRTWinMDGenerator" AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" TaskFactory="TaskHostFactory" />
   <Target
     Name="GenerateWindowsRuntimeInternalWinMD"
     AfterTargets="CoreCompile"

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -67,12 +67,24 @@
     the persistent MSBuild build server keeps a custom-task assembly loaded across
     incremental builds (MSB3027 "The file is locked by MSBuild.exe (...)"). No build-time
     dependency on 'WinRT.Generator.Tasks' is required for this project.
+
+    'UndefineProperties' drops the build-tool publishing properties ('BuildToolArch' and
+    'PublishBuildTool', plus 'RuntimeIdentifier' / 'SelfContained') from this reference so the
+    generator is always built *framework-dependent for the build host* (output under 'net10.0\',
+    with no 'win-<arch>' RID subfolder). In official builds, CI sets 'BuildToolArch' to the target
+    platform (e.g. 'arm64') and the arm64 leg is cross-compiled on an x64 host; without this, the
+    generator would be produced as an arm64 Native AOT binary that cannot execute on the x64 host
+    (failing with exit code 216, ERROR_EXE_MACHINE_TYPE_MISMATCH). The generated '.winmd' is
+    architecture-neutral, so a host-built generator produces identical metadata. The separate,
+    solution-level build of 'WinRT.WinMD.Generator' (which produces the arch-specific binary that
+    ships in the NuGet package) is unaffected by this reference.
   -->
   <ItemGroup>
     <ProjectReference
       Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
       ReferenceOutputAssembly="false"
       OutputItemType="_CsWinRTToolReference"
+      UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained"
       Private="false" />
   </ItemGroup>
 
@@ -104,14 +116,14 @@
     <PropertyGroup>
 
       <!--
-        Resolve 'cswinrtwinmdgen.exe' via the shared 'CsWinRTWinMDGenEffectiveToolsDirectory' property (from
-        'Directory.Build.props'), rather than hard-coding the 'net10.0' output folder. When the build tools are
-        published for a specific architecture (CI sets 'PublishBuildTool=true' and 'BuildToolArch=<arch>'), the
-        generator is emitted under a 'win-<arch>' RID subfolder (e.g. 'net10.0\win-arm64\'), which this property
-        accounts for via '_CsWinRTToolsArchFolder'. Hard-coding 'net10.0\cswinrtwinmdgen.exe' would miss that
-        subfolder and fail with MSB3073 (exit code 9009, "file not found") on architectures such as arm64.
+        Resolve the host-built, framework-dependent 'cswinrtwinmdgen.exe' under 'net10.0\' (no
+        'win-<arch>' RID subfolder). The 'ProjectReference' above undefines 'BuildToolArch' and
+        'PublishBuildTool' so the generator is built for the build host and lands here, which is
+        why this path is intentionally architecture-agnostic (unlike 'CsWinRTWinMDGenEffectiveToolsDirectory',
+        which points at the arch-specific 'win-<arch>\' output used for the shipping NuGet binary).
+        This is what lets the cross-compiled arm64 leg (built on an x64 host) still run the tool.
       -->
-      <_CsWinRTWinMDGenExePath>$([MSBuild]::NormalizePath('$(CsWinRTWinMDGenEffectiveToolsDirectory)', 'cswinrtwinmdgen.exe'))</_CsWinRTWinMDGenExePath>
+      <_CsWinRTWinMDGenExePath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0', 'cswinrtwinmdgen.exe'))</_CsWinRTWinMDGenExePath>
       <_CsWinRTInternalWinMDOutputPath>$([MSBuild]::NormalizePath('$(TargetDir)', '$(AssemblyName).winmd'))</_CsWinRTInternalWinMDOutputPath>
       <_CsWinRTInternalWinMDResponseFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'cswinrtwinmdgen.rsp'))</_CsWinRTInternalWinMDResponseFile>
     </PropertyGroup>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 
     <!--
@@ -41,10 +40,12 @@
     <!-- The produced '.dll' is just an intermediate artifact, only the generated '.winmd' is shipped -->
     <IsPackable>false</IsPackable>
 
-    <!-- Suppress XML doc warnings for parameters/return doc tags we omit on interop methods.
-         'NETSDK1229' is also suppressed: this project intentionally targets the CsWinRT 3.0
-         preview Windows SDK projections to author Windows Runtime metadata, so the preview
-         warning is not actionable. -->
+    <!--
+      Suppress XML doc warnings for parameters/return doc tags we omit on interop methods.
+      'NETSDK1229' is also suppressed: this project intentionally targets the CsWinRT 3.0
+      preview Windows SDK projections to author Windows Runtime metadata, so the preview
+      warning is not actionable.
+    -->
     <NoWarn>$(NoWarn);CS1591;1701;CS1702;NETSDK1229</NoWarn>
   </PropertyGroup>
 
@@ -68,7 +69,11 @@
     dependency on 'WinRT.Generator.Tasks' is required for this project.
   -->
   <ItemGroup>
-    <ProjectReference Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj" ReferenceOutputAssembly="false" OutputItemType="_CsWinRTToolReference" Private="false" />
+    <ProjectReference
+      Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
+      ReferenceOutputAssembly="false"
+      OutputItemType="_CsWinRTToolReference"
+      Private="false" />
   </ItemGroup>
 
   <!--
@@ -82,7 +87,7 @@
 
     The tool is invoked via '<Exec>' (not via the 'RunCsWinRTWinMDGenerator' MSBuild
     task) so that the build doesn't depend on 'WinRT.Generator.Tasks.dll' being loaded
-    by the MSBuild engine — that DLL is the one that's prone to being locked across
+    by the MSBuild engine. That DLL is the one that's prone to being locked across
     incremental builds when the build server (in Visual Studio or 'dotnet build') keeps
     a handle to the custom-task assembly. The tool's argument set is the same: we hand-
     write a '.rsp' response file and pass it via the '@<file>' convention that
@@ -112,6 +117,7 @@
       <_CsWinRTInternalWinMDReferenceAssemblyPaths>@(ReferencePathWithRefAssemblies->'%(FullPath)', ',')</_CsWinRTInternalWinMDReferenceAssemblyPaths>
     </PropertyGroup>
 
+    <!-- Prepare all lines for the '.rsp' file we'll pass to the generator -->
     <ItemGroup>
       <_CsWinRTInternalWinMDResponseLines Include="--input-assembly-path $(_CsWinRTInternalWinMDInputAssemblyPath)" />
       <_CsWinRTInternalWinMDResponseLines Include="--reference-assembly-paths $(_CsWinRTInternalWinMDReferenceAssemblyPaths)" />
@@ -120,6 +126,7 @@
       <_CsWinRTInternalWinMDResponseLines Include="--use-windows-ui-xaml-projections false" />
     </ItemGroup>
 
+    <!-- Write the '.rsp' file to disk for invocation -->
     <WriteLinesToFile
       File="$(_CsWinRTInternalWinMDResponseFile)"
       Lines="@(_CsWinRTInternalWinMDResponseLines)"
@@ -131,10 +138,10 @@
       Command="&quot;$(_CsWinRTWinMDGenExePath)&quot; @&quot;$(_CsWinRTInternalWinMDResponseFile)&quot;"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
 
+    <!-- Mark the '.rsp' file and the generated '.winmd' files as file writes (for incremental builds) -->
     <ItemGroup>
       <FileWrites Include="$(_CsWinRTInternalWinMDResponseFile)" />
       <FileWrites Include="$(_CsWinRTInternalWinMDOutputPath)" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -102,7 +102,16 @@
 
     <!-- Setup the folder for the generator to invoke, the response file, and the target output folder for the produced '.winmd' -->
     <PropertyGroup>
-      <_CsWinRTWinMDGenExePath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0', 'cswinrtwinmdgen.exe'))</_CsWinRTWinMDGenExePath>
+
+      <!--
+        Resolve 'cswinrtwinmdgen.exe' via the shared 'CsWinRTWinMDGenEffectiveToolsDirectory' property (from
+        'Directory.Build.props'), rather than hard-coding the 'net10.0' output folder. When the build tools are
+        published for a specific architecture (CI sets 'PublishBuildTool=true' and 'BuildToolArch=<arch>'), the
+        generator is emitted under a 'win-<arch>' RID subfolder (e.g. 'net10.0\win-arm64\'), which this property
+        accounts for via '_CsWinRTToolsArchFolder'. Hard-coding 'net10.0\cswinrtwinmdgen.exe' would miss that
+        subfolder and fail with MSB3073 (exit code 9009, "file not found") on architectures such as arm64.
+      -->
+      <_CsWinRTWinMDGenExePath>$([MSBuild]::NormalizePath('$(CsWinRTWinMDGenEffectiveToolsDirectory)', 'cswinrtwinmdgen.exe'))</_CsWinRTWinMDGenExePath>
       <_CsWinRTInternalWinMDOutputPath>$([MSBuild]::NormalizePath('$(TargetDir)', '$(AssemblyName).winmd'))</_CsWinRTInternalWinMDOutputPath>
       <_CsWinRTInternalWinMDResponseFile>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', 'cswinrtwinmdgen.rsp'))</_CsWinRTInternalWinMDResponseFile>
     </PropertyGroup>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -1,28 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+
     <!--
-      Target a 'CsWinRT 3.0' Windows TFM (revision .1) so the .NET SDK selects the
-      'cswinrt3' Windows SDK projection reference assemblies (with '[WindowsRuntimeMetadata]'
-      attributes). The C# source files in this project reference Windows Runtime types
-      (e.g. 'Windows.UI.ApplicationSettings.AccountsSettingsPane') through those projections.
+      Target a CsWinRT 3.0 Windows TFM (revision .1) so the .NET SDK selects the
+      correct Windows SDK projection reference assemblies. We need to target a
+      Windows TFM because this is a "normal" authoring project. Additionally,
+      some of the C# source files in this project reference Windows Runtime types
+      (e.g. 'Windows.UI.ApplicationSettings.AccountsSettingsPane') as well.
     -->
     <TargetFramework>net10.0-windows10.0.26100.1</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+ 
     <!--
       Pin the 'Microsoft.Windows.SDK.NET.Ref' package version so the .NET SDK adds an implicit
-      'FrameworkReference' to it (matching the cswinrt3 projections required by this project).
+      'FrameworkReference' to it (matching the 'cswinrt3' projections required by this project).
     -->
     <WindowsSdkPackageVersion>10.0.26100.85-preview</WindowsSdkPackageVersion>
-    <Nullable>enable</Nullable>
-    <RootNamespace>WindowsRuntime.Internal</RootNamespace>
+
+    <!-- Disable nullability annotations (not supported by the Windows Runtime type system yet) -->
+    <Nullable>disable</Nullable>
+ 
     <!--
       The assembly name must match the legacy 'WindowsRuntime.Internal' identity that the rest
       of the CsWinRT toolchain (and downstream Windows Runtime metadata consumers) references.
     -->
     <AssemblyName>WindowsRuntime.Internal</AssemblyName>
-    <LangVersion>14.0</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!--
       This project contains hand-authored Windows Runtime metadata that is fed back into the
@@ -35,41 +38,35 @@
     <CsWinRTGenerateInteropAssembly>false</CsWinRTGenerateInteropAssembly>
     <CsWinRTGenerateInteropAssembly2>false</CsWinRTGenerateInteropAssembly2>
 
-    <!-- The produced .dll is just an intermediate artifact; only the generated .winmd is shipped. -->
+    <!-- The produced '.dll' is just an intermediate artifact, only the generated '.winmd' is shipped -->
     <IsPackable>false</IsPackable>
 
     <!-- Suppress XML doc warnings for parameters/return doc tags we omit on interop methods.
-         NETSDK1229 is also suppressed: this project intentionally targets the CsWinRT 3.0
+         'NETSDK1229' is also suppressed: this project intentionally targets the CsWinRT 3.0
          preview Windows SDK projections to author Windows Runtime metadata, so the preview
          warning is not actionable. -->
-    <NoWarn>$(NoWarn);1591;1701;1702;NETSDK1229</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;1701;CS1702;NETSDK1229</NoWarn>
   </PropertyGroup>
 
   <!--
-    Reference the already-built 'WinRT.Runtime.dll' directly (cswinrt3 SDK projections depend on it)
+    Reference the already-built 'WinRT.Runtime.dll' directly (the SDK projections depend on it)
     so this project can compile without needing the 'Microsoft.Windows.CsWinRT' NuGet package.
     A 'ProjectReference' is used (rather than '<Reference HintPath="..." />' as in
-    WinRT.Sdk.Projection) so that 'dotnet build' on this project alone implicitly builds
-    WinRT.Runtime2 first. 'Private=false' keeps the .dll out of the bin output / publish set.
+    'WinRT.Sdk.Projection') so that 'dotnet build' on this project alone implicitly builds
+    'WinRT.Runtime2' first. 'Private=false' keeps the '.dll' out of the bin output / publish set.
   -->
   <ItemGroup>
     <ProjectReference Include="..\WinRT.Runtime2\WinRT.Runtime.csproj" Private="false" />
   </ItemGroup>
 
   <!--
-    Build-order dependencies: WinRT.WinMD.Generator (cswinrtwinmdgen.exe, the tool we invoke)
-    and WinRT.Generator.Tasks (RunCsWinRTWinMDGenerator MSBuild task). Neither contributes
+    Build-order dependencies: 'WinRT.WinMD.Generator' ('cswinrtwinmdgen.exe', the tool we invoke)
+    and 'WinRT.Generator.Tasks' ('RunCsWinRTWinMDGenerator' MSBuild task). Neither contributes
     a runtime reference to this project's compilation.
   -->
   <ItemGroup>
-    <ProjectReference Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="_CsWinRTToolReference"
-                      Private="false" />
-    <ProjectReference Include="..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="_CsWinRTToolReference"
-                      Private="false" />
+    <ProjectReference Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj" ReferenceOutputAssembly="false" OutputItemType="_CsWinRTToolReference" Private="false" />
+    <ProjectReference Include="..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj" ReferenceOutputAssembly="false" OutputItemType="_CsWinRTToolReference" Private="false" />
   </ItemGroup>
 
   <!--
@@ -77,17 +74,17 @@
                         GenerateWindowsRuntimeInternalWinMD
 
     Invokes 'cswinrtwinmdgen.exe' (built from this solution) to produce
-    'WindowsRuntime.Internal.winmd' from the compiled WindowsRuntime.Internal.dll.
-    The .winmd is the actual artifact consumed by the CsWinRT toolchain;
-    the .dll itself is just an intermediate build artifact.
+    'WindowsRuntime.Internal.winmd' from the compiled 'WindowsRuntime.Internal.dll'.
+    The '.winmd' is the actual artifact consumed by the CsWinRT toolchain, and
+    the '.dll' itself is just an intermediate build artifact, which is not used.
     ============================================================
   -->
-  <UsingTask TaskName="RunCsWinRTWinMDGenerator"
-             AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" />
-  <Target Name="GenerateWindowsRuntimeInternalWinMD"
-          AfterTargets="CoreCompile"
-          Inputs="@(IntermediateAssembly);@(ReferencePathWithRefAssemblies)"
-          Outputs="$(TargetDir)$(AssemblyName).winmd">
+  <UsingTask TaskName="RunCsWinRTWinMDGenerator" AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" />
+  <Target
+    Name="GenerateWindowsRuntimeInternalWinMD"
+    AfterTargets="CoreCompile"
+    Inputs="@(IntermediateAssembly);@(ReferencePathWithRefAssemblies)"
+    Outputs="$(TargetDir)$(AssemblyName).winmd">
 
     <PropertyGroup>
       <_CsWinRTWinMDGenToolsDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0'))</_CsWinRTWinMDGenToolsDirectory>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -55,4 +55,57 @@
     </Reference>
   </ItemGroup>
 
+  <!--
+    Build-order dependencies: WinRT.WinMD.Generator (cswinrtwinmdgen.exe, the tool we invoke)
+    and WinRT.Generator.Tasks (RunCsWinRTWinMDGenerator MSBuild task). Neither contributes
+    a runtime reference to this project's compilation.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="_CsWinRTToolReference"
+                      Private="false" />
+    <ProjectReference Include="..\WinRT.Generator.Tasks\WinRT.Generator.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="_CsWinRTToolReference"
+                      Private="false" />
+  </ItemGroup>
+
+  <!--
+    ============================================================
+                        GenerateWindowsRuntimeInternalWinMD
+
+    Invokes 'cswinrtwinmdgen.exe' (built from this solution) to produce
+    'WindowsRuntime.Internal.winmd' from the compiled WindowsRuntime.Internal.dll.
+    The .winmd is the actual artifact consumed by the CsWinRT toolchain;
+    the .dll itself is just an intermediate build artifact.
+    ============================================================
+  -->
+  <UsingTask TaskName="RunCsWinRTWinMDGenerator"
+             AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" />
+  <Target Name="GenerateWindowsRuntimeInternalWinMD"
+          AfterTargets="CoreCompile"
+          Inputs="@(IntermediateAssembly);@(ReferencePathWithRefAssemblies)"
+          Outputs="$(TargetDir)$(AssemblyName).winmd">
+
+    <PropertyGroup>
+      <_CsWinRTWinMDGenToolsDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0'))</_CsWinRTWinMDGenToolsDirectory>
+      <_CsWinRTInternalWinMDOutputPath>$([MSBuild]::NormalizePath('$(TargetDir)', '$(AssemblyName).winmd'))</_CsWinRTInternalWinMDOutputPath>
+    </PropertyGroup>
+
+    <RunCsWinRTWinMDGenerator
+      InputAssemblyPath="@(IntermediateAssembly)"
+      ReferenceAssemblyPaths="@(ReferencePathWithRefAssemblies)"
+      OutputWinmdPath="$(_CsWinRTInternalWinMDOutputPath)"
+      AssemblyVersion="$(AssemblyVersion)"
+      UseWindowsUIXamlProjections="false"
+      CsWinRTToolsDirectory="$(_CsWinRTWinMDGenToolsDirectory)"
+      CsWinRTToolsArchitecture="AnyCPU" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_CsWinRTInternalWinMDOutputPath)" />
+    </ItemGroup>
+  </Target>
+
 </Project>
+

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -86,18 +86,23 @@
     'MSB3027 / file is locked' errors on incremental builds in Visual Studio.
     ============================================================
   -->
-  <UsingTask TaskName="RunCsWinRTWinMDGenerator" AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))" TaskFactory="TaskHostFactory" />
+  <UsingTask
+    TaskName="RunCsWinRTWinMDGenerator"
+    AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.Generator.Tasks', 'bin', '$(Configuration)', 'netstandard2.0', 'WinRT.Generator.Tasks.dll'))"
+    TaskFactory="TaskHostFactory" />
   <Target
     Name="GenerateWindowsRuntimeInternalWinMD"
     AfterTargets="CoreCompile"
     Inputs="@(IntermediateAssembly);@(ReferencePathWithRefAssemblies)"
     Outputs="$(TargetDir)$(AssemblyName).winmd">
 
+    <!-- Setup the folder for the generator to invoke, and the target output folder for the produced '.winmd' -->
     <PropertyGroup>
       <_CsWinRTWinMDGenToolsDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'WinRT.WinMD.Generator', 'bin', '$(Configuration)', 'net10.0'))</_CsWinRTWinMDGenToolsDirectory>
       <_CsWinRTInternalWinMDOutputPath>$([MSBuild]::NormalizePath('$(TargetDir)', '$(AssemblyName).winmd'))</_CsWinRTInternalWinMDOutputPath>
     </PropertyGroup>
 
+    <!-- Manually invoke the '.winmd' generator task to produce the '.winmd' from this project -->
     <RunCsWinRTWinMDGenerator
       InputAssemblyPath="@(IntermediateAssembly)"
       ReferenceAssemblyPaths="@(ReferencePathWithRefAssemblies)"
@@ -107,6 +112,7 @@
       CsWinRTToolsDirectory="$(_CsWinRTWinMDGenToolsDirectory)"
       CsWinRTToolsArchitecture="AnyCPU" />
 
+    <!-- Mark the generated '.winmd' file as a file write (for incremental builds) -->
     <ItemGroup>
       <FileWrites Include="$(_CsWinRTInternalWinMDOutputPath)" />
     </ItemGroup>

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -16,7 +16,11 @@
     <WindowsSdkPackageVersion>10.0.26100.85-preview</WindowsSdkPackageVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>WindowsRuntime.Internal</RootNamespace>
-    <AssemblyName>WinRT.Internal</AssemblyName>
+    <!--
+      The assembly name must match the legacy 'WindowsRuntime.Internal' identity that the rest
+      of the CsWinRT toolchain (and downstream Windows Runtime metadata consumers) references.
+    -->
+    <AssemblyName>WindowsRuntime.Internal</AssemblyName>
     <LangVersion>14.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/src/WinRT.WinMD.Generator/References/WinMDValues.cs
+++ b/src/WinRT.WinMD.Generator/References/WinMDValues.cs
@@ -19,4 +19,10 @@ internal static class WinMDValues
     /// Gets the version of the <c>mscorlib</c> reference for .winmd files.
     /// </summary>
     public static Version MSCorLibVersion { get; } = new(0xFF, 0xFF, 0xFF, 0xFF);
+
+    /// <summary>
+    /// Gets the assembly version stamped onto every authored .winmd, matching the WinRT convention
+    /// of <c>255.255.255.255</c> (the "unbound" version used by all Windows Runtime metadata).
+    /// </summary>
+    public static Version AssemblyVersion { get; } = new(0xFF, 0xFF, 0xFF, 0xFF);
 }

--- a/src/WinRT.WinMD.Generator/References/WinMDValues.cs
+++ b/src/WinRT.WinMD.Generator/References/WinMDValues.cs
@@ -21,8 +21,9 @@ internal static class WinMDValues
     public static Version MSCorLibVersion { get; } = new(0xFF, 0xFF, 0xFF, 0xFF);
 
     /// <summary>
-    /// Gets the assembly version stamped onto every authored .winmd, matching the WinRT convention
-    /// of <c>255.255.255.255</c> (the "unbound" version used by all Windows Runtime metadata).
+    /// Gets the assembly version stamped onto every authored .winmd, matching
+    /// the Windows Runtime convention of <c>255.255.255.255</c> (the "unbound"
+    /// version used by all Windows Runtime metadata).
     /// </summary>
     public static Version AssemblyVersion { get; } = new(0xFF, 0xFF, 0xFF, 0xFF);
 }

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -135,8 +135,8 @@ internal sealed partial class WinMDWriter
     /// parameter type:
     /// </para>
     /// <list type="bullet">
-    ///   <item><see cref="ReadOnlySpan{T}"/> → <c>[in] T[]</c> (PassArray)</item>
-    ///   <item><see cref="Span{T}"/> → <c>[out] T[]</c> without BYREF (FillArray)</item>
+    ///   <item><see cref="System.ReadOnlySpan{T}"/> → <c>[in] T[]</c> (PassArray)</item>
+    ///   <item><see cref="System.Span{T}"/> → <c>[out] T[]</c> without BYREF (FillArray)</item>
     ///   <item><c>out T[]</c> (byref to <c>SzArray</c>) → <c>[out] T[]</c> with BYREF (ReceiveArray); already captured by the input's <c>Out</c> flag.</item>
     ///   <item>Any other by-reference type (e.g. <c>ref Guid</c> on a COM interop interface) → <c>[in]</c>, matching the MIDL convention for <c>ref const T</c> parameters.</item>
     ///   <item>All other params → <c>[in]</c>.</item>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -174,7 +174,7 @@ internal sealed partial class WinMDWriter
     /// </remarks>
     private static ParameterAttributes GetWinRTParameterAttributes(ParameterDefinition inputParam, TypeSignature inputParamType)
     {
-        // Preserve any In/Out direction flags the input parameter already carries
+        // Preserve any 'In'/'Out' direction flags the input parameter already carries
         ParameterAttributes inputDirectionFlags = inputParam.Attributes & (ParameterAttributes.In | ParameterAttributes.Out);
 
         if (inputDirectionFlags != 0)
@@ -182,7 +182,7 @@ internal sealed partial class WinMDWriter
             return inputDirectionFlags;
         }
 
-        // Span<T> → FillArray pattern: [out] without BYREF
+        // 'Span<T>' → 'FillArray' pattern: '[out]' without 'BYREF'
         if (inputParamType is GenericInstanceTypeSignature genericInstanceSignature &&
             genericInstanceSignature.GenericType.FullName == "System.Span`1")
         {
@@ -190,8 +190,8 @@ internal sealed partial class WinMDWriter
         }
 
         // By-reference parameters with no explicit direction flag (e.g. 'ref Guid riid'
-        // on a COM interop interface) default to [in], matching the MIDL convention for
-        // 'ref const T' parameters. ReadOnlySpan<T> and everything else also default to [in].
+        // on a COM interop interface) default to '[in]', matching the MIDL convention for
+        // 'ref const T' parameters. 'ReadOnlySpan<T>' and everything else also default to '[in]'.
         return ParameterAttributes.In;
     }
 

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -125,12 +125,23 @@ internal sealed partial class WinMDWriter
 
     /// <summary>
     /// Adds parameter definitions to an output method with correct Windows Runtime attributes.
-    /// Handles Span/ReadOnlySpan → array parameter attribute mapping:
-    /// - ReadOnlySpan&lt;T&gt; → [in] T[] (PassArray)
-    /// - Span&lt;T&gt; → [out] T[] without BYREF (FillArray)
-    /// - out T[] → [out] T[] with BYREF (ReceiveArray)
-    /// - All other params → [in]
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The In/Out flags on the input parameters are honored as-is when present. This allows
+    /// authors to opt-in or opt-out of the WinRT defaults explicitly (e.g. <c>[In] ref T</c>
+    /// preserves the <c>In</c> flag, <c>[Out] ref T</c> preserves the <c>Out</c> flag). When
+    /// no In/Out flag is set on the input parameter, the WinRT default is inferred from the
+    /// parameter type:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><see cref="ReadOnlySpan{T}"/> → <c>[in] T[]</c> (PassArray)</item>
+    ///   <item><see cref="Span{T}"/> → <c>[out] T[]</c> without BYREF (FillArray)</item>
+    ///   <item><c>out T[]</c> (byref to <c>SzArray</c>) → <c>[out] T[]</c> with BYREF (ReceiveArray); already captured by the input's <c>Out</c> flag.</item>
+    ///   <item>Any other by-reference type (e.g. <c>ref Guid</c> on a COM interop interface) → <c>[in]</c>, matching the MIDL convention for <c>ref const T</c> parameters.</item>
+    ///   <item>All other params → <c>[in]</c>.</item>
+    /// </list>
+    /// </remarks>
     private static void AddParameterDefinitions(MethodDefinition outputMethod, MethodDefinition inputMethod)
     {
         int paramIndex = 1;
@@ -143,7 +154,7 @@ internal sealed partial class WinMDWriter
 
             if (sigIndex < inputParamTypes.Count)
             {
-                paramattributes = GetWinRTParameterAttributes(inputParamTypes[sigIndex]);
+                paramattributes = GetWinRTParameterAttributes(inputParam, inputParamTypes[sigIndex]);
             }
 
             outputMethod.ParameterDefinitions.Add(new ParameterDefinition(
@@ -154,28 +165,33 @@ internal sealed partial class WinMDWriter
     }
 
     /// <summary>
-    /// Determines the Windows Runtime parameter attributes based on the input parameter type.
+    /// Determines the Windows Runtime parameter attributes based on the input parameter and its type.
     /// </summary>
-    private static ParameterAttributes GetWinRTParameterAttributes(TypeSignature inputParamType)
+    /// <remarks>
+    /// If the input parameter already has <see cref="ParameterAttributes.In"/> or
+    /// <see cref="ParameterAttributes.Out"/> set, those flags are preserved unchanged. Otherwise,
+    /// the type drives the default per the rules documented on <see cref="AddParameterDefinitions"/>.
+    /// </remarks>
+    private static ParameterAttributes GetWinRTParameterAttributes(ParameterDefinition inputParam, TypeSignature inputParamType)
     {
-        // out parameters (ByRef) stay as Out
-        if (inputParamType is ByReferenceTypeSignature)
+        // Preserve any In/Out direction flags the input parameter already carries
+        ParameterAttributes inputDirectionFlags = inputParam.Attributes & (ParameterAttributes.In | ParameterAttributes.Out);
+
+        if (inputDirectionFlags != 0)
+        {
+            return inputDirectionFlags;
+        }
+
+        // Span<T> → FillArray pattern: [out] without BYREF
+        if (inputParamType is GenericInstanceTypeSignature genericInstanceSignature &&
+            genericInstanceSignature.GenericType.FullName == "System.Span`1")
         {
             return ParameterAttributes.Out;
         }
 
-        // Span<T> → FillArray pattern: [out] without BYREF
-        if (inputParamType is GenericInstanceTypeSignature genericInstanceSignature)
-        {
-            string typeName = genericInstanceSignature.GenericType.FullName;
-
-            if (typeName == "System.Span`1")
-            {
-                return ParameterAttributes.Out;
-            }
-        }
-
-        // ReadOnlySpan<T> and everything else → [in]
+        // By-reference parameters with no explicit direction flag (e.g. 'ref Guid riid'
+        // on a COM interop interface) default to [in], matching the MIDL convention for
+        // 'ref const T' parameters. ReadOnlySpan<T> and everything else also default to [in].
         return ParameterAttributes.In;
     }
 

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
@@ -712,8 +712,8 @@ internal sealed partial class WinMDWriter
 
             for (int i = 0; i < paramNames.Length; i++)
             {
-                ParameterAttributes paramAttr = i < parameterTypes.Length
-                    ? GetWinRTParameterAttributes(method.Signature!.ParameterTypes[i])
+                ParameterAttributes paramAttr = i < parameterTypes.Length && i < method.ParameterDefinitions.Count
+                    ? GetWinRTParameterAttributes(method.ParameterDefinitions[i], method.Signature!.ParameterTypes[i])
                     : ParameterAttributes.In;
 
                 outputMethod.ParameterDefinitions.Add(new ParameterDefinition(

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
@@ -110,8 +110,11 @@ internal sealed partial class WinMDWriter
 
         _assemblyReferenceCache["mscorlib"] = defaultCorLib;
 
-        // Create the output assembly with WindowsRuntime flag (keep reference alive via module)
-        _ = new AssemblyDefinition(assemblyName, new Version(version))
+        // Create the output assembly with WindowsRuntime flag (keep reference alive via module).
+        // Per WinRT convention, the assembly identity always uses version 255.255.255.255 (the
+        // "unbound" version). The 'version' parameter is only used for the type-level
+        // '[Windows.Foundation.Metadata.Version]' attribute applied to each authored type.
+        _ = new AssemblyDefinition(assemblyName, WinMDValues.AssemblyVersion)
         {
             Modules = { _outputModule },
             Attributes = AssemblyAttributes.ContentWindowsRuntime,

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
@@ -110,9 +110,9 @@ internal sealed partial class WinMDWriter
 
         _assemblyReferenceCache["mscorlib"] = defaultCorLib;
 
-        // Create the output assembly with WindowsRuntime flag (keep reference alive via module).
-        // Per WinRT convention, the assembly identity always uses version 255.255.255.255 (the
-        // "unbound" version). The 'version' parameter is only used for the type-level
+        // Create the output assembly with 'WindowsRuntime' flag (keep reference alive via module).
+        // Per Windows Runtime convention, the assembly identity always uses version '255.255.255.255'
+        // (the "unbound" version). The 'version' parameter is only used for the type-level
         // '[Windows.Foundation.Metadata.Version]' attribute applied to each authored type.
         _ = new AssemblyDefinition(assemblyName, WinMDValues.AssemblyVersion)
         {

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -251,8 +251,6 @@ if "%cswinrt_label%"=="functionaltest" exit /b 0
 rem We set the properties of the CsWinRT.nuspec here, and pass them as the -Properties option when we call `nuget pack`
 set cswinrt_bin_dir=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\cswinrt\bin\
 set cswinrt_exe=%cswinrt_bin_dir%cswinrt.exe
-rem 'WindowsRuntime.Internal.winmd' is produced by the managed WinRT.Internal project (C#); it
-rem no longer comes from the legacy cswinrt C++ project's output directory.
 set interop_winmd=%this_dir%WinRT.Internal\bin\%cswinrt_configuration%\net10.0-windows10.0.26100.1\WindowsRuntime.Internal.winmd
 set net10_runtime=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.dll
 set net10_runtime_xml=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.xml

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -251,7 +251,9 @@ if "%cswinrt_label%"=="functionaltest" exit /b 0
 rem We set the properties of the CsWinRT.nuspec here, and pass them as the -Properties option when we call `nuget pack`
 set cswinrt_bin_dir=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\cswinrt\bin\
 set cswinrt_exe=%cswinrt_bin_dir%cswinrt.exe
-set interop_winmd=%cswinrt_bin_dir%WindowsRuntime.Internal.winmd
+rem 'WindowsRuntime.Internal.winmd' is produced by the managed WinRT.Internal project (C#); it
+rem no longer comes from the legacy cswinrt C++ project's output directory.
+set interop_winmd=%this_dir%WinRT.Internal\bin\%cswinrt_configuration%\net10.0-windows10.0.26100.1\WindowsRuntime.Internal.winmd
 set net10_runtime=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.dll
 set net10_runtime_xml=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.xml
 set source_generator_roslyn4120=%this_dir%Authoring\WinRT.SourceGenerator.Roslyn4120\bin\%cswinrt_configuration%\netstandard2.0\WinRT.SourceGenerator.dll

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -425,6 +425,7 @@
   </Project>
   <Project Path="WinRT.Generator.Tasks/WinRT.Generator.Tasks.csproj" />
   <Project Path="WinRT.Impl.Generator/WinRT.Impl.Generator.csproj" />
+  <Project Path="WinRT.Internal/Windows.Internal.csproj" />
   <Project Path="WinRT.Interop.Generator/WinRT.Interop.Generator.csproj" />
   <Project Path="WinRT.Projection.Writer/WinRT.Projection.Writer.csproj" />
   <Project Path="WinRT.Projection.Generator/WinRT.Projection.Generator.csproj" />

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -425,7 +425,9 @@
   </Project>
   <Project Path="WinRT.Generator.Tasks/WinRT.Generator.Tasks.csproj" />
   <Project Path="WinRT.Impl.Generator/WinRT.Impl.Generator.csproj" />
-  <Project Path="WinRT.Internal/Windows.Internal.csproj" />
+  <Project Path="WinRT.Internal/WinRT.Internal.csproj">
+    <Build Project="false" />
+  </Project>
   <Project Path="WinRT.Interop.Generator/WinRT.Interop.Generator.csproj" />
   <Project Path="WinRT.Projection.Writer/WinRT.Projection.Writer.csproj" />
   <Project Path="WinRT.Projection.Generator/WinRT.Projection.Generator.csproj" />

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -425,9 +425,7 @@
   </Project>
   <Project Path="WinRT.Generator.Tasks/WinRT.Generator.Tasks.csproj" />
   <Project Path="WinRT.Impl.Generator/WinRT.Impl.Generator.csproj" />
-  <Project Path="WinRT.Internal/WinRT.Internal.csproj">
-    <Build Project="false" />
-  </Project>
+  <Project Path="WinRT.Internal/WinRT.Internal.csproj" />
   <Project Path="WinRT.Interop.Generator/WinRT.Interop.Generator.csproj" />
   <Project Path="WinRT.Projection.Writer/WinRT.Projection.Writer.csproj" />
   <Project Path="WinRT.Projection.Generator/WinRT.Projection.Generator.csproj" />


### PR DESCRIPTION
## Summary

Port the contents of `src/cswinrt/WindowsRuntime.Internal.idl` (the hand-authored Windows Runtime metadata that the legacy C++ `cswinrt` tool used to compile into `WindowsRuntime.Internal.winmd`) to a new C# `WinRT.Internal` project, and wire the existing C# WinMD generator in as the producer of the `.winmd`. The new `WinRT.Internal` project now owns this artifact end-to-end so the CsWinRT toolchain no longer needs the legacy C++ `cswinrt` project to be built at all.

## Motivation

The legacy C++ `cswinrt` project does two things: it produces `cswinrt.exe` (the old projection compiler) **and** it compiles `WindowsRuntime.Internal.idl` into `WindowsRuntime.Internal.winmd`. The first responsibility has already been ported to C# (the `WinRT.Projection.Writer` library + `cswinrtprojectiongen.exe`); the second was still tying the rest of the build to the C++ project.

Moving the `.idl` to a C# source-of-truth + the C# WinMD generator removes that dependency. A follow-up PR can now delete `src/cswinrt` entirely.

## Changes

### New `WinRT.Internal` C# project

- **`src/WinRT.Internal/WinRT.Internal.csproj`**: targets `net10.0-windows10.0.26100.1` (TFM revision `.1` selects the `cswinrt3` Windows SDK projection reference assemblies which carry `[WindowsRuntimeMetadata]` attributes the WinMD generator reads). Pins `WindowsSdkPackageVersion` so the SDK adds the matching framework reference. Disables all CsWinRT MSBuild processing (`CsWinRTEnabled` / `CsWinRTGenerateProjection` / `CsWinRTGenerateInteropAssembly[2]`) since this project itself feeds back into the CsWinRT toolchain. References the locally built `WinRT.Runtime.dll` directly via a `ProjectReference Private="false"`.
- **`src/WinRT.Internal/HWND.cs`**: struct counterpart of the IDL `HWND` (custom-mapped to `nint` by the projection writer).
- **`src/WinRT.Internal/ProjectionInternalAttribute.cs`**: forward declaration of the `[ProjectionInternal]` marker the projection writer reads to emit `internal` projections.
- **`src/WinRT.Internal/I*Interop.cs`**: one file per interop interface, all 14 of the IDL ones (`IAccountsSettingsPaneInterop`, `IDragDropManagerInterop`, `IInputPaneInterop`, `IPlayToManagerInterop`, `IPrintManagerInterop`, `IRadialControllerInterop`, `IRadialControllerConfigurationInterop`, `IRadialControllerIndependentInputSourceInterop`, `ISpatialInteractionManagerInterop`, `ISystemMediaTransportControlsInterop`, `IUIViewSettingsInterop`, `IUserConsentVerifierInterop`, `IWebAuthenticationCoreManagerInterop`, `IDisplayInformationStaticsInterop`) with their original IIDs, parameter ordering, and reference links to the corresponding Win32 `*interop.idl` documentation pages.

### WinMD generator improvements

Two small fixes to `WinRT.WinMD.Generator` were needed for the output to be functionally equivalent to the C++ `cswinrt`-generated `.winmd`:

- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs`**: `GetWinRTParameterAttributes` now preserves the input parameter's `[In]` / `[Out]` flags rather than unconditionally emitting `[Out]` for any by-reference parameter. When no flag is set on the input, byref params default to `[In]` (matching MIDL's convention for `ref const T`), keeping the projection writer's `ParameterCategoryResolver` classifying `ref Guid riid` as `ParameterCategory.Ref` rather than `Out`.
- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs`** + **`src/WinRT.WinMD.Generator/References/WinMDValues.cs`**: The authored `.winmd` assembly identity is now always stamped `255.255.255.255` (the WinRT "unbound" convention used by every Windows Runtime metadata assembly). The `--assembly-version` argument continues to drive the type-level `[Windows.Foundation.Metadata.Version]` attribute. Verified against the existing `TestComponent` / `TestComponentCSharp` `.winmd` outputs, both of which carry `v255.255.255.255` regardless of the project's `<AssemblyVersion>`.

### MSBuild integration

- **`src/WinRT.Internal/WinRT.Internal.csproj`** (target `GenerateWindowsRuntimeInternalWinMD`): writes a response file to `$(IntermediateOutputPath)` and invokes `cswinrtwinmdgen.exe` directly via `<Exec>` (instead of a `UsingTask`). This avoids the `MSB3027` file-lock contention that happens in Visual Studio when the persistent MSBuild build server keeps a custom-task assembly loaded across incremental builds — MSBuild never needs to load `WinRT.Generator.Tasks.dll` for this project at all.

### Build infrastructure rewiring

- **`src/Directory.Build.props`**: `$(CsWinRTInteropMetadata)` now resolves to `src/WinRT.Internal/bin/$(Configuration)/net10.0-windows10.0.26100.1/WindowsRuntime.Internal.winmd`. `$(AssemblyVersionNumber)` defaults to `3.0.0.0` so `dotnet build` works locally without explicit `/p:AssemblyVersionNumber=...`. Legacy `$(CsWinRTPath)` / `$(CsWinRTExe)` are kept defined as path strings (the `.exe` no longer needs to exist; they will be removed entirely once `src/cswinrt` is dropped).
- **`src/build.cmd`**: `interop_winmd` now points at the WinRT.Internal output instead of `_build/.../cswinrt/bin/`.
- **`build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml`**: the "Stage WindowsRuntime.Internal.winmd" task copies from `src/WinRT.Internal/bin/.../net10.0-windows10.0.26100.1/` rather than the `cswinrt` bin folder; downstream staging into `$(StagingFolder)/native` is unchanged so the nuget pack step still finds it at the same place.
- **`src/cswinrt.slnx`**: `WinRT.Internal` is included in the default solution-level build.

## Verification

- The new `WindowsRuntime.Internal.winmd` contains exactly the same set of public types (`HWND` + 14 interop interfaces + `ProjectionInternalAttribute`) with identical IIDs and method counts as the legacy C++-generated `WindowsRuntime.Internal.winmd`.
- `dotnet build src/WinRT.Sdk.Projection/...` successfully consumes the new `.winmd` and produces a `WinRT.Sdk.Projection.dll` containing the expected `ABI.WindowsRuntime.Internal.IAccountsSettingsPaneInteropMethods` internal projection alongside the regular `Windows.UI.ApplicationSettings.AccountsSettingsPane` runtime class, confirming the full interop pipeline still works.
- Four back-to-back incremental builds (including ones that force rebuilds of `WinRT.Generator.Tasks.dll` and `cswinrtwinmdgen.exe` themselves while the build session is alive) all complete cleanly with `0` errors — no `MSB3027` file-lock issues.

## Follow-up

The legacy `src/cswinrt` directory is still on disk for now (no consumer depends on it being built). It will be deleted entirely in a follow-up PR.
