### PR TITLE
Add CSWINRT2023 analyzer for reads from write-only Span<T> parameters

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -29,3 +29,4 @@ CSWINRT2019 | WindowsRuntime.SourceGenerator | Warning | '[WindowsRuntimeNativeE
 CSWINRT2020 | WindowsRuntime.SourceGenerator | Warning | Duplicate '[WindowsRuntimeNativeExposedType]' target type
 CSWINRT2021 | WindowsRuntime.SourceGenerator | Warning | Unsupported '[Experimental]' target for Windows Runtime metadata
 CSWINRT2022 | WindowsRuntime.SourceGenerator | Warning | '[Obsolete]' on an authored API without '[Deprecated]'
+CSWINRT2023 | WindowsRuntime.SourceGenerator | Warning | Reading from a write-only 'Span<T>' parameter

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -83,7 +83,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
                 foreach (IOperation operationBlock in context.OperationBlocks)
                 {
-                    bool allowsSuppression = AllowsSuppression(operationBlock, symbols);
+                    bool allowsSuppression = AllowsSuppression(operationBlock);
 
                     foreach (IOperation operation in operationBlock.DescendantsAndSelf())
                     {
@@ -568,11 +568,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// <returns>Whether <paramref name="operation"/> might be skipped, or run at some later point.</returns>
     private static bool IsConditionallyExecuted(IOperation operation, WellKnownSymbols symbols)
     {
-        // A call to a method annotated with '[Conditional]' is removed entirely by the compiler, arguments
-        // included, when the associated preprocessor symbol is not defined for the current compilation
-        return (operation is IInvocationOperation { TargetMethod: { } targetMethod } &&
-                symbols.ConditionalAttributeType is { } conditionalAttributeType &&
-                IsConditionalMethod(targetMethod, conditionalAttributeType)) ||
+        return (operation is IInvocationOperation { TargetMethod: { } targetMethod } && IsErasableCall(targetMethod, symbols)) ||
             operation is
                 IConditionalOperation or            // 'if' statements and '?:' expressions
                 IConditionalAccessOperation or      // '?.' and '?[]' accesses
@@ -588,15 +584,27 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Checks whether calls to a given method are conditionally compiled.
+    /// Checks whether calls to a given method might be removed entirely by the compiler, arguments included.
     /// </summary>
     /// <param name="method">The method to check.</param>
-    /// <param name="conditionalAttributeType">The <see cref="INamedTypeSymbol"/> for <c>[Conditional]</c>.</param>
-    /// <returns>Whether calls to <paramref name="method"/> might be removed by the compiler.</returns>
-    private static bool IsConditionalMethod(IMethodSymbol method, INamedTypeSymbol conditionalAttributeType)
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
+    /// <returns>Whether calls to <paramref name="method"/> might not survive compilation.</returns>
+    private static bool IsErasableCall(IMethodSymbol method, WellKnownSymbols symbols)
     {
-        // An override cannot carry '[Conditional]' itself, but it does inherit the conditional
-        // symbols of the method it overrides, so the whole chain has to be inspected here
+        // A 'partial void' method that has no implementing declaration has all of its call sites removed
+        if (method is { IsPartialDefinition: true, PartialImplementationPart: null })
+        {
+            return true;
+        }
+
+        if (symbols.ConditionalAttributeType is not { } conditionalAttributeType)
+        {
+            return false;
+        }
+
+        // A call to a method annotated with '[Conditional]' is removed when the associated preprocessor symbol
+        // is not defined. An override cannot carry the attribute itself, but it does inherit the conditional
+        // symbols of the method it overrides, so the whole chain of overridden methods is inspected here.
         for (IMethodSymbol? currentMethod = method; currentMethod is not null; currentMethod = currentMethod.OverriddenMethod)
         {
             if (currentMethod.HasAttributeWithType(conditionalAttributeType))
@@ -628,6 +636,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // A reference to an operand handed out anywhere in the method (e.g. 'Foo(ref i)') can outlive the call
+        // that receives it, so it might be used to modify that operand from a place the scan below can't see
+        if (AreOperandsEscaping(GetOperationBlock(statements[readIndex]), target, indexSymbol))
+        {
+            return false;
+        }
+
         for (int i = writeIndex; i <= readIndex; i++)
         {
             foreach (IOperation operation in statements[i].DescendantsAndSelf())
@@ -647,6 +662,51 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Checks whether a reference to the operands a covering write depends on is handed out anywhere in an
+    /// operation block (e.g. as a <c>ref</c> argument), which could be used to modify them at any point.
+    /// </summary>
+    /// <param name="operationBlock">The operation block to inspect.</param>
+    /// <param name="target">The location the write covers.</param>
+    /// <param name="indexSymbol">The local or parameter used as the index, if there is one.</param>
+    /// <returns>Whether a reference to one of the operands might have escaped.</returns>
+    private static bool AreOperandsEscaping(IOperation operationBlock, ReadTarget target, ISymbol? indexSymbol)
+    {
+        foreach (IOperation operation in operationBlock.DescendantsAndSelf())
+        {
+            // A reference passed to another method can outlive the call that receives it (e.g. by being stored
+            // in a 'ref' field, or by being wrapped in a span), so it is not enough to only look at the calls
+            // between the write and the read: one made before the write can still be used to modify an operand.
+            if (operation is not IArgumentOperation { Parameter.RefKind: not RefKind.None, Value: { } value })
+            {
+                continue;
+            }
+
+            if (IsReferenceTo(value, target.Parameter) ||
+                (indexSymbol is not null && IsReferenceTo(value, indexSymbol)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the operation block containing a given operation.
+    /// </summary>
+    /// <param name="operation">The operation to get the operation block for.</param>
+    /// <returns>The root operation containing <paramref name="operation"/>.</returns>
+    private static IOperation GetOperationBlock(IOperation operation)
+    {
+        while (operation.Parent is { } parent)
+        {
+            operation = parent;
+        }
+
+        return operation;
     }
 
     /// <summary>
@@ -781,14 +841,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// Checks whether reads in a given operation block can be skipped when they are preceded by a covering write.
     /// </summary>
     /// <param name="operationBlock">The operation block to inspect.</param>
-    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <returns>Whether preceding writes can be relied upon for reads in <paramref name="operationBlock"/>.</returns>
     /// <remarks>
     /// Recognizing a preceding write relies on being able to see every write to the span parameter and to the
     /// index variables in source order. That is not possible when the body can jump around, or when it creates
     /// an indirection that could be used to modify a variable from a place the ordered scan can't account for.
     /// </remarks>
-    private static bool AllowsSuppression(IOperation operationBlock, WellKnownSymbols symbols)
+    private static bool AllowsSuppression(IOperation operationBlock)
     {
         foreach (IOperation operation in operationBlock.DescendantsAndSelf())
         {
@@ -803,18 +862,12 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
                 // A pointer can be used to modify a variable without any visible write to it
                 case { Type: IPointerTypeSymbol }:
-                    return false;
 
-                // A writable 'ref' alias can be used to modify whatever it points at from anywhere it is in
-                // scope. An alias to an element of a span is the one exception: it can only ever be used to
-                // write to that element, never to redirect the span itself or to change an index variable.
-                case IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref, Initializer.Value: { } aliasedValue }
-                    when !IsSpanElementReference(aliasedValue, symbols):
-                    return false;
-
-                // The same applies to a 'ref' reassignment of an existing alias
-                case ISimpleAssignmentOperation { IsRef: true, Value: { } reassignedValue }
-                    when !IsSpanElementReference(reassignedValue, symbols):
+                // A writable 'ref' alias, whether declared or reassigned, can be used to modify whatever
+                // it points at from anywhere it is in scope. Note that the loop variable of a 'foreach'
+                // loop is not a concern here, as its declarator does not have an initializer.
+                case IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref, Initializer: not null }:
+                case ISimpleAssignmentOperation { IsRef: true }:
                     return false;
                 default:
                     break;
@@ -822,19 +875,6 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Checks whether a given operation references an element of a <see cref="System.Span{T}"/> value.
-    /// </summary>
-    /// <param name="operation">The operation to check.</param>
-    /// <param name="symbols">The well known symbols used by the analyzer.</param>
-    /// <returns>Whether <paramref name="operation"/> is an access to an element of a <see cref="System.Span{T}"/>.</returns>
-    private static bool IsSpanElementReference(IOperation operation, WellKnownSymbols symbols)
-    {
-        return
-            operation is IPropertyReferenceOperation { Property.IsIndexer: true, Instance.Type: { } instanceType } &&
-            SymbolEqualityComparer.Default.Equals(instanceType.OriginalDefinition, symbols.SpanType);
     }
 
     /// <summary>

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -52,143 +52,283 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            // This handles reading the value (or a readonly reference) of an element, such as:
-            //
-            // _ = span[i];
-            // Foo(span[i]);
-            // ref readonly var x = ref span[i];
-            // Foo(in span[i]);
-            // span[i]++;
-            // span[i] += 1;
-            context.RegisterOperationAction(context =>
+            // The whole body of a method is analyzed at once, rather than each operation in isolation, so that
+            // each candidate read can also be inspected in the context of the code that necessarily runs before it
+            context.RegisterOperationBlockAction(context =>
             {
-                IPropertyReferenceOperation operation = (IPropertyReferenceOperation)context.Operation;
-
-                // We only care about the 'Span<T>' indexer (i.e. 'span[i]'), not other properties (e.g. 'Length')
-                if (!operation.Property.IsIndexer)
+                // Only look at methods that are part of the Windows Runtime ABI surface and that actually have
+                // at least one fill array parameter, which is the only thing this analyzer is concerned with
+                if (context.OwningSymbol is not IMethodSymbol method ||
+                    !HasFillArrayParameter(method, spanType) ||
+                    !IsWindowsRuntimeMethod(method))
                 {
                     return;
                 }
 
-                // The indexer must be invoked directly on a write-only 'Span<T>' parameter
-                if (operation.Instance is not IParameterReferenceOperation { Parameter: { } parameter } ||
-                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
+                foreach (IOperation operationBlock in context.OperationBlocks)
                 {
-                    return;
+                    foreach (IOperation operation in operationBlock.DescendantsAndSelf())
+                    {
+                        switch (operation)
+                        {
+                            case IPropertyReferenceOperation propertyReference:
+                                AnalyzeElementRead(context, propertyReference, method, spanType);
+                                break;
+                            case IConversionOperation conversion:
+                                AnalyzeSpanConversion(context, conversion, method, spanType, readOnlySpanType);
+                                break;
+                            case IForEachLoopOperation forEachLoop:
+                                AnalyzeForEachLoop(context, forEachLoop, method, spanType);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
                 }
-
-                // Skip usages that only write to the element, which are valid for a fill array
-                if (IsWriteOnlyElementUsage(operation))
-                {
-                    return;
-                }
-
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
-                    operation.Syntax.GetLocation(),
-                    parameter.Name));
-            }, OperationKind.PropertyReference);
-
-            // This handles converting the span to 'ReadOnlySpan<T>', which would allow reads, such as:
-            //
-            // ReadOnlySpan<int> readOnlySpan = span;
-            // Foo((ReadOnlySpan<int>)span);
-            context.RegisterOperationAction(context =>
-            {
-                IConversionOperation operation = (IConversionOperation)context.Operation;
-
-                // The conversion must target 'ReadOnlySpan<T>' (a read-only view over the span elements)
-                if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, readOnlySpanType))
-                {
-                    return;
-                }
-
-                // The operand must be a write-only 'Span<T>' parameter
-                if (operation.Operand is not IParameterReferenceOperation { Parameter: { } parameter } ||
-                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
-                {
-                    return;
-                }
-
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
-                    operation.Syntax.GetLocation(),
-                    parameter.Name));
-            }, OperationKind.Conversion);
-
-            // This handles iterating over the span, which reads each element, such as:
-            //
-            // foreach (int x in span)
-            // {
-            // }
-            //
-            // It also handles reading the current element through a writable 'ref' loop variable, such as:
-            //
-            // foreach (ref int x in span)
-            // {
-            //     int y = x;
-            // }
-            context.RegisterOperationAction(context =>
-            {
-                if (context.Operation is not IForEachLoopOperation operation)
-                {
-                    return;
-                }
-
-                // The iterated collection is the span parameter, possibly wrapped in an identity conversion
-                IOperation collection = operation.Collection is IConversionOperation { Operand: { } operand }
-                    ? operand
-                    : operation.Collection;
-
-                // The iterated collection must be a write-only 'Span<T>' parameter
-                if (collection is not IParameterReferenceOperation { Parameter: { } parameter } ||
-                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
-                {
-                    return;
-                }
-
-                // Iterating with a writable 'ref' loop variable may be used to fill the span, so the loop
-                // itself is valid. In that case, only the individual reads through the loop variable (which
-                // aliases the current element) are reported. By-value and 'ref readonly' loop variables can
-                // only ever read the elements, so for those the loop itself is reported instead.
-                if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol: { RefKind: RefKind.Ref } loopVariable })
-                {
-                    ReportElementReadsThroughLoopVariable(context, operation.Body, loopVariable, parameter);
-
-                    return;
-                }
-
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
-                    operation.Collection.Syntax.GetLocation(),
-                    parameter.Name));
-            }, OperationKind.Loop);
+            });
         });
     }
 
     /// <summary>
-    /// Checks whether a given parameter is a write-only <see cref="System.Span{T}"/> parameter on a Windows
-    /// Runtime method (i.e. a parameter that is projected as a fill array in the ABI).
+    /// Analyzes a property reference, to detect reads of an element of a write-only <see cref="System.Span{T}"/> parameter.
+    /// </summary>
+    /// <param name="context">The context to report diagnostics to.</param>
+    /// <param name="operation">The property reference to analyze.</param>
+    /// <param name="method">The method being analyzed.</param>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <remarks>
+    /// This handles reading the value (or a readonly reference) of an element, such as:
+    /// <code>
+    /// _ = span[i];
+    /// Foo(span[i]);
+    /// ref readonly var x = ref span[i];
+    /// Foo(in span[i]);
+    /// span[i]++;
+    /// span[i] += 1;
+    /// </code>
+    /// </remarks>
+    private static void AnalyzeElementRead(
+        OperationBlockAnalysisContext context,
+        IPropertyReferenceOperation operation,
+        IMethodSymbol method,
+        INamedTypeSymbol spanType)
+    {
+        // We only care about the 'Span<T>' indexer (i.e. 'span[i]'), not other properties (e.g. 'Length')
+        if (!operation.Property.IsIndexer)
+        {
+            return;
+        }
+
+        // The indexer must be invoked directly on a write-only 'Span<T>' parameter
+        if (operation.Instance is not IParameterReferenceOperation { Parameter: { } parameter } ||
+            !IsFillArrayParameter(parameter, method, spanType))
+        {
+            return;
+        }
+
+        // Skip usages that only write to the element, which are valid for a fill array
+        if (IsWriteOnlyElementUsage(operation))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.WriteOnlySpanParameterRead,
+            operation.Syntax.GetLocation(),
+            parameter.Name));
+    }
+
+    /// <summary>
+    /// Analyzes a conversion, to detect a write-only <see cref="System.Span{T}"/> parameter being converted to
+    /// <see cref="System.ReadOnlySpan{T}"/>, which would allow reading all of its elements.
+    /// </summary>
+    /// <param name="context">The context to report diagnostics to.</param>
+    /// <param name="operation">The conversion to analyze.</param>
+    /// <param name="method">The method being analyzed.</param>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="readOnlySpanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.ReadOnlySpan{T}"/>.</param>
+    /// <remarks>
+    /// This handles converting the span to <see cref="System.ReadOnlySpan{T}"/>, such as:
+    /// <code>
+    /// ReadOnlySpan&lt;int&gt; readOnlySpan = span;
+    /// Foo((ReadOnlySpan&lt;int&gt;)span);
+    /// </code>
+    /// </remarks>
+    private static void AnalyzeSpanConversion(
+        OperationBlockAnalysisContext context,
+        IConversionOperation operation,
+        IMethodSymbol method,
+        INamedTypeSymbol spanType,
+        INamedTypeSymbol readOnlySpanType)
+    {
+        // The conversion must target 'ReadOnlySpan<T>' (a read-only view over the span elements)
+        if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, readOnlySpanType))
+        {
+            return;
+        }
+
+        // The operand must be a write-only 'Span<T>' parameter
+        if (operation.Operand is not IParameterReferenceOperation { Parameter: { } parameter } ||
+            !IsFillArrayParameter(parameter, method, spanType))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.WriteOnlySpanParameterRead,
+            operation.Syntax.GetLocation(),
+            parameter.Name));
+    }
+
+    /// <summary>
+    /// Analyzes a <c>foreach</c> loop, to detect iteration over a write-only <see cref="System.Span{T}"/> parameter.
+    /// </summary>
+    /// <param name="context">The context to report diagnostics to.</param>
+    /// <param name="operation">The <c>foreach</c> loop to analyze.</param>
+    /// <param name="method">The method being analyzed.</param>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <remarks>
+    /// This handles iterating over the span, which reads each element, such as:
+    /// <code>
+    /// foreach (int x in span)
+    /// {
+    /// }
+    /// </code>
+    /// It also handles reading the current element through a writable <c>ref</c> loop variable, such as:
+    /// <code>
+    /// foreach (ref int x in span)
+    /// {
+    ///     int y = x;
+    /// }
+    /// </code>
+    /// </remarks>
+    private static void AnalyzeForEachLoop(
+        OperationBlockAnalysisContext context,
+        IForEachLoopOperation operation,
+        IMethodSymbol method,
+        INamedTypeSymbol spanType)
+    {
+        // The iterated collection is the span parameter, possibly wrapped in an identity conversion
+        IOperation collection = operation.Collection is IConversionOperation { Operand: { } operand }
+            ? operand
+            : operation.Collection;
+
+        // The iterated collection must be a write-only 'Span<T>' parameter
+        if (collection is not IParameterReferenceOperation { Parameter: { } parameter } ||
+            !IsFillArrayParameter(parameter, method, spanType))
+        {
+            return;
+        }
+
+        // Iterating with a writable 'ref' loop variable may be used to fill the span, so the loop
+        // itself is valid. In that case, only the individual reads through the loop variable (which
+        // aliases the current element) are reported. By-value and 'ref readonly' loop variables can
+        // only ever read the elements, so for those the loop itself is reported instead.
+        if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol: { RefKind: RefKind.Ref } loopVariable })
+        {
+            AnalyzeLoopVariableReads(context, operation.Body, parameter, loopVariable);
+
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.WriteOnlySpanParameterRead,
+            operation.Collection.Syntax.GetLocation(),
+            parameter.Name));
+    }
+
+    /// <summary>
+    /// Analyzes the body of a <c>foreach</c> loop iterating over a write-only <see cref="System.Span{T}"/> parameter
+    /// with a writable <c>ref</c> loop variable, to detect reads of the current element through that variable.
+    /// </summary>
+    /// <param name="context">The context to report diagnostics to.</param>
+    /// <param name="loopBody">The body of the <c>foreach</c> loop declaring <paramref name="loopVariable"/>.</param>
+    /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being iterated over.</param>
+    /// <param name="loopVariable">The writable <c>ref</c> loop variable, aliasing the current element.</param>
+    private static void AnalyzeLoopVariableReads(
+        OperationBlockAnalysisContext context,
+        IOperation loopBody,
+        IParameterSymbol parameter,
+        ILocalSymbol loopVariable)
+    {
+        foreach (IOperation operation in loopBody.DescendantsAndSelf())
+        {
+            // We only care about references to the loop variable, as those alias an element of the span.
+            // The loop variable can't be captured by a lambda or ref reassigned, so all aliasing usages
+            // of the current element are guaranteed to appear directly in the body of the loop.
+            if (operation is not ILocalReferenceOperation { Local: { } local } ||
+                !SymbolEqualityComparer.Default.Equals(local, loopVariable))
+            {
+                continue;
+            }
+
+            // Skip usages that only write to the element, which are valid for a fill array
+            if (IsWriteOnlyElementUsage(operation))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.WriteOnlySpanParameterRead,
+                operation.Syntax.GetLocation(),
+                parameter.Name));
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a given method has at least one write-only <see cref="System.Span{T}"/> parameter.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <returns>Whether <paramref name="method"/> has at least one write-only fill array parameter.</returns>
+    private static bool HasFillArrayParameter(IMethodSymbol method, INamedTypeSymbol spanType)
+    {
+        foreach (IParameterSymbol parameter in method.Parameters)
+        {
+            if (IsFillArrayParameter(parameter, method, spanType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a given parameter is a write-only <see cref="System.Span{T}"/> parameter of a given method
+    /// (i.e. a parameter that is projected as a fill array in the Windows Runtime ABI).
     /// </summary>
     /// <param name="parameter">The parameter to check.</param>
+    /// <param name="method">The method being analyzed.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
-    /// <returns>Whether <paramref name="parameter"/> is a write-only fill array parameter.</returns>
-    private static bool IsWindowsRuntimeFillArrayParameter(IParameterSymbol parameter, INamedTypeSymbol spanType)
+    /// <returns>Whether <paramref name="parameter"/> is a write-only fill array parameter of <paramref name="method"/>.</returns>
+    private static bool IsFillArrayParameter(IParameterSymbol parameter, IMethodSymbol method, INamedTypeSymbol spanType)
     {
-        // The parameter must be a by-value 'System.Span<T>': only this is projected as a fill array (a 'ref',
-        // 'in' or 'out' variant is not a valid Windows Runtime parameter, and 'ReadOnlySpan<T>' is a pass array).
-        if (parameter.RefKind is not RefKind.None ||
-            !SymbolEqualityComparer.Default.Equals(parameter.Type.OriginalDefinition, spanType))
+        // The parameter must belong to the method being analyzed, and not to a nested lambda or local function,
+        // which are never projected (and could not reference the parameters of the method anyway, as a span
+        // is a 'ref struct' type, and as such it cannot be captured by any of them).
+        if (!SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, method))
         {
             return false;
         }
 
-        // The parameter must belong to an ordinary method, a constructor, or an explicit interface
+        // The parameter must be a by-value 'System.Span<T>': only this is projected as a fill array (a 'ref',
+        // 'in' or 'out' variant is not a valid Windows Runtime parameter, and 'ReadOnlySpan<T>' is a pass array).
+        return
+            parameter.RefKind is RefKind.None &&
+            SymbolEqualityComparer.Default.Equals(parameter.Type.OriginalDefinition, spanType);
+    }
+
+    /// <summary>
+    /// Checks whether a given method is part of the Windows Runtime ABI surface of an authored component.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <returns>Whether <paramref name="method"/> is projected to the Windows Runtime.</returns>
+    private static bool IsWindowsRuntimeMethod(IMethodSymbol method)
+    {
+        // The method must be an ordinary method, a constructor, or an explicit interface
         // implementation (and not e.g. a local function, a lambda, an operator or a property accessor).
-        if (parameter.ContainingSymbol is not IMethodSymbol
-            {
-                MethodKind: MethodKind.Ordinary or MethodKind.Constructor or MethodKind.ExplicitInterfaceImplementation
-            } method)
+        if (method.MethodKind is not (MethodKind.Ordinary or MethodKind.Constructor or MethodKind.ExplicitInterfaceImplementation))
         {
             return false;
         }
@@ -217,44 +357,6 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Reports all reads of the current element of a write-only <see cref="System.Span{T}"/> parameter that are
-    /// performed through the writable <c>ref</c> loop variable of a <c>foreach</c> loop iterating over it.
-    /// </summary>
-    /// <param name="context">The context to report diagnostics to.</param>
-    /// <param name="loopBody">The body of the <c>foreach</c> loop declaring <paramref name="loopVariable"/>.</param>
-    /// <param name="loopVariable">The writable <c>ref</c> loop variable, aliasing the current element.</param>
-    /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being iterated over.</param>
-    private static void ReportElementReadsThroughLoopVariable(
-        OperationAnalysisContext context,
-        IOperation loopBody,
-        ILocalSymbol loopVariable,
-        IParameterSymbol parameter)
-    {
-        foreach (IOperation operation in loopBody.Descendants())
-        {
-            // We only care about references to the loop variable, as those alias an element of the span.
-            // The loop variable can't be captured by a lambda or ref reassigned, so all aliasing usages
-            // of the current element are guaranteed to appear directly in the body of the loop.
-            if (operation is not ILocalReferenceOperation { Local: { } local } ||
-                !SymbolEqualityComparer.Default.Equals(local, loopVariable))
-            {
-                continue;
-            }
-
-            // Skip usages that only write to the element, which are valid for a fill array
-            if (IsWriteOnlyElementUsage(operation))
-            {
-                continue;
-            }
-
-            context.ReportDiagnostic(Diagnostic.Create(
-                DiagnosticDescriptors.WriteOnlySpanParameterRead,
-                operation.Syntax.GetLocation(),
-                parameter.Name));
-        }
     }
 
     /// <summary>

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -19,6 +19,11 @@ namespace WindowsRuntime.SourceGenerator.Diagnostics;
 /// implementation is given a buffer allocated by the caller that it is expected to fill, and reading from it is not supported.
 /// This analyzer detects the most common ways a method might read from such a parameter, while avoiding false positives on
 /// write-only usages.
+/// <para>
+/// Reading back a value the method itself has just written is valid, as the element being read is no longer uninitialized.
+/// To account for that, a read is not reported when a write covering the same location is guaranteed to run before it,
+/// such as a preceding <c>span.Clear()</c> or <c>span.Fill(value)</c> call, or a preceding assignment to that same element.
+/// </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
@@ -67,18 +72,22 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
                 foreach (IOperation operationBlock in context.OperationBlocks)
                 {
+                    // A 'goto' can jump over a write that would otherwise always run before a given read, so
+                    // no read is ever suppressed in a body containing one (this is extremely rare in practice)
+                    bool allowsSuppression = !ContainsGotoBranch(operationBlock);
+
                     foreach (IOperation operation in operationBlock.DescendantsAndSelf())
                     {
                         switch (operation)
                         {
                             case IPropertyReferenceOperation propertyReference:
-                                AnalyzeElementRead(context, propertyReference, method, spanType);
+                                AnalyzeElementRead(context, propertyReference, method, spanType, allowsSuppression);
                                 break;
                             case IConversionOperation conversion:
-                                AnalyzeSpanConversion(context, conversion, method, spanType, readOnlySpanType);
+                                AnalyzeSpanConversion(context, conversion, method, spanType, readOnlySpanType, allowsSuppression);
                                 break;
                             case IForEachLoopOperation forEachLoop:
-                                AnalyzeForEachLoop(context, forEachLoop, method, spanType);
+                                AnalyzeForEachLoop(context, forEachLoop, method, spanType, allowsSuppression);
                                 break;
                             default:
                                 break;
@@ -96,6 +105,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// <param name="operation">The property reference to analyze.</param>
     /// <param name="method">The method being analyzed.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles reading the value (or a readonly reference) of an element, such as:
     /// <code>
@@ -111,7 +121,8 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         OperationBlockAnalysisContext context,
         IPropertyReferenceOperation operation,
         IMethodSymbol method,
-        INamedTypeSymbol spanType)
+        INamedTypeSymbol spanType,
+        bool allowsSuppression)
     {
         // We only care about the 'Span<T>' indexer (i.e. 'span[i]'), not other properties (e.g. 'Length')
         if (!operation.Property.IsIndexer)
@@ -132,6 +143,14 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // Skip reads of an element that the method is guaranteed to have already written to
+        if (allowsSuppression &&
+            operation.Arguments is [{ Value: { } index }] &&
+            IsPrecededByCoveringWrite(operation, ReadTarget.ForElement(parameter, spanType, index)))
+        {
+            return;
+        }
+
         context.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.WriteOnlySpanParameterRead,
             operation.Syntax.GetLocation(),
@@ -147,6 +166,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// <param name="method">The method being analyzed.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
     /// <param name="readOnlySpanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.ReadOnlySpan{T}"/>.</param>
+    /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles converting the span to <see cref="System.ReadOnlySpan{T}"/>, such as:
     /// <code>
@@ -159,7 +179,8 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         IConversionOperation operation,
         IMethodSymbol method,
         INamedTypeSymbol spanType,
-        INamedTypeSymbol readOnlySpanType)
+        INamedTypeSymbol readOnlySpanType,
+        bool allowsSuppression)
     {
         // The conversion must target 'ReadOnlySpan<T>' (a read-only view over the span elements)
         if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, readOnlySpanType))
@@ -170,6 +191,12 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // The operand must be a write-only 'Span<T>' parameter
         if (operation.Operand is not IParameterReferenceOperation { Parameter: { } parameter } ||
             !IsFillArrayParameter(parameter, method, spanType))
+        {
+            return;
+        }
+
+        // Skip conversions of a span that the method is guaranteed to have already filled entirely
+        if (allowsSuppression && IsPrecededByCoveringWrite(operation, ReadTarget.ForSpan(parameter, spanType)))
         {
             return;
         }
@@ -187,6 +214,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// <param name="operation">The <c>foreach</c> loop to analyze.</param>
     /// <param name="method">The method being analyzed.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles iterating over the span, which reads each element, such as:
     /// <code>
@@ -206,7 +234,8 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         OperationBlockAnalysisContext context,
         IForEachLoopOperation operation,
         IMethodSymbol method,
-        INamedTypeSymbol spanType)
+        INamedTypeSymbol spanType,
+        bool allowsSuppression)
     {
         // The iterated collection is the span parameter, possibly wrapped in an identity conversion
         IOperation collection = operation.Collection is IConversionOperation { Operand: { } operand }
@@ -226,8 +255,14 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // only ever read the elements, so for those the loop itself is reported instead.
         if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol: { RefKind: RefKind.Ref } loopVariable })
         {
-            AnalyzeLoopVariableReads(context, operation.Body, parameter, loopVariable);
+            AnalyzeLoopVariableReads(context, operation.Body, ReadTarget.ForAlias(parameter, spanType, loopVariable), allowsSuppression);
 
+            return;
+        }
+
+        // Skip iterations over a span that the method is guaranteed to have already filled entirely
+        if (allowsSuppression && IsPrecededByCoveringWrite(operation.Collection, ReadTarget.ForSpan(parameter, spanType)))
+        {
             return;
         }
 
