### PR TITLE
Document that PR descriptions must not be hard-wrapped

### DIFF
--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -42,10 +42,7 @@ Brief summary of what this PR does (1-3 sentences).
 
 ## Motivation
 
-Explain *why* these changes are being made. What problem do they solve?
-What improvement do they bring? If the user provided motivation when
-asking for the PR, use that. Otherwise, infer from the diff, commit
-messages, and code comments.
+Explain *why* these changes are being made. What problem do they solve? What improvement do they bring? If the user provided motivation when asking for the PR, use that. Otherwise, infer from the diff, commit messages, and code comments.
 
 ## Changes
 
@@ -57,6 +54,7 @@ List the key changes in the PR:
 ```
 
 **Formatting rules:**
+- **Do not hard-wrap text like a commit message.** A PR description is not a commit message: never break paragraphs or bullet points at a fixed column width (e.g. 72 characters). Write each paragraph and each bullet point as a single continuous line and let it soft-wrap. GitHub-Flavored Markdown renders a single newline inside a paragraph as a hard `<br>` line break, so commit-style wrapping makes the description render with line breaks mid-sentence. Only use blank lines to separate paragraphs, list items, and sections.
 - Use clean, standard markdown (no HTML entities, no non-printable characters)
 - Use backticks for file paths, type names, and code references
 - Keep bullet points concise
@@ -128,15 +126,11 @@ Remove-Item $bodyFile
 ```markdown
 ## Summary
 
-Add comprehensive Copilot instructions documenting the CsWinRT 3.0
-architecture, build pipeline, and coding conventions.
+Add comprehensive Copilot instructions documenting the CsWinRT 3.0 architecture, build pipeline, and coding conventions.
 
 ## Motivation
 
-The CsWinRT 3.0 codebase is complex, with multiple interrelated build
-tools and a multi-phase build pipeline. Having detailed Copilot
-instructions helps contributors and AI assistants understand the
-architecture and make correct changes without extensive ramp-up time.
+The CsWinRT 3.0 codebase is complex, with multiple interrelated build tools and a multi-phase build pipeline. Having detailed Copilot instructions helps contributors and AI assistants understand the architecture and make correct changes without extensive ramp-up time.
 
 ## Changes
 


### PR DESCRIPTION
## Summary

Add an explicit formatting rule to the `pull-request` skill stating that PR descriptions must not be hard-wrapped like commit messages, and reflow the skill's own example descriptions so they model single-line paragraphs.

## Motivation

PR descriptions are not commit messages. GitHub-Flavored Markdown renders a single newline inside a paragraph as a hard `<br>` line break, so wrapping a description at a fixed column width (as you would for a commit message body) makes it render with line breaks mid-sentence. The `pull-request` skill previously had no rule against this, and its own example descriptions were themselves hard-wrapped, actively modeling the bad pattern. This recently led to a PR being created with a commit-style hard-wrapped description that rendered poorly. This change documents the correct behavior so it doesn't happen again.

## Changes

- **`.github/skills/pull-request/SKILL.md`**: added a "do not hard-wrap text like a commit message" rule to the description formatting rules, explaining the GitHub `<br>` rendering behavior. Also reflowed the in-skill `## Motivation` template text and the example PR description so each paragraph is a single continuous line, rather than demonstrating commit-style wrapping.
