### PR TITLE
Skip emitting [ApiContract] attribute for implementation assemblies

### DIFF
--- a/src/cswinrt/code_writers.h
+++ b/src/cswinrt/code_writers.h
@@ -2594,8 +2594,8 @@ remove => %;
                 {
                     allow_multiple = true;
                 }
-                // ContractVersion is only emitted for reference assemblies
-                if (attribute_name == "ContractVersion")
+                // ContractVersion and ApiContract are only emitted for reference assemblies
+                if (attribute_name == "ContractVersion" || attribute_name == "ApiContract")
                 {
                     if (!settings.reference_projection)
                     {


### PR DESCRIPTION
## Summary

Skip emitting the `[ApiContract]` attribute when generating implementation (projection) assemblies, emitting it only for reference projections. This mirrors the existing behavior for the `[ContractVersion]` attribute.

## Motivation

In the CsWinRT 3.0 reference/implementation assembly split, metadata-only attributes from the `Windows.Foundation.Metadata` namespace should only appear in reference projections, not in the implementation assemblies that contain the actual projection code. `[ContractVersion]` was already filtered out for implementation assemblies, but `[ApiContract]` was still being emitted, leaking metadata-only information into the implementation assembly. This change makes `[ApiContract]` consistent with `[ContractVersion]`.

## Changes

- **`src/cswinrt/code_writers.h`**: in `write_custom_attributes`, extend the metadata attribute filter so that `[ApiContract]` is treated like `[ContractVersion]` — emitted only when `settings.reference_projection` is set, and skipped otherwise.
