### PR TITLE
Remove leftover AD0001 NoWarn workaround

### DIFF
--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -74,13 +74,6 @@
     -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <!--
-      Workaround for: "CSC(0,0): Error AD0001: Analyzer 'ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer' threw
-      an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type
-      'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.NonErrorNamedTypeSymbol' to type 'Microsoft.CodeAnalysis.IMethodSymbol'.'.".
-    -->
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
-
     <!-- Ignore warnings for '[Obsolete]' members that are a private implementation detail (since they're allowed here) -->
     <NoWarn>$(NoWarn);CSWINRT3001</NoWarn>
 


### PR DESCRIPTION
## Summary

Remove the leftover `AD0001` `NoWarn` suppression from `WinRT.Runtime.csproj`. This workaround is no longer needed.

## Motivation

`AD0001` was suppressed to work around a crash in the ILLink Roslyn analyzer (`DynamicallyAccessedMembersAnalyzer`), which threw an `InvalidCastException` ("Unable to cast object of type `NonErrorNamedTypeSymbol` to type `IMethodSymbol`"). That crash no longer reproduces, so the suppression is now dead weight. Suppressing `AD0001` globally is also undesirable on its own, since it silences *all* analyzer crashes and can mask genuine failures, so removing the obsolete workaround restores visibility into any future analyzer issues.

## Changes

- **`src/WinRT.Runtime2/WinRT.Runtime.csproj`**: remove the `<NoWarn>$(NoWarn);AD0001</NoWarn>` entry, along with its explanatory comment, that worked around the now-fixed analyzer crash.
