### PR TITLE
Add debug repro support to the remaining CsWinRT 3.0 build tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -407,6 +407,8 @@ A **.NET CLI tool** (`cswinrtprojectionrefgen.exe`) published as a **Native AOT*
 
 The tool is wired through the `RunCsWinRTProjectionRefGenerator` MSBuild task (in `WinRT.Generator.Tasks`).
 
+**Debug repro support**: when `--debug-repro-directory` is provided, captures the expanded set of input `.winmd` files (resolving any `local` / `sdk` / `sdk+` / version / directory tokens to concrete files) and a faithful `.rsp` into a self-contained `ref-projection-debug-repro.zip`. The tool also accepts a `.zip` as input and replays the captured run.
+
 ### 5. Impl generator (`src/WinRT.Impl.Generator/`)
 
 A **.NET CLI tool** (`cswinrtimplgen.exe`) published as a **Native AOT** binary. Generates **forwarder/impl assemblies** that contain only type forwards (no actual code).
@@ -435,6 +437,8 @@ A **.NET CLI tool** (`cswinrtimplgen.exe`) published as a **Native AOT** binary.
 4. Emits `[TypeForwarder]` entries for all public top-level types, routing to the appropriate projection assembly
 5. Optionally signs with a strong-name key
 
+**Debug repro support**: when `--debug-repro-directory` is provided, captures the output assembly and all reference assemblies along with a faithful `.rsp` into a self-contained `impl-debug-repro.zip`. The tool also accepts a `.zip` as input and replays the captured run.
+
 ### 6. Projection generator (`src/WinRT.Projection.Generator/`)
 
 A **.NET CLI tool** (`cswinrtprojectiongen.exe`) published as a **Native AOT** binary. Runs at **app build / publish time** to produce a single projection `.dll` for the Windows SDK, the UWP XAML SDK, or all third-party Windows Runtime components referenced by the app. The tool drives the projection writer in-process and then compiles the resulting C# sources with Roslyn.
@@ -458,6 +462,8 @@ A **.NET CLI tool** (`cswinrtprojectiongen.exe`) published as a **Native AOT** b
 1. **Process References**: load reference assemblies via AsmResolver, build a `ProjectionWriterOptions` describing the inputs, output folder, and namespace filters.
 2. **Generate Sources**: invoke `ProjectionWriter.Run(options)` in-process to produce C# files.
 3. **Emit Assembly**: parse the generated `.cs` files with Roslyn, compile to `.dll` with `CSharpCompilation`, emit with embedded debug info.
+
+**Debug repro support**: when `--debug-repro-directory` is provided, captures all reference `.dll`-s, all input `.winmd` files, and the expanded Windows metadata files (bundled into a separate `windows-metadata/` subfolder) along with a faithful `.rsp` into a self-contained `projection-debug-repro.zip`. The tool also accepts a `.zip` as input and replays the captured run.
 
 ### 7. Interop generator (`src/WinRT.Interop.Generator/`)
 
@@ -493,7 +499,7 @@ There's two reasons for this:
 1. **Discover phase**: loads all input assemblies in parallel, scans for Windows Runtime types, generic instantiations, user-defined types implementing Windows Runtime interfaces. Uses visitor pattern (`AllGenericTypesVisitor`, `AllSzArrayTypesVisitor`).
 2. **Emit phase**: creates `WinRT.Interop.dll` via AsmResolver. Uses a two-pass IL generation approach (stub creation → rewriting via `InteropMethodRewriter`), then applies IL fixups.
 
-**Debug repro support**: can capture all inputs into a `.zip` file for reproducible debugging.
+**Debug repro support**: when `--debug-repro-directory` is provided, captures all reference and implementation `.dll`-s, the output assembly, and the resolved private implementation assemblies along with a faithful `.rsp` into a self-contained `interop-debug-repro.zip`. The tool also accepts a `.zip` as input and replays the captured run.
 
 ### 8. WinMD generator (`src/WinRT.WinMD.Generator/`)
 
@@ -532,6 +538,7 @@ WinRT.WinMD.Generator/
 | `--output-winmd-path` | Output `.winmd` file path |
 | `--assembly-version` | Assembly version stamped into the generated WinMD |
 | `--use-windows-ui-xaml-projections` | Use UWP XAML (`Windows.UI.Xaml`) instead of WinUI |
+| `--debug-repro-directory` | Optional directory to write a self-contained debug repro `.zip` to |
 
 **How it integrates with the build:**
 
@@ -539,6 +546,8 @@ WinRT.WinMD.Generator/
 - Invoked through the `RunCsWinRTWinMDGenerator` MSBuild task (in `WinRT.Generator.Tasks`)
 - Runs after `CoreCompile` (it needs the compiled .dll), gated on `CsWinRTComponent == true` and `DesignTimeBuild != true`
 - Output is `$(IntermediateOutputPath)$(AssemblyName).winmd`, then copied to `$(TargetDir)` by the authoring targets and packaged into the component's NuGet
+
+**Debug repro support**: when `--debug-repro-directory` is provided, captures the input component `.dll` and all reference assemblies along with a faithful `.rsp` into a self-contained `winmd-debug-repro.zip`. The tool also accepts a `.zip` as input and replays the captured run.
 
 ### 9. Generator tasks (`src/WinRT.Generator.Tasks/`)
 
@@ -662,6 +671,7 @@ All five .NET build tools (`cswinrtprojectionrefgen`, `cswinrtprojectiongen`, `c
   - `WellKnown*Exception` for expected errors (with error IDs like `CSWINRTIMPLGEN0001`)
   - `Unhandled*Exception` for unexpected errors (suggests opening a GitHub issue)
   - `CommandLineArgumentNameAttribute` maps properties to CLI flag names
+- Support a **debug repro** mode: when `--debug-repro-directory` is provided, each tool packages all of its input files (with hashed names to avoid collisions) and a faithful `.rsp` into a self-contained `.zip` (`impl-debug-repro.zip`, `interop-debug-repro.zip`, `projection-debug-repro.zip`, `ref-projection-debug-repro.zip`, `winmd-debug-repro.zip`). Each tool also accepts a `.zip` as input and replays the captured run from a temporary unpack directory, with original file names restored. The MSBuild task wrappers in `WinRT.Generator.Tasks` expose this via a `DebugReproDirectory` parameter, plumbed from the `$(CsWinRTGeneratorDebugReproDirectory)` MSBuild property.
 - Security hardening: Control Flow Guard, `IlcResilient = false` (fail on unresolved assemblies)
 
 ### Error ID ranges
@@ -669,12 +679,12 @@ All five .NET build tools (`cswinrtprojectionrefgen`, `cswinrtprojectiongen`, `c
 | Project | Error ID Pattern | Range |
 |---------|-----------------|-------|
 | Source Generator | `CSWINRT2xxx` | `CSWINRT2000`–`CSWINRT2009` |
-| Reference Projection Generator | `CSWINRTPROJECTIONREFGENxxxx` | `0001`–`0005`, `9999` |
-| Projection Generator (host) | `CSWINRTPROJECTIONGENxxxx` | `0001`–`0008`, `9999` |
+| Reference Projection Generator | `CSWINRTPROJECTIONREFGENxxxx` | `0001`–`0008`, `9999` |
+| Projection Generator (host) | `CSWINRTPROJECTIONGENxxxx` | `0001`–`0011`, `9999` |
 | Projection Writer (library) | `CSWINRTPROJECTIONGEN5xxx` | `5003`–`5021`, `9999` (shares the `CSWINRTPROJECTIONGEN` prefix with the host; the writer reserves the 5000+ range so the two never collide) |
 | Impl Generator | `CSWINRTIMPLGENxxxx` | `0001`–`0014`, `9999` |
 | Interop Generator | `CSWINRTINTEROPGENxxxx` | `0001`–`0097`, `9999` |
-| WinMD Generator | `CSWINRTWINMDGENxxxx` | `0001`–`0007`, `9999` |
+| WinMD Generator | `CSWINRTWINMDGENxxxx` | `0001`–`0010`, `9999` |
 | Runtime (obsolete markers) | `CSWINRT3xxx` | `CSWINRT3001` |
 
 ---

--- a/.github/skills/update-copilot-instructions/SKILL.md
+++ b/.github/skills/update-copilot-instructions/SKILL.md
@@ -46,11 +46,13 @@ Launch parallel explore agents for each of the 11 CsWinRT 3.0 projects listed in
    - Error ID range (`CSWINRTPROJECTIONREFGENxxxx`) in `Errors/WellKnownReferenceProjectionGeneratorExceptions.cs` is accurate
    - Project settings (Native AOT, dependencies) are current
    - MSBuild integration via `nuget/Microsoft.Windows.CsWinRT.targets` (CsWinRTGenerateProjection target → `RunCsWinRTProjectionRefGenerator`) is wired
+   - Debug repro support is documented (mentions `--debug-repro-directory`, `ref-projection-debug-repro.zip`, expansion of input tokens to concrete `.winmd` files)
 
 5. **Impl generator (`src/WinRT.Impl.Generator/`)**
    - Type forward routing logic is current
    - Project settings and dependencies are current
    - CLI parameters are current
+   - Debug repro support is documented (mentions `--debug-repro-directory`, `impl-debug-repro.zip`, output assembly + reference assemblies bundled)
 
 6. **Projection generator (`src/WinRT.Projection.Generator/`)**
    - Three projection modes are accurately described
@@ -58,22 +60,26 @@ Launch parallel explore agents for each of the 11 CsWinRT 3.0 projects listed in
    - Project settings and dependencies (project reference to `WinRT.Projection.Writer`) are current
    - The pipeline is documented as in-process (the projection writer is invoked as a library)
    - `ProjectionGeneratorArgs` no longer contains any leftover `CsWinRTExePath` field
+   - Debug repro support is documented (mentions `--debug-repro-directory`, `projection-debug-repro.zip`, expanded Windows metadata bundled into a `windows-metadata/` subfolder)
 
 7. **Interop generator (`src/WinRT.Interop.Generator/`)**
    - Generated content categories are current
    - Directory structure and key types are accurate
    - Project settings and dependencies are current
+   - Debug repro support is documented (mentions `--debug-repro-directory`, `interop-debug-repro.zip`, reference + implementation `.dll`-s bundled into separate subfolders)
 
 8. **WinMD generator (`src/WinRT.WinMD.Generator/`)**
    - CLI parameters on `WinMDGeneratorArgs` are current
    - Error ID range (`CSWINRTWINMDGENxxxx`) in `Errors/WellKnownWinMDExceptions.cs` is accurate
    - Project settings and dependencies are current
    - MSBuild integration via `nuget/Microsoft.Windows.CsWinRT.Authoring.WinMD.targets` is wired (gated on `CsWinRTComponent`)
+   - Debug repro support is documented (mentions `--debug-repro-directory`, `winmd-debug-repro.zip`, input component `.dll` + reference assemblies bundled)
 
 9. **Generator tasks (`src/WinRT.Generator.Tasks/`)**
    - MSBuild task classes are accurately listed (including `RunCsWinRTProjectionRefGenerator` and `RunCsWinRTWinMDGenerator`)
    - Task-to-tool mappings are current
    - No leftover `CsWinRTExePath` parameter on `RunCsWinRTMergedProjectionGenerator`
+   - All five tasks expose a `DebugReproDirectory` parameter plumbed from `$(CsWinRTGeneratorDebugReproDirectory)`
 
 10. **SDK projection builds (`src/WinRT.Sdk.Projection/`)**
     - Assembly name logic (base vs XAML) is current

--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.WinMD.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.WinMD.targets
@@ -86,6 +86,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       OutputWinmdPath="$(_CsWinRTWinMDOutputPath)"
       AssemblyVersion="$(AssemblyVersion)"
       UseWindowsUIXamlProjections="$(CsWinRTUseWindowsUIXamlProjections)"
+      DebugReproDirectory="$(CsWinRTGeneratorDebugReproDirectory)"
       CsWinRTToolsDirectory="$(CsWinRTWinMDGenEffectiveToolsDirectory)"
       CsWinRTToolsArchitecture="$(CsWinRTToolsArchitecture)"
       StandardOutputImportance="$(CsWinRTGeneratorStandardOutputImportance)"

--- a/nuget/Microsoft.Windows.CsWinRT.CsWinRTGen.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.CsWinRTGen.targets
@@ -343,6 +343,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       WinMDPaths="@(_WinMDPathsList)"
       TargetFramework="$(CsWinRTExeTFM)"
       WindowsMetadata="$(CsWinRTWindowsMetadata)"      
+      DebugReproDirectory="$(CsWinRTGeneratorDebugReproDirectory)"
       CsWinRTToolsDirectory="$(CsWinRTMergedProjectionEffectiveToolsDirectory)"
       CsWinRTToolsArchitecture="$(CsWinRTToolsArchitecture)"
       AdditionalArguments="@(CsWinRTGeneratorAdditionalArgument)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -314,6 +314,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         PublicExclusiveTo="$(CsWinRTPublicExclusiveToInterfaces)"
         IdicExclusiveTo="$(CsWinRTDynamicallyInterfaceCastableExclusiveTo)"
         ReferenceProjection="$(CsWinRTGenerateReferenceProjection)"
+        DebugReproDirectory="$(CsWinRTGeneratorDebugReproDirectory)"
         CsWinRTToolsDirectory="$(CsWinRTRefGenEffectiveToolsDirectory)"
         CsWinRTToolsArchitecture="$(CsWinRTToolsArchitecture)"
         ContinueOnError="$(CsWinRTContinueOnError)" />

--- a/src/WinRT.Generator.Tasks/RunCsWinRTMergedProjectionGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTMergedProjectionGenerator.cs
@@ -87,6 +87,12 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
     /// <remarks>If not set, the default will match the number of available processor cores.</remarks>
     public int MaxDegreesOfParallelism { get; set; } = -1;
 
+    /// <summary>
+    /// Gets or sets the directory where the debug repro will be produced.
+    /// </summary>
+    /// <remarks>If not set, no debug repro will be produced.</remarks>
+    public string? DebugReproDirectory { get; set; }
+
     /// <inheritdoc/>
     protected override string ToolName => "cswinrtprojectiongen.exe";
 
@@ -130,6 +136,13 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
         if (CsWinRTToolsDirectory is null || !Directory.Exists(CsWinRTToolsDirectory))
         {
             Log.LogWarning("Tools directory '{0}' is invalid or does not exist.", CsWinRTToolsDirectory);
+
+            return false;
+        }
+
+        if (DebugReproDirectory is not null && !Directory.Exists(DebugReproDirectory))
+        {
+            Log.LogWarning("Debug repro directory '{0}' is invalid or does not exist.", DebugReproDirectory);
 
             return false;
         }
@@ -208,6 +221,7 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
         }
 
         AppendResponseFileCommand(args, "--max-degrees-of-parallelism", MaxDegreesOfParallelism.ToString());
