### PR TITLE
Port Keys/Values dictionary codegen fix to the C# projection writer

### DIFF
--- a/src/WinRT.Projection.Writer/Factories/MappedInterfaceStubFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/MappedInterfaceStubFactory.cs
@@ -261,9 +261,13 @@ internal static class MappedInterfaceStubFactory
         string prefix = "IReadOnlyDictionaryMethods_" + keyId + "_" + valId + "_";
 
         writer.WriteLine();
+
+        // 'Keys'/'Values' take the projected runtime class directly (passed as 'this'), rather than the
+        // interface object reference like the other accessors. This lets the returned collection be cached
+        // in the public property's backing 'field' so it preserves reference identity across accesses.
+        EmitUnsafeAccessor(writer, "Keys", $"IEnumerable<{k}>", $"{prefix}Keys", interopType, "", receiver: "WindowsRuntimeObject windowsRuntimeObject");
+        EmitUnsafeAccessor(writer, "Values", $"IEnumerable<{v}>", $"{prefix}Values", interopType, "", receiver: "WindowsRuntimeObject windowsRuntimeObject");
         EmitUnsafeAccessors(writer, interopType, [
-            new("Keys",        $"ICollection<{k}>", $"{prefix}Keys",        ""),
-            new("Values",      $"ICollection<{v}>", $"{prefix}Values",      ""),
             new("Count",       "int",               $"{prefix}Count",       ""),
             new("Item",        v,                   $"{prefix}Item",        $", {k} key"),
             new("ContainsKey", "bool",              $"{prefix}ContainsKey", $", {k} key"),
@@ -273,8 +277,8 @@ internal static class MappedInterfaceStubFactory
         // EmitGenericEnumerable invocation.
         writer.WriteLine();
         writer.WriteLine($"public {v} this[{k} key] => {prefix}Item(null, {objRefName}, key);");
-        writer.WriteLine($"public IEnumerable<{k}> Keys => {prefix}Keys(null, {objRefName});");
-        writer.WriteLine($"public IEnumerable<{v}> Values => {prefix}Values(null, {objRefName});");
+        writer.WriteLine($"public IEnumerable<{k}> Keys => field ??= {prefix}Keys(null, this);");
+        writer.WriteLine($"public IEnumerable<{v}> Values => field ??= {prefix}Values(null, this);");
         writer.WriteLine($"public int Count => {prefix}Count(null, {objRefName});");
         writer.WriteLine($"public bool ContainsKey({k} key) => {prefix}ContainsKey(null, {objRefName}, key);");
         writer.WriteLine($"public bool TryGetValue({k} key, out {v} value) => {prefix}TryGetValue(null, {objRefName}, key, out value);");
@@ -380,9 +384,12 @@ internal static class MappedInterfaceStubFactory
 
     /// <summary>
     /// Emits a single <c>[UnsafeAccessor]</c> static extern declaration that targets a method on a
-    /// WinRT.Interop helper type. The function signature is built from the supplied parts.
+    /// WinRT.Interop helper type. The function signature is built from the supplied parts. The
+    /// <paramref name="receiver"/> defaults to the interface object reference
+    /// (<c>WindowsRuntimeObjectReference objRef</c>); a few accessors (e.g. dictionary
+    /// <c>Keys</c>/<c>Values</c>) instead take the projected runtime class (<c>WindowsRuntimeObject</c>).
     /// </summary>
-    private static void EmitUnsafeAccessor(IndentedTextWriter writer, string accessName, string returnType, string functionName, string interopType, string extraParams)
+    private static void EmitUnsafeAccessor(IndentedTextWriter writer, string accessName, string returnType, string functionName, string interopType, string extraParams, string receiver = "WindowsRuntimeObjectReference objRef")
     {
         UnsafeAccessorFactory.EmitStaticMethod(
             writer,
@@ -390,14 +397,14 @@ internal static class MappedInterfaceStubFactory
             returnType: returnType,
             functionName: functionName,
             interopType: interopType,
-            parameterList: $"WindowsRuntimeObjectReference objRef{extraParams}");
+            parameterList: $"{receiver}{extraParams}");
         writer.WriteLine();
     }
 
     /// <summary>
     /// Emits a sequence of <c>[UnsafeAccessor]</c> static extern declarations sharing the same
     /// <paramref name="interopType"/>. Each row of <paramref name="accessors"/> is forwarded to
-    /// <see cref="EmitUnsafeAccessor(IndentedTextWriter, string, string, string, string, string)"/>.
+    /// <see cref="EmitUnsafeAccessor(IndentedTextWriter, string, string, string, string, string, string)"/>.
     /// Used by the collection-stub emitters which emit table-shaped sets of accessors.
     /// </summary>
     private static void EmitUnsafeAccessors(

--- a/src/WinRT.Projection.Writer/Factories/MappedInterfaceStubFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/MappedInterfaceStubFactory.cs
@@ -203,9 +203,13 @@ internal static class MappedInterfaceStubFactory
         string enumerableObjRefName = "_objRef_System_Collections_Generic_IEnumerable_" + IidExpressionGenerator.EscapeTypeNameForIdentifier(kvLong, stripGlobal: false) + "_";
 
         writer.WriteLine();
+
+        // 'Keys'/'Values' take the projected runtime class directly (passed as 'this'), rather than the
+        // interface object reference like the other accessors. This lets the returned collection be cached
+        // in the public property's backing 'field' so it preserves reference identity across accesses.
+        EmitUnsafeAccessor(writer, "Keys", $"ICollection<{k}>", $"{prefix}Keys", interopType, "", receiver: "WindowsRuntimeObject windowsRuntimeObject");
+        EmitUnsafeAccessor(writer, "Values", $"ICollection<{v}>", $"{prefix}Values", interopType, "", receiver: "WindowsRuntimeObject windowsRuntimeObject");
         EmitUnsafeAccessors(writer, interopType, [
-            new("Keys",         $"ICollection<{k}>", $"{prefix}Keys",         ""),
-            new("Values",       $"ICollection<{v}>", $"{prefix}Values",       ""),
             new("Count",        "int",               $"{prefix}Count",        ""),
             new("Item",         v,                   $"{prefix}Item",         $", {k} key"),
             new("Item",         "void",              $"{prefix}Item",         $", {k} key, {v} value"),
@@ -223,8 +227,8 @@ internal static class MappedInterfaceStubFactory
         // GetEnumerator is NOT emitted here -- it's handled separately by IIterable<KVP>'s own
         // EmitGenericEnumerable invocation.
         writer.WriteLine(isMultiline: true, $$"""
-            public ICollection<{{k}}> Keys => {{prefix}}Keys(null, {{objRefName}});
-            public ICollection<{{v}}> Values => {{prefix}}Values(null, {{objRefName}});
+            public ICollection<{{k}}> Keys => field ??= {{prefix}}Keys(null, this);
+            public ICollection<{{v}}> Values => field ??= {{prefix}}Values(null, this);
             public int Count => {{prefix}}Count(null, {{objRefName}});
             public bool IsReadOnly => false;
             public {{v}} this[{{k}} key]


### PR DESCRIPTION
## Summary

Ports the projection code-generation fix from merged PR #2427 (`Fix missing Keys/Values on projected dictionary types`) from the C++ generator (`src/cswinrt/code_writers.h`) to the C# projection writer. Only the projection writer is changed here; the interop-generator and unit-test parts of #2427 arrive when this branch is merged back into `staging/3.0`.

## Motivation

PR #2427 fixed the projected `Keys`/`Values` members on dictionary types (`IMap<K,V>` -> `IDictionary<K,V>` and `IMapView<K,V>` -> `IReadOnlyDictionary<K,V>`). Since the C# projection writer is a port of the C++ `cswinrt` code writers, it needs the same fix so it emits identical stubs. Without it, the C# writer would emit `Keys`/`Values` accessors that bind to the wrong interop contract and re-allocate a fresh collection wrapper on every access.

## Changes

- **`src/WinRT.Projection.Writer/Factories/MappedInterfaceStubFactory.cs`**: ported the fix to both dictionary stub emitters:
  - `Keys`/`Values` `[UnsafeAccessor]` declarations now take the projected runtime class (`WindowsRuntimeObject windowsRuntimeObject`, passed as `this`) instead of the interface object reference (`WindowsRuntimeObjectReference objRef`), matching the interop helper signatures introduced by #2427.
  - For the read-only path, the `Keys`/`Values` accessor return type is corrected from `ICollection<T>` to `IEnumerable<T>` to match the actual `IReadOnlyDictionaryMethods.Keys/Values` contract (the public property was already `IEnumerable<T>`, so the accessor return type was a latent mismatch).
  - The public `Keys`/`Values` properties now cache the returned collection via the C# 14 `field` keyword (`=> field ??= ...(null, this)`), preserving reference identity across repeated accesses.
  - `EmitUnsafeAccessor` gains an optional `receiver` parameter (defaulting to `WindowsRuntimeObjectReference objRef`) so the dictionary `Keys`/`Values` accessors can opt into the `WindowsRuntimeObject` receiver while every other accessor is unchanged.

## Validation

- Build is clean (0 warnings) for the projection writer and the reference projection generator.
- Generated the full `Windows.winmd` reference projection (347 files): both `IDictionaryMethods` and `IReadOnlyDictionaryMethods` stubs match the expected output, and the new `WindowsRuntimeObject` receiver appears only on dictionary `Keys`/`Values` (all other collection accessors keep the `WindowsRuntimeObjectReference` receiver).
- The run is deterministic (347/347 files, 0 diffs across two runs).
