### PR TITLE
Port [ApiContract] reference-only gating to the C# projection writer

### DIFF
--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -416,7 +416,8 @@ internal static class CustomAttributeFactory
                     allowMultiple = true;
                 }
 
-                if (strippedName == "ContractVersion")
+                // ContractVersion and ApiContract are only emitted for reference assemblies
+                if (strippedName is "ContractVersion" or "ApiContract")
                 {
                     if (!context.Settings.ReferenceProjection)
                     {


### PR DESCRIPTION
## Summary

Ports the projection code-generation fix from merged PR #2436 (`Skip emitting [ApiContract] attribute for implementation assemblies`) from the C++ generator (`src/cswinrt/code_writers.h`) to the C# projection writer. Only the projection writer is changed here; any interop-generator or test parts of #2436 arrive when this branch is merged back into `staging/3.0`.

## Motivation

The C# projection writer is a port of the C++ `cswinrt` code writers, so it needs the same attribute-filtering fix to emit identical output. Like `[ContractVersion]`, the `[ApiContract]` attribute is metadata that belongs only in reference assemblies, not in implementation (merged) projections. Without this change the C# writer dropped `[ApiContract]` entirely (for both reference and implementation projections), so reference projections were missing it.

## Changes

- **`src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs`**: in the `Windows.Foundation.Metadata` attribute filter inside `WriteCustomAttributes`, `ApiContract` is now gated the same way as `ContractVersion` (`strippedName is "ContractVersion" or "ApiContract"`). As a result `[ApiContract]` is emitted for reference projections and skipped for implementation projections, matching the C++ generator. Previously `ApiContract` fell into the catch-all `else if` and was dropped for every projection.

## Validation

Generated the full `Windows.winmd` projection in both modes:

- Reference mode: 91 `[ApiContract]` attributes emitted, all applied to `enum` types (consistent with `ApiContractAttribute`'s `[AttributeUsage(AttributeTargets.Enum)]`). The new output differs from the pre-change baseline by exactly those 91 added lines (73 files, +91/-0, no other changes).
- Implementation mode: 0 `[ApiContract]` emitted, and byte-identical to the pre-change output (347/347 files, 0 diffs), confirming the change only affects reference projections.
- `Windows.Foundation.Metadata.ApiContractAttribute` is provided by `WinRT.Runtime2` (the same library that supplies the already-emitted `ContractVersionAttribute`), so the emitted `[ApiContract]` resolves and compiles.
- Build is clean (0 warnings) for the projection writer and the reference projection generator.