+        AppendResponseFileOptionalCommand(args, "--debug-repro-directory", DebugReproDirectory);
 
         // Add any additional arguments that are not statically known
         foreach (ITaskItem additionalArgument in AdditionalArguments ?? [])
@@ -227,5 +241,20 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
     private static void AppendResponseFileCommand(StringBuilder args, string commandName, string commandValue)
     {
         _ = args.Append($"{commandName} ").AppendLine(commandValue);
+    }
+
+    /// <summary>
+    /// Appends an optional command line argument to the response file arguments, with the right format.
+    /// </summary>
+    /// <param name="args">The command line arguments being built.</param>
+    /// <param name="commandName">The command name to append.</param>
+    /// <param name="commandValue">The optional command value to append.</param>
+    /// <remarks>This method will not append the command if <paramref name="commandValue"/> is <see langword="null"/>.</remarks>
+    private static void AppendResponseFileOptionalCommand(StringBuilder args, string commandName, string? commandValue)
+    {
+        if (commandValue is not null)
+        {
+            AppendResponseFileCommand(args, commandName, commandValue);
+        }
     }
 }

--- a/src/WinRT.Generator.Tasks/RunCsWinRTProjectionRefGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTProjectionRefGenerator.cs
@@ -85,6 +85,12 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
     public bool ReferenceProjection { get; set; }
 
     /// <summary>
+    /// Gets or sets the directory where the debug repro will be produced.
+    /// </summary>
+    /// <remarks>If not set, no debug repro will be produced.</remarks>
+    public string? DebugReproDirectory { get; set; }
+
+    /// <summary>
     /// Gets or sets the tools directory where the 'cswinrtprojectionrefgen' tool is located.
     /// </summary>
     [Required]
@@ -144,6 +150,13 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
         if (CsWinRTToolsDirectory is null || !Directory.Exists(CsWinRTToolsDirectory))
         {
             Log.LogWarning("Tools directory '{0}' is invalid or does not exist.", CsWinRTToolsDirectory);
+
+            return false;
+        }
+
+        if (DebugReproDirectory is not null && !Directory.Exists(DebugReproDirectory))
+        {
+            Log.LogWarning("Debug repro directory '{0}' is invalid or does not exist.", DebugReproDirectory);
 
             return false;
         }
@@ -247,6 +260,8 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
             AppendResponseFileCommand(args, "--reference-projection", "true");
         }
 
+        AppendResponseFileOptionalCommand(args, "--debug-repro-directory", DebugReproDirectory);
+
         // Add any additional arguments that are not statically known
         foreach (ITaskItem additionalArgument in AdditionalArguments ?? [])
         {
@@ -265,5 +280,20 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
     private static void AppendResponseFileCommand(StringBuilder args, string commandName, string commandValue)
     {
         _ = args.Append($"{commandName} ").AppendLine(commandValue);
+    }
+
+    /// <summary>
+    /// Appends an optional command line argument to the response file arguments, with the right format.
+    /// </summary>
+    /// <param name="args">The command line arguments being built.</param>
+    /// <param name="commandName">The command name to append.</param>
+    /// <param name="commandValue">The optional command value to append.</param>
+    /// <remarks>This method will not append the command if <paramref name="commandValue"/> is <see langword="null"/>.</remarks>
+    private static void AppendResponseFileOptionalCommand(StringBuilder args, string commandName, string? commandValue)
+    {
+        if (commandValue is not null)
+        {
+            AppendResponseFileCommand(args, commandName, commandValue);
+        }
     }
 }

--- a/src/WinRT.Generator.Tasks/RunCsWinRTWinMDGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTWinMDGenerator.cs
@@ -46,6 +46,12 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
     public bool UseWindowsUIXamlProjections { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets the directory where the debug repro will be produced.
+    /// </summary>
+    /// <remarks>If not set, no debug repro will be produced.</remarks>
+    public string? DebugReproDirectory { get; set; }
+
+    /// <summary>
     /// Gets or sets the tools directory where the 'cswinrtwinmdgen' tool is located.
     /// </summary>
     [Required]
@@ -104,6 +110,12 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
             return false;
         }
 
+        if (DebugReproDirectory is not null && !Directory.Exists(DebugReproDirectory))
+        {
+            Log.LogWarning("Debug repro directory '{0}' is invalid or does not exist.", DebugReproDirectory);
+            return false;
+        }
+
         return true;
     }
 
@@ -145,6 +157,7 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
         AppendResponseFileCommand(args, "--output-winmd-path", OutputWinmdPath!);
         AppendResponseFileCommand(args, "--assembly-version", AssemblyVersion!);
         AppendResponseFileCommand(args, "--use-windows-ui-xaml-projections", UseWindowsUIXamlProjections.ToString());
+        AppendResponseFileOptionalCommand(args, "--debug-repro-directory", DebugReproDirectory);
 
         return args.ToString();
     }
@@ -155,5 +168,17 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
     private static void AppendResponseFileCommand(StringBuilder args, string commandName, string commandValue)
     {
         _ = args.Append($"{commandName} ").AppendLine(commandValue);
+    }
+
+    /// <summary>
+    /// Appends an optional command line argument to the response file arguments, with the right format.
+    /// </summary>
+    /// <remarks>This method will not append the command if <paramref name="commandValue"/> is <see langword="null"/>.</remarks>
+    private static void AppendResponseFileOptionalCommand(StringBuilder args, string commandName, string? commandValue)
+    {
+        if (commandValue is not null)
+        {
+            AppendResponseFileCommand(args, commandName, commandValue);
+        }
     }
 }

--- a/src/WinRT.Projection.Generator/Errors/WellKnownProjectionGeneratorExceptions.cs
+++ b/src/WinRT.Projection.Generator/Errors/WellKnownProjectionGeneratorExceptions.cs
@@ -93,6 +93,30 @@ internal static class WellKnownProjectionGeneratorExceptions
     }
 
     /// <summary>
