### PR TITLE
Allow ContractVersionAttribute on constructors

### DIFF
--- a/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs
@@ -19,6 +19,7 @@ namespace Windows.Foundation.Metadata;
     AttributeTargets.Event |
     AttributeTargets.Field |
     AttributeTargets.Interface |
+    AttributeTargets.Constructor |
     AttributeTargets.Method |
     AttributeTargets.Property |
     AttributeTargets.Class |


### PR DESCRIPTION
## Summary

Add `AttributeTargets.Constructor` to the `[AttributeUsage]` of `ContractVersionAttribute` so that the attribute can be applied to constructors.

## Motivation

Windows Runtime metadata allows the `ContractVersion` attribute to be applied to constructors (for example, to indicate the API contract version in which a given constructor was introduced). The managed `ContractVersionAttribute` declaration was missing `AttributeTargets.Constructor` in its `[AttributeUsage]` list, which prevented the projection from emitting the attribute on constructors. Adding the flag aligns the managed attribute with the set of targets it needs to support.

## Changes

- **`src/WinRT.Runtime2/Windows.Foundation/Metadata/ContractVersionAttribute.cs`**: add `AttributeTargets.Constructor` to the `[AttributeUsage]` flags so the attribute can be applied to constructors.