@@ -242,14 +277,14 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// with a writable <c>ref</c> loop variable, to detect reads of the current element through that variable.
     /// </summary>
     /// <param name="context">The context to report diagnostics to.</param>
-    /// <param name="loopBody">The body of the <c>foreach</c> loop declaring <paramref name="loopVariable"/>.</param>
-    /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being iterated over.</param>
-    /// <param name="loopVariable">The writable <c>ref</c> loop variable, aliasing the current element.</param>
+    /// <param name="loopBody">The body of the <c>foreach</c> loop declaring the loop variable.</param>
+    /// <param name="target">The element aliased by the writable <c>ref</c> loop variable of the loop.</param>
+    /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     private static void AnalyzeLoopVariableReads(
         OperationBlockAnalysisContext context,
         IOperation loopBody,
-        IParameterSymbol parameter,
-        ILocalSymbol loopVariable)
+        ReadTarget target,
+        bool allowsSuppression)
     {
         foreach (IOperation operation in loopBody.DescendantsAndSelf())
         {
@@ -257,7 +292,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             // The loop variable can't be captured by a lambda or ref reassigned, so all aliasing usages
             // of the current element are guaranteed to appear directly in the body of the loop.
             if (operation is not ILocalReferenceOperation { Local: { } local } ||
-                !SymbolEqualityComparer.Default.Equals(local, loopVariable))
+                !SymbolEqualityComparer.Default.Equals(local, target.Alias))
             {
                 continue;
             }
@@ -268,10 +303,16 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            // Skip reads of an element that the method is guaranteed to have already written to
+            if (allowsSuppression && IsPrecededByCoveringWrite(operation, target))
+            {
+                continue;
+            }
+
             context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.WriteOnlySpanParameterRead,
                 operation.Syntax.GetLocation(),
-                parameter.Name));
+                target.Parameter.Name));
         }
     }
 