+    /// The debug repro directory does not exist.
+    /// </summary>
+    public static Exception DebugReproDirectoryDoesNotExist(string path)
+    {
+        return Exception(9, $"The debug repro directory '{path}' does not exist.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that has no mapping.
+    /// </summary>
+    public static Exception DebugReproMissingFileEntryMapping(string path)
+    {
+        return Exception(10, $"The debug repro file entry with path '{path}' is missing its assembly path mapping.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that was not recognized.
+    /// </summary>
+    public static Exception DebugReproUnrecognizedFileEntry(string path)
+    {
+        return Exception(11, $"The debug repro file entry with path '{path}' was not recognized.");
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     /// <param name="id">The exception id.</param>

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.DebugRepro.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.DebugRepro.cs
@@ -1,0 +1,400 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using WindowsRuntime.InteropGenerator;
+using WindowsRuntime.ProjectionGenerator.Errors;
+using WindowsRuntime.ProjectionGenerator.Helpers;
+using WindowsRuntime.ProjectionWriter.Helpers;
+
+#pragma warning disable IDE0008
+
+namespace WindowsRuntime.ProjectionGenerator.Generation;
+
+/// <inheritdoc cref="ProjectionGenerator"/>
+internal static partial class ProjectionGenerator
+{
+    /// <summary>
+    /// The file name for the original names of the reference .dll-s.
+    /// </summary>
+    private const string ReferencePathMapFileName = "original-reference-paths.json";
+
+    /// <summary>
+    /// The file name for the original names of the input .winmd files.
+    /// </summary>
+    private const string WinMDPathMapFileName = "original-winmd-paths.json";
+
+    /// <summary>
+    /// The file name for the original names of the Windows metadata .winmd files.
+    /// </summary>
+    private const string WindowsMetadataPathMapFileName = "original-windows-metadata-paths.json";
+
+    /// <summary>
+    /// The subfolder name (relative to the debug repro root) where reference .dll-s are stored.
+    /// </summary>
+    private const string ReferenceSubfolder = "reference";
+
+    /// <summary>
+    /// The subfolder name (relative to the debug repro root) where input .winmd files are stored.
+    /// </summary>
+    private const string WinMDSubfolder = "winmd";
+
+    /// <summary>
+    /// The subfolder name (relative to the debug repro root) where the expanded Windows metadata
+    /// .winmd files are stored. The replay run sets <see cref="ProjectionGeneratorArgs.WindowsMetadata"/>
+    /// to the absolute path of this folder so the writer picks up its contents via recursive scan.
+    /// </summary>
+    private const string WindowsMetadataSubfolder = "windows-metadata";
+
+    /// <summary>
+    /// Runs the debug repro unpack logic for the generator.
+    /// </summary>
+    /// <param name="path">The path to the debug repro file to unpack.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The path to the resulting response file to use.</returns>
+    private static string UnpackDebugRepro(string path, CancellationToken token)
+    {
+        // Create a temporary directory to extract the files from the debug repro
+        string tempFolderName = $"cswinrtprojectiongen-debug-repro-unpack-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+
+        _ = Directory.CreateDirectory(tempDirectory);
+
+        token.ThrowIfCancellationRequested();
+
+        using ZipArchive archive = ZipFile.OpenRead(path);
+
+        // Get all entries of interest
+        ZipArchiveEntry responseFileEntry = archive.Entries.Single(entry => entry.Name == "cswinrtprojectiongen.rsp");
+        ZipArchiveEntry originalReferencePathsEntry = archive.Entries.Single(entry => entry.Name == ReferencePathMapFileName);
+        ZipArchiveEntry originalWinMDPathsEntry = archive.Entries.Single(entry => entry.Name == WinMDPathMapFileName);
+        ZipArchiveEntry originalWindowsMetadataPathsEntry = archive.Entries.Single(entry => entry.Name == WindowsMetadataPathMapFileName);
+        ZipArchiveEntry[] assemblyEntries =
+        [
+            .. archive.Entries.Where(entry =>
+            {
+                string extension = Path.GetExtension(Path.Normalize(entry.Name));
+
+                return extension is ".dll" or ".winmd";
+            })
+        ];
+
+        token.ThrowIfCancellationRequested();
+
+        ProjectionGeneratorArgs args;
+
+        // Parse the debug repro .rsp file
+        using (Stream stream = responseFileEntry.Open())
+        {
+            args = ProjectionGeneratorArgs.ParseFromResponseFile(stream, token);
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Load the mappings with all the original file paths
+        Dictionary<string, string> originalReferencePaths = ExtractPathMap(originalReferencePathsEntry);
+        Dictionary<string, string> originalWinMDPaths = ExtractPathMap(originalWinMDPathsEntry);
+        Dictionary<string, string> originalWindowsMetadataPaths = ExtractPathMap(originalWindowsMetadataPathsEntry);
+
+        token.ThrowIfCancellationRequested();
+
+        List<string> referencePaths = [];
+        List<string> winmdPaths = [];
+
+        // Define subdirectories for each category of input. We don't put these in the top level
+        // temporary folder so that the number of files there remains very small. The reason is just
+        // to make inspecting the resulting files easier, without having to scroll past many folders.
+        // It also makes it possible to directly inspect the different sets of input files.
+        string referenceDirectory = Path.Combine(tempDirectory, ReferenceSubfolder);
+        string winmdDirectory = Path.Combine(tempDirectory, WinMDSubfolder);
+        string windowsMetadataDirectory = Path.Combine(tempDirectory, WindowsMetadataSubfolder);
+
+        // Create the directories in advance, so that we can directly extract the files there
+        _ = Directory.CreateDirectory(referenceDirectory);
+        _ = Directory.CreateDirectory(winmdDirectory);
+        _ = Directory.CreateDirectory(windowsMetadataDirectory);
+
+        // Extract all .dll/.winmd files, one per directory based on category, so we can ensure
+        // there's no name conflicts between the different sets of input files.
+        foreach (ZipArchiveEntry assemblyEntry in assemblyEntries)
+        {
+            bool isReferenceAssembly = Path.IsWithinDirectoryName(assemblyEntry.FullName, ReferenceSubfolder);
+            bool isWinMDAssembly = Path.IsWithinDirectoryName(assemblyEntry.FullName, WinMDSubfolder);
+            bool isWindowsMetadataAssembly = Path.IsWithinDirectoryName(assemblyEntry.FullName, WindowsMetadataSubfolder);
+
+            // Select the right mapping based on the entry's category
+            Dictionary<string, string> originalPaths = isReferenceAssembly
+                ? originalReferencePaths
+                : isWinMDAssembly
+                    ? originalWinMDPaths
+                    : originalWindowsMetadataPaths;
+
+            // Make sure the debug repro is well-formed and contains the mapping for this entry
+            if (!originalPaths.TryGetValue(assemblyEntry.Name, out string? originalPath))
+            {
+                throw WellKnownProjectionGeneratorExceptions.DebugReproMissingFileEntryMapping(assemblyEntry.FullName);
+            }
+
+            // Construct the path in the temporary subfolder with the original assembly name
+            string originalName = Path.GetFileName(Path.Normalize(originalPath));
+            string destinationFolder = isReferenceAssembly
+                ? referenceDirectory
+                : isWinMDAssembly
+                    ? winmdDirectory
+                    : windowsMetadataDirectory;
+            string destinationPath = Path.Combine(destinationFolder, originalName);
+
+            // Extract the file to the new destination path
+            assemblyEntry.ExtractToFile(destinationPath, overwrite: true);
+
+            if (isReferenceAssembly)
+            {
+                referencePaths.Add(destinationPath);
+            }
+            else if (isWinMDAssembly)
+            {
+                winmdPaths.Add(destinationPath);
+            }
+            else if (!isWindowsMetadataAssembly)
+            {
+                // We should never hit this case, so throw to validate that the debug repro is valid.
+                // Entries should always be either reference, winmd, or windows-metadata assemblies.
+                throw WellKnownProjectionGeneratorExceptions.DebugReproUnrecognizedFileEntry(assemblyEntry.FullName);
+            }
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Prepare the .rsp file with all updated arguments. The 'WindowsMetadata' value points at the
+        // bundled folder, which the writer scans recursively to pick up all the .winmd files it contains.
+        string rspText = new ProjectionGeneratorArgs
+        {
+            ReferenceAssemblyPaths = [.. referencePaths],
+            GeneratedAssemblyDirectory = tempDirectory,
+            WinMDPaths = [.. winmdPaths],
+            TargetFramework = args.TargetFramework,
+            WindowsMetadata = windowsMetadataDirectory,
+            AssemblyName = args.AssemblyName,
+            WindowsSdkOnly = args.WindowsSdkOnly,
+            WindowsUIXamlProjection = args.WindowsUIXamlProjection,
+            MaxDegreesOfParallelism = args.MaxDegreesOfParallelism,
+            DebugReproDirectory = null,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtprojectiongen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        // Return the resulting .rsp file so it can be used to replay the debug repro
+        return rspFilePath;
+    }
+
+    /// <summary>
+    /// Runs the debug repro save logic for the generator.
+    /// </summary>
+    /// <param name="args">The arguments for this invocation.</param>
+    private static void SaveDebugRepro(ProjectionGeneratorArgs args)
+    {
+        // We expect callers to have already performed this check, but just in case
+        if (args.DebugReproDirectory is null)
+        {
+            return;
+        }
+
+        // The target folder must exist
+        if (!Directory.Exists(args.DebugReproDirectory))
+        {
+            throw WellKnownProjectionGeneratorExceptions.DebugReproDirectoryDoesNotExist(args.DebugReproDirectory);
+        }
+
+        // Path for the ZIP archive
+        string zipPath = Path.Combine(args.DebugReproDirectory, "projection-debug-repro.zip");
+
+        // Create a temporary directory to stage files for the ZIP
+        string tempFolderName = $"cswinrtprojectiongen-debug-repro-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+        string referenceDirectory = Path.Combine(tempDirectory, ReferenceSubfolder);
+        string winmdDirectory = Path.Combine(tempDirectory, WinMDSubfolder);
+        string windowsMetadataDirectory = Path.Combine(tempDirectory, WindowsMetadataSubfolder);
+
+        _ = Directory.CreateDirectory(tempDirectory);
+        _ = Directory.CreateDirectory(referenceDirectory);
+        _ = Directory.CreateDirectory(winmdDirectory);
+        _ = Directory.CreateDirectory(windowsMetadataDirectory);
+
+        // Maps with all the original paths
+        Dictionary<string, string> originalReferencePaths = [];
+        Dictionary<string, string> originalWinMDPaths = [];
+        Dictionary<string, string> originalWindowsMetadataPaths = [];
+
+        // Add all reference and .winmd paths with hashed names to the respective subdirectories under the
+        // temporary directory, and store them with the updated names in a list to use to build the .rsp file.
+        List<string> updatedReferenceNames = CopyHashedFilesToDirectory(args.ReferenceAssemblyPaths, referenceDirectory, originalReferencePaths, args.Token);
+        List<string> updatedWinMDNames = CopyHashedFilesToDirectory(args.WinMDPaths, winmdDirectory, originalWinMDPaths, args.Token);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Expand the Windows metadata token (a literal path, 'local', 'sdk', 'sdk+', or a version like
+        // '10.0.26100.0') to the concrete set of .winmd files the writer would actually consume. This
+        // makes the debug repro fully self-contained, even when the original Windows metadata token was
+        // a special value that depends on the host environment (e.g. a registered SDK installation).
+        List<string> expandedWindowsMetadataPaths = [];
+
+        foreach (string expanded in WindowsMetadataExpander.Expand(args.WindowsMetadata))
+        {
+            // The expander may return either individual files or directories; we want individual
+            // files in the bundled repro so the layout is fully self-describing.
+            if (File.Exists(expanded))
+            {
+                expandedWindowsMetadataPaths.Add(expanded);
+            }
+            else if (Directory.Exists(expanded))
+            {
+                expandedWindowsMetadataPaths.AddRange(Directory.EnumerateFiles(expanded, "*.winmd", SearchOption.AllDirectories));
+            }
+        }
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Bundle the expanded Windows metadata files into the windows-metadata subdirectory
+        _ = CopyHashedFilesToDirectory([.. expandedWindowsMetadataPaths], windowsMetadataDirectory, originalWindowsMetadataPaths, args.Token);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Prepare the .rsp file with all updated arguments. The 'WindowsMetadata' value is just the
+        // subfolder name (relative path); the replay run resolves it to an absolute path inside its
+        // own temporary unpack directory, since the original 'DebugReproDirectory' may not exist there.
+        string rspText = new ProjectionGeneratorArgs
+        {
+            ReferenceAssemblyPaths = [.. updatedReferenceNames],
+            GeneratedAssemblyDirectory = args.GeneratedAssemblyDirectory,
+            WinMDPaths = [.. updatedWinMDNames],
+            TargetFramework = args.TargetFramework,
+            WindowsMetadata = WindowsMetadataSubfolder,
+            AssemblyName = args.AssemblyName,
+            WindowsSdkOnly = args.WindowsSdkOnly,
+            WindowsUIXamlProjection = args.WindowsUIXamlProjection,
+            MaxDegreesOfParallelism = args.MaxDegreesOfParallelism,
+            DebugReproDirectory = args.DebugReproDirectory,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtprojectiongen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Create the .json files with the path maps for each category
+        CopyPathMapToDirectory(originalReferencePaths, tempDirectory, ReferencePathMapFileName);
+        CopyPathMapToDirectory(originalWinMDPaths, tempDirectory, WinMDPathMapFileName);
+        CopyPathMapToDirectory(originalWindowsMetadataPaths, tempDirectory, WindowsMetadataPathMapFileName);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Delete the previous file, if it exists
+        if (File.Exists(zipPath))
+        {
+            File.Delete(zipPath);
+        }
+
+        // Create the actual .zip file in the target directory
+        ZipFile.CreateFromDirectory(tempDirectory, zipPath);
+
+        // Clean up the temporary directory
+        Directory.Delete(tempDirectory, recursive: true);
+    }
+
+    /// <summary>
+    /// Generates a hashed filename by appending a hash of the original filename.
+    /// </summary>
+    /// <param name="filePath">The original file path.</param>
+    /// <returns>The hashed filename.</returns>
+    private static string GetHashedFileName(string filePath)
+    {
+        string fileName = Path.GetFileName(Path.Normalize(filePath));
+        byte[] utf8Data = Encoding.UTF8.GetBytes(filePath);
+        byte[] hashData = Shake128.HashData(utf8Data, outputLength: 16);
+        string hash = Convert.ToHexString(hashData);
+
+        return $"{Path.GetFileNameWithoutExtension(fileName)}_{hash}{Path.GetExtension(fileName)}";
+    }
+
+    /// <summary>
+    /// Copies all specified files to a target folder, and returns the list of updated hashed filenames.
+    /// </summary>
+    /// <param name="filePaths">The input file paths.</param>
+    /// <param name="destinationDirectory">The target directory to copy the files to.</param>
+    /// <param name="originalPaths">A dictionary to store the original paths of the copied files.</param>
+    /// <param name="token">A cancellation token to monitor for cancellation requests.</param>
+    /// <returns>The list of updated hashed filenames.</returns>
+    private static List<string> CopyHashedFilesToDirectory(
+        string[] filePaths,
+        string destinationDirectory,
+        Dictionary<string, string> originalPaths,
+        CancellationToken token)
+    {
+        List<string> updatedNames = [];
+
+        foreach (string filePath in filePaths)
+        {
+            token.ThrowIfCancellationRequested();
+
+            string hashedName = GetHashedFileName(filePath);
+            string destinationPath = Path.Combine(destinationDirectory, hashedName);
+
+            File.Copy(filePath, destinationPath, overwrite: true);
+
+            updatedNames.Add(hashedName);
+            originalPaths.Add(hashedName, filePath);
+        }
+
+        return updatedNames;
+    }
+
+    /// <summary>
+    /// Copies an input path map to a target directory, as a serialized JSON file.
+    /// </summary>
+    /// <param name="pathMap">The input path map.</param>
+    /// <param name="destinationDirectory">The target directory to copy the assemblies to.</param>
+    /// <param name="fileName">The name to use for the file with the serialized path map.</param>
+    private static void CopyPathMapToDirectory(
+        Dictionary<string, string> pathMap,
+        string destinationDirectory,
+        string fileName)
+    {
+        // Create the .json file with the input path map
+        string jsonFilePath = Path.Combine(destinationDirectory, fileName);
+
+        using Stream jsonStream = File.Create(jsonFilePath);
+
+        // Serialize the path map to the target file
+        JsonSerializer.Serialize(jsonStream, pathMap, ProjectionGeneratorJsonSerializerContext.Default.DictionaryStringString);
+    }
+
+    /// <summary>
+    /// Extracts an input path from a .zip archive entry.
+    /// </summary>
+    /// <param name="pathMapEntry">The input path map entry.</param>
+    /// <remarks>
+    /// The <paramref name="pathMapEntry"/> value is expected to have the content produced by calls to <see cref="CopyPathMapToDirectory"/>.
+    /// </remarks>
+    private static Dictionary<string, string> ExtractPathMap(ZipArchiveEntry pathMapEntry)
+    {
+        using Stream stream = pathMapEntry.Open();
+
+        // Load the mapping with all the original file paths for the included assemblies
+        return JsonSerializer.Deserialize(stream, ProjectionGeneratorJsonSerializerContext.Default.DictionaryStringString)!;
+    }
+}

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using ConsoleAppFramework;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.ProjectionGenerator.Errors;
 
 namespace WindowsRuntime.ProjectionGenerator.Generation;
@@ -17,10 +18,36 @@ internal static partial class ProjectionGenerator
     /// <summary>
     /// Runs the projection generator to produce the resulting <c>WinRT.Projection.dll</c> assembly.
     /// </summary>
-    /// <param name="responseFilePath">The path to the response file to use.</param>
+    /// <param name="inputFilePath">The path to the response file or debug repro to use.</param>
     /// <param name="token">The token for the operation.</param>
-    public static void Run([Argument] string responseFilePath, CancellationToken token)
+    public static void Run([Argument] string inputFilePath, CancellationToken token)
     {
+        string responseFilePath = inputFilePath;
+        bool isUsingDebugRepro = false;
+
+        // Load the debug repro to investigate with, if we have one
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            if (Path.GetExtension(Path.Normalize(inputFilePath)) == ".zip")
+            {
+                ConsoleApp.Log("Unpacking input 'cswinrtprojectiongen' debug repro");
+
+                isUsingDebugRepro = true;
+
+                // If we unpacked a debug repro, we'll also replace the input file
+                // path with the extracted response file from the input repro.
+                responseFilePath = UnpackDebugRepro(inputFilePath, token);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledProjectionGeneratorException("unpack-debug-repro", e);
+        }
+
+        token.ThrowIfCancellationRequested();
+
         ProjectionGeneratorArgs args;
 
         // Parse the actual arguments from the response file
@@ -31,6 +58,27 @@ internal static partial class ProjectionGenerator
         catch (Exception e) when (!e.IsWellKnown)
         {
             throw new UnhandledProjectionGeneratorException("parsing", e);
+        }
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Save a debug repro, if needed
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            // We also skip this if we're currently processing an input debug
+            // repro, as there would be no point in creating a new one from that.
+            if (args.DebugReproDirectory is not null && !isUsingDebugRepro)
+            {
+                ConsoleApp.Log("Saving 'cswinrtprojectiongen' debug repro");
+
+                SaveDebugRepro(args);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledProjectionGeneratorException("save-debug-repro", e);
         }
 
         args.Token.ThrowIfCancellationRequested();

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.Formatting.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.Formatting.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace WindowsRuntime.ProjectionGenerator.Generation;
+
+/// <inheritdoc cref="ProjectionGeneratorArgs"/>
+internal partial class ProjectionGeneratorArgs
+{
+    /// <summary>
+    /// Formats the current <see cref="ProjectionGeneratorArgs"/> instance into a response file text.
+    /// </summary>
+    /// <returns>The resulting response file text.</returns>
+    public string FormatToResponseFile()
+    {
+        StringBuilder builder = new();
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(ReferenceAssemblyPaths)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(string.Join(',', ReferenceAssemblyPaths));
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(GeneratedAssemblyDirectory)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(GeneratedAssemblyDirectory);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(WinMDPaths)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(string.Join(',', WinMDPaths));
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(TargetFramework)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(TargetFramework);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(WindowsMetadata)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(WindowsMetadata);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(AssemblyName)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(AssemblyName);
+
+        if (WindowsSdkOnly)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(WindowsSdkOnly)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(WindowsSdkOnly.ToString());
+        }
+
+        if (WindowsUIXamlProjection)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(WindowsUIXamlProjection)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(WindowsUIXamlProjection.ToString());
+        }
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(MaxDegreesOfParallelism)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(MaxDegreesOfParallelism.ToString());
+
+        if (DebugReproDirectory is not null)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(DebugReproDirectory)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(DebugReproDirectory);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.Parsing.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.Parsing.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.ProjectionGenerator.Attributes;
 using WindowsRuntime.ProjectionGenerator.Errors;
 
@@ -43,12 +44,42 @@ internal partial class ProjectionGeneratorArgs
             throw WellKnownProjectionGeneratorExceptions.ResponseFileReadError(e);
         }
 
+        return ParseFromResponseFile(responseArgs, token);
+    }
+
+    /// <summary>
+    /// Parses an <see cref="ProjectionGeneratorArgs"/> instance from a target response file.
+    /// </summary>
+    /// <param name="stream">The stream to the response file.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The resulting <see cref="ProjectionGeneratorArgs"/> instance.</returns>
+    public static ProjectionGeneratorArgs ParseFromResponseFile(Stream stream, CancellationToken token)
+    {
+        string[] responseArgs = File.ReadAllLines(stream);
+
+        return ParseFromResponseFile(responseArgs, token);
+    }
+
+    /// <summary>
+    /// Parses an <see cref="ProjectionGeneratorArgs"/> instance from the lines of a response file.
+    /// </summary>
+    /// <param name="lines">The lines read from the response file.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The resulting <see cref="ProjectionGeneratorArgs"/> instance.</returns>
+    private static ProjectionGeneratorArgs ParseFromResponseFile(string[] lines, CancellationToken token)
+    {
         Dictionary<string, string> argsMap = [];
 
         // Build a map with all the commands and their values
-        foreach (string line in responseArgs)
+        foreach (string line in lines)
         {
             string trimmedLine = line.Trim();
+
+            // Skip empty lines (the MSBuild ToolTask may emit blank lines).
+            if (trimmedLine.Length == 0)
+            {
+                continue;
+            }
 
             // Each line has the command line argument name followed by a space, and then the
             // argument value. If there are no spaces on any given line, the file is malformed.
@@ -82,6 +113,7 @@ internal partial class ProjectionGeneratorArgs
             WindowsSdkOnly = GetOptionalBoolArgument(argsMap, nameof(WindowsSdkOnly)),
             WindowsUIXamlProjection = GetOptionalBoolArgument(argsMap, nameof(WindowsUIXamlProjection)),
             MaxDegreesOfParallelism = GetInt32Argument(argsMap, nameof(MaxDegreesOfParallelism)),
+            DebugReproDirectory = GetNullableStringArgument(argsMap, nameof(DebugReproDirectory)),
             Token = token
         };
     }
@@ -150,6 +182,22 @@ internal partial class ProjectionGeneratorArgs
         }
 
         return defaultValue;
+    }
+
+    /// <summary>
+    /// Parses a nullable (optional) <see cref="string"/> argument.
+    /// </summary>
+    /// <param name="argsMap">The input map with raw arguments.</param>
+    /// <param name="propertyName">The target property name.</param>
+    /// <returns>The resulting argument, or <see langword="null"/> if not present.</returns>
+    private static string? GetNullableStringArgument(Dictionary<string, string> argsMap, string propertyName)
+    {
+        if (argsMap.TryGetValue(GetCommandLineArgumentName(propertyName), out string? argumentValue))
+        {
+            return argumentValue;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGeneratorArgs.cs
@@ -56,4 +56,8 @@ internal sealed partial class ProjectionGeneratorArgs
 
     /// <summary>Gets the token for the operation.</summary>
     public required CancellationToken Token { get; init; }
+
+    /// <summary>Gets the directory to use to place the debug repro, if requested.</summary>
+    [CommandLineArgumentName("--debug-repro-directory")]
+    public string? DebugReproDirectory { get; init; }
 }

--- a/src/WinRT.Projection.Generator/Helpers/ProjectionGeneratorJsonSerializerContext.cs
+++ b/src/WinRT.Projection.Generator/Helpers/ProjectionGeneratorJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WindowsRuntime.ProjectionGenerator.Helpers;
+
+/// <summary>
+/// A <see cref="JsonSerializerContext"/> for types used in the projection generator.
+/// </summary>
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal sealed partial class ProjectionGeneratorJsonSerializerContext : JsonSerializerContext;

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -39,7 +39,7 @@
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
 
     <!-- Temporarily suppress warnings for 'Microsoft.CodeAnalysis.CSharp' -->    
-    <NoWarn>$(NoWarn);IL2091;IL2050;IL2072;IL2075;IL2026;</NoWarn>
+    <NoWarn>$(NoWarn);IL2091;IL2050;IL2072;IL2075;IL2026;IDE0028</NoWarn>
   </PropertyGroup>
 
   <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
@@ -52,6 +52,11 @@
     <IlcDehydrate>false</IlcDehydrate>
     <IlcResilient>false</IlcResilient>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\FileExtensions.cs" Link="Extensions\FileExtensions.cs" />
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\PathExtensions.cs" Link="Extensions\PathExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WinRT.Projection.Writer\WinRT.Projection.Writer.csproj" />

--- a/src/WinRT.Projection.Ref.Generator/Errors/WellKnownReferenceProjectionGeneratorExceptions.cs
+++ b/src/WinRT.Projection.Ref.Generator/Errors/WellKnownReferenceProjectionGeneratorExceptions.cs
@@ -56,6 +56,30 @@ internal static class WellKnownReferenceProjectionGeneratorExceptions
     }
 
     /// <summary>
+    /// The debug repro directory does not exist.
+    /// </summary>
+    public static Exception DebugReproDirectoryDoesNotExist(string path)
+    {
+        return Exception(6, $"The debug repro directory '{path}' does not exist.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that has no mapping.
+    /// </summary>
+    public static Exception DebugReproMissingFileEntryMapping(string path)
+    {
+        return Exception(7, $"The debug repro file entry with path '{path}' is missing its assembly path mapping.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that was not recognized.
+    /// </summary>
+    public static Exception DebugReproUnrecognizedFileEntry(string path)
+    {
+        return Exception(8, $"The debug repro file entry with path '{path}' was not recognized.");
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     /// <param name="id">The exception id.</param>

--- a/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGenerator.DebugRepro.cs
+++ b/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGenerator.DebugRepro.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using WindowsRuntime.InteropGenerator;
+using WindowsRuntime.ProjectionWriter.Helpers;
+using WindowsRuntime.ReferenceProjectionGenerator.Errors;
+using WindowsRuntime.ReferenceProjectionGenerator.Helpers;
+
+#pragma warning disable IDE0008
+
+namespace WindowsRuntime.ReferenceProjectionGenerator.Generation;
+
+/// <inheritdoc cref="ReferenceProjectionGenerator"/>
+internal static partial class ReferenceProjectionGenerator
+{
+    /// <summary>
+    /// The file name for the original names of the input .winmd files.
+    /// </summary>
+    private const string InputPathMapFileName = "original-input-paths.json";
+
+    /// <summary>
+    /// Runs the debug repro unpack logic for the generator.
+    /// </summary>
+    /// <param name="path">The path to the debug repro file to unpack.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The path to the resulting response file to use.</returns>
+    private static string UnpackDebugRepro(string path, CancellationToken token)
+    {
+        // Create a temporary directory to extract the files from the debug repro
+        string tempFolderName = $"cswinrtprojectionrefgen-debug-repro-unpack-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+
+        _ = Directory.CreateDirectory(tempDirectory);
+
+        token.ThrowIfCancellationRequested();
+
+        using ZipArchive archive = ZipFile.OpenRead(path);
+
+        // Get all entries of interest
+        ZipArchiveEntry responseFileEntry = archive.Entries.Single(entry => entry.Name == "cswinrtprojectionrefgen.rsp");
+        ZipArchiveEntry originalInputPathsEntry = archive.Entries.Single(entry => entry.Name == InputPathMapFileName);
+        ZipArchiveEntry[] winmdEntries = [.. archive.Entries.Where(entry => Path.GetExtension(Path.Normalize(entry.Name)) == ".winmd")];
+
+        token.ThrowIfCancellationRequested();
+
+        ReferenceProjectionGeneratorArgs args;
+
+        // Parse the debug repro .rsp file
+        using (Stream stream = responseFileEntry.Open())
+        {
+            args = ReferenceProjectionGeneratorArgs.ParseFromResponseFile(stream, token);
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Load the mappings with all the original file paths for the input .winmd files
+        Dictionary<string, string> originalInputPaths = ExtractPathMap(originalInputPathsEntry);
+
+        token.ThrowIfCancellationRequested();
+
+        List<string> inputPaths = [];
+
+        // Define a subdirectory for all the input .winmd paths. We don't put these in the top level
+        // temporary folder so that the number of files there remains very small. The reason is just to
+        // make inspecting the resulting files easier, without having to scroll past hundreds of folders.
+        string inputDirectory = Path.Combine(tempDirectory, "input");
+
+        // Create the directory in advance, so that we can directly extract the .winmd files there
+        _ = Directory.CreateDirectory(inputDirectory);
+
+        // Extract all .winmd files, restoring their original filenames
+        foreach (ZipArchiveEntry winmdEntry in winmdEntries)
+        {
+            bool isInputWinMD = Path.IsWithinDirectoryName(winmdEntry.FullName, "input");
+
+            // Make sure the debug repro is well-formed and contains the mapping for this entry
+            if (!originalInputPaths.TryGetValue(winmdEntry.Name, out string? originalPath))
+            {
+                throw WellKnownReferenceProjectionGeneratorExceptions.DebugReproMissingFileEntryMapping(winmdEntry.FullName);
+            }
+
+            // Construct the path in the temporary subfolder with the original .winmd name
+            string originalName = Path.GetFileName(Path.Normalize(originalPath));
+            string destinationPath = Path.Combine(inputDirectory, originalName);
+
+            // Extract the .winmd to the new destination path
+            winmdEntry.ExtractToFile(destinationPath, overwrite: true);
+
+            if (isInputWinMD)
+            {
+                inputPaths.Add(destinationPath);
+            }
+            else
+            {
+                // We should never hit this case, so throw to validate that the debug repro is valid.
+                // Entries should always be input .winmd files under the "input" folder.
+                throw WellKnownReferenceProjectionGeneratorExceptions.DebugReproUnrecognizedFileEntry(winmdEntry.FullName);
+            }
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Prepare the .rsp file with all updated arguments
+        string rspText = new ReferenceProjectionGeneratorArgs
+        {
+            InputPaths = [.. inputPaths],
+            OutputDirectory = tempDirectory,
+            TargetFramework = args.TargetFramework,
+            IncludeNamespaces = args.IncludeNamespaces,
+            ExcludeNamespaces = args.ExcludeNamespaces,
+            AdditionExcludeNamespaces = args.AdditionExcludeNamespaces,
+            Verbose = args.Verbose,
+            Component = args.Component,
+            PublicExclusiveTo = args.PublicExclusiveTo,
+            IdicExclusiveTo = args.IdicExclusiveTo,
+            ReferenceProjection = args.ReferenceProjection,
+            DebugReproDirectory = null,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtprojectionrefgen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        // Return the resulting .rsp file so it can be used to replay the debug repro
+        return rspFilePath;
+    }
+
+    /// <summary>
+    /// Runs the debug repro save logic for the generator.
+    /// </summary>
+    /// <param name="args">The arguments for this invocation.</param>
+    private static void SaveDebugRepro(ReferenceProjectionGeneratorArgs args)
+    {
+        // We expect callers to have already performed this check, but just in case
+        if (args.DebugReproDirectory is null)
+        {
+            return;
+        }
+
+        // The target folder must exist
+        if (!Directory.Exists(args.DebugReproDirectory))
+        {
+            throw WellKnownReferenceProjectionGeneratorExceptions.DebugReproDirectoryDoesNotExist(args.DebugReproDirectory);
+        }
+
+        // Path for the ZIP archive
+        string zipPath = Path.Combine(args.DebugReproDirectory, "ref-projection-debug-repro.zip");
+
+        // Create a temporary directory to stage files for the ZIP
+        string tempFolderName = $"cswinrtprojectionrefgen-debug-repro-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+        string inputDirectory = Path.Combine(tempDirectory, "input");
+
+        _ = Directory.CreateDirectory(tempDirectory);
+        _ = Directory.CreateDirectory(inputDirectory);
+
+        // Expand all input paths (which may be file paths, directories to recursively scan, or
+        // special tokens like 'local', 'sdk', 'sdk+', or a version like '10.0.26100.0') into the
+        // concrete set of .winmd files the writer would actually consume. This ensures the debug
+        // repro is fully self-contained and can be replayed without needing the Windows SDK installed.
+        List<string> expandedInputPaths = [];
+
+        foreach (string inputPath in args.InputPaths)
+        {
+            expandedInputPaths.AddRange(WindowsMetadataExpander.Expand(inputPath));
+        }
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Map with all the original paths
+        Dictionary<string, string> originalInputPaths = [];
+
+        // Add all input paths with hashed names to the input subdirectory under the temporary
+        // directory, and store them with the updated names in a list to use to build the .rsp file.
+        List<string> updatedInputNames = CopyHashedFilesToDirectory([.. expandedInputPaths], inputDirectory, originalInputPaths, args.Token);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Prepare the .rsp file with all updated arguments
+        string rspText = new ReferenceProjectionGeneratorArgs
+        {
+            InputPaths = [.. updatedInputNames],
+            OutputDirectory = args.OutputDirectory,
+            TargetFramework = args.TargetFramework,
+            IncludeNamespaces = args.IncludeNamespaces,
+            ExcludeNamespaces = args.ExcludeNamespaces,
+            AdditionExcludeNamespaces = args.AdditionExcludeNamespaces,
+            Verbose = args.Verbose,
+            Component = args.Component,
+            PublicExclusiveTo = args.PublicExclusiveTo,
+            IdicExclusiveTo = args.IdicExclusiveTo,
+            ReferenceProjection = args.ReferenceProjection,
+            DebugReproDirectory = args.DebugReproDirectory,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtprojectionrefgen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Create the .json file with the input path map
+        CopyPathMapToDirectory(originalInputPaths, tempDirectory, InputPathMapFileName);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Delete the previous file, if it exists
+        if (File.Exists(zipPath))
+        {
+            File.Delete(zipPath);
+        }
+
+        // Create the actual .zip file in the target directory
+        ZipFile.CreateFromDirectory(tempDirectory, zipPath);
+
+        // Clean up the temporary directory
+        Directory.Delete(tempDirectory, recursive: true);
+    }
+
+    /// <summary>
+    /// Generates a hashed filename by appending a hash of the original filename.
+    /// </summary>
+    /// <param name="filePath">The original file path.</param>
+    /// <returns>The hashed filename.</returns>
+    private static string GetHashedFileName(string filePath)
+    {
+        string fileName = Path.GetFileName(Path.Normalize(filePath));
+        byte[] utf8Data = Encoding.UTF8.GetBytes(filePath);
+        byte[] hashData = Shake128.HashData(utf8Data, outputLength: 16);
+        string hash = Convert.ToHexString(hashData);
+
+        return $"{Path.GetFileNameWithoutExtension(fileName)}_{hash}{Path.GetExtension(fileName)}";
+    }
+
+    /// <summary>
+    /// Copies all specified files to a target folder, and returns the list of updated hashed filenames.
+    /// </summary>
+    /// <param name="filePaths">The input file paths.</param>
+    /// <param name="destinationDirectory">The target directory to copy the files to.</param>
+    /// <param name="originalPaths">A dictionary to store the original paths of the copied files.</param>
+    /// <param name="token">A cancellation token to monitor for cancellation requests.</param>
+    /// <returns>The list of updated hashed filenames.</returns>
+    private static List<string> CopyHashedFilesToDirectory(
+        string[] filePaths,
+        string destinationDirectory,
+        Dictionary<string, string> originalPaths,
+        CancellationToken token)
+    {
+        List<string> updatedFileNames = [];
+
+        foreach (string filePath in filePaths)
+        {
+            token.ThrowIfCancellationRequested();
+
+            string hashedName = GetHashedFileName(filePath);
+            string destinationPath = Path.Combine(destinationDirectory, hashedName);
+
+            File.Copy(filePath, destinationPath, overwrite: true);
+
+            updatedFileNames.Add(hashedName);
+            originalPaths.Add(hashedName, filePath);
+        }
+
+        return updatedFileNames;
+    }
+
+    /// <summary>
+    /// Copies an input path map to a target directory, as a serialized JSON file.
+    /// </summary>
+    /// <param name="pathMap">The input path map.</param>
+    /// <param name="destinationDirectory">The target directory to copy the assemblies to.</param>
+    /// <param name="fileName">The name to use for the file with the serialized path map.</param>
+    private static void CopyPathMapToDirectory(
+        Dictionary<string, string> pathMap,
+        string destinationDirectory,
+        string fileName)
+    {
+        // Create the .json file with the input path map
+        string jsonFilePath = Path.Combine(destinationDirectory, fileName);
+
+        using Stream jsonStream = File.Create(jsonFilePath);
+
+        // Serialize the path map to the target file
+        JsonSerializer.Serialize(jsonStream, pathMap, ReferenceProjectionGeneratorJsonSerializerContext.Default.DictionaryStringString);
+    }
+
+    /// <summary>
+    /// Extracts an input path from a .zip archive entry.
+    /// </summary>
+    /// <param name="pathMapEntry">The input path map entry.</param>
+    /// <remarks>
+    /// The <paramref name="pathMapEntry"/> value is expected to have the content produced by calls to <see cref="CopyPathMapToDirectory"/>.
+    /// </remarks>
+    private static Dictionary<string, string> ExtractPathMap(ZipArchiveEntry pathMapEntry)
+    {
+        using Stream stream = pathMapEntry.Open();
+
+        // Load the mapping with all the original file paths for the included files
+        return JsonSerializer.Deserialize(stream, ReferenceProjectionGeneratorJsonSerializerContext.Default.DictionaryStringString)!;
+    }
+}

--- a/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGenerator.cs
+++ b/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using ConsoleAppFramework;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.ProjectionWriter;
 using WindowsRuntime.ProjectionWriter.Helpers;
 using WindowsRuntime.ReferenceProjectionGenerator.Errors;
@@ -17,15 +18,41 @@ namespace WindowsRuntime.ReferenceProjectionGenerator.Generation;
 /// <c>CsWinRTGenerateProjection</c> MSBuild target to produce <c>.cs</c> files that get compiled
 /// into the user's library/component <c>.dll</c>.
 /// </summary>
-internal static class ReferenceProjectionGenerator
+internal static partial class ReferenceProjectionGenerator
 {
     /// <summary>
     /// Runs the reference projection source generator.
     /// </summary>
-    /// <param name="responseFilePath">The path to the response file to use.</param>
+    /// <param name="inputFilePath">The path to the response file or debug repro to use.</param>
     /// <param name="token">The token for the operation.</param>
-    public static void Run([Argument] string responseFilePath, CancellationToken token)
+    public static void Run([Argument] string inputFilePath, CancellationToken token)
     {
+        string responseFilePath = inputFilePath;
+        bool isUsingDebugRepro = false;
+
+        // Load the debug repro to investigate with, if we have one
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            if (Path.GetExtension(Path.Normalize(inputFilePath)) == ".zip")
+            {
+                ConsoleApp.Log("Unpacking input 'cswinrtprojectionrefgen' debug repro");
+
+                isUsingDebugRepro = true;
+
+                // If we unpacked a debug repro, we'll also replace the input file
+                // path with the extracted response file from the input repro.
+                responseFilePath = UnpackDebugRepro(inputFilePath, token);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledReferenceProjectionGeneratorException("unpack-debug-repro", e);
+        }
+
+        token.ThrowIfCancellationRequested();
+
         ReferenceProjectionGeneratorArgs args;
 
         // Parse the actual arguments from the response file
@@ -36,6 +63,27 @@ internal static class ReferenceProjectionGenerator
         catch (Exception e) when (!e.IsWellKnown)
         {
             throw new UnhandledReferenceProjectionGeneratorException("parsing", e);
+        }
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Save a debug repro, if needed
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            // We also skip this if we're currently processing an input debug
+            // repro, as there would be no point in creating a new one from that.
+            if (args.DebugReproDirectory is not null && !isUsingDebugRepro)
+            {
+                ConsoleApp.Log("Saving 'cswinrtprojectionrefgen' debug repro");
+
+                SaveDebugRepro(args);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledReferenceProjectionGeneratorException("save-debug-repro", e);
         }
 
         args.Token.ThrowIfCancellationRequested();

--- a/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.Formatting.cs
+++ b/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.Formatting.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace WindowsRuntime.ReferenceProjectionGenerator.Generation;
+
+/// <inheritdoc cref="ReferenceProjectionGeneratorArgs"/>
+internal partial class ReferenceProjectionGeneratorArgs
+{
+    /// <summary>
+    /// Formats the current <see cref="ReferenceProjectionGeneratorArgs"/> instance into a response file text.
+    /// </summary>
+    /// <returns>The resulting response file text.</returns>
+    public string FormatToResponseFile()
+    {
+        StringBuilder builder = new();
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(InputPaths)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(string.Join(',', InputPaths));
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(OutputDirectory)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(OutputDirectory);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(TargetFramework)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(TargetFramework);
+
+        if (IncludeNamespaces.Length > 0)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(IncludeNamespaces)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(string.Join(',', IncludeNamespaces));
+        }
+
+        if (ExcludeNamespaces.Length > 0)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(ExcludeNamespaces)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(string.Join(',', ExcludeNamespaces));
+        }
+
+        if (AdditionExcludeNamespaces.Length > 0)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(AdditionExcludeNamespaces)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(string.Join(',', AdditionExcludeNamespaces));
+        }
+
+        if (Verbose)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(Verbose)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(Verbose.ToString());
+        }
+
+        if (Component)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(Component)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(Component.ToString());
+        }
+
+        if (PublicExclusiveTo)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(PublicExclusiveTo)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(PublicExclusiveTo.ToString());
+        }
+
+        if (IdicExclusiveTo)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(IdicExclusiveTo)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(IdicExclusiveTo.ToString());
+        }
+
+        if (ReferenceProjection)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(ReferenceProjection)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(ReferenceProjection.ToString());
+        }
+
+        if (DebugReproDirectory is not null)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(DebugReproDirectory)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(DebugReproDirectory);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.Parsing.cs
+++ b/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.Parsing.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.ReferenceProjectionGenerator.Attributes;
 using WindowsRuntime.ReferenceProjectionGenerator.Errors;
 
@@ -43,10 +44,34 @@ internal partial class ReferenceProjectionGeneratorArgs
             throw WellKnownReferenceProjectionGeneratorExceptions.ResponseFileReadError(e);
         }
 
+        return ParseFromResponseFile(responseArgs, token);
+    }
+
+    /// <summary>
+    /// Parses an <see cref="ReferenceProjectionGeneratorArgs"/> instance from a target response file.
+    /// </summary>
+    /// <param name="stream">The stream to the response file.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The resulting <see cref="ReferenceProjectionGeneratorArgs"/> instance.</returns>
+    public static ReferenceProjectionGeneratorArgs ParseFromResponseFile(Stream stream, CancellationToken token)
+    {
+        string[] responseArgs = File.ReadAllLines(stream);
+
+        return ParseFromResponseFile(responseArgs, token);
+    }
+
+    /// <summary>
+    /// Parses an <see cref="ReferenceProjectionGeneratorArgs"/> instance from the lines of a response file.
+    /// </summary>
+    /// <param name="lines">The lines read from the response file.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The resulting <see cref="ReferenceProjectionGeneratorArgs"/> instance.</returns>
+    private static ReferenceProjectionGeneratorArgs ParseFromResponseFile(string[] lines, CancellationToken token)
+    {
         Dictionary<string, string> argsMap = [];
 
         // Build a map with all the commands and their values
-        foreach (string line in responseArgs)
+        foreach (string line in lines)
         {
             string trimmedLine = line.Trim();
 
@@ -90,6 +115,7 @@ internal partial class ReferenceProjectionGeneratorArgs
             PublicExclusiveTo = GetOptionalBoolArgument(argsMap, nameof(PublicExclusiveTo)),
             IdicExclusiveTo = GetOptionalBoolArgument(argsMap, nameof(IdicExclusiveTo)),
             ReferenceProjection = GetOptionalBoolArgument(argsMap, nameof(ReferenceProjection)),
+            DebugReproDirectory = GetNullableStringArgument(argsMap, nameof(DebugReproDirectory)),
             Token = token
         };
     }
@@ -157,6 +183,22 @@ internal partial class ReferenceProjectionGeneratorArgs
         }
 
         throw WellKnownReferenceProjectionGeneratorExceptions.ResponseFileArgumentParsingError(propertyName);
+    }
+
+    /// <summary>
+    /// Parses a nullable (optional) <see cref="string"/> argument.
+    /// </summary>
+    /// <param name="argsMap">The input map with raw arguments.</param>
+    /// <param name="propertyName">The target property name.</param>
+    /// <returns>The resulting argument.</returns>
+    private static string? GetNullableStringArgument(Dictionary<string, string> argsMap, string propertyName)
+    {
+        if (argsMap.TryGetValue(GetCommandLineArgumentName(propertyName), out string? argumentValue))
+        {
+            return argumentValue;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.cs
+++ b/src/WinRT.Projection.Ref.Generator/Generation/ReferenceProjectionGeneratorArgs.cs
@@ -58,4 +58,8 @@ internal sealed partial class ReferenceProjectionGeneratorArgs
 
     /// <summary>Gets the token for the operation.</summary>
     public required CancellationToken Token { get; init; }
+
+    /// <summary>Gets the directory to use to place the debug repro, if requested.</summary>
+    [CommandLineArgumentName("--debug-repro-directory")]
+    public string? DebugReproDirectory { get; init; }
 }

--- a/src/WinRT.Projection.Ref.Generator/Helpers/ReferenceProjectionGeneratorJsonSerializerContext.cs
+++ b/src/WinRT.Projection.Ref.Generator/Helpers/ReferenceProjectionGeneratorJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WindowsRuntime.ReferenceProjectionGenerator.Helpers;
+
+/// <summary>
+/// A <see cref="JsonSerializerContext"/> for types used in the reference projection generator.
+/// </summary>
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal sealed partial class ReferenceProjectionGeneratorJsonSerializerContext : JsonSerializerContext;

--- a/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
+++ b/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
@@ -51,6 +51,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\FileExtensions.cs" Link="Extensions\FileExtensions.cs" />
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\PathExtensions.cs" Link="Extensions\PathExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WinRT.Projection.Writer\WinRT.Projection.Writer.csproj" />
   </ItemGroup>
 

--- a/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
+++ b/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
@@ -72,6 +72,30 @@ internal static class WellKnownWinMDExceptions
     }
 
     /// <summary>
+    /// The debug repro directory does not exist.
+    /// </summary>
+    public static Exception DebugReproDirectoryDoesNotExist(string path)
+    {
+        return Exception(8, $"The debug repro directory '{path}' does not exist.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that has no mapping.
+    /// </summary>
+    public static Exception DebugReproMissingFileEntryMapping(string path)
+    {
+        return Exception(9, $"The debug repro file entry with path '{path}' is missing its assembly path mapping.");
+    }
+
+    /// <summary>
+    /// The debug repro contains a file entry that was not recognized.
+    /// </summary>
+    public static Exception DebugReproUnrecognizedFileEntry(string path)
+    {
+        return Exception(10, $"The debug repro file entry with path '{path}' was not recognized.");
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     private static Exception Exception(int id, string message, Exception? innerException = null)

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.DebugRepro.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.DebugRepro.cs
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using WindowsRuntime.InteropGenerator;
+using WindowsRuntime.WinMDGenerator.Errors;
+using WindowsRuntime.WinMDGenerator.Helpers;
+
+#pragma warning disable IDE0008
+
+namespace WindowsRuntime.WinMDGenerator.Generation;
+
+/// <inheritdoc cref="WinMDGenerator"/>
+internal static partial class WinMDGenerator
+{
+    /// <summary>
+    /// The file name for the original names of the reference assemblies.
+    /// </summary>
+    private const string ReferencePathMapFileName = "original-reference-paths.json";
+
+    /// <summary>
+    /// Runs the debug repro unpack logic for the generator.
+    /// </summary>
+    /// <param name="path">The path to the debug repro file to unpack.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The path to the resulting response file to use.</returns>
+    private static string UnpackDebugRepro(string path, CancellationToken token)
+    {
+        // Create a temporary directory to extract the files from the debug repro
+        string tempFolderName = $"cswinrtwinmdgen-debug-repro-unpack-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+
+        _ = Directory.CreateDirectory(tempDirectory);
+
+        token.ThrowIfCancellationRequested();
+
+        using ZipArchive archive = ZipFile.OpenRead(path);
+
+        // Get all entries of interest
+        ZipArchiveEntry responseFileEntry = archive.Entries.Single(entry => entry.Name == "cswinrtwinmdgen.rsp");
+        ZipArchiveEntry originalReferencePathsEntry = archive.Entries.Single(entry => entry.Name == ReferencePathMapFileName);
+        ZipArchiveEntry[] assemblyEntries =
+        [
+            .. archive.Entries.Where(entry =>
+            {
+                string extension = Path.GetExtension(Path.Normalize(entry.Name));
+
+                return extension is ".dll" or ".winmd";
+            })
+        ];
+
+        token.ThrowIfCancellationRequested();
+
+        WinMDGeneratorArgs args;
+
+        // Parse the debug repro .rsp file
+        using (Stream stream = responseFileEntry.Open())
+        {
+            args = WinMDGeneratorArgs.ParseFromResponseFile(stream, token);
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Load the mappings with all the original file paths for reference assemblies
+        Dictionary<string, string> originalReferencePaths = ExtractPathMap(originalReferencePathsEntry);
+
+        token.ThrowIfCancellationRequested();
+
+        List<string> referencePaths = [];
+        string? inputAssemblyPath = null;
+
+        // Define a subdirectory for all the reference assembly paths. We don't put these in the top level
+        // temporary folder so that the number of files there remains very small. The reason is just to
+        // make inspecting the resulting files easier, without having to scroll past hundreds of folders.
+        string referenceDirectory = Path.Combine(tempDirectory, "reference");
+
+        // Create the directory in advance, so that we can directly extract the files there
+        _ = Directory.CreateDirectory(referenceDirectory);
+
+        // Extract all .dll/.winmd files, restoring their original filenames
+        foreach (ZipArchiveEntry assemblyEntry in assemblyEntries)
+        {
+            bool isReferenceAssembly = Path.IsWithinDirectoryName(assemblyEntry.FullName, "reference");
+
+            // Make sure the debug repro is well-formed and contains the mapping for this entry
+            if (!originalReferencePaths.TryGetValue(assemblyEntry.Name, out string? originalPath))
+            {
+                throw WellKnownWinMDExceptions.DebugReproMissingFileEntryMapping(assemblyEntry.FullName);
+            }
+
+            // Construct the path in the temporary subfolder with the original assembly name
+            string originalName = Path.GetFileName(Path.Normalize(originalPath));
+            string destinationFolder = isReferenceAssembly ? referenceDirectory : tempDirectory;
+            string destinationPath = Path.Combine(destinationFolder, originalName);
+
+            // Extract the file to the new destination path
+            assemblyEntry.ExtractToFile(destinationPath, overwrite: true);
+
+            // Track the extracted paths. The input assembly lives at the top level, while
+            // all reference assemblies live inside the "reference" subfolder.
+            if (assemblyEntry.Name == args.InputAssemblyPath)
+            {
+                inputAssemblyPath = destinationPath;
+            }
+            else if (isReferenceAssembly)
+            {
+                referencePaths.Add(destinationPath);
+            }
+            else
+            {
+                // We should never hit this case, so throw to validate that the debug repro is valid.
+                // Entries should always be either reference assemblies or the input assembly.
+                throw WellKnownWinMDExceptions.DebugReproUnrecognizedFileEntry(assemblyEntry.FullName);
+            }
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        // Place the output .winmd into the temporary directory, using the original name
+        string originalOutputName = Path.GetFileName(Path.Normalize(args.OutputWinmdPath));
+        string outputWinmdPath = Path.Combine(tempDirectory, originalOutputName);
+
+        // Prepare the .rsp file with all updated arguments
+        string rspText = new WinMDGeneratorArgs
+        {
+            InputAssemblyPath = inputAssemblyPath!,
+            ReferenceAssemblyPaths = [.. referencePaths],
+            OutputWinmdPath = outputWinmdPath,
+            AssemblyVersion = args.AssemblyVersion,
+            UseWindowsUIXamlProjections = args.UseWindowsUIXamlProjections,
+            DebugReproDirectory = null,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtwinmdgen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        // Return the resulting .rsp file so it can be used to replay the debug repro
+        return rspFilePath;
+    }
+
+    /// <summary>
+    /// Runs the debug repro save logic for the generator.
+    /// </summary>
+    /// <param name="args">The arguments for this invocation.</param>
+    private static void SaveDebugRepro(WinMDGeneratorArgs args)
+    {
+        // We expect callers to have already performed this check, but just in case
+        if (args.DebugReproDirectory is null)
+        {
+            return;
+        }
+
+        // The target folder must exist
+        if (!Directory.Exists(args.DebugReproDirectory))
+        {
+            throw WellKnownWinMDExceptions.DebugReproDirectoryDoesNotExist(args.DebugReproDirectory);
+        }
+
+        // Path for the ZIP archive
+        string zipPath = Path.Combine(args.DebugReproDirectory, "winmd-debug-repro.zip");
+
+        // Create a temporary directory to stage files for the ZIP
+        string tempFolderName = $"cswinrtwinmdgen-debug-repro-{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        string tempDirectory = Path.Combine(Path.GetTempPath(), tempFolderName);
+        string referenceDirectory = Path.Combine(tempDirectory, "reference");
+
+        _ = Directory.CreateDirectory(tempDirectory);
+        _ = Directory.CreateDirectory(referenceDirectory);
+
+        // Map with all the original paths
+        Dictionary<string, string> originalReferencePaths = [];
+
+        // Add all reference paths with hashed names to the reference subdirectory under the
+        // temporary directory, and store them with the updated names in a list to use to build the .rsp file.
+        List<string> updatedReferenceNames = CopyHashedFilesToDirectory(args.ReferenceAssemblyPaths, referenceDirectory, originalReferencePaths, args.Token);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Hash and copy the input assembly to the top level temporary directory
+        string inputAssemblyHashedName = CopyHashedFileToDirectory(args.InputAssemblyPath, tempDirectory, originalReferencePaths, args.Token);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Prepare the .rsp file with all updated arguments
+        string rspText = new WinMDGeneratorArgs
+        {
+            InputAssemblyPath = inputAssemblyHashedName,
+            ReferenceAssemblyPaths = [.. updatedReferenceNames],
+            OutputWinmdPath = args.OutputWinmdPath,
+            AssemblyVersion = args.AssemblyVersion,
+            UseWindowsUIXamlProjections = args.UseWindowsUIXamlProjections,
+            DebugReproDirectory = args.DebugReproDirectory,
+            Token = CancellationToken.None
+        }.FormatToResponseFile();
+
+        // Create the actual .rsp file
+        string rspFilePath = Path.Combine(tempDirectory, "cswinrtwinmdgen.rsp");
+
+        File.WriteAllText(rspFilePath, rspText);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Create the .json file with the reference path map
+        CopyPathMapToDirectory(originalReferencePaths, tempDirectory, ReferencePathMapFileName);
+
+        args.Token.ThrowIfCancellationRequested();
+
+        // Delete the previous file, if it exists
+        if (File.Exists(zipPath))
+        {
+            File.Delete(zipPath);
+        }
+
+        // Create the actual .zip file in the target directory
+        ZipFile.CreateFromDirectory(tempDirectory, zipPath);
+
+        // Clean up the temporary directory
+        Directory.Delete(tempDirectory, recursive: true);
+    }
+
+    /// <summary>
+    /// Generates a hashed filename by appending a hash of the original filename.
+    /// </summary>
+    /// <param name="filePath">The original file path.</param>
+    /// <returns>The hashed filename.</returns>
+    private static string GetHashedFileName(string filePath)
+    {
+        string fileName = Path.GetFileName(Path.Normalize(filePath));
+        byte[] utf8Data = Encoding.UTF8.GetBytes(filePath);
+        byte[] hashData = Shake128.HashData(utf8Data, outputLength: 16);
+        string hash = Convert.ToHexString(hashData);
+
+        return $"{Path.GetFileNameWithoutExtension(fileName)}_{hash}{Path.GetExtension(fileName)}";
+    }
+
+    /// <summary>
+    /// Copies all specified assemblies to a target folder, and returns the list of updated hashed filenames.
+    /// </summary>
+    /// <param name="assemblyPaths">The input assembly paths.</param>
+    /// <param name="destinationDirectory">The target directory to copy the assemblies to.</param>
+    /// <param name="originalPaths">A dictionary to store the original paths of the copied assemblies.</param>
+    /// <param name="token">A cancellation token to monitor for cancellation requests.</param>
+    /// <returns>The list of updated hashed filenames.</returns>
+    private static List<string> CopyHashedFilesToDirectory(
+        string[] assemblyPaths,
+        string destinationDirectory,
+        Dictionary<string, string> originalPaths,
+        CancellationToken token)
+    {
+        List<string> updatedNames = [];
+
+        foreach (string assemblyPath in assemblyPaths)
+        {
+            token.ThrowIfCancellationRequested();
+
+            string hashedName = GetHashedFileName(assemblyPath);
+            string destinationPath = Path.Combine(destinationDirectory, hashedName);
+
+            File.Copy(assemblyPath, destinationPath, overwrite: true);
+
+            updatedNames.Add(hashedName);
+            originalPaths.Add(hashedName, assemblyPath);
+        }
+
+        return updatedNames;
+    }
+
+    /// <summary>
+    /// Copies a specified assembly to a target folder.
+    /// </summary>
+    /// <param name="assemblyPath">The input assembly path.</param>
+    /// <param name="destinationDirectory">The target directory to copy the assembly to.</param>
+    /// <param name="originalPaths">A dictionary to store the original paths of the copied assemblies.</param>
+    /// <param name="token">A cancellation token to monitor for cancellation requests.</param>
+    /// <returns>The hashed filename.</returns>
+    [return: NotNullIfNotNull(nameof(assemblyPath))]
+    private static string? CopyHashedFileToDirectory(
+        string? assemblyPath,
+        string destinationDirectory,
+        Dictionary<string, string> originalPaths,
+        CancellationToken token)
+    {
+        if (assemblyPath is null)
+        {
+            return null;
+        }
+
+        string hashedName = GetHashedFileName(assemblyPath);
+        string destinationPath = Path.Combine(destinationDirectory, hashedName);
+
+        File.Copy(assemblyPath, destinationPath, overwrite: true);
+
+        token.ThrowIfCancellationRequested();
+
+        originalPaths.Add(hashedName, assemblyPath);
+
+        return hashedName;
+    }
+
+    /// <summary>
+    /// Copies an input path map to a target directory, as a serialized JSON file.
+    /// </summary>
+    /// <param name="pathMap">The input path map.</param>
+    /// <param name="destinationDirectory">The target directory to copy the assemblies to.</param>
+    /// <param name="fileName">The name to use for the file with the serialized path map.</param>
+    private static void CopyPathMapToDirectory(
+        Dictionary<string, string> pathMap,
+        string destinationDirectory,
+        string fileName)
+    {
+        // Create the .json file with the input path map
+        string jsonFilePath = Path.Combine(destinationDirectory, fileName);
+
+        using Stream jsonStream = File.Create(jsonFilePath);
+
+        // Serialize the path map to the target file
+        JsonSerializer.Serialize(jsonStream, pathMap, WinMDGeneratorJsonSerializerContext.Default.DictionaryStringString);
+    }
+
+    /// <summary>
+    /// Extracts an input path from a .zip archive entry.
+    /// </summary>
+    /// <param name="pathMapEntry">The input path map entry.</param>
+    /// <remarks>
+    /// The <paramref name="pathMapEntry"/> value is expected to have the content produced by calls to <see cref="CopyPathMapToDirectory"/>.
+    /// </remarks>
+    private static Dictionary<string, string> ExtractPathMap(ZipArchiveEntry pathMapEntry)
+    {
+        using Stream stream = pathMapEntry.Open();
+
+        // Load the mapping with all the original file paths for the included assemblies
+        return JsonSerializer.Deserialize(stream, WinMDGeneratorJsonSerializerContext.Default.DictionaryStringString)!;
+    }
+}

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading;
 using ConsoleAppFramework;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.WinMDGenerator.Errors;
 
 namespace WindowsRuntime.WinMDGenerator.Generation;
@@ -32,16 +34,42 @@ internal static partial class WinMDGenerator
     /// <summary>
     /// Runs the WinMD generator to produce a <c>.winmd</c> file from a compiled assembly.
     /// </summary>
-    /// <param name="inputFilePath">The path to the response file to use.</param>
+    /// <param name="inputFilePath">The path to the response file or debug repro to use.</param>
     /// <param name="token">The token for the operation.</param>
     public static void Run([Argument] string inputFilePath, CancellationToken token)
     {
+        string responseFilePath = inputFilePath;
+        bool isUsingDebugRepro = false;
+
+        // Load the debug repro to investigate with, if we have one
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            if (Path.GetExtension(Path.Normalize(inputFilePath)) == ".zip")
+            {
+                ConsoleApp.Log("Unpacking input 'cswinrtwinmdgen' debug repro");
+
+                isUsingDebugRepro = true;
+
+                // If we unpacked a debug repro, we'll also replace the input file
+                // path with the extracted response file from the input repro.
+                responseFilePath = UnpackDebugRepro(inputFilePath, token);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledWinMDException("unpack-debug-repro", e);
+        }
+
+        token.ThrowIfCancellationRequested();
+
         WinMDGeneratorArgs args;
 
         // Parse the arguments from the response file
         try
         {
-            args = WinMDGeneratorArgs.ParseFromResponseFile(inputFilePath, token);
+            args = WinMDGeneratorArgs.ParseFromResponseFile(responseFilePath, token);
         }
         catch (Exception e) when (!e.IsWellKnown)
         {
@@ -49,6 +77,27 @@ internal static partial class WinMDGenerator
         }
 
         token.ThrowIfCancellationRequested();
+
+        // Save a debug repro, if needed
+        try
+        {
+            // If no debug repro directory was provided, we have nothing to do.
+            // This is fully expected, it just means no debug repro is needed.
+            // We also skip this if we're currently processing an input debug
+            // repro, as there would be no point in creating a new one from that.
+            if (args.DebugReproDirectory is not null && !isUsingDebugRepro)
+            {
+                ConsoleApp.Log("Saving 'cswinrtwinmdgen' debug repro");
+
+                SaveDebugRepro(args);
+            }
+        }
+        catch (Exception e) when (!e.IsWellKnown)
+        {
+            throw new UnhandledWinMDException("save-debug-repro", e);
+        }
+
+        args.Token.ThrowIfCancellationRequested();
 
         // Discover the types to process
         WinMDGeneratorDiscoveryState discoveryState;

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.Formatting.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.Formatting.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace WindowsRuntime.WinMDGenerator.Generation;
+
+/// <inheritdoc cref="WinMDGeneratorArgs"/>
+internal partial class WinMDGeneratorArgs
+{
+    /// <summary>
+    /// Formats the current <see cref="WinMDGeneratorArgs"/> instance into a response file text.
+    /// </summary>
+    /// <returns>The resulting response file text.</returns>
+    public string FormatToResponseFile()
+    {
+        StringBuilder builder = new();
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(InputAssemblyPath)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(InputAssemblyPath);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(ReferenceAssemblyPaths)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(string.Join(',', ReferenceAssemblyPaths));
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(OutputWinmdPath)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(OutputWinmdPath);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(AssemblyVersion)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(AssemblyVersion);
+
+        _ = builder.Append(GetCommandLineArgumentName(nameof(UseWindowsUIXamlProjections)));
+        _ = builder.Append(' ');
+        _ = builder.AppendLine(UseWindowsUIXamlProjections.ToString());
+
+        if (DebugReproDirectory is not null)
+        {
+            _ = builder.Append(GetCommandLineArgumentName(nameof(DebugReproDirectory)));
+            _ = builder.Append(' ');
+            _ = builder.AppendLine(DebugReproDirectory);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.Parsing.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.Parsing.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using WindowsRuntime.InteropGenerator;
 using WindowsRuntime.WinMDGenerator.Attributes;
 using WindowsRuntime.WinMDGenerator.Errors;
 
@@ -48,6 +49,19 @@ internal partial class WinMDGeneratorArgs
         }
 
         return ParseFromResponseFile(lines, token);
+    }
+
+    /// <summary>
+    /// Parses a <see cref="WinMDGeneratorArgs"/> instance from a target response file.
+    /// </summary>
+    /// <param name="stream">The stream to the response file.</param>
+    /// <param name="token">The token for the operation.</param>
+    /// <returns>The resulting <see cref="WinMDGeneratorArgs"/> instance.</returns>
+    public static WinMDGeneratorArgs ParseFromResponseFile(Stream stream, CancellationToken token)
+    {
+        string[] responseArgs = File.ReadAllLines(stream);
+
+        return ParseFromResponseFile(responseArgs, token);
     }
 
     /// <summary>
@@ -104,6 +118,7 @@ internal partial class WinMDGeneratorArgs
             OutputWinmdPath = GetStringArgument(argsMap, nameof(OutputWinmdPath)),
             AssemblyVersion = GetStringArgument(argsMap, nameof(AssemblyVersion)),
             UseWindowsUIXamlProjections = GetBooleanArgument(argsMap, nameof(UseWindowsUIXamlProjections)),
+            DebugReproDirectory = GetNullableStringArgument(argsMap, nameof(DebugReproDirectory)),
             Token = token
         };
     }
@@ -156,6 +171,22 @@ internal partial class WinMDGeneratorArgs
         }
 
         throw WellKnownWinMDExceptions.ResponseFileArgumentParsingError(propertyName);
+    }
+
+    /// <summary>
+    /// Parses a nullable (optional) <see cref="string"/> argument.
+    /// </summary>
+    /// <param name="argsMap">The parsed arguments map.</param>
+    /// <param name="propertyName">The property name to look up.</param>
+    /// <returns>The resulting argument, or <see langword="null"/> if not present.</returns>
+    private static string? GetNullableStringArgument(Dictionary<string, string> argsMap, string propertyName)
+    {
+        if (argsMap.TryGetValue(GetCommandLineArgumentName(propertyName), out string? argumentValue))
+        {
+            return argumentValue;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGeneratorArgs.cs
@@ -33,4 +33,8 @@ internal sealed partial class WinMDGeneratorArgs
 
     /// <summary>Gets the token for the operation.</summary>
     public required CancellationToken Token { get; init; }
+
+    /// <summary>Gets the directory to use to place the debug repro, if requested.</summary>
+    [CommandLineArgumentName("--debug-repro-directory")]
+    public string? DebugReproDirectory { get; init; }
 }

--- a/src/WinRT.WinMD.Generator/Helpers/WinMDGeneratorJsonSerializerContext.cs
+++ b/src/WinRT.WinMD.Generator/Helpers/WinMDGeneratorJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WindowsRuntime.WinMDGenerator.Helpers;
+
+/// <summary>
+/// A <see cref="JsonSerializerContext"/> for types used in the WinMD generator.
+/// </summary>
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal sealed partial class WinMDGeneratorJsonSerializerContext : JsonSerializerContext;

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -37,6 +37,11 @@
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
+
+    <!-- Suppress IDE0028 ('Collection initialization can be simplified'), which fires on the
+         'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
+         collection literal would drop the comparer, so the suggestion is not actually correct. -->
+    <NoWarn>$(NoWarn);IDE0028</NoWarn>
   </PropertyGroup>
 
   <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
@@ -49,6 +54,11 @@
     <IlcDehydrate>false</IlcDehydrate>
     <IlcResilient>false</IlcResilient>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\FileExtensions.cs" Link="Extensions\FileExtensions.cs" />
+    <Compile Include="..\WinRT.Interop.Generator\Extensions\PathExtensions.cs" Link="Extensions\PathExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsmResolver.DotNet" />


### PR DESCRIPTION
## Summary

Adds `--debug-repro-directory` support to the three remaining CsWinRT 3.0 build tools that lacked it (`cswinrtprojectionrefgen`, `cswinrtwinmdgen`, `cswinrtprojectiongen`), mirroring the pattern already used by `cswinrtimplgen` and `cswinrtinteropgen`. With this PR, all five build tools can now produce and replay self-contained debug repros.

## Motivation

The interop and impl generators have shipped with debug repro support since their initial port to CsWinRT 3.0, and that support has already proven invaluable for diagnosing problems on user machines without needing to replicate their full build environment. The other three generators (ref-projection, projection, WinMD) were missing this capability, leaving gaps in our ability to triage issues reported against any tool other than those two. This PR closes that gap so that every CsWinRT build tool now offers the same diagnostic experience.

## Changes

### New debug repro infrastructure (one set per project)

For each of `WinRT.Projection.Ref.Generator/`, `WinRT.WinMD.Generator/`, `WinRT.Projection.Generator/`:

- **`Generation/<Tool>.DebugRepro.cs`**: new partial implementing `SaveDebugRepro` (packages all inputs into a self-contained `.zip` with hashed file names + original-path mapping JSON) and `UnpackDebugRepro` (extracts the archive to a temp directory, restores original file names, rewrites the response file with the local paths).
- **`Generation/<Tool>GeneratorArgs.Formatting.cs`**: new partial implementing `FormatToResponseFile()` so the in-memory args can be round-tripped back to a `.rsp` for the repro replay.
- **`Generation/<Tool>GeneratorArgs.Parsing.cs`**: new `ParseFromResponseFile(Stream)` overload (the `.zip`-embedded `.rsp` is read directly from the archive entry) plus a `DebugReproDirectory` parsing line.
- **`Generation/<Tool>GeneratorArgs.cs`**: new `DebugReproDirectory` property with `[CommandLineArgumentName("--debug-repro-directory")]`.
- **`Generation/<Tool>Generator.cs`**: entry point updated to (1) detect a `.zip` input and unpack it, (2) parse the response file, (3) save a debug repro if requested, then proceed with the regular pipeline. Same try/catch + `UnhandledException` wrapping pattern used by the impl/interop generators.
- **`Helpers/<Tool>GeneratorJsonSerializerContext.cs`**: new source-generated `JsonSerializerContext` for the `Dictionary<string, string>` path map.
- **`Errors/WellKnown<Tool>Exceptions.cs`**: three new error IDs per project (`DebugReproDirectoryDoesNotExist`, `DebugReproMissingFileEntryMapping`, `DebugReproUnrecognizedFileEntry`).
- **`<Tool>.csproj`**: links `PathExtensions.cs` and `FileExtensions.cs` from `WinRT.Interop.Generator` (same `<Compile Include … Link=… />` pattern the impl generator already uses).

### Per-generator specifics

- **`cswinrtprojectionrefgen`**: produces `ref-projection-debug-repro.zip`. Expands input tokens (`local`, `sdk`, `sdk+`, version numbers, directories) to concrete `.winmd` files so the repro is self-contained even when the original input was a token that depends on the host environment.
- **`cswinrtwinmdgen`**: produces `winmd-debug-repro.zip`. Bundles the input component `.dll` plus all reference assemblies.
- **`cswinrtprojectiongen`**: produces `projection-debug-repro.zip`. Bundles all reference `.dll`-s, all input `.winmd` files, AND the expanded `WindowsMetadata` token results (placed into a separate `windows-metadata/` subfolder so the replay can rewrite `--windows-metadata` to point at that absolute path).

### MSBuild plumbing

- **`src/WinRT.Generator.Tasks/RunCsWinRTProjectionRefGenerator.cs`**, **`RunCsWinRTMergedProjectionGenerator.cs`**, **`RunCsWinRTWinMDGenerator.cs`**: new `DebugReproDirectory` task parameter wired through to the tool's `--debug-repro-directory` CLI flag, with validation matching the impl/interop tasks.
- **`nuget/Microsoft.Windows.CsWinRT.targets`**: `_CsWinRTGenerateProjection` target now passes `DebugReproDirectory="$(CsWinRTGeneratorDebugReproDirectory)"` to `RunCsWinRTProjectionRefGenerator`.
- **`nuget/Microsoft.Windows.CsWinRT.CsWinRTGen.targets`**: `_RunCsWinRTMergedProjectionGenerator` target now passes the same property to `RunCsWinRTMergedProjectionGenerator`.
- **`nuget/Microsoft.Windows.CsWinRT.Authoring.WinMD.targets`**: `_RunCsWinRTWinMDGenerator` target now passes the same property to `RunCsWinRTWinMDGenerator`.

### Build hygiene

- **`src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj`** and **`src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj`**: scoped `<NoWarn>$(NoWarn);IDE0028</NoWarn>` added locally. Latest analyzer versions flag the existing `new(StringComparer.Ordinal)` pattern in `WinMDWriter` for "collection initialization can be simplified", but simplifying those calls to a collection literal would silently drop the `StringComparer.Ordinal` comparer, so the suggestion is not actionable.

### Documentation

- **`.github/copilot-instructions.md`**: added a consistent "Debug repro support" one-liner to each of the five generator sections; expanded the shared "Build tool patterns" section with a comprehensive debug-repro entry; bumped the error ID ranges to reflect the three new well-known errors per generator (`CSWINRTPROJECTIONREFGEN0001-0008`, `CSWINRTPROJECTIONGEN0001-0011`, `CSWINRTWINMDGEN0001-0010`); added the new `--debug-repro-directory` row to the WinMD generator's CLI parameters table.
- **`.github/skills/update-copilot-instructions/SKILL.md`**: added a "Debug repro support is documented" validation step to each generator entry and a debug-repro plumbing check to the Generator tasks entry so future skill runs verify the docs stay in sync.

## Validation

Captured a debug repro and replayed it for each of the three new tools:

- **`cswinrtprojectionrefgen`**: replayed against the captured Windows 10.0.26100.0 SDK `.winmd` input. **0 diffs** across 8 generated `.cs` files.
- **`cswinrtwinmdgen`**: replayed against the captured `WindowsRuntime.Internal.dll` build inputs. Output `.winmd` is byte-identical to the baseline except for a single 16-byte difference (the `Guid.NewGuid()` MVID, which is the only intentionally non-deterministic field).
- **`cswinrtprojectiongen`**: replayed against captured Windows SDK projection inputs. Replay produced **327 generated `.cs` files, 0 diffs** vs the baseline.

All three tools also build with **0 warnings** in `Release` and AOT-publish cleanly for `win-arm64`.