@@ -387,5 +428,393 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             // compound assignment, or an increment/decrement), which is not valid for a write-only fill array.
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Checks whether a given read from a write-only <see cref="System.Span{T}"/> parameter is preceded by a write
+    /// that is guaranteed to run before it, and that covers the same location. Such a read only ever observes values
+    /// that the method itself has just written, so it is valid even though the parameter is a fill array.
+    /// </summary>
+    /// <param name="read">The operation performing the read.</param>
+    /// <param name="target">The location that <paramref name="read"/> accesses.</param>
+    /// <returns>Whether <paramref name="read"/> is preceded by a write covering <paramref name="target"/>.</returns>
+    /// <remarks>
+    /// Only writes appearing in a statement that precedes (an ancestor of) <paramref name="read"/> in some enclosing
+    /// block are considered, and only when they are unconditionally reached within that statement. This is meant to
+    /// be conservative: it is fine to miss a write that does happen, but a write must never be reported as guaranteed
+    /// unless it necessarily runs first, as that would silently hide an actual read of an uninitialized element.
+    /// </remarks>
+    private static bool IsPrecededByCoveringWrite(IOperation read, ReadTarget target)
+    {
+        IOperation current = read;
+        IOperation? parent = read.Parent;
+
+        while (parent is not null)
+        {
+            // Never look at the enclosing method when the read is inside a lambda or a local function, as those
+            // can be invoked at any point. This can't normally be reached, given that a span is a 'ref struct'
+            // type, and as such it cannot be captured by either of them, but it is cheap to guard against.
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return false;
+            }
+
+            // Only the statements within a block are ordered with respect to one another. Any other kind of parent
+            // is just skipped, meaning the search resumes from the closest enclosing statement in the parent block.
+            if (parent is IBlockOperation block)
+            {
+                int index = block.Operations.IndexOf(current);
+
+                for (int i = index - 1; i >= 0; i--)
+                {
+                    if (IsGuaranteedCoveringWrite(block.Operations[i], target))
+                    {
+                        // A preceding write only covers the read if the operands it depends on can't have changed in
+                        // between. If they can, no earlier write can be relied upon either, as it would span an even
+                        // wider range of statements, so there is no point in continuing the search past this one.
+                        return AreOperandsStable(block.Operations, i, index, target);
+                    }
+                }
+            }
+
+            current = parent;
+            parent = parent.Parent;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a given operation contains a write covering a target location that is guaranteed to be reached.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <param name="target">The location that the write should cover.</param>
+    /// <returns>Whether <paramref name="operation"/> necessarily performs a write covering <paramref name="target"/>.</returns>
+    private static bool IsGuaranteedCoveringWrite(IOperation operation, ReadTarget target)
+    {
+        // Constructs that might not run at all can never guarantee that a write nested in them will happen
+        if (IsConditionallyExecuted(operation))
+        {
+            return false;
+        }
+
+        if (IsCoveringWrite(operation, target))
+        {
+            return true;
+        }
+
+        foreach (IOperation child in operation.ChildOperations)
+        {
+            if (IsGuaranteedCoveringWrite(child, target))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a given operation is a write covering a target location.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <param name="target">The location that the write should cover.</param>
+    /// <returns>Whether <paramref name="operation"/> writes to all of <paramref name="target"/>.</returns>
+    private static bool IsCoveringWrite(IOperation operation, ReadTarget target)
+    {
+        // 'span.Clear()' and 'span.Fill(value)' initialize every element of the span, so
+        // they cover any subsequent read from it, no matter which elements it looks at.
+        if (operation is IInvocationOperation { TargetMethod: { Name: "Clear", Parameters: [] } or { Name: "Fill", Parameters: [_] } } invocation &&
+            SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType.OriginalDefinition, target.SpanType) &&
+            invocation.Instance is { } instance &&
+            IsReferenceTo(instance, target.Parameter))
+        {
+            return true;
+        }
+
+        // 'span[i] = value' and 'Foo(out span[i])' initialize a single element, so they only
+        // cover reads of that same element (i.e. reads through an equivalent index expression).
+        if (target.Index is { } index &&
+            operation is IPropertyReferenceOperation { Property.IsIndexer: true, Instance: { } spanInstance, Arguments: [{ Value: { } writeIndex }] } &&
+            IsReferenceTo(spanInstance, target.Parameter) &&
+            IsDefiniteWrite(operation) &&
+            AreIndexesEquivalent(writeIndex, index))
+        {
+            return true;
+        }
+
+        // 'x = value' and 'Foo(out x)' through a writable 'ref' 'foreach' loop variable initialize
+        // the element it aliases, so they cover reads of that element through the same variable.
+        return
+            target.Alias is { } alias &&
+            IsReferenceTo(operation, alias) &&
+            IsDefiniteWrite(operation);
+    }
+
+    /// <summary>
+    /// Checks whether a given operation might not be reached during the execution of its parent operation.
+    /// </summary>
+    /// <param name="operation">The operation to check.</param>
+    /// <returns>Whether <paramref name="operation"/> might be skipped, or run at some later point.</returns>
+    private static bool IsConditionallyExecuted(IOperation operation)
+    {
+        return operation is
+            IConditionalOperation or            // 'if' statements and '?:' expressions
+            IConditionalAccessOperation or      // '?.' and '?[]' accesses
+            ICoalesceOperation or               // '??' expressions
+            ICoalesceAssignmentOperation or     // '??=' expressions
+            ISwitchOperation or                 // 'switch' statements
+            ISwitchExpressionOperation or       // 'switch' expressions
+            ILoopOperation or                   // all loops, as the body might never run
+            ITryOperation or                    // 'try' blocks, as an exception might skip the rest of the body
+            IAnonymousFunctionOperation or      // lambdas and anonymous methods
+            ILocalFunctionOperation or          // local functions
+            IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr };
+    }
+
+    /// <summary>
+    /// Checks whether the operands a covering write depends on (i.e. the span parameter itself, and the index
+    /// variable, if the target is a single element) can't have been modified between that write and a later read.
+    /// </summary>
+    /// <param name="statements">The statements of the block containing both the write and the read.</param>
+    /// <param name="writeIndex">The index of the statement containing the write.</param>
+    /// <param name="readIndex">The index of the statement containing the read.</param>
+    /// <param name="target">The location that the write covers.</param>
+    /// <returns>Whether the write still applies to <paramref name="target"/> when the read is reached.</returns>
+    private static bool AreOperandsStable(ImmutableArray<IOperation> statements, int writeIndex, int readIndex, ReadTarget target)
+    {
+        ISymbol? indexSymbol = target.IndexSymbol;
+
+        for (int i = writeIndex; i <= readIndex; i++)
+        {
+            foreach (IOperation operation in statements[i].DescendantsAndSelf())
+            {
+                // Reassigning the span parameter would make the write apply to an entirely different buffer
+                if (IsPotentialWrite(operation, target.Parameter))
+                {
+                    return false;
+                }
+
+                // Likewise, modifying the index variable would make the two accesses target different elements
+                if (indexSymbol is not null && IsPotentialWrite(operation, indexSymbol))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether a given operation is a reference to a local or parameter that might modify its value.
+    /// </summary>
+    /// <param name="operation">The operation to check.</param>
+    /// <param name="symbol">The local or parameter to look for.</param>
+    /// <returns>Whether <paramref name="operation"/> might modify the value of <paramref name="symbol"/>.</returns>
+    private static bool IsPotentialWrite(IOperation operation, ISymbol symbol)
+    {
+        return IsReferenceTo(operation, symbol) && operation.Parent switch
+        {
+            // 'x = value', 'x += value' and 'x ??= value'
+            IAssignmentOperation assignment => ReferenceEquals(assignment.Target, operation),
+
+            // 'x++' and 'x--'
+            IIncrementOrDecrementOperation incrementOrDecrement => ReferenceEquals(incrementOrDecrement.Target, operation),
+
+            // 'Foo(out x)' and 'Foo(ref x)'
+            IArgumentOperation { Parameter.RefKind: RefKind.Out or RefKind.Ref } => true,
+
+            // 'ref var alias = ref x', which can then be used to write to it
+            IVariableInitializerOperation { Parent: IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref } } => true,
+
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks whether a given reference to an element of a write-only <see cref="System.Span{T}"/> parameter is
+    /// guaranteed to initialize that element, as opposed to just possibly writing to it.
+    /// </summary>
+    /// <param name="operation">The operation referencing the element (either an indexer access, or a <c>ref</c> alias).</param>
+    /// <returns>Whether <paramref name="operation"/> necessarily writes to the element.</returns>
+    private static bool IsDefiniteWrite(IOperation operation)
+    {
+        return operation.Parent switch
+        {
+            // 'span[i] = value' or 'x = value': the element is definitely assigned
+            ISimpleAssignmentOperation simpleAssignment => ReferenceEquals(simpleAssignment.Target, operation),
+
+            // 'Foo(out span[i])' or 'Foo(out x)': the callee has to assign the element before returning
+            IArgumentOperation { Parameter.RefKind: RefKind.Out } => true,
+
+            // Note that 'ref' arguments and writable 'ref' aliases are not definite writes: the callee (or the
+            // code using the alias) might never actually write to the element, so they can't be relied upon.
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks whether a given operation is a reference to a specific local or parameter.
+    /// </summary>
+    /// <param name="operation">The operation to check.</param>
+    /// <param name="symbol">The local or parameter to look for.</param>
+    /// <returns>Whether <paramref name="operation"/> is a reference to <paramref name="symbol"/>.</returns>
+    private static bool IsReferenceTo(IOperation operation, ISymbol symbol)
+    {
+        return operation switch
+        {
+            ILocalReferenceOperation localReference => SymbolEqualityComparer.Default.Equals(localReference.Local, symbol),
+            IParameterReferenceOperation parameterReference => SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, symbol),
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks whether two index expressions are guaranteed to produce the same value.
+    /// </summary>
+    /// <param name="left">The first index expression to compare.</param>
+    /// <param name="right">The second index expression to compare.</param>
+    /// <returns>Whether <paramref name="left"/> and <paramref name="right"/> necessarily refer to the same element.</returns>
+    /// <remarks>
+    /// Two index expressions referring to the same variable are only equivalent as long as that variable is not
+    /// modified in between. It is up to callers to validate that (see <see cref="AreOperandsStable"/>).
+    /// </remarks>
+    private static bool AreIndexesEquivalent(IOperation left, IOperation right)
+    {
+        // Constant indices are equivalent when they have the same value (e.g. 'span[0]' and 'span[0]')
+        if (left.ConstantValue is { HasValue: true, Value: { } leftValue } &&
+            right.ConstantValue is { HasValue: true, Value: { } rightValue })
+        {
+            return leftValue.Equals(rightValue);
+        }
+
+        // Otherwise, only a reference to the same local or parameter is recognized (e.g. 'span[i]' in a loop)
+        return (UnwrapImplicitConversions(left), UnwrapImplicitConversions(right)) switch
+        {
+            (ILocalReferenceOperation leftLocal, ILocalReferenceOperation rightLocal) => SymbolEqualityComparer.Default.Equals(leftLocal.Local, rightLocal.Local),
+            (IParameterReferenceOperation leftParameter, IParameterReferenceOperation rightParameter) => SymbolEqualityComparer.Default.Equals(leftParameter.Parameter, rightParameter.Parameter),
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Unwraps all compiler inserted conversions from a given operation (e.g. the widening conversion in <c>span[byteIndex]</c>).
+    /// </summary>
+    /// <param name="operation">The operation to unwrap.</param>
+    /// <returns>The innermost operand of <paramref name="operation"/> that is not an implicit conversion.</returns>
+    private static IOperation? UnwrapImplicitConversions(IOperation? operation)
+    {
+        while (operation is IConversionOperation { IsImplicit: true } conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation;
+    }
+
+    /// <summary>
+    /// Checks whether a given operation block contains a <c>goto</c> branch.
+    /// </summary>
+    /// <param name="operationBlock">The operation block to inspect.</param>
+    /// <returns>Whether <paramref name="operationBlock"/> contains a <c>goto</c> branch.</returns>
+    private static bool ContainsGotoBranch(IOperation operationBlock)
+    {
+        foreach (IOperation operation in operationBlock.DescendantsAndSelf())
+        {
+            if (operation is IBranchOperation { BranchKind: BranchKind.GoTo })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Describes the location that a read from a write-only <see cref="System.Span{T}"/> parameter accesses, so
+    /// that writes which are guaranteed to have already initialized that same location can be recognized.
+    /// </summary>
+    private readonly struct ReadTarget
+    {
+        /// <summary>
+        /// Creates a new <see cref="ReadTarget"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
+        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="index">The index of the element being read, if the read goes through the span indexer.</param>
+        /// <param name="alias">The writable <c>ref</c> <c>foreach</c> loop variable aliasing the element being read, if any.</param>
+        private ReadTarget(IParameterSymbol parameter, INamedTypeSymbol spanType, IOperation? index, ILocalSymbol? alias)
+        {
+            Parameter = parameter;
+            SpanType = spanType;
+            Index = index;
+            Alias = alias;
+        }
+
+        /// <summary>
+        /// Gets the write-only <see cref="System.Span{T}"/> parameter being read from.
+        /// </summary>
+        public IParameterSymbol Parameter { get; }
+
+        /// <summary>
+        /// Gets the <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.
+        /// </summary>
+        public INamedTypeSymbol SpanType { get; }
+
+        /// <summary>
+        /// Gets the index of the element being read, if the read goes through the span indexer.
+        /// </summary>
+        public IOperation? Index { get; }
+
+        /// <summary>
+        /// Gets the writable <c>ref</c> <c>foreach</c> loop variable aliasing the element being read, if any.
+        /// </summary>
+        public ILocalSymbol? Alias { get; }
+
+        /// <summary>
+        /// Gets the local or parameter that <see cref="Index"/> refers to, if it is a plain variable reference.
+        /// </summary>
+        public ISymbol? IndexSymbol => UnwrapImplicitConversions(Index) switch
+        {
+            ILocalReferenceOperation localReference => localReference.Local,
+            IParameterReferenceOperation parameterReference => parameterReference.Parameter,
+            _ => null
+        };
+
+        /// <summary>
+        /// Creates a <see cref="ReadTarget"/> for a read of all the elements of a span (e.g. a <c>foreach</c> loop).
+        /// </summary>
+        /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
+        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
+        public static ReadTarget ForSpan(IParameterSymbol parameter, INamedTypeSymbol spanType)
+        {
+            return new(parameter, spanType, index: null, alias: null);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ReadTarget"/> for a read of a single element through the span indexer.
+        /// </summary>
+        /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
+        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="index">The index of the element being read.</param>
+        /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
+        public static ReadTarget ForElement(IParameterSymbol parameter, INamedTypeSymbol spanType, IOperation index)
+        {
+            return new(parameter, spanType, index, alias: null);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ReadTarget"/> for a read of the element aliased by a writable <c>ref</c> loop variable.
+        /// </summary>
+        /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
+        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="alias">The writable <c>ref</c> <c>foreach</c> loop variable aliasing the element being read.</param>
+        /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
+        public static ReadTarget ForAlias(IParameterSymbol parameter, INamedTypeSymbol spanType, ILocalSymbol alias)
+        {
+            return new(parameter, spanType, index: null, alias);
+        }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -580,7 +580,11 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                 ITryOperation or                    // 'try' blocks, as an exception might skip the rest of the body
                 IAnonymousFunctionOperation or      // lambdas and anonymous methods
                 ILocalFunctionOperation or          // local functions
-                IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr };
+                IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr } or
+
+                // Interpolated strings using a handler that can report failure, as the holes are not evaluated then
+                IInterpolatedStringHandlerCreationOperation { HandlerCreationHasSuccessParameter: true } or
+                IInterpolatedStringHandlerCreationOperation { HandlerAppendCallsReturnBool: true };
     }
 
     /// <summary>

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -57,37 +57,46 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            // Also get the '[Conditional]' symbol, which is used to detect calls that might be removed entirely
+            INamedTypeSymbol? conditionalAttributeType = context.Compilation.GetTypeByMetadataName("System.Diagnostics.ConditionalAttribute");
+
+            WellKnownSymbols symbols = new(spanType, readOnlySpanType, conditionalAttributeType);
+
             // The whole body of a method is analyzed at once, rather than each operation in isolation, so that
             // each candidate read can also be inspected in the context of the code that necessarily runs before it
             context.RegisterOperationBlockAction(context =>
             {
-                // Only look at methods that are part of the Windows Runtime ABI surface and that actually have
-                // at least one fill array parameter, which is the only thing this analyzer is concerned with
-                if (context.OwningSymbol is not IMethodSymbol method ||
-                    !HasFillArrayParameter(method, spanType) ||
-                    !IsWindowsRuntimeMethod(method))
+                // Fill array parameters can only be declared by a method on a public, top-level class (see
+                // 'IsWindowsRuntimeMethod'), which is a cheap way to skip most of the code being compiled
+                if (context.OwningSymbol.ContainingType is not { TypeKind: TypeKind.Class, DeclaredAccessibility: Accessibility.Public, ContainingType: null })
+                {
+                    return;
+                }
+
+                // For a method, the parameters are known up front, so bodies that can't possibly read from a fill
+                // array parameter are skipped right away. That is not the case for field and property initializers,
+                // which can also reference the parameters of the primary constructor of their containing type.
+                if (context.OwningSymbol is IMethodSymbol method && !HasSpanParameter(method, spanType))
                 {
                     return;
                 }
 
                 foreach (IOperation operationBlock in context.OperationBlocks)
                 {
-                    // A 'goto' can jump over a write that would otherwise always run before a given read, so
-                    // no read is ever suppressed in a body containing one (this is extremely rare in practice)
-                    bool allowsSuppression = !ContainsGotoBranch(operationBlock);
+                    bool allowsSuppression = AllowsSuppression(operationBlock);
 
                     foreach (IOperation operation in operationBlock.DescendantsAndSelf())
                     {
                         switch (operation)
                         {
                             case IPropertyReferenceOperation propertyReference:
-                                AnalyzeElementRead(context, propertyReference, method, spanType, allowsSuppression);
+                                AnalyzeElementRead(context, propertyReference, symbols, allowsSuppression);
                                 break;
                             case IConversionOperation conversion:
-                                AnalyzeSpanConversion(context, conversion, method, spanType, readOnlySpanType, allowsSuppression);
+                                AnalyzeSpanConversion(context, conversion, symbols, allowsSuppression);
                                 break;
                             case IForEachLoopOperation forEachLoop:
-                                AnalyzeForEachLoop(context, forEachLoop, method, spanType, allowsSuppression);
+                                AnalyzeForEachLoop(context, forEachLoop, symbols, allowsSuppression);
                                 break;
                             default:
                                 break;
@@ -103,8 +112,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <param name="context">The context to report diagnostics to.</param>
     /// <param name="operation">The property reference to analyze.</param>
-    /// <param name="method">The method being analyzed.</param>
-    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles reading the value (or a readonly reference) of an element, such as:
@@ -120,8 +128,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeElementRead(
         OperationBlockAnalysisContext context,
         IPropertyReferenceOperation operation,
-        IMethodSymbol method,
-        INamedTypeSymbol spanType,
+        WellKnownSymbols symbols,
         bool allowsSuppression)
     {
         // We only care about the 'Span<T>' indexer (i.e. 'span[i]'), not other properties (e.g. 'Length')
@@ -132,7 +139,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
         // The indexer must be invoked directly on a write-only 'Span<T>' parameter
         if (operation.Instance is not IParameterReferenceOperation { Parameter: { } parameter } ||
-            !IsFillArrayParameter(parameter, method, spanType))
+            !IsFillArrayParameter(parameter, symbols))
         {
             return;
         }
@@ -146,7 +153,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // Skip reads of an element that the method is guaranteed to have already written to
         if (allowsSuppression &&
             operation.Arguments is [{ Value: { } index }] &&
-            IsPrecededByCoveringWrite(operation, ReadTarget.ForElement(parameter, spanType, index)))
+            IsPrecededByCoveringWrite(operation, ReadTarget.ForElement(parameter, symbols, index)))
         {
             return;
         }
@@ -163,9 +170,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <param name="context">The context to report diagnostics to.</param>
     /// <param name="operation">The conversion to analyze.</param>
-    /// <param name="method">The method being analyzed.</param>
-    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
-    /// <param name="readOnlySpanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.ReadOnlySpan{T}"/>.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles converting the span to <see cref="System.ReadOnlySpan{T}"/>, such as:
@@ -177,26 +182,24 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeSpanConversion(
         OperationBlockAnalysisContext context,
         IConversionOperation operation,
-        IMethodSymbol method,
-        INamedTypeSymbol spanType,
-        INamedTypeSymbol readOnlySpanType,
+        WellKnownSymbols symbols,
         bool allowsSuppression)
     {
         // The conversion must target 'ReadOnlySpan<T>' (a read-only view over the span elements)
-        if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, readOnlySpanType))
+        if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, symbols.ReadOnlySpanType))
         {
             return;
         }
 
         // The operand must be a write-only 'Span<T>' parameter
         if (operation.Operand is not IParameterReferenceOperation { Parameter: { } parameter } ||
-            !IsFillArrayParameter(parameter, method, spanType))
+            !IsFillArrayParameter(parameter, symbols))
         {
             return;
         }
 
         // Skip conversions of a span that the method is guaranteed to have already filled entirely
-        if (allowsSuppression && IsPrecededByCoveringWrite(operation, ReadTarget.ForSpan(parameter, spanType)))
+        if (allowsSuppression && IsPrecededByCoveringWrite(operation, ReadTarget.ForSpan(parameter, symbols)))
         {
             return;
         }
@@ -212,8 +215,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <param name="context">The context to report diagnostics to.</param>
     /// <param name="operation">The <c>foreach</c> loop to analyze.</param>
-    /// <param name="method">The method being analyzed.</param>
-    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <param name="allowsSuppression">Whether reads preceded by a covering write can be suppressed.</param>
     /// <remarks>
     /// This handles iterating over the span, which reads each element, such as:
@@ -233,8 +235,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeForEachLoop(
         OperationBlockAnalysisContext context,
         IForEachLoopOperation operation,
-        IMethodSymbol method,
-        INamedTypeSymbol spanType,
+        WellKnownSymbols symbols,
         bool allowsSuppression)
     {
         // The iterated collection is the span parameter, possibly wrapped in an identity conversion
@@ -244,7 +245,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
         // The iterated collection must be a write-only 'Span<T>' parameter
         if (collection is not IParameterReferenceOperation { Parameter: { } parameter } ||
-            !IsFillArrayParameter(parameter, method, spanType))
+            !IsFillArrayParameter(parameter, symbols))
         {
             return;
         }
@@ -255,13 +256,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // only ever read the elements, so for those the loop itself is reported instead.
         if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol: { RefKind: RefKind.Ref } loopVariable })
         {
-            AnalyzeLoopVariableReads(context, operation.Body, ReadTarget.ForAlias(parameter, spanType, loopVariable), allowsSuppression);
+            AnalyzeLoopVariableReads(context, operation.Body, ReadTarget.ForAlias(parameter, symbols, loopVariable), allowsSuppression);
 
             return;
         }
 
         // Skip iterations over a span that the method is guaranteed to have already filled entirely
-        if (allowsSuppression && IsPrecededByCoveringWrite(operation.Collection, ReadTarget.ForSpan(parameter, spanType)))
+        if (allowsSuppression && IsPrecededByCoveringWrite(operation.Collection, ReadTarget.ForSpan(parameter, symbols)))
         {
             return;
         }
@@ -317,16 +318,16 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Checks whether a given method has at least one write-only <see cref="System.Span{T}"/> parameter.
+    /// Checks whether a given method has at least one by-value <see cref="System.Span{T}"/> parameter.
     /// </summary>
     /// <param name="method">The method to check.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
-    /// <returns>Whether <paramref name="method"/> has at least one write-only fill array parameter.</returns>
-    private static bool HasFillArrayParameter(IMethodSymbol method, INamedTypeSymbol spanType)
+    /// <returns>Whether <paramref name="method"/> has at least one by-value <see cref="System.Span{T}"/> parameter.</returns>
+    private static bool HasSpanParameter(IMethodSymbol method, INamedTypeSymbol spanType)
     {
         foreach (IParameterSymbol parameter in method.Parameters)
         {
-            if (IsFillArrayParameter(parameter, method, spanType))
+            if (IsSpanParameter(parameter, spanType))
             {
                 return true;
             }
@@ -336,28 +337,36 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Checks whether a given parameter is a write-only <see cref="System.Span{T}"/> parameter of a given method
-    /// (i.e. a parameter that is projected as a fill array in the Windows Runtime ABI).
+    /// Checks whether a given parameter is a by-value <see cref="System.Span{T}"/> parameter.
     /// </summary>
     /// <param name="parameter">The parameter to check.</param>
-    /// <param name="method">The method being analyzed.</param>
     /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
-    /// <returns>Whether <paramref name="parameter"/> is a write-only fill array parameter of <paramref name="method"/>.</returns>
-    private static bool IsFillArrayParameter(IParameterSymbol parameter, IMethodSymbol method, INamedTypeSymbol spanType)
+    /// <returns>Whether <paramref name="parameter"/> is a by-value <see cref="System.Span{T}"/> parameter.</returns>
+    private static bool IsSpanParameter(IParameterSymbol parameter, INamedTypeSymbol spanType)
     {
-        // The parameter must belong to the method being analyzed, and not to a nested lambda or local function,
-        // which are never projected (and could not reference the parameters of the method anyway, as a span
-        // is a 'ref struct' type, and as such it cannot be captured by any of them).
-        if (!SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, method))
-        {
-            return false;
-        }
-
-        // The parameter must be a by-value 'System.Span<T>': only this is projected as a fill array (a 'ref',
-        // 'in' or 'out' variant is not a valid Windows Runtime parameter, and 'ReadOnlySpan<T>' is a pass array).
+        // Only a by-value 'System.Span<T>' is projected as a fill array (a 'ref', 'in' or 'out'
+        // variant is not a valid Windows Runtime parameter, and 'ReadOnlySpan<T>' is a pass array).
         return
             parameter.RefKind is RefKind.None &&
             SymbolEqualityComparer.Default.Equals(parameter.Type.OriginalDefinition, spanType);
+    }
+
+    /// <summary>
+    /// Checks whether a given parameter is a write-only <see cref="System.Span{T}"/> parameter (i.e. a parameter
+    /// that is projected as a fill array in the Windows Runtime ABI).
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
+    /// <returns>Whether <paramref name="parameter"/> is a write-only fill array parameter.</returns>
+    private static bool IsFillArrayParameter(IParameterSymbol parameter, WellKnownSymbols symbols)
+    {
+        // The parameter must belong to a method that is projected to the Windows Runtime. This also filters
+        // out the parameters of nested lambdas and local functions, which are never projected (and could not
+        // reference the parameters of the enclosing method anyway, as a span cannot be captured by them).
+        return
+            IsSpanParameter(parameter, symbols.SpanType) &&
+            parameter.ContainingSymbol is IMethodSymbol method &&
+            IsWindowsRuntimeMethod(method);
     }
 
     /// <summary>
@@ -493,7 +502,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     private static bool IsGuaranteedCoveringWrite(IOperation operation, ReadTarget target)
     {
         // Constructs that might not run at all can never guarantee that a write nested in them will happen
-        if (IsConditionallyExecuted(operation))
+        if (IsConditionallyExecuted(operation, target.Symbols))
         {
             return false;
         }
@@ -525,7 +534,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // 'span.Clear()' and 'span.Fill(value)' initialize every element of the span, so
         // they cover any subsequent read from it, no matter which elements it looks at.
         if (operation is IInvocationOperation { TargetMethod: { Name: "Clear", Parameters: [] } or { Name: "Fill", Parameters: [_] } } invocation &&
-            SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType.OriginalDefinition, target.SpanType) &&
+            SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType.OriginalDefinition, target.Symbols.SpanType) &&
             invocation.Instance is { } instance &&
             IsReferenceTo(instance, target.Parameter))
         {
@@ -555,21 +564,27 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// Checks whether a given operation might not be reached during the execution of its parent operation.
     /// </summary>
     /// <param name="operation">The operation to check.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <returns>Whether <paramref name="operation"/> might be skipped, or run at some later point.</returns>
-    private static bool IsConditionallyExecuted(IOperation operation)
+    private static bool IsConditionallyExecuted(IOperation operation, WellKnownSymbols symbols)
     {
-        return operation is
-            IConditionalOperation or            // 'if' statements and '?:' expressions
-            IConditionalAccessOperation or      // '?.' and '?[]' accesses
-            ICoalesceOperation or               // '??' expressions
-            ICoalesceAssignmentOperation or     // '??=' expressions
-            ISwitchOperation or                 // 'switch' statements
-            ISwitchExpressionOperation or       // 'switch' expressions
-            ILoopOperation or                   // all loops, as the body might never run
-            ITryOperation or                    // 'try' blocks, as an exception might skip the rest of the body
-            IAnonymousFunctionOperation or      // lambdas and anonymous methods
-            ILocalFunctionOperation or          // local functions
-            IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr };
+        // A call to a method annotated with '[Conditional]' is removed entirely by the compiler, arguments
+        // included, when the associated preprocessor symbol is not defined for the current compilation
+        return (operation is IInvocationOperation { TargetMethod: { } targetMethod } &&
+                symbols.ConditionalAttributeType is { } conditionalAttributeType &&
+                targetMethod.HasAttributeWithType(conditionalAttributeType)) ||
+            operation is
+                IConditionalOperation or            // 'if' statements and '?:' expressions
+                IConditionalAccessOperation or      // '?.' and '?[]' accesses
+                ICoalesceOperation or               // '??' expressions
+                ICoalesceAssignmentOperation or     // '??=' expressions
+                ISwitchOperation or                 // 'switch' statements
+                ISwitchExpressionOperation or       // 'switch' expressions
+                ILoopOperation or                   // all loops, as the body might never run
+                ITryOperation or                    // 'try' blocks, as an exception might skip the rest of the body
+                IAnonymousFunctionOperation or      // lambdas and anonymous methods
+                ILocalFunctionOperation or          // local functions
+                IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr };
     }
 
     /// <summary>
@@ -628,8 +643,29 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             // 'ref var alias = ref x', which can then be used to write to it
             IVariableInitializerOperation { Parent: IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref } } => true,
 
+            // '(x, y) = value' (a deconstruction assignment), where the reference is nested in the target tuple
+            ITupleOperation tuple => IsDeconstructionTarget(tuple),
+
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Checks whether a given tuple is (nested in) the target of a deconstruction assignment.
+    /// </summary>
+    /// <param name="tuple">The tuple to check.</param>
+    /// <returns>Whether <paramref name="tuple"/> is being assigned to by a deconstruction.</returns>
+    private static bool IsDeconstructionTarget(ITupleOperation tuple)
+    {
+        IOperation current = tuple;
+
+        // Deconstructions can be nested (e.g. '((x, y), z) = value'), so walk up all the enclosing tuples
+        while (current.Parent is ITupleOperation parent)
+        {
+            current = parent;
+        }
+
+        return current.Parent is IDeconstructionAssignmentOperation deconstruction && ReferenceEquals(deconstruction.Target, current);
     }
 
     /// <summary>
@@ -714,21 +750,74 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Checks whether a given operation block contains a <c>goto</c> branch.
+    /// Checks whether reads in a given operation block can be skipped when they are preceded by a covering write.
     /// </summary>
     /// <param name="operationBlock">The operation block to inspect.</param>
-    /// <returns>Whether <paramref name="operationBlock"/> contains a <c>goto</c> branch.</returns>
-    private static bool ContainsGotoBranch(IOperation operationBlock)
+    /// <returns>Whether preceding writes can be relied upon for reads in <paramref name="operationBlock"/>.</returns>
+    /// <remarks>
+    /// Recognizing a preceding write relies on being able to see every write to the span parameter and to the
+    /// index variables in source order. That is not possible when the body can jump around, or when it creates
+    /// an indirection that could be used to modify a variable from a place the ordered scan can't account for.
+    /// </remarks>
+    private static bool AllowsSuppression(IOperation operationBlock)
     {
         foreach (IOperation operation in operationBlock.DescendantsAndSelf())
         {
-            if (operation is IBranchOperation { BranchKind: BranchKind.GoTo })
+            switch (operation)
             {
-                return true;
+                // A 'goto' can jump over a write that would otherwise always run before a given read
+                case IBranchOperation { BranchKind: BranchKind.GoTo }:
+
+                // A lambda or a local function can capture a variable and modify it when invoked, which
+                // can happen at any point (a span itself can never be captured, as it is a 'ref struct')
+                case IAnonymousFunctionOperation or ILocalFunctionOperation:
+
+                // A writable 'ref' alias to a local or parameter (e.g. the span itself, or an index
+                // variable) can be used to modify it from anywhere the alias is in scope. Note that an
+                // alias to an element of the span (e.g. 'ref var slot = ref span[i]') is not a concern
+                // here, as it can only ever be used to write to that element, never to invalidate it.
+                case IVariableDeclaratorOperation
+                {
+                    Symbol.RefKind: RefKind.Ref,
+                    Initializer.Value: ILocalReferenceOperation or IParameterReferenceOperation
+                }:
+
+                // The same applies to a 'ref' reassignment of an existing alias
+                case ISimpleAssignmentOperation { IsRef: true, Value: ILocalReferenceOperation or IParameterReferenceOperation }:
+                    return false;
+                default:
+                    break;
             }
         }
 
-        return false;
+        return true;
+    }
+
+    /// <summary>
+    /// The well known symbols used by the analyzer.
+    /// </summary>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <param name="readOnlySpanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.ReadOnlySpan{T}"/>.</param>
+    /// <param name="conditionalAttributeType">The <see cref="INamedTypeSymbol"/> for <c>[Conditional]</c>, if available.</param>
+    private readonly struct WellKnownSymbols(
+        INamedTypeSymbol spanType,
+        INamedTypeSymbol readOnlySpanType,
+        INamedTypeSymbol? conditionalAttributeType)
+    {
+        /// <summary>
+        /// Gets the <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.
+        /// </summary>
+        public INamedTypeSymbol SpanType => spanType;
+
+        /// <summary>
+        /// Gets the <see cref="INamedTypeSymbol"/> for <see cref="System.ReadOnlySpan{T}"/>.
+        /// </summary>
+        public INamedTypeSymbol ReadOnlySpanType => readOnlySpanType;
+
+        /// <summary>
+        /// Gets the <see cref="INamedTypeSymbol"/> for <c>[Conditional]</c>, if available.
+        /// </summary>
+        public INamedTypeSymbol? ConditionalAttributeType => conditionalAttributeType;
     }
 
     /// <summary>
@@ -741,13 +830,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         /// Creates a new <see cref="ReadTarget"/> instance with the specified parameters.
         /// </summary>
         /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
-        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="symbols">The well known symbols used by the analyzer.</param>
         /// <param name="index">The index of the element being read, if the read goes through the span indexer.</param>
         /// <param name="alias">The writable <c>ref</c> <c>foreach</c> loop variable aliasing the element being read, if any.</param>
-        private ReadTarget(IParameterSymbol parameter, INamedTypeSymbol spanType, IOperation? index, ILocalSymbol? alias)
+        private ReadTarget(IParameterSymbol parameter, WellKnownSymbols symbols, IOperation? index, ILocalSymbol? alias)
         {
             Parameter = parameter;
-            SpanType = spanType;
+            Symbols = symbols;
             Index = index;
             Alias = alias;
         }
@@ -758,9 +847,9 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         public IParameterSymbol Parameter { get; }
 
         /// <summary>
-        /// Gets the <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.
+        /// Gets the well known symbols used by the analyzer.
         /// </summary>
-        public INamedTypeSymbol SpanType { get; }
+        public WellKnownSymbols Symbols { get; }
 
         /// <summary>
         /// Gets the index of the element being read, if the read goes through the span indexer.
@@ -786,35 +875,35 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         /// Creates a <see cref="ReadTarget"/> for a read of all the elements of a span (e.g. a <c>foreach</c> loop).
         /// </summary>
         /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
-        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="symbols">The well known symbols used by the analyzer.</param>
         /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
-        public static ReadTarget ForSpan(IParameterSymbol parameter, INamedTypeSymbol spanType)
+        public static ReadTarget ForSpan(IParameterSymbol parameter, WellKnownSymbols symbols)
         {
-            return new(parameter, spanType, index: null, alias: null);
+            return new(parameter, symbols, index: null, alias: null);
         }
 
         /// <summary>
         /// Creates a <see cref="ReadTarget"/> for a read of a single element through the span indexer.
         /// </summary>
         /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
-        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="symbols">The well known symbols used by the analyzer.</param>
         /// <param name="index">The index of the element being read.</param>
         /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
-        public static ReadTarget ForElement(IParameterSymbol parameter, INamedTypeSymbol spanType, IOperation index)
+        public static ReadTarget ForElement(IParameterSymbol parameter, WellKnownSymbols symbols, IOperation index)
         {
-            return new(parameter, spanType, index, alias: null);
+            return new(parameter, symbols, index, alias: null);
         }
 
         /// <summary>
         /// Creates a <see cref="ReadTarget"/> for a read of the element aliased by a writable <c>ref</c> loop variable.
         /// </summary>
         /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being read from.</param>
-        /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+        /// <param name="symbols">The well known symbols used by the analyzer.</param>
         /// <param name="alias">The writable <c>ref</c> <c>foreach</c> loop variable aliasing the element being read.</param>
         /// <returns>The resulting <see cref="ReadTarget"/> value.</returns>
-        public static ReadTarget ForAlias(IParameterSymbol parameter, INamedTypeSymbol spanType, ILocalSymbol alias)
+        public static ReadTarget ForAlias(IParameterSymbol parameter, WellKnownSymbols symbols, ILocalSymbol alias)
         {
-            return new(parameter, spanType, index: null, alias);
+            return new(parameter, symbols, index: null, alias);
         }
     }
 }

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -83,7 +83,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
 
                 foreach (IOperation operationBlock in context.OperationBlocks)
                 {
-                    bool allowsSuppression = AllowsSuppression(operationBlock);
+                    bool allowsSuppression = AllowsSuppression(operationBlock, symbols);
 
                     foreach (IOperation operation in operationBlock.DescendantsAndSelf())
                     {
@@ -572,7 +572,7 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         // included, when the associated preprocessor symbol is not defined for the current compilation
         return (operation is IInvocationOperation { TargetMethod: { } targetMethod } &&
                 symbols.ConditionalAttributeType is { } conditionalAttributeType &&
-                targetMethod.HasAttributeWithType(conditionalAttributeType)) ||
+                IsConditionalMethod(targetMethod, conditionalAttributeType)) ||
             operation is
                 IConditionalOperation or            // 'if' statements and '?:' expressions
                 IConditionalAccessOperation or      // '?.' and '?[]' accesses
@@ -588,6 +588,27 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
+    /// Checks whether calls to a given method are conditionally compiled.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="conditionalAttributeType">The <see cref="INamedTypeSymbol"/> for <c>[Conditional]</c>.</param>
+    /// <returns>Whether calls to <paramref name="method"/> might be removed by the compiler.</returns>
+    private static bool IsConditionalMethod(IMethodSymbol method, INamedTypeSymbol conditionalAttributeType)
+    {
+        // An override cannot carry '[Conditional]' itself, but it does inherit the conditional
+        // symbols of the method it overrides, so the whole chain has to be inspected here
+        for (IMethodSymbol? currentMethod = method; currentMethod is not null; currentMethod = currentMethod.OverriddenMethod)
+        {
+            if (currentMethod.HasAttributeWithType(conditionalAttributeType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Checks whether the operands a covering write depends on (i.e. the span parameter itself, and the index
     /// variable, if the target is a single element) can't have been modified between that write and a later read.
     /// </summary>
@@ -599,6 +620,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     private static bool AreOperandsStable(ImmutableArray<IOperation> statements, int writeIndex, int readIndex, ReadTarget target)
     {
         ISymbol? indexSymbol = target.IndexSymbol;
+
+        // An index that is itself a 'ref' local or parameter aliases some other storage (e.g. a field, or an
+        // array element), so its value can change without any write to the symbol itself being visible here
+        if (indexSymbol is ILocalSymbol { RefKind: not RefKind.None } or IParameterSymbol { RefKind: not RefKind.None })
+        {
+            return false;
+        }
 
         for (int i = writeIndex; i <= readIndex; i++)
         {
@@ -753,13 +781,14 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     /// Checks whether reads in a given operation block can be skipped when they are preceded by a covering write.
     /// </summary>
     /// <param name="operationBlock">The operation block to inspect.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
     /// <returns>Whether preceding writes can be relied upon for reads in <paramref name="operationBlock"/>.</returns>
     /// <remarks>
     /// Recognizing a preceding write relies on being able to see every write to the span parameter and to the
     /// index variables in source order. That is not possible when the body can jump around, or when it creates
     /// an indirection that could be used to modify a variable from a place the ordered scan can't account for.
     /// </remarks>
-    private static bool AllowsSuppression(IOperation operationBlock)
+    private static bool AllowsSuppression(IOperation operationBlock, WellKnownSymbols symbols)
     {
         foreach (IOperation operation in operationBlock.DescendantsAndSelf())
         {
@@ -772,18 +801,20 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                 // can happen at any point (a span itself can never be captured, as it is a 'ref struct')
                 case IAnonymousFunctionOperation or ILocalFunctionOperation:
 
-                // A writable 'ref' alias to a local or parameter (e.g. the span itself, or an index
-                // variable) can be used to modify it from anywhere the alias is in scope. Note that an
-                // alias to an element of the span (e.g. 'ref var slot = ref span[i]') is not a concern
-                // here, as it can only ever be used to write to that element, never to invalidate it.
-                case IVariableDeclaratorOperation
-                {
-                    Symbol.RefKind: RefKind.Ref,
-                    Initializer.Value: ILocalReferenceOperation or IParameterReferenceOperation
-                }:
+                // A pointer can be used to modify a variable without any visible write to it
+                case { Type: IPointerTypeSymbol }:
+                    return false;
+
+                // A writable 'ref' alias can be used to modify whatever it points at from anywhere it is in
+                // scope. An alias to an element of a span is the one exception: it can only ever be used to
+                // write to that element, never to redirect the span itself or to change an index variable.
+                case IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref, Initializer.Value: { } aliasedValue }
+                    when !IsSpanElementReference(aliasedValue, symbols):
+                    return false;
 
                 // The same applies to a 'ref' reassignment of an existing alias
-                case ISimpleAssignmentOperation { IsRef: true, Value: ILocalReferenceOperation or IParameterReferenceOperation }:
+                case ISimpleAssignmentOperation { IsRef: true, Value: { } reassignedValue }
+                    when !IsSpanElementReference(reassignedValue, symbols):
                     return false;
                 default:
                     break;
@@ -791,6 +822,19 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Checks whether a given operation references an element of a <see cref="System.Span{T}"/> value.
+    /// </summary>
+    /// <param name="operation">The operation to check.</param>
+    /// <param name="symbols">The well known symbols used by the analyzer.</param>
+    /// <returns>Whether <paramref name="operation"/> is an access to an element of a <see cref="System.Span{T}"/>.</returns>
+    private static bool IsSpanElementReference(IOperation operation, WellKnownSymbols symbols)
+    {
+        return
+            operation is IPropertyReferenceOperation { Property.IsIndexer: true, Instance.Type: { } instanceType } &&
+            SymbolEqualityComparer.Default.Equals(instanceType.OriginalDefinition, symbols.SpanType);
     }
 
     /// <summary>

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that warns when the implementation of a Windows Runtime method reads from a
+/// <see cref="System.Span{T}"/> parameter, which is projected as a write-only fill array in the ABI.
+/// </summary>
+/// <remarks>
+/// In the Windows Runtime ABI, array parameters use one of three conventions: a <see cref="System.ReadOnlySpan{T}"/> parameter
+/// is a "pass array" (<c>[in]</c>, read-only), an <c>out T[]</c> parameter is a "receive array" (<c>[out]</c> with byref), and
+/// a <see cref="System.Span{T}"/> parameter is a "fill array" ([out] without byref). A fill array is write-only: the
+/// implementation is given a buffer allocated by the caller that it is expected to fill, and reading from it is not supported.
+/// This analyzer detects the most common ways a method might read from such a parameter, while avoiding false positives on
+/// write-only usages.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.WriteOnlySpanParameterRead];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // 'Span<T>' parameters are only projected as fill arrays when authoring a Windows Runtime component
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the 'System.Span<T>' symbol (the type that is projected as a write-only fill array)
+            if (context.Compilation.GetTypeByMetadataName("System.Span`1") is not { } spanType)
+            {
+                return;
+            }
+
+            // Get the 'System.ReadOnlySpan<T>' symbol (used to detect conversions that would allow reads)
+            if (context.Compilation.GetTypeByMetadataName("System.ReadOnlySpan`1") is not { } readOnlySpanType)
+            {
+                return;
+            }
+
+            // This handles reading the value (or a readonly reference) of an element, such as:
+            //
+            // _ = span[i];
+            // Foo(span[i]);
+            // ref readonly var x = ref span[i];
+            // Foo(in span[i]);
+            // span[i]++;
+            // span[i] += 1;
+            context.RegisterOperationAction(context =>
+            {
+                IPropertyReferenceOperation operation = (IPropertyReferenceOperation)context.Operation;
+
+                // We only care about the 'Span<T>' indexer (i.e. 'span[i]'), not other properties (e.g. 'Length')
+                if (!operation.Property.IsIndexer)
+                {
+                    return;
+                }
+
+                // The indexer must be invoked directly on a write-only 'Span<T>' parameter
+                if (operation.Instance is not IParameterReferenceOperation { Parameter: { } parameter } ||
+                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
+                {
+                    return;
+                }
+
+                // Skip usages that only write to the element, which are valid for a fill array
+                if (IsWriteOnlyElementUsage(operation))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
+                    operation.Syntax.GetLocation(),
+                    parameter.Name));
+            }, OperationKind.PropertyReference);
+
+            // This handles converting the span to 'ReadOnlySpan<T>', which would allow reads, such as:
+            //
+            // ReadOnlySpan<int> readOnlySpan = span;
+            // Foo((ReadOnlySpan<int>)span);
+            context.RegisterOperationAction(context =>
+            {
+                IConversionOperation operation = (IConversionOperation)context.Operation;
+
+                // The conversion must target 'ReadOnlySpan<T>' (a read-only view over the span elements)
+                if (!SymbolEqualityComparer.Default.Equals(operation.Type?.OriginalDefinition, readOnlySpanType))
+                {
+                    return;
+                }
+
+                // The operand must be a write-only 'Span<T>' parameter
+                if (operation.Operand is not IParameterReferenceOperation { Parameter: { } parameter } ||
+                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
+                    operation.Syntax.GetLocation(),
+                    parameter.Name));
+            }, OperationKind.Conversion);
+
+            // This handles iterating over the span, which reads each element, such as:
+            //
+            // foreach (int x in span)
+            // {
+            // }
+            context.RegisterOperationAction(context =>
+            {
+                if (context.Operation is not IForEachLoopOperation operation)
+                {
+                    return;
+                }
+
+                // The iterated collection is the span parameter, possibly wrapped in an identity conversion
+                IOperation collection = operation.Collection is IConversionOperation { Operand: { } operand }
+                    ? operand
+                    : operation.Collection;
+
+                // The iterated collection must be a write-only 'Span<T>' parameter
+                if (collection is not IParameterReferenceOperation { Parameter: { } parameter } ||
+                    !IsWindowsRuntimeFillArrayParameter(parameter, spanType))
+                {
+                    return;
+                }
+
+                // Iterating with a writable 'ref' loop variable may be used to fill the span, so skip it to
+                // avoid false positives (by-value and 'ref readonly' loop variables can only read elements).
+                if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref })
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.WriteOnlySpanParameterRead,
+                    operation.Collection.Syntax.GetLocation(),
+                    parameter.Name));
+            }, OperationKind.Loop);
+        });
+    }
+
+    /// <summary>
+    /// Checks whether a given parameter is a write-only <see cref="System.Span{T}"/> parameter on a Windows
+    /// Runtime method (i.e. a parameter that is projected as a fill array in the ABI).
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <param name="spanType">The <see cref="INamedTypeSymbol"/> for <see cref="System.Span{T}"/>.</param>
+    /// <returns>Whether <paramref name="parameter"/> is a write-only fill array parameter.</returns>
+    private static bool IsWindowsRuntimeFillArrayParameter(IParameterSymbol parameter, INamedTypeSymbol spanType)
+    {
+        // The parameter must be a by-value 'System.Span<T>': only this is projected as a fill array (a 'ref',
+        // 'in' or 'out' variant is not a valid Windows Runtime parameter, and 'ReadOnlySpan<T>' is a pass array).
+        if (parameter.RefKind is not RefKind.None ||
+            !SymbolEqualityComparer.Default.Equals(parameter.Type.OriginalDefinition, spanType))
+        {
+            return false;
+        }
+
+        // The parameter must belong to an ordinary method, a constructor, or an explicit interface
+        // implementation (and not e.g. a local function, a lambda, an operator or a property accessor).
+        if (parameter.ContainingSymbol is not IMethodSymbol
+            {
+                MethodKind: MethodKind.Ordinary or MethodKind.Constructor or MethodKind.ExplicitInterfaceImplementation
+            } method)
+        {
+            return false;
+        }
+
+        // The containing type must be a public, top-level class (i.e. an authored runtime class). Other type
+        // kinds can't have method bodies with fill array parameters, and nested types are never projected.
+        if (method.ContainingType is not { TypeKind: TypeKind.Class, DeclaredAccessibility: Accessibility.Public, ContainingType: null })
+        {
+            return false;
+        }
+
+        // Public methods (including overrides and implicit interface implementations) are part of the ABI surface
+        if (method.DeclaredAccessibility is Accessibility.Public)
+        {
+            return true;
+        }
+
+        // Explicit interface implementations are also part of the ABI surface, through the interfaces they
+        // implement. Only public interfaces are considered, as those are the ones projected to the Windows Runtime.
+        foreach (IMethodSymbol implementedMethod in method.ExplicitInterfaceImplementations)
+        {
+            if (implementedMethod.ContainingType.DeclaredAccessibility is Accessibility.Public)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a given <see cref="System.Span{T}"/> indexer reference is only used to write to the
+    /// target element (which is valid for a fill array), as opposed to also reading its current value.
+    /// </summary>
+    /// <param name="operation">The <see cref="IPropertyReferenceOperation"/> for the indexer access.</param>
+    /// <returns>Whether <paramref name="operation"/> is a write-only usage of the element.</returns>
+    private static bool IsWriteOnlyElementUsage(IPropertyReferenceOperation operation)
+    {
+        return operation.Parent switch
+        {
+            // 'span[i] = value' (the element is the target of the assignment): this only writes to the element.
+            // Note that a compound assignment ('span[i] += value') is not handled here, as it also reads.
+            ISimpleAssignmentOperation simpleAssignment => ReferenceEquals(simpleAssignment.Target, operation),
+
+            // 'Foo(out span[i])' or 'Foo(ref span[i])': the callee may write to the element, and we can't tell
+            // whether it also reads it, so we conservatively treat these as write-only to avoid false positives.
+            IArgumentOperation { Parameter.RefKind: RefKind.Out or RefKind.Ref } => true,
+
+            // 'ref var x = ref span[i]' (a writable 'ref' alias to the element): the alias may be used to write
+            // to the element, so we also conservatively treat it as write-only (a 'ref readonly' alias cannot).
+            IVariableInitializerOperation { Parent: IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref } } => true,
+
+            // Any other usage reads the value (e.g. as a value, a 'ref readonly' alias, an 'in' argument, a
+            // compound assignment, or an increment/decrement), which is not valid for a write-only fill array.
+            _ => false
+        };
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs
@@ -121,6 +121,13 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
             // foreach (int x in span)
             // {
             // }
+            //
+            // It also handles reading the current element through a writable 'ref' loop variable, such as:
+            //
+            // foreach (ref int x in span)
+            // {
+            //     int y = x;
+            // }
             context.RegisterOperationAction(context =>
             {
                 if (context.Operation is not IForEachLoopOperation operation)
@@ -140,10 +147,14 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                // Iterating with a writable 'ref' loop variable may be used to fill the span, so skip it to
-                // avoid false positives (by-value and 'ref readonly' loop variables can only read elements).
-                if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol.RefKind: RefKind.Ref })
+                // Iterating with a writable 'ref' loop variable may be used to fill the span, so the loop
+                // itself is valid. In that case, only the individual reads through the loop variable (which
+                // aliases the current element) are reported. By-value and 'ref readonly' loop variables can
+                // only ever read the elements, so for those the loop itself is reported instead.
+                if (operation.LoopControlVariable is IVariableDeclaratorOperation { Symbol: { RefKind: RefKind.Ref } loopVariable })
                 {
+                    ReportElementReadsThroughLoopVariable(context, operation.Body, loopVariable, parameter);
+
                     return;
                 }
 
@@ -209,13 +220,53 @@ public sealed class WriteOnlySpanParameterAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Checks whether a given <see cref="System.Span{T}"/> indexer reference is only used to write to the
-    /// target element (which is valid for a fill array), as opposed to also reading its current value.
+    /// Reports all reads of the current element of a write-only <see cref="System.Span{T}"/> parameter that are
+    /// performed through the writable <c>ref</c> loop variable of a <c>foreach</c> loop iterating over it.
     /// </summary>
-    /// <param name="operation">The <see cref="IPropertyReferenceOperation"/> for the indexer access.</param>
-    /// <returns>Whether <paramref name="operation"/> is a write-only usage of the element.</returns>
-    private static bool IsWriteOnlyElementUsage(IPropertyReferenceOperation operation)
+    /// <param name="context">The context to report diagnostics to.</param>
+    /// <param name="loopBody">The body of the <c>foreach</c> loop declaring <paramref name="loopVariable"/>.</param>
+    /// <param name="loopVariable">The writable <c>ref</c> loop variable, aliasing the current element.</param>
+    /// <param name="parameter">The write-only <see cref="System.Span{T}"/> parameter being iterated over.</param>
+    private static void ReportElementReadsThroughLoopVariable(
+        OperationAnalysisContext context,
+        IOperation loopBody,
+        ILocalSymbol loopVariable,
+        IParameterSymbol parameter)
     {
+        foreach (IOperation operation in loopBody.Descendants())
+        {
+            // We only care about references to the loop variable, as those alias an element of the span.
+            // The loop variable can't be captured by a lambda or ref reassigned, so all aliasing usages
+            // of the current element are guaranteed to appear directly in the body of the loop.
+            if (operation is not ILocalReferenceOperation { Local: { } local } ||
+                !SymbolEqualityComparer.Default.Equals(local, loopVariable))
+            {
+                continue;
+            }
+
+            // Skip usages that only write to the element, which are valid for a fill array
+            if (IsWriteOnlyElementUsage(operation))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.WriteOnlySpanParameterRead,
+                operation.Syntax.GetLocation(),
+                parameter.Name));
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a given reference to an element of a write-only <see cref="System.Span{T}"/> parameter is
+    /// only used to write to that element (which is valid for a fill array), as opposed to also reading its value.
+    /// </summary>
+    /// <param name="operation">The operation referencing the element (either an indexer access, or a <c>ref</c> alias).</param>
+    /// <returns>Whether <paramref name="operation"/> is a write-only usage of the element.</returns>
+    private static bool IsWriteOnlyElementUsage(IOperation operation)
+    {
+        // The examples below use an indexer access for the element reference, but the same reasoning
+        // applies verbatim to a 'ref' alias to the element (e.g. a writable 'foreach' loop variable).
         return operation.Parent switch
         {
             // 'span[i] = value' (the element is the target of the assignment): this only writes to the element.

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -312,4 +312,17 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Deprecating a publicly exposed API of a Windows Runtime component requires '[Windows.Foundation.Metadata.Deprecated]', which is the only deprecation the '.winmd' can carry. '[Obsolete]' is a .NET concept with no Windows Runtime counterpart: it is not translated by the WinMD generator, so on its own it deprecates the API for nobody but the C# code inside the component itself.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for reading from a write-only <see cref="System.Span{T}"/> parameter on a Windows Runtime method.
+    /// </summary>
+    public static readonly DiagnosticDescriptor WriteOnlySpanParameterRead = new(
+        id: "CSWINRT2023",
+        title: "Reading from a write-only 'Span<T>' parameter",
+        messageFormat: """The 'Span<T>' parameter '{0}' is projected as a fill array in the Windows Runtime ABI, which is write-only, so the method implementation should only write to it and not read from it""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A 'Span<T>' parameter on a Windows Runtime method is projected as a fill array in the ABI, meaning the implementation is only allowed to write to it, not read from it. Reading from such a parameter (e.g. by indexing it for a value or a readonly reference, converting it to 'ReadOnlySpan<T>', or iterating over it) is not supported. Use 'ReadOnlySpan<T>' for a parameter that should be read from instead.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -928,6 +928,136 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
     }
 
     [TestMethod]
+    public async Task PrimaryConstructorInitializers_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample(Span<int> span)
+            {
+                private int _field = {|CSWINRT2023:span[0]|};
+
+                private int Property { get; } = {|CSWINRT2023:span[1]|};
+
+                private int _converted = Read({|CSWINRT2023:span|});
+
+                private static int Read(ReadOnlySpan<int> span) => span.Length;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterDeconstructedIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int i = 0;
+
+                    span[i] = 1;
+                    (i, _) = (5, 0);                        // A deconstruction also modifies the index
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsWithAliasedIndexOrSpan_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void FillWithAliasedIndex(Span<int> span)
+                {
+                    int i = 0;
+                    ref int alias = ref i;                  // The alias can modify the index from anywhere
+
+                    span[i] = 1;
+                    alias = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public void FillWithAliasedSpan(Span<int> span, Span<int> other)
+                {
+                    ref Span<int> alias = ref span;         // The alias can redirect the span from anywhere
+
+                    span.Clear();
+                    alias = other;
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsWithCapturedIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int i = 0;
+
+                    void Advance() => i++;                  // The capture can modify the index when invoked
+
+                    span[i] = 1;
+                    Advance();
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterConditionalMethodWrite_Warn()
+    {
+        const string source = """
+            using System;
+            using System.Diagnostics;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    // The whole call, arguments included, is removed when 'DEBUG' is not defined
+                    Log(span[0] = 1);
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+
+                [Conditional("DEBUG")]
+                private static void Log(int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
     public async Task ForEachWithWriteInBody_Warns()
     {
         const string source = """

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -1189,6 +1189,78 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
     }
 
     [TestMethod]
+    public async Task ReadsWithEscapingIndex_Warn()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.InteropServices;
+
+            public ref struct Cursor
+            {
+                private ref int _index;
+
+                public Cursor(ref int index)
+                {
+                    _index = ref index;
+                }
+
+                public void Advance() => _index++;
+            }
+
+            public class Sample
+            {
+                public void FillWithStoredIndexReference(Span<int> span)
+                {
+                    int i = 0;
+                    Cursor cursor = new(ref i);                     // The reference outlives the call
+
+                    span[i] = 1;
+                    cursor.Advance();
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public void FillWithSpanOverIndex(Span<int> span)
+                {
+                    int i = 0;
+                    Span<int> window = MemoryMarshal.CreateSpan(ref i, 1);
+
+                    span[i] = 1;
+                    window[0] = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterUnimplementedPartialMethodWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public partial class Sample
+            {
+                // Calls to a 'partial void' method with no implementing declaration are
+                // removed entirely by the compiler, the evaluation of arguments included
+                partial void Log(int x);
+
+                public void Fill(Span<int> span)
+                {
+                    Log(span[0] = 1);
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
     public async Task ForEachWithWriteInBody_Warns()
     {
         const string source = """

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -220,8 +220,187 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
         await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
     }
 
-    // --- Tests where the analyzer SHOULD warn ---
+    [TestMethod]
+    public async Task ReadsAfterClear_DoNotWarn()
+    {
+        const string source = """
+            using System;
 
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    // Every element is initialized, so any subsequent read is fine
+                    span.Clear();
+
+                    int value = span[0];
+                    In(in span[1]);
+                    ref readonly int readOnlyReference = ref span[2];
+                    ReadOnlySpan<int> readOnlySpan = span;
+
+                    Read(span);
+
+                    foreach (int x in span)
+                    {
+                    }
+
+                    foreach (ref readonly int y in span)
+                    {
+                    }
+
+                    foreach (ref int z in span)
+                    {
+                        int nested = z;
+                    }
+
+                    if (condition)
+                    {
+                        int inBranch = span[3];
+                    }
+                }
+
+                private static void In(in int x)
+                {
+                }
+
+                private static void Read(ReadOnlySpan<int> span)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterFill_DoNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    span.Fill(42);
+
+                    int value = span[0];
+                    ReadOnlySpan<int> readOnlySpan = span;
+
+                    foreach (int x in span)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ElementReadsAfterWriteToSameIndex_DoNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    const int Index = 3;
+
+                    span[0] = 1;
+                    int value = span[0];            // Reading back an element that was just written is fine
+                    In(in span[0]);
+                    RefReadOnly(in span[0]);
+                    ref readonly int readOnlyReference = ref span[0];
+                    span[0]++;
+                    span[0] += 1;
+
+                    Out(out span[1]);               // An 'out' argument is also a definite write
+                    int other = span[1];
+
+                    span[Index] = 2;                // Constant indices are compared by value
+                    int constant = span[3];
+
+                    for (int i = 0; i < span.Length; i++)
+                    {
+                        span[i] = i;
+                        int inLoop = span[i];
+                    }
+                }
+
+                private static void In(in int x)
+                {
+                }
+
+                private static void RefReadOnly(ref readonly int x)
+                {
+                }
+
+                private static void Out(out int x) => x = 0;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task LoopVariableReadsAfterWrite_DoNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    foreach (ref int x in span)
+                    {
+                        x = 0;                      // The element is initialized through the alias
+
+                        int value = x;
+                        Value(x);
+                        In(in x);
+                        RefReadOnly(in x);
+                        ref readonly int readOnlyReference = ref x;
+                        x++;
+                        x += 1;
+
+                        if (condition)
+                        {
+                            Value(x);               // Nested reads are fine as well
+                        }
+                    }
+
+                    foreach (ref int y in span)
+                    {
+                        Out(out y);                 // An 'out' argument is also a definite write
+
+                        int value = y;
+                    }
+                }
+
+                private static void Value(int x)
+                {
+                }
+
+                private static void In(in int x)
+                {
+                }
+
+                private static void RefReadOnly(ref readonly int x)
+                {
+                }
+
+                private static void Out(out int x) => x = 0;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    // --- Tests where the analyzer SHOULD warn ---
     [TestMethod]
     public async Task IndexerReads_Warn()
     {
@@ -314,12 +493,6 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
                 {
                     foreach (ref int x in span)
                     {
-                        x = 0;                                      // Writing through the alias is valid
-                        Out(out x);                                 // Writing through an 'out' argument is valid
-                        Ref(ref x);                                 // Passing by 'ref' may write, so it is allowed
-                        ref int slot = ref x;                       // A writable 'ref' alias may write, so it is allowed
-                        slot = 1;
-
                         int value = {|CSWINRT2023:x|};
                         Value({|CSWINRT2023:x|});
                         In(in {|CSWINRT2023:x|});
@@ -332,6 +505,12 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
                         {
                             Value({|CSWINRT2023:x|});               // Nested reads are detected as well
                         }
+
+                        x = 0;                                      // Writing through the alias is valid
+                        Out(out x);                                 // Writing through an 'out' argument is valid
+                        Ref(ref x);                                 // Passing by 'ref' may write, so it is allowed
+                        ref int slot = ref x;                       // A writable 'ref' alias may write, so it is allowed
+                        slot = 1;
                     }
                 }
 
@@ -410,6 +589,359 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
                 void IFillable.Fill(Span<int> span)
                 {
                     int x = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsBeforeWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    // The write only covers reads that come after it
+                    int value = {|CSWINRT2023:span[0]|};
+
+                    span[0] = 1;
+                    span.Clear();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ElementReadsAfterWriteToOtherIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, int index)
+                {
+                    span[0] = 1;
+                    int value = {|CSWINRT2023:span[1]|};         // A different constant index
+
+                    span[index] = 2;
+                    int other = {|CSWINRT2023:span[index + 1]|}; // Not provably the same index
+
+                    // A single element being initialized says nothing about all the other ones
+                    ReadOnlySpan<int> readOnlySpan = {|CSWINRT2023:span|};
+
+                    foreach (int x in {|CSWINRT2023:span|})
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ElementReadsAfterModifiedIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int i = 0;
+
+                    span[i] = 1;
+                    i++;                                    // The two accesses no longer target the same element
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterReassignedSpan_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    span.Clear();
+                    span = default;                         // The write applies to a different buffer
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterConditionalWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    if (condition)
+                    {
+                        span.Clear();
+                    }
+
+                    int value = {|CSWINRT2023:span[0]|};
+
+                    while (condition)
+                    {
+                        span.Fill(1);                       // A loop body might never run
+                    }
+
+                    int other = {|CSWINRT2023:span[1]|};
+
+                    try
+                    {
+                        span.Clear();                       // An exception might skip the rest of the block
+                    }
+                    catch (Exception)
+                    {
+                    }
+
+                    int last = {|CSWINRT2023:span[2]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterNonDefiniteWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    Ref(ref span[0]);                       // The callee might never write to the element
+                    int value = {|CSWINRT2023:span[0]|};
+
+                    ref int slot = ref span[1];             // The alias might never be written to
+                    int other = {|CSWINRT2023:span[1]|};
+
+                    foreach (ref int x in span)
+                    {
+                        Ref(ref x);
+
+                        int nested = {|CSWINRT2023:x|};
+                    }
+                }
+
+                private static void Ref(ref int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterWriteToOtherSpan_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, Span<int> other)
+                {
+                    other.Clear();
+                    other[0] = 1;
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterWriteSkippedByGoto_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    if (condition)
+                    {
+                        goto Read;
+                    }
+
+                    span.Clear();
+
+                Read:
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task LoopVariableReadsBeforeWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    foreach (ref int x in span)
+                    {
+                        int value = {|CSWINRT2023:x|};      // The write only covers later reads
+
+                        x = 0;
+                    }
+
+                    foreach (ref int y in span)
+                    {
+                        if (condition)
+                        {
+                            y = 0;                          // The write might not happen
+                        }
+
+                        int value = {|CSWINRT2023:y|};
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterWriteInSwitchSection_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, int selector)
+                {
+                    switch (selector)
+                    {
+                        case 0:
+                            span.Clear();
+                            break;
+                        default:
+                            span.Fill(1);
+                            break;
+                    }
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterShortCircuitedWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span, bool condition)
+                {
+                    // The write is only reached when the left operand is 'true'
+                    bool result = condition && Set(out span[0]);
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+
+                private static bool Set(out int x)
+                {
+                    x = 0;
+
+                    return true;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsAfterExtensionMethodCall_Warn()
+    {
+        const string source = """
+            using System;
+
+            public static class SpanExtensions
+            {
+                public static void Clear(this Span<int> span, bool flag)
+                {
+                }
+            }
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    span.Clear(true);                       // Not the 'Span<T>.Clear()' method
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ForEachWithWriteInBody_Warns()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    // The write happens after each element has already been read
+                    foreach (int x in {|CSWINRT2023:span|})
+                    {
+                        span.Clear();
+                    }
                 }
             }
             """;

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -1058,6 +1058,137 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
     }
 
     [TestMethod]
+    public async Task ReadsAfterConditionalOverrideWrite_Warn()
+    {
+        const string source = """
+            using System;
+            using System.Diagnostics;
+
+            public class Logger
+            {
+                [Conditional("DEBUG")]
+                public virtual void Log(int x)
+                {
+                }
+            }
+
+            public class Sample : Logger
+            {
+                // An override inherits the conditional symbols of the method it overrides
+                public override void Log(int x)
+                {
+                }
+
+                public void Fill(Span<int> span)
+                {
+                    Log(span[0] = 1);
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsWithIndirectlyAliasedIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void FillWithConditionalAlias(Span<int> span, bool condition)
+                {
+                    int i = 0;
+                    int j = 0;
+                    ref int alias = ref (condition ? ref i : ref j);
+
+                    span[i] = 1;
+                    alias = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public void FillWithReturnedAlias(Span<int> span)
+                {
+                    int i = 0;
+                    ref int alias = ref Identity(ref i);
+
+                    span[i] = 1;
+                    alias = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public unsafe void FillWithPointer(Span<int> span)
+                {
+                    int i = 0;
+                    int* pointer = &i;
+
+                    span[i] = 1;
+                    *pointer = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                private static ref int Identity(ref int x) => ref x;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadsWithRefLocalIndex_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                private int _index;
+
+                public void FillWithFieldIndex(Span<int> span)
+                {
+                    // The index aliases the field, so it changes with no write to 'i' in sight
+                    ref int i = ref _index;
+
+                    span[i] = 1;
+                    _index = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public void FillWithReadOnlyFieldIndex(Span<int> span)
+                {
+                    ref readonly int i = ref _index;
+
+                    span[i] = 1;
+                    Reset();
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                public void FillWithArrayIndex(Span<int> span, int[] indices)
+                {
+                    ref int i = ref indices[0];
+
+                    span[i] = 1;
+                    indices[0] = 5;
+
+                    int value = {|CSWINRT2023:span[i]|};
+                }
+
+                private void Reset() => _index = 5;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
     public async Task ForEachWithWriteInBody_Warns()
     {
         const string source = """

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -303,6 +303,62 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
     }
 
     [TestMethod]
+    public async Task ForEachWritableRefVariableReads_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    foreach (ref int x in span)
+                    {
+                        x = 0;                                      // Writing through the alias is valid
+                        Out(out x);                                 // Writing through an 'out' argument is valid
+                        Ref(ref x);                                 // Passing by 'ref' may write, so it is allowed
+                        ref int slot = ref x;                       // A writable 'ref' alias may write, so it is allowed
+                        slot = 1;
+
+                        int value = {|CSWINRT2023:x|};
+                        Value({|CSWINRT2023:x|});
+                        In(in {|CSWINRT2023:x|});
+                        RefReadOnly(in {|CSWINRT2023:x|});
+                        ref readonly int readOnlyReference = ref {|CSWINRT2023:x|};
+                        {|CSWINRT2023:x|}++;
+                        {|CSWINRT2023:x|} += 1;
+
+                        if (value > 0)
+                        {
+                            Value({|CSWINRT2023:x|});               // Nested reads are detected as well
+                        }
+                    }
+                }
+
+                private static void Value(int x)
+                {
+                }
+
+                private static void In(in int x)
+                {
+                }
+
+                private static void RefReadOnly(ref readonly int x)
+                {
+                }
+
+                private static void Out(out int x) => x = 0;
+
+                private static void Ref(ref int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
     public async Task StaticMethod_Warns()
     {
         const string source = """

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -1261,6 +1261,27 @@ public sealed class Test_WriteOnlySpanParameterAnalyzer
     }
 
     [TestMethod]
+    public async Task ReadsAfterInterpolatedStringHandlerWrite_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<char> destination, Span<int> span)
+                {
+                    // The handler can report failure, in which case the holes are never evaluated
+                    destination.TryWrite($"{span[0] = 1}", out int written);
+
+                    int value = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
     public async Task ForEachWithWriteInBody_Warns()
     {
         const string source = """

--- a/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<WriteOnlySpanParameterAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="WriteOnlySpanParameterAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_WriteOnlySpanParameterAnalyzer
+{
+    // --- Tests where the analyzer should NOT warn ---
+
+    [TestMethod]
+    public async Task WriteOnlyUsages_DoNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    span[0] = 1;                    // Writing to an element is valid
+                    int length = span.Length;       // Reading non-indexer properties is valid
+                    bool empty = span.IsEmpty;
+                    Out(out span[1]);               // Writing through an 'out' argument is valid
+                    Ref(ref span[2]);               // Passing by 'ref' may write, so it is allowed
+                    ref int slot = ref span[3];     // A writable 'ref' alias may write, so it is allowed
+                    slot = 4;
+
+                    foreach (ref int x in span)     // A writable 'ref' loop variable may write
+                    {
+                        x = 5;
+                    }
+                }
+
+                private static void Out(out int x) => x = 0;
+
+                private static void Ref(ref int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ForEachWithWritableRefVariable_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    // A writable 'ref' loop variable can be used to write to all elements sequentially
+                    foreach (ref var x in span)
+                    {
+                    }
+
+                    foreach (ref int y in span)
+                    {
+                        y = 1;
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadOnlySpanParameter_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Read(ReadOnlySpan<int> span)
+                {
+                    int x = span[0];
+                    ReadOnlySpan<int> other = span;
+
+                    foreach (int y in span)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int x = span[0];
+                    ReadOnlySpan<int> other = span;
+
+                    foreach (int y in span)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task PrivateMethod_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                private void Fill(Span<int> span)
+                {
+                    int x = span[0];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task InternalClass_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            internal class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int x = span[0];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task NestedClass_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Outer
+            {
+                public class Inner
+                {
+                    public void Fill(Span<int> span)
+                    {
+                        int x = span[0];
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task Struct_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public struct Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int x = span[0];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task LocalFunction_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Method()
+                {
+                    static void Fill(Span<int> span)
+                    {
+                        int x = span[0];
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    // --- Tests where the analyzer SHOULD warn ---
+
+    [TestMethod]
+    public async Task IndexerReads_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    int value = {|CSWINRT2023:span[0]|};
+                    Value({|CSWINRT2023:span[1]|});
+                    ref readonly int readOnlyReference = ref {|CSWINRT2023:span[2]|};
+                    In(in {|CSWINRT2023:span[3]|});
+                    {|CSWINRT2023:span[4]|}++;
+                    {|CSWINRT2023:span[5]|} += 1;
+                }
+
+                private static void Value(int x)
+                {
+                }
+
+                private static void In(in int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ReadOnlySpanConversions_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    ReadOnlySpan<int> implicitConversion = {|CSWINRT2023:span|};
+                    ReadOnlySpan<int> explicitConversion = {|CSWINRT2023:(ReadOnlySpan<int>)span|};
+
+                    Read({|CSWINRT2023:span|});
+                }
+
+                private static void Read(ReadOnlySpan<int> span)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ForEachReads_Warn()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public void Fill(Span<int> span)
+                {
+                    foreach (int x in {|CSWINRT2023:span|})
+                    {
+                    }
+
+                    foreach (ref readonly int y in {|CSWINRT2023:span|})
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task StaticMethod_Warns()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public static void Fill(Span<int> span)
+                {
+                    int x = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task Constructor_Warns()
+    {
+        const string source = """
+            using System;
+
+            public class Sample
+            {
+                public Sample(Span<int> span)
+                {
+                    int x = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExplicitInterfaceImplementation_Warns()
+    {
+        const string source = """
+            using System;
+
+            public interface IFillable
+            {
+                void Fill(Span<int> span);
+            }
+
+            public class Sample : IFillable
+            {
+                void IFillable.Fill(Span<int> span)
+                {
+                    int x = {|CSWINRT2023:span[0]|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new Roslyn analyzer (`CSWINRT2023`, severity `Warning`) that detects when the implementation of an authored Windows Runtime method reads from a `Span<T>` parameter. Such parameters are projected as write-only **fill arrays** in the Windows Runtime ABI, so reading them is not supported.

## Motivation

In the Windows Runtime ABI, array parameters use one of three conventions:

- `ReadOnlySpan<T>` -> **pass array** (`[in]`, read-only)
- `out T[]` -> **receive array** (`[out]` with byref)
- `Span<T>` -> **fill array** (`[out]` without byref)

A fill array is **write-only**: the implementation is handed a caller-allocated buffer that it is expected to fill, and reading the existing contents is not supported (see [this write-up on WinRT array parameters](https://devblogs.microsoft.com/oldnewthing/20200205-00/?p=103398)). Until now nothing flagged accidental reads from such a parameter, which can lead to subtle, hard-to-diagnose bugs in authored components. This analyzer surfaces the most common mistakes at compile time, while being careful to avoid false positives on legitimate write-only usage.

## What it detects

For a by-value `System.Span<T>` parameter of a Windows Runtime-exposed method, the analyzer reports a read when it sees:

- **Indexer reads**: `var x = span[i]`, `Foo(span[i])`, `ref readonly var x = ref span[i]`, `Foo(in span[i])`, `span[i]++`, `span[i] += 1`
- **Conversions** of the span to `ReadOnlySpan<T>` (implicit or explicit), including when passed as an argument
- **`foreach`** iteration over the span, when the loop variable is by-value or `ref readonly` (every element is read)
- **Reads through a writable `ref` `foreach` loop variable**, which aliases the current element. The loop itself is valid (it can be used to fill the span), so only the individual reads are reported:

  ```csharp
  public void Fill(Span<int> span)
  {
      foreach (ref int x in span)
      {
          int y = x;     // CSWINRT2023, this reads an uninitialized element
          x = 42;        // Fine, this writes to the element
      }
  }
  ```

## Reading back what the method has written

Reading back a value the method itself has just written is perfectly valid, as the element being read is no longer uninitialized. The analyzer accounts for that, and skips a read whenever a write covering the same location is guaranteed to run before it:

```csharp
public void Fill(Span<int> span)
{
    span.Clear();

    int a = span[0];                    // Fine, every element was initialized

    span[1] = 2;
    int b = span[1];                    // Fine, this element was initialized

    foreach (ref int x in span)
    {
        x = 3;
        int c = x;                      // Fine, this element was initialized
    }
}
```

The writes that are recognized are `span.Clear()` and `span.Fill(value)` (which cover any subsequent read, including `foreach` loops and `ReadOnlySpan<T>` conversions), and `span[i] = value` / `Foo(out span[i])` (which cover subsequent reads of that same element, including `in` arguments and `ref readonly` aliases). The same two forms through a writable `ref` `foreach` loop variable cover subsequent reads of the element it aliases.

The analysis is deliberately conservative, since missing a write only means an extra warning, whereas trusting one that doesn't actually happen would silently hide a real bug. A write is only ever considered when it appears in a statement that precedes (an ancestor of) the read within a common enclosing block, and when it is unconditionally reached within that statement: anything nested in a construct that might be skipped is ignored (`if`, `?:`, `??`, `?.`, `switch`, loops, `try`, lambdas, local functions, `&&` and `||`, plus calls that the compiler can erase together with their arguments, such as `[Conditional]` methods, unimplemented `partial void` methods, and holes of an interpolated string whose handler can report failure). Only definite writes count, so `ref` arguments and writable `ref` aliases are not treated as initializing.

Nothing is skipped at all in a body that could modify a variable in a way the ordered scan of statements cannot see: one containing a `goto`, a lambda, a local function, a pointer, or a writable `ref` alias. On top of that, a write is discarded when the span parameter or the index variable might have been reassigned in between, when the index is itself a `ref` local or parameter (so it aliases storage that can change on its own), or when a reference to either of them is handed out anywhere in the method (as it can outlive the call that receives it).

## Avoiding false positives

The analyzer only runs when authoring a component (`CsWinRTComponent` is `true`), and only for by-value `Span<T>` parameters of methods that are actually part of the ABI surface: public methods and constructors, or explicit implementations of public interfaces, declared on **public, top-level classes**. It intentionally does **not** warn on:

- Write-only usages of an element, whether accessed through the indexer or through a writable `ref` `foreach` loop variable: assignments (`span[i] = value`, `x = value`), `out`/`ref` arguments, and writable `ref` aliases (`ref var slot = ref span[i]`)
- `foreach` loops with a writable `ref` loop variable, which can be used to fill all elements
- Non-indexer members such as `span.Length` and `span.IsEmpty`
- Parameters on private/internal methods, nested types, structs, or local functions, and `ReadOnlySpan<T>` parameters

Reads that flow through aliasing or a call to another method taking a `Span<T>` are an accepted blind spot, since the analyzer cannot reason about the callee's behavior.

## Changes

- **`src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs`**: add the `CSWINRT2023` (`WriteOnlySpanParameterRead`) descriptor.
- **`src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md`**: register `CSWINRT2023` under the `3.0.0` release.
- **`src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WriteOnlySpanParameterAnalyzer.cs`**: new analyzer, using an operation block action so that each candidate read can be inspected together with the code that necessarily runs before it.
- **`src/Tests/SourceGenerator2Test/Test_WriteOnlySpanParameterAnalyzer.cs`**: tests covering the warning cases, the write-only / non-exposed cases that must stay silent, and the reads that are skipped because the method has already written to the same location.