### PR TITLE
Validate array/span parameters in the WinMD generator and add failure tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -737,7 +737,7 @@ All five .NET build tools (`cswinrtprojectionrefgen`, `cswinrtprojectiongen`, `c
 | Projection Writer (library) | `CSWINRTPROJECTIONGEN5xxx` | `5003`–`5021`, `9999` (shares the `CSWINRTPROJECTIONGEN` prefix with the host; the writer reserves the 5000+ range so the two never collide) |
 | Impl Generator | `CSWINRTIMPLGENxxxx` | `0001`–`0014`, `9999` |
 | Interop Generator | `CSWINRTINTEROPGENxxxx` | `0001`–`0100`, `9999` |
-| WinMD Generator | `CSWINRTWINMDGENxxxx` | `0001`–`0010`, `9999` |
+| WinMD Generator | `CSWINRTWINMDGENxxxx` | `0001`–`0014`, `9999` |
 | Runtime (obsolete markers) | `CSWINRT3xxx` | `CSWINRT3001` (deriving from `WindowsRuntimeObject`), `CSWINRT3002` (type map group types), `CSWINRT3003` (component authoring attributes), `CSWINRT3004` (`WindowsRuntimeReferenceAssemblyAttribute`) |
 
 ---

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -255,12 +255,12 @@ public async Task InvalidType_Warns()
 - **TFM:** `net10.0`, multi-platform (x64/x86)
 - **Output type:** Exe, `CsWinRTEnabled=false`
 - **Key dependencies:** MSTest packages, `Basic.Reference.Assemblies.Net100` and `Microsoft.CodeAnalysis.CSharp` (used to compile the C# inputs)
-- **References:** `WinRT.WinMD.Generator` via `ProjectReference` with `ReferenceOutputAssembly="false"` and `GlobalPropertiesToRemove="RuntimeIdentifier"` — the tool is **built but not referenced**, and tests invoke it as a separate process. Its path is passed to the tests via an `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`).
+- **References:** `WinRT.WinMD.Generator` via `ProjectReference` with `ReferenceOutputAssembly="false"` and `UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained"` — the tool is **built but not referenced**, and tests invoke it as a separate process. Its path is passed to the tests via an `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`).
 
 **Test classes:**
 | Test class | What it tests |
 |------------|---------------|
-| `Test_ParameterConventions` | Unsupported array/span parameter shapes (`ref`/`in` arrays, `out` spans) → `CSWINRTWINMDGEN0011`/`0012`, plus a valid smoke test |
+| `Test_ParameterConventions` | Unsupported array/span parameter shapes (`ref`/`in` arrays, `out` spans) → `CSWINRTWINMDGEN0013`/`0014`, plus a valid smoke test |
 | `Test_InvalidInputs` | Invalid invocations: malformed/missing response files, bad arguments, missing/corrupt input assemblies, an unwritable output path, a missing debug-repro directory |
 
 **Test helper (in `Helpers/`):**
@@ -276,7 +276,7 @@ public void RefArrayParameter_IsRejected()
         {
             void Method(ref int[] values);
         }
-        """, error: "CSWINRTWINMDGEN0011");
+        """, error: "CSWINRTWINMDGEN0013");
 }
 ```
 

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -13,7 +13,7 @@ Before adding tests, always check whether tests for the same functionality alrea
 
 ## Test project overview
 
-CsWinRT 3.0 has 6 primary test project areas, each serving a different purpose. Additional specialized test projects also exist under `src/Tests/`:
+CsWinRT 3.0 has 7 primary test project areas, each serving a different purpose. Additional specialized test projects also exist under `src/Tests/`:
 
 ### 1. Unit tests (`src/Tests/UnitTest/`)
 
@@ -244,6 +244,45 @@ public async Task InvalidType_Warns()
 
 **How they run:** `run-smoke-tests.ps1` (parameterized by `-Test` and `-Runtime`) builds and runs the consumption app (asserting a clean exit code), builds the authoring component and verifies the generated `Authoring.winmd` defines `Authoring.Greeter`, and builds each reference-projection library (`Projection`, `WindowsSdkProjection`, `WindowsSdkXamlProjection`) verifying it produces both a forwarder and a `ref` reference assembly (shared verification). The consumption and authoring tests run on both CoreCLR and Native AOT (`-Runtime`); the three reference-projection tests are build-only and run on CoreCLR only. It is invoked after the `nuget pack` step in `src/build.cmd` (x64 only; skippable via `cswinrt_run_smoke_tests=false`) and as individual steps in `build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml`.
 
+### 7. WinMD generator tests (`src/Tests/WinMDGeneratorTest/`)
+
+**What it tests:** End-to-end behavior of the `cswinrtwinmdgen` build tool (the WinMD generator). It focuses on **failure cases** — unsupported authored component shapes and invalid tool invocations — that can be asserted without breaking a real build.
+
+**When to add tests here:** For testing a WinMD generator failure mode — a new `CSWINRTWINMDGEN` validation error, an unsupported authoring pattern, or a malformed/invalid invocation. Authored shapes that produce a valid `.winmd` are covered by the authoring tests (`AuthoringTest/`) instead.
+
+**Project settings:**
+- **Test framework:** MSTest (`[TestClass]`, `[TestMethod]`, `Assert.*`)
+- **TFM:** `net10.0`, multi-platform (x64/x86)
+- **Output type:** Exe, `CsWinRTEnabled=false`
+- **Key dependencies:** MSTest packages, `Basic.Reference.Assemblies.Net100` and `Microsoft.CodeAnalysis.CSharp` (used to compile the C# inputs)
+- **References:** `WinRT.WinMD.Generator` via `ProjectReference` with `ReferenceOutputAssembly="false"` and `GlobalPropertiesToRemove="RuntimeIdentifier"` — the tool is **built but not referenced**, and tests invoke it as a separate process. Its path is passed to the tests via an `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`).
+
+**Test classes:**
+| Test class | What it tests |
+|------------|---------------|
+| `Test_ParameterConventions` | Unsupported array/span parameter shapes (`ref`/`in` arrays, `out` spans) → `CSWINRTWINMDGEN0011`/`0012`, plus a valid smoke test |
+| `Test_InvalidInputs` | Invalid invocations: malformed/missing response files, bad arguments, missing/corrupt input assemblies, an unwritable output path, a missing debug-repro directory |
+
+**Test helper (in `Helpers/`):**
+- `WinMDGeneratorRunner` — compiles a C# input, runs the actual tool as a subprocess, and asserts the outcome. Public entry points: `AssertSuccess`, `AssertFailure` (from component source or full response-file content), `AssertFailureForMissingResponseFile`, and `CompileComponent`.
+
+**Pattern:**
+```csharp
+[TestMethod]
+public void RefArrayParameter_IsRejected()
+{
+    WinMDGeneratorRunner.AssertFailure("""
+        public interface IComponent
+        {
+            void Method(ref int[] values);
+        }
+        """, error: "CSWINRTWINMDGEN0011");
+}
+```
+
+- Each test is a single `AssertSuccess`/`AssertFailure` call; the runner makes the exit-code and error-output assertions
+- Failure cases assert the tool exits non-zero and its output contains the expected `CSWINRTWINMDGEN` error id
+
 ## Deciding where to add tests
 
 | You want to test... | Add test to... |
@@ -258,6 +297,7 @@ public async Task InvalidType_Warns()
 | GC/reference tracking behavior | `ObjectLifetimeTests/` |
 | XAML visual tree element lifetime | `ObjectLifetimeTests/` |
 | WinRT component authoring patterns | `AuthoringTest/` |
+| A WinMD generator failure mode (a `CSWINRTWINMDGEN` error) | `WinMDGeneratorTest/` (add to `Test_ParameterConventions` or `Test_InvalidInputs`) |
 | The produced NuGet package works end-to-end (real `ref`/`lib` assemblies, generators) | `SmokeTests/` (`Consumption/`, `Authoring/`, or a reference-projection project) |
 | Generated projection code patterns or cross-ABI control flow | Update `TestComponentCSharp/` and add tests in `UnitTest/` or `FunctionalTests/` |
 

--- a/.github/skills/update-testing-instructions/SKILL.md
+++ b/.github/skills/update-testing-instructions/SKILL.md
@@ -86,7 +86,19 @@ Launch an explore agent to verify:
 - **"Referenced from" list** is current
 - **"When to update" guidance** is still correct
 
-### Step 9: verify the "deciding where to add tests" table
+### Step 9: verify WinMD generator tests (`src/Tests/WinMDGeneratorTest/`)
+
+Launch an explore agent to analyze the WinMD generator test project. Verify:
+
+- **Project settings** are current: test framework, TFM, platforms, output type, `CsWinRTEnabled` setting
+- **Tool wiring** is accurate: the `WinRT.WinMD.Generator` `ProjectReference` is built but not referenced (`ReferenceOutputAssembly="false"` + `GlobalPropertiesToRemove="RuntimeIdentifier"`), and the `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`) passes the built tool's path to the tests
+- **Key dependencies** are current (MSTest packages, `Basic.Reference.Assemblies.Net100`, `Microsoft.CodeAnalysis.CSharp`)
+- **Test class table** is complete and accurate — check all `Test_*.cs` files, verify no classes have been added, removed, or renamed, and verify each class's description matches its actual content
+- **Test helper** (`WinMDGeneratorRunner` in `Helpers/`) is accurately described, including its public entry points (`AssertSuccess`, `AssertFailure`, `AssertFailureForMissingResponseFile`, `CompileComponent`)
+- **Pattern example** matches the actual single-call `AssertSuccess`/`AssertFailure` style
+- **Error ids** referenced (`CSWINRTWINMDGEN*`) are still produced by the generator
+
+### Step 10: verify the "deciding where to add tests" table
 
 Check every row in the routing table against the actual test projects. Verify:
 
@@ -95,7 +107,7 @@ Check every row in the routing table against the actual test projects. Verify:
 - No new test project categories exist that should be added as rows
 - The `TestComponentCSharp` guidance is still accurate
 
-### Step 10: verify code examples
+### Step 11: verify code examples
 
 For each code example in the testing skill, verify it matches the conventions actually used in the test files:
 
@@ -103,8 +115,9 @@ For each code example in the testing skill, verify it matches the conventions ac
 - **Functional test pattern**: verify the example uses the correct exit codes and top-level statement style
 - **Generator test pattern**: verify the `VerifySources` call matches the actual method signature and style. Check an actual test method in `Test_CustomPropertyProviderGenerator` to confirm
 - **Analyzer test pattern**: verify the `VerifyAnalyzerAsync` call matches the actual method signature and style. Check an actual test method in the analyzer test files to confirm
+- **WinMD generator test pattern**: verify the single-call `AssertSuccess`/`AssertFailure` example matches the actual style. Check an actual test method in `Test_ParameterConventions` or `Test_InvalidInputs` to confirm
 
-### Step 11: update the testing instructions
+### Step 12: update the testing instructions
 
 Apply surgical edits to `.github/skills/testing/SKILL.md` to fix any discrepancies found. Typical updates include:
 
@@ -125,17 +138,17 @@ Apply surgical edits to `.github/skills/testing/SKILL.md` to fix any discrepanci
 - Do not add unnecessary commentary or explanation beyond what's needed for test placement guidance
 </style_rules>
 
-### Step 12: update this skill if needed
+### Step 13: update this skill if needed
 
 If significant changes to the test suite were discovered (e.g. test projects added or removed, new categories of tests, changed validation criteria), also update this skill file (`.github/skills/update-testing-instructions/SKILL.md`) to reflect those changes. In particular:
 
-- The **per-project verification steps** (steps 2–8) must stay in sync with the actual test projects. If a test project is added or removed, add or remove its verification step accordingly.
+- The **per-project verification steps** (steps 2–9) must stay in sync with the actual test projects. If a test project is added or removed, add or remove its verification step accordingly.
 - The **verification criteria** for each step should reflect what is actually worth checking. If a project gains new aspects worth validating (e.g. new test helper classes, new build settings), add those to the checklist.
-- The **code example verification step** (step 10) should list all code examples present in the testing skill.
+- The **code example verification step** (step 11) should list all code examples present in the testing skill.
 
 This ensures the skill remains useful and accurate for future runs.
 
-### Step 13: summarize changes
+### Step 14: summarize changes
 
 After editing, provide a clear summary of what was updated and why, so the user can review the changes before committing.
 

--- a/.github/skills/update-testing-instructions/SKILL.md
+++ b/.github/skills/update-testing-instructions/SKILL.md
@@ -91,7 +91,7 @@ Launch an explore agent to verify:
 Launch an explore agent to analyze the WinMD generator test project. Verify:
 
 - **Project settings** are current: test framework, TFM, platforms, output type, `CsWinRTEnabled` setting
-- **Tool wiring** is accurate: the `WinRT.WinMD.Generator` `ProjectReference` is built but not referenced (`ReferenceOutputAssembly="false"` + `GlobalPropertiesToRemove="RuntimeIdentifier"`), and the `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`) passes the built tool's path to the tests
+- **Tool wiring** is accurate: the `WinRT.WinMD.Generator` `ProjectReference` is built but not referenced (`ReferenceOutputAssembly="false"` + `UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained"`), and the `AssemblyMetadata` item (`WinMDGeneratorAssemblyPath`) passes the built tool's path to the tests
 - **Key dependencies** are current (MSTest packages, `Basic.Reference.Assemblies.Net100`, `Microsoft.CodeAnalysis.CSharp`)
 - **Test class table** is complete and accurate — check all `Test_*.cs` files, verify no classes have been added, removed, or renamed, and verify each class's description matches its actual content
 - **Test helper** (`WinMDGeneratorRunner` in `Helpers/`) is accurately described, including its public entry points (`AssertSuccess`, `AssertFailure`, `AssertFailureForMissingResponseFile`, `CompileComponent`)

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -52,12 +51,13 @@ internal static class WinMDGeneratorRunner
     /// </summary>
     /// <remarks>
     /// The <paramref name="responseFileFactory"/> receives a fresh temporary working directory and
-    /// returns the response file lines to run with. It can use <see cref="CompileComponent"/> to produce
-    /// an input assembly, or reference any other path under the directory (e.g. to test invalid inputs).
+    /// returns the full response file content to run with (one <c>--argument value</c> pair per line). It
+    /// can use <see cref="CompileComponent"/> to produce an input assembly, or reference any other path
+    /// under the directory (e.g. to test invalid inputs).
     /// </remarks>
-    /// <param name="responseFileFactory">Builds the response file lines for a given temporary directory.</param>
+    /// <param name="responseFileFactory">Builds the full response file content for a given temporary directory.</param>
     /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0002"</c>) the output must contain.</param>
-    public static void AssertFailure(Func<string, IReadOnlyList<string>> responseFileFactory, string error)
+    public static void AssertFailure(Func<string, string> responseFileFactory, string error)
     {
         AssertFailureResult(Run(responseFileFactory), error);
     }
@@ -78,7 +78,7 @@ internal static class WinMDGeneratorRunner
     /// Compiles the given C# <paramref name="source"/> into <c>TestInput.dll</c> in <paramref name="directory"/>.
     /// </summary>
     /// <remarks>
-    /// This is exposed for the <see cref="AssertFailure(Func{string, IReadOnlyList{string}}, string)"/>
+    /// This is exposed for the <see cref="AssertFailure(Func{string, string}, string)"/>
     /// scenarios that need a valid input assembly before triggering a later-stage failure (e.g. an
     /// unwritable output path).
     /// </remarks>
@@ -122,31 +122,30 @@ internal static class WinMDGeneratorRunner
         {
             string inputAssemblyPath = CompileComponent(source, temporaryDirectory);
 
-            return
-            [
-                $"--input-assembly-path {inputAssemblyPath}",
-                $"--reference-assembly-paths {inputAssemblyPath}",
-                $"--output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}",
-                "--assembly-version 1.0.0.0",
-                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
-            ];
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections {useWindowsUIXamlProjections}
+                """;
         });
     }
 
     /// <summary>
     /// Runs the WinMD generator against a caller-provided response file.
     /// </summary>
-    private static (int ExitCode, string Output) Run(Func<string, IReadOnlyList<string>> responseFileFactory)
+    private static (int ExitCode, string Output) Run(Func<string, string> responseFileFactory)
     {
         string toolPath = GetGeneratorPath();
         string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
 
         try
         {
-            IReadOnlyList<string> responseFileLines = responseFileFactory(temporaryDirectory);
+            string responseFileContent = responseFileFactory(temporaryDirectory);
             string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
 
-            File.WriteAllLines(responseFilePath, responseFileLines);
+            File.WriteAllText(responseFilePath, responseFileContent);
 
             return RunTool(toolPath, responseFilePath);
         }

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -15,38 +15,40 @@ using Microsoft.CodeAnalysis.Emit;
 namespace WinMDGeneratorTest.Helpers;
 
 /// <summary>
-/// Helpers to drive the WinMD generator (<c>cswinrtwinmdgen</c>) end-to-end: compile a small C# input,
-/// run the actual tool against it as a separate process, and capture its result.
+/// Runs the WinMD generator (<c>cswinrtwinmdgen</c>) end-to-end and asserts its outcome.
 /// </summary>
-internal static class WinMDGeneratorTestHelper
+/// <remarks>
+/// Each entry point compiles a small C# input (or builds a raw response file), runs the actual tool as
+/// a separate process, and asserts the result. Tests should call <see cref="AssertSuccess"/> or one of
+/// the <c>AssertFailure</c> overloads so each scenario stays a single call.
+/// </remarks>
+internal static class WinMDGeneratorRunner
 {
     /// <summary>
-    /// Compiles the given C# <paramref name="source"/> into an assembly and runs the WinMD generator
-    /// against it with a standard response file, returning the process exit code and combined output.
+    /// Asserts that the generator succeeds (exit code <c>0</c>) for the given component source.
     /// </summary>
     /// <param name="source">The C# source defining the authored component types.</param>
     /// <param name="useWindowsUIXamlProjections">Whether to use the UWP (<c>Windows.UI.Xaml</c>) projections.</param>
-    /// <returns>The generator process exit code and its combined standard output and error.</returns>
-    public static (int ExitCode, string Output) RunGenerator(string source, bool useWindowsUIXamlProjections = false)
+    public static void AssertSuccess(string source, bool useWindowsUIXamlProjections = false)
     {
-        return RunGenerator(temporaryDirectory =>
-        {
-            string inputAssemblyPath = CompileComponent(source, temporaryDirectory);
+        (int exitCode, string output) = Run(source, useWindowsUIXamlProjections);
 
-            return
-            [
-                $"--input-assembly-path {inputAssemblyPath}",
-                $"--reference-assembly-paths {inputAssemblyPath}",
-                $"--output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}",
-                "--assembly-version 1.0.0.0",
-                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
-            ];
-        });
+        Assert.AreEqual(0, exitCode, output);
     }
 
     /// <summary>
-    /// Runs the WinMD generator against a caller-provided response file, returning the process exit
-    /// code and combined output.
+    /// Asserts that the generator fails for the given component source, reporting the expected error.
+    /// </summary>
+    /// <param name="source">The C# source defining the authored component types.</param>
+    /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0011"</c>) the output must contain.</param>
+    /// <param name="useWindowsUIXamlProjections">Whether to use the UWP (<c>Windows.UI.Xaml</c>) projections.</param>
+    public static void AssertFailure(string source, string error, bool useWindowsUIXamlProjections = false)
+    {
+        AssertFailureResult(Run(source, useWindowsUIXamlProjections), error);
+    }
+
+    /// <summary>
+    /// Asserts that the generator fails for a caller-provided response file, reporting the expected error.
     /// </summary>
     /// <remarks>
     /// The <paramref name="responseFileFactory"/> receives a fresh temporary working directory and
@@ -54,41 +56,32 @@ internal static class WinMDGeneratorTestHelper
     /// an input assembly, or reference any other path under the directory (e.g. to test invalid inputs).
     /// </remarks>
     /// <param name="responseFileFactory">Builds the response file lines for a given temporary directory.</param>
-    /// <returns>The generator process exit code and its combined standard output and error.</returns>
-    public static (int ExitCode, string Output) RunGenerator(Func<string, IReadOnlyList<string>> responseFileFactory)
+    /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0002"</c>) the output must contain.</param>
+    public static void AssertFailure(Func<string, IReadOnlyList<string>> responseFileFactory, string error)
     {
-        string toolPath = GetGeneratorPath();
-        string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
-
-        try
-        {
-            IReadOnlyList<string> responseFileLines = responseFileFactory(temporaryDirectory);
-            string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
-
-            File.WriteAllLines(responseFilePath, responseFileLines);
-
-            return RunTool(toolPath, responseFilePath);
-        }
-        finally
-        {
-            TryDeleteDirectory(temporaryDirectory);
-        }
+        AssertFailureResult(Run(responseFileFactory), error);
     }
 
     /// <summary>
-    /// Runs the WinMD generator pointed at a response file path that does not exist.
+    /// Asserts that the generator fails when pointed at a response file path that does not exist,
+    /// reporting the expected error.
     /// </summary>
-    /// <returns>The generator process exit code and its combined standard output and error.</returns>
-    public static (int ExitCode, string Output) RunGeneratorWithMissingResponseFile()
+    /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0001"</c>) the output must contain.</param>
+    public static void AssertFailureForMissingResponseFile(string error)
     {
         string missingResponseFilePath = Path.Combine(Path.GetTempPath(), $"WinMDGeneratorTest_{Guid.NewGuid():N}.rsp");
 
-        return RunTool(GetGeneratorPath(), missingResponseFilePath);
+        AssertFailureResult(RunTool(GetGeneratorPath(), missingResponseFilePath), error);
     }
 
     /// <summary>
     /// Compiles the given C# <paramref name="source"/> into <c>TestInput.dll</c> in <paramref name="directory"/>.
     /// </summary>
+    /// <remarks>
+    /// This is exposed for the <see cref="AssertFailure(Func{string, IReadOnlyList{string}}, string)"/>
+    /// scenarios that need a valid input assembly before triggering a later-stage failure (e.g. an
+    /// unwritable output path).
+    /// </remarks>
     /// <param name="source">The C# source defining the authored component types.</param>
     /// <param name="directory">The directory to emit the assembly into.</param>
     /// <returns>The full path to the compiled assembly.</returns>
@@ -117,6 +110,59 @@ internal static class WinMDGeneratorTestHelper
         Assert.IsTrue(result.Success, $"Input compilation failed:\n{string.Join("\n", result.Diagnostics)}");
 
         return outputPath;
+    }
+
+    /// <summary>
+    /// Compiles the given C# <paramref name="source"/> into an assembly and runs the WinMD generator
+    /// against it with a standard response file.
+    /// </summary>
+    private static (int ExitCode, string Output) Run(string source, bool useWindowsUIXamlProjections)
+    {
+        return Run(temporaryDirectory =>
+        {
+            string inputAssemblyPath = CompileComponent(source, temporaryDirectory);
+
+            return
+            [
+                $"--input-assembly-path {inputAssemblyPath}",
+                $"--reference-assembly-paths {inputAssemblyPath}",
+                $"--output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}",
+                "--assembly-version 1.0.0.0",
+                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
+            ];
+        });
+    }
+
+    /// <summary>
+    /// Runs the WinMD generator against a caller-provided response file.
+    /// </summary>
+    private static (int ExitCode, string Output) Run(Func<string, IReadOnlyList<string>> responseFileFactory)
+    {
+        string toolPath = GetGeneratorPath();
+        string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
+
+        try
+        {
+            IReadOnlyList<string> responseFileLines = responseFileFactory(temporaryDirectory);
+            string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
+
+            File.WriteAllLines(responseFilePath, responseFileLines);
+
+            return RunTool(toolPath, responseFilePath);
+        }
+        finally
+        {
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Asserts that a generator run failed (non-zero exit code) and its output contains the expected error.
+    /// </summary>
+    private static void AssertFailureResult((int ExitCode, string Output) result, string error)
+    {
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(result.Output, error);
     }
 
     /// <summary>
@@ -151,7 +197,7 @@ internal static class WinMDGeneratorTestHelper
     /// </summary>
     private static string GetGeneratorPath()
     {
-        string? path = typeof(WinMDGeneratorTestHelper).Assembly
+        string? path = typeof(WinMDGeneratorRunner).Assembly
             .GetCustomAttributes<AssemblyMetadataAttribute>()
             .FirstOrDefault(static attribute => attribute.Key == "WinMDGeneratorAssemblyPath")?.Value;
 

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -39,7 +39,7 @@ internal static class WinMDGeneratorRunner
     /// Asserts that the generator fails for the given component source, reporting the expected error.
     /// </summary>
     /// <param name="source">The C# source defining the authored component types.</param>
-    /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0011"</c>) the output must contain.</param>
+    /// <param name="error">The expected error id (e.g. <c>"CSWINRTWINMDGEN0013"</c>) the output must contain.</param>
     /// <param name="useWindowsUIXamlProjections">Whether to use the UWP (<c>Windows.UI.Xaml</c>) projections.</param>
     public static void AssertFailure(string source, string error, bool useWindowsUIXamlProjections = false)
     {

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorTestHelper.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorTestHelper.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Basic.Reference.Assemblies;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace WinMDGeneratorTest.Helpers;
+
+/// <summary>
+/// Helpers to drive the WinMD generator (<c>cswinrtwinmdgen</c>) end-to-end: compile a small C# input,
+/// run the actual tool against it as a separate process, and capture its result.
+/// </summary>
+internal static class WinMDGeneratorTestHelper
+{
+    /// <summary>
+    /// Compiles the given C# <paramref name="source"/> into an assembly and runs the WinMD generator
+    /// against it, returning the process exit code and combined output.
+    /// </summary>
+    /// <param name="source">The C# source defining the authored component types.</param>
+    /// <param name="useWindowsUIXamlProjections">Whether to use the UWP (<c>Windows.UI.Xaml</c>) projections.</param>
+    /// <returns>The generator process exit code and its combined standard output and error.</returns>
+    public static (int ExitCode, string Output) RunGenerator(string source, bool useWindowsUIXamlProjections = false)
+    {
+        string toolPath = GetGeneratorPath();
+        string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
+
+        try
+        {
+            string inputAssemblyPath = Path.Combine(temporaryDirectory, "TestInput.dll");
+            string outputWinmdPath = Path.Combine(temporaryDirectory, "TestInput.winmd");
+            string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
+
+            CompileInputAssembly(source, inputAssemblyPath);
+
+            // Each line of the response file is a single '<argument-name> <value>' pair. The input
+            // assembly is also passed as its own reference path (its directory seeds the resolver).
+            File.WriteAllLines(responseFilePath,
+            [
+                $"--input-assembly-path {inputAssemblyPath}",
+                $"--reference-assembly-paths {inputAssemblyPath}",
+                $"--output-winmd-path {outputWinmdPath}",
+                "--assembly-version 1.0.0.0",
+                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
+            ]);
+
+            return RunTool(toolPath, responseFilePath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best effort cleanup; a leftover temp directory must not fail the test
+            }
+        }
+    }
+
+    /// <summary>
+    /// Compiles the given C# <paramref name="source"/> into an assembly on disk.
+    /// </summary>
+    private static void CompileInputAssembly(string source, string outputPath)
+    {
+        CSharpParseOptions parseOptions = new(LanguageVersion.Preview);
+
+        // The target framework attribute lets the generator probe the .NET runtime version. It is added
+        // in a separate syntax tree so it does not interfere with any 'using' directives in the test
+        // source (an assembly attribute must precede type declarations but follow 'using' directives).
+        SyntaxTree sourceTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        SyntaxTree assemblyInfoTree = CSharpSyntaxTree.ParseText(
+            """[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0")]""",
+            parseOptions);
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "TestInput",
+            syntaxTrees: [sourceTree, assemblyInfoTree],
+            references: Net100.References.All,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+        EmitResult result = compilation.Emit(outputPath);
+
+        Assert.IsTrue(result.Success, $"Input compilation failed:\n{string.Join("\n", result.Diagnostics)}");
+    }
+
+    /// <summary>
+    /// Runs <c>dotnet exec &lt;tool&gt; &lt;responseFile&gt;</c> and captures the exit code and output.
+    /// </summary>
+    private static (int ExitCode, string Output) RunTool(string toolPath, string responseFilePath)
+    {
+        ProcessStartInfo startInfo = new("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add(toolPath);
+        startInfo.ArgumentList.Add(responseFilePath);
+
+        using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the WinMD generator process.");
+
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+
+        process.WaitForExit();
+
+        return (process.ExitCode, standardOutput + standardError);
+    }
+
+    /// <summary>
+    /// Resolves the path to the built <c>cswinrtwinmdgen</c> tool from assembly metadata.
+    /// </summary>
+    private static string GetGeneratorPath()
+    {
+        string? path = typeof(WinMDGeneratorTestHelper).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(static attribute => attribute.Key == "WinMDGeneratorAssemblyPath")?.Value;
+
+        Assert.IsFalse(string.IsNullOrEmpty(path), "The 'WinMDGeneratorAssemblyPath' assembly metadata was not found.");
+
+        string fullPath = Path.GetFullPath(path!);
+
+        Assert.IsTrue(File.Exists(fullPath), $"The WinMD generator was not found at '{fullPath}'.");
+
+        return fullPath;
+    }
+}

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorTestHelper.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorTestHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -21,55 +22,80 @@ internal static class WinMDGeneratorTestHelper
 {
     /// <summary>
     /// Compiles the given C# <paramref name="source"/> into an assembly and runs the WinMD generator
-    /// against it, returning the process exit code and combined output.
+    /// against it with a standard response file, returning the process exit code and combined output.
     /// </summary>
     /// <param name="source">The C# source defining the authored component types.</param>
     /// <param name="useWindowsUIXamlProjections">Whether to use the UWP (<c>Windows.UI.Xaml</c>) projections.</param>
     /// <returns>The generator process exit code and its combined standard output and error.</returns>
     public static (int ExitCode, string Output) RunGenerator(string source, bool useWindowsUIXamlProjections = false)
     {
+        return RunGenerator(temporaryDirectory =>
+        {
+            string inputAssemblyPath = CompileComponent(source, temporaryDirectory);
+
+            return
+            [
+                $"--input-assembly-path {inputAssemblyPath}",
+                $"--reference-assembly-paths {inputAssemblyPath}",
+                $"--output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}",
+                "--assembly-version 1.0.0.0",
+                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
+            ];
+        });
+    }
+
+    /// <summary>
+    /// Runs the WinMD generator against a caller-provided response file, returning the process exit
+    /// code and combined output.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="responseFileFactory"/> receives a fresh temporary working directory and
+    /// returns the response file lines to run with. It can use <see cref="CompileComponent"/> to produce
+    /// an input assembly, or reference any other path under the directory (e.g. to test invalid inputs).
+    /// </remarks>
+    /// <param name="responseFileFactory">Builds the response file lines for a given temporary directory.</param>
+    /// <returns>The generator process exit code and its combined standard output and error.</returns>
+    public static (int ExitCode, string Output) RunGenerator(Func<string, IReadOnlyList<string>> responseFileFactory)
+    {
         string toolPath = GetGeneratorPath();
         string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
 
         try
         {
-            string inputAssemblyPath = Path.Combine(temporaryDirectory, "TestInput.dll");
-            string outputWinmdPath = Path.Combine(temporaryDirectory, "TestInput.winmd");
+            IReadOnlyList<string> responseFileLines = responseFileFactory(temporaryDirectory);
             string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
 
-            CompileInputAssembly(source, inputAssemblyPath);
-
-            // Each line of the response file is a single '<argument-name> <value>' pair. The input
-            // assembly is also passed as its own reference path (its directory seeds the resolver).
-            File.WriteAllLines(responseFilePath,
-            [
-                $"--input-assembly-path {inputAssemblyPath}",
-                $"--reference-assembly-paths {inputAssemblyPath}",
-                $"--output-winmd-path {outputWinmdPath}",
-                "--assembly-version 1.0.0.0",
-                $"--use-windows-ui-xaml-projections {useWindowsUIXamlProjections}",
-            ]);
+            File.WriteAllLines(responseFilePath, responseFileLines);
 
             return RunTool(toolPath, responseFilePath);
         }
         finally
         {
-            try
-            {
-                Directory.Delete(temporaryDirectory, recursive: true);
-            }
-            catch (IOException)
-            {
-                // Best effort cleanup; a leftover temp directory must not fail the test
-            }
+            TryDeleteDirectory(temporaryDirectory);
         }
     }
 
     /// <summary>
-    /// Compiles the given C# <paramref name="source"/> into an assembly on disk.
+    /// Runs the WinMD generator pointed at a response file path that does not exist.
     /// </summary>
-    private static void CompileInputAssembly(string source, string outputPath)
+    /// <returns>The generator process exit code and its combined standard output and error.</returns>
+    public static (int ExitCode, string Output) RunGeneratorWithMissingResponseFile()
     {
+        string missingResponseFilePath = Path.Combine(Path.GetTempPath(), $"WinMDGeneratorTest_{Guid.NewGuid():N}.rsp");
+
+        return RunTool(GetGeneratorPath(), missingResponseFilePath);
+    }
+
+    /// <summary>
+    /// Compiles the given C# <paramref name="source"/> into <c>TestInput.dll</c> in <paramref name="directory"/>.
+    /// </summary>
+    /// <param name="source">The C# source defining the authored component types.</param>
+    /// <param name="directory">The directory to emit the assembly into.</param>
+    /// <returns>The full path to the compiled assembly.</returns>
+    public static string CompileComponent(string source, string directory)
+    {
+        string outputPath = Path.Combine(directory, "TestInput.dll");
+
         CSharpParseOptions parseOptions = new(LanguageVersion.Preview);
 
         // The target framework attribute lets the generator probe the .NET runtime version. It is added
@@ -89,12 +115,14 @@ internal static class WinMDGeneratorTestHelper
         EmitResult result = compilation.Emit(outputPath);
 
         Assert.IsTrue(result.Success, $"Input compilation failed:\n{string.Join("\n", result.Diagnostics)}");
+
+        return outputPath;
     }
 
     /// <summary>
-    /// Runs <c>dotnet exec &lt;tool&gt; &lt;responseFile&gt;</c> and captures the exit code and output.
+    /// Runs <c>dotnet exec &lt;tool&gt; &lt;argument&gt;</c> and captures the exit code and output.
     /// </summary>
-    private static (int ExitCode, string Output) RunTool(string toolPath, string responseFilePath)
+    private static (int ExitCode, string Output) RunTool(string toolPath, string argument)
     {
         ProcessStartInfo startInfo = new("dotnet")
         {
@@ -106,7 +134,7 @@ internal static class WinMDGeneratorTestHelper
 
         startInfo.ArgumentList.Add("exec");
         startInfo.ArgumentList.Add(toolPath);
-        startInfo.ArgumentList.Add(responseFilePath);
+        startInfo.ArgumentList.Add(argument);
 
         using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the WinMD generator process.");
 
@@ -134,5 +162,20 @@ internal static class WinMDGeneratorTestHelper
         Assert.IsTrue(File.Exists(fullPath), $"The WinMD generator was not found at '{fullPath}'.");
 
         return fullPath;
+    }
+
+    /// <summary>
+    /// Deletes a directory recursively, ignoring failures (best effort cleanup).
+    /// </summary>
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup; a leftover temp directory must not fail the test
+        }
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
@@ -28,47 +28,43 @@ public class Test_InvalidInputs
     public void MalformedResponseFile_IsReported()
     {
         // A response file line must be a '<argument-name> <value>' pair; a line without a space is invalid
-        WinMDGeneratorRunner.AssertFailure(static _ =>
-        [
-            "--assembly-version 1.0.0.0",
-            "this-line-has-no-space",
-        ], error: "CSWINRTWINMDGEN0002");
+        WinMDGeneratorRunner.AssertFailure(static _ => """
+            --assembly-version 1.0.0.0
+            this-line-has-no-space
+            """, error: "CSWINRTWINMDGEN0002");
     }
 
     [TestMethod]
     public void DuplicateArgument_IsReported()
     {
-        WinMDGeneratorRunner.AssertFailure(static _ =>
-        [
-            "--assembly-version 1.0.0.0",
-            "--assembly-version 2.0.0.0",
-        ], error: "CSWINRTWINMDGEN0002");
+        WinMDGeneratorRunner.AssertFailure(static _ => """
+            --assembly-version 1.0.0.0
+            --assembly-version 2.0.0.0
+            """, error: "CSWINRTWINMDGEN0002");
     }
 
     [TestMethod]
     public void MissingRequiredArgument_IsReported()
     {
         // The required '--output-winmd-path' argument is omitted
-        WinMDGeneratorRunner.AssertFailure(static _ =>
-        [
-            "--input-assembly-path input.dll",
-            "--reference-assembly-paths input.dll",
-            "--assembly-version 1.0.0.0",
-            "--use-windows-ui-xaml-projections False",
-        ], error: "CSWINRTWINMDGEN0003");
+        WinMDGeneratorRunner.AssertFailure(static _ => """
+            --input-assembly-path input.dll
+            --reference-assembly-paths input.dll
+            --assembly-version 1.0.0.0
+            --use-windows-ui-xaml-projections False
+            """, error: "CSWINRTWINMDGEN0003");
     }
 
     [TestMethod]
     public void InvalidBooleanArgument_IsReported()
     {
-        WinMDGeneratorRunner.AssertFailure(static _ =>
-        [
-            "--input-assembly-path input.dll",
-            "--reference-assembly-paths input.dll",
-            "--output-winmd-path output.winmd",
-            "--assembly-version 1.0.0.0",
-            "--use-windows-ui-xaml-projections not-a-boolean",
-        ], error: "CSWINRTWINMDGEN0003");
+        WinMDGeneratorRunner.AssertFailure(static _ => """
+            --input-assembly-path input.dll
+            --reference-assembly-paths input.dll
+            --output-winmd-path output.winmd
+            --assembly-version 1.0.0.0
+            --use-windows-ui-xaml-projections not-a-boolean
+            """, error: "CSWINRTWINMDGEN0003");
     }
 
     [TestMethod]
@@ -78,14 +74,13 @@ public class Test_InvalidInputs
         {
             string missingInput = Path.Combine(temporaryDirectory, "DoesNotExist.dll");
 
-            return
-            [
-                $"--input-assembly-path {missingInput}",
-                $"--reference-assembly-paths {missingInput}",
-                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
-                "--assembly-version 1.0.0.0",
-                "--use-windows-ui-xaml-projections False",
-            ];
+            return $"""
+                --input-assembly-path {missingInput}
+                --reference-assembly-paths {missingInput}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                """;
         }, error: "CSWINRTWINMDGEN0004");
     }
 
@@ -98,14 +93,13 @@ public class Test_InvalidInputs
 
             File.WriteAllText(invalidInput, "This is not a valid PE image.");
 
-            return
-            [
-                $"--input-assembly-path {invalidInput}",
-                $"--reference-assembly-paths {invalidInput}",
-                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
-                "--assembly-version 1.0.0.0",
-                "--use-windows-ui-xaml-projections False",
-            ];
+            return $"""
+                --input-assembly-path {invalidInput}
+                --reference-assembly-paths {invalidInput}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                """;
         }, error: "CSWINRTWINMDGEN0004");
     }
 
@@ -122,14 +116,13 @@ public class Test_InvalidInputs
                 }
                 """, temporaryDirectory);
 
-            return
-            [
-                $"--input-assembly-path {inputAssemblyPath}",
-                $"--reference-assembly-paths {inputAssemblyPath}",
-                $"--output-winmd-path {temporaryDirectory}",
-                "--assembly-version 1.0.0.0",
-                "--use-windows-ui-xaml-projections False",
-            ];
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath}
+                --output-winmd-path {temporaryDirectory}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                """;
         }, error: "CSWINRTWINMDGEN0006");
     }
 
@@ -147,15 +140,14 @@ public class Test_InvalidInputs
 
             string missingDebugReproDirectory = Path.Combine(temporaryDirectory, "does-not-exist");
 
-            return
-            [
-                $"--input-assembly-path {inputAssemblyPath}",
-                $"--reference-assembly-paths {inputAssemblyPath}",
-                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
-                "--assembly-version 1.0.0.0",
-                "--use-windows-ui-xaml-projections False",
-                $"--debug-repro-directory {missingDebugReproDirectory}",
-            ];
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                --debug-repro-directory {missingDebugReproDirectory}
+                """;
         }, error: "CSWINRTWINMDGEN0008");
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
@@ -21,75 +21,60 @@ public class Test_InvalidInputs
     [TestMethod]
     public void MissingResponseFile_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGeneratorWithMissingResponseFile();
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0001");
+        WinMDGeneratorRunner.AssertFailureForMissingResponseFile(error: "CSWINRTWINMDGEN0001");
     }
 
     [TestMethod]
     public void MalformedResponseFile_IsReported()
     {
         // A response file line must be a '<argument-name> <value>' pair; a line without a space is invalid
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        WinMDGeneratorRunner.AssertFailure(static _ =>
         [
             "--assembly-version 1.0.0.0",
             "this-line-has-no-space",
-        ]);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0002");
+        ], error: "CSWINRTWINMDGEN0002");
     }
 
     [TestMethod]
     public void DuplicateArgument_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        WinMDGeneratorRunner.AssertFailure(static _ =>
         [
             "--assembly-version 1.0.0.0",
             "--assembly-version 2.0.0.0",
-        ]);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0002");
+        ], error: "CSWINRTWINMDGEN0002");
     }
 
     [TestMethod]
     public void MissingRequiredArgument_IsReported()
     {
         // The required '--output-winmd-path' argument is omitted
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        WinMDGeneratorRunner.AssertFailure(static _ =>
         [
             "--input-assembly-path input.dll",
             "--reference-assembly-paths input.dll",
             "--assembly-version 1.0.0.0",
             "--use-windows-ui-xaml-projections False",
-        ]);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0003");
+        ], error: "CSWINRTWINMDGEN0003");
     }
 
     [TestMethod]
     public void InvalidBooleanArgument_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        WinMDGeneratorRunner.AssertFailure(static _ =>
         [
             "--input-assembly-path input.dll",
             "--reference-assembly-paths input.dll",
             "--output-winmd-path output.winmd",
             "--assembly-version 1.0.0.0",
             "--use-windows-ui-xaml-projections not-a-boolean",
-        ]);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0003");
+        ], error: "CSWINRTWINMDGEN0003");
     }
 
     [TestMethod]
     public void MissingInputAssembly_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        WinMDGeneratorRunner.AssertFailure(static temporaryDirectory =>
         {
             string missingInput = Path.Combine(temporaryDirectory, "DoesNotExist.dll");
 
@@ -101,16 +86,13 @@ public class Test_InvalidInputs
                 "--assembly-version 1.0.0.0",
                 "--use-windows-ui-xaml-projections False",
             ];
-        });
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0004");
+        }, error: "CSWINRTWINMDGEN0004");
     }
 
     [TestMethod]
     public void InvalidInputAssembly_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        WinMDGeneratorRunner.AssertFailure(static temporaryDirectory =>
         {
             string invalidInput = Path.Combine(temporaryDirectory, "NotAPortableExecutable.dll");
 
@@ -124,19 +106,16 @@ public class Test_InvalidInputs
                 "--assembly-version 1.0.0.0",
                 "--use-windows-ui-xaml-projections False",
             ];
-        });
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0004");
+        }, error: "CSWINRTWINMDGEN0004");
     }
 
     [TestMethod]
     public void UnwritableOutputPath_IsReported()
     {
         // The output path points at an existing directory, so the '.winmd' cannot be written
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        WinMDGeneratorRunner.AssertFailure(static temporaryDirectory =>
         {
-            string inputAssemblyPath = WinMDGeneratorTestHelper.CompileComponent("""
+            string inputAssemblyPath = WinMDGeneratorRunner.CompileComponent("""
                 public interface IComponent
                 {
                     int Method(int value);
@@ -151,18 +130,15 @@ public class Test_InvalidInputs
                 "--assembly-version 1.0.0.0",
                 "--use-windows-ui-xaml-projections False",
             ];
-        });
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0006");
+        }, error: "CSWINRTWINMDGEN0006");
     }
 
     [TestMethod]
     public void MissingDebugReproDirectory_IsReported()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        WinMDGeneratorRunner.AssertFailure(static temporaryDirectory =>
         {
-            string inputAssemblyPath = WinMDGeneratorTestHelper.CompileComponent("""
+            string inputAssemblyPath = WinMDGeneratorRunner.CompileComponent("""
                 public interface IComponent
                 {
                     int Method(int value);
@@ -180,9 +156,6 @@ public class Test_InvalidInputs
                 "--use-windows-ui-xaml-projections False",
                 $"--debug-repro-directory {missingDebugReproDirectory}",
             ];
-        });
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0008");
+        }, error: "CSWINRTWINMDGEN0008");
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_InvalidInputs.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+using WinMDGeneratorTest.Helpers;
+
+namespace WinMDGeneratorTest;
+
+/// <summary>
+/// End-to-end tests for the WinMD generator's handling of invalid invocations: malformed or missing
+/// response files, bad arguments, missing or corrupt input assemblies, an unwritable output path, and
+/// a missing debug-repro directory.
+/// </summary>
+/// <remarks>
+/// Each test runs the actual <c>cswinrtwinmdgen</c> tool and asserts a non-zero exit code and the
+/// expected <c>CSWINRTWINMDGEN</c> error in the output.
+/// </remarks>
+[TestClass]
+public class Test_InvalidInputs
+{
+    [TestMethod]
+    public void MissingResponseFile_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGeneratorWithMissingResponseFile();
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0001");
+    }
+
+    [TestMethod]
+    public void MalformedResponseFile_IsReported()
+    {
+        // A response file line must be a '<argument-name> <value>' pair; a line without a space is invalid
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        [
+            "--assembly-version 1.0.0.0",
+            "this-line-has-no-space",
+        ]);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0002");
+    }
+
+    [TestMethod]
+    public void DuplicateArgument_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        [
+            "--assembly-version 1.0.0.0",
+            "--assembly-version 2.0.0.0",
+        ]);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0002");
+    }
+
+    [TestMethod]
+    public void MissingRequiredArgument_IsReported()
+    {
+        // The required '--output-winmd-path' argument is omitted
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        [
+            "--input-assembly-path input.dll",
+            "--reference-assembly-paths input.dll",
+            "--assembly-version 1.0.0.0",
+            "--use-windows-ui-xaml-projections False",
+        ]);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0003");
+    }
+
+    [TestMethod]
+    public void InvalidBooleanArgument_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static _ =>
+        [
+            "--input-assembly-path input.dll",
+            "--reference-assembly-paths input.dll",
+            "--output-winmd-path output.winmd",
+            "--assembly-version 1.0.0.0",
+            "--use-windows-ui-xaml-projections not-a-boolean",
+        ]);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0003");
+    }
+
+    [TestMethod]
+    public void MissingInputAssembly_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        {
+            string missingInput = Path.Combine(temporaryDirectory, "DoesNotExist.dll");
+
+            return
+            [
+                $"--input-assembly-path {missingInput}",
+                $"--reference-assembly-paths {missingInput}",
+                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
+                "--assembly-version 1.0.0.0",
+                "--use-windows-ui-xaml-projections False",
+            ];
+        });
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0004");
+    }
+
+    [TestMethod]
+    public void InvalidInputAssembly_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        {
+            string invalidInput = Path.Combine(temporaryDirectory, "NotAPortableExecutable.dll");
+
+            File.WriteAllText(invalidInput, "This is not a valid PE image.");
+
+            return
+            [
+                $"--input-assembly-path {invalidInput}",
+                $"--reference-assembly-paths {invalidInput}",
+                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
+                "--assembly-version 1.0.0.0",
+                "--use-windows-ui-xaml-projections False",
+            ];
+        });
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0004");
+    }
+
+    [TestMethod]
+    public void UnwritableOutputPath_IsReported()
+    {
+        // The output path points at an existing directory, so the '.winmd' cannot be written
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        {
+            string inputAssemblyPath = WinMDGeneratorTestHelper.CompileComponent("""
+                public interface IComponent
+                {
+                    int Method(int value);
+                }
+                """, temporaryDirectory);
+
+            return
+            [
+                $"--input-assembly-path {inputAssemblyPath}",
+                $"--reference-assembly-paths {inputAssemblyPath}",
+                $"--output-winmd-path {temporaryDirectory}",
+                "--assembly-version 1.0.0.0",
+                "--use-windows-ui-xaml-projections False",
+            ];
+        });
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0006");
+    }
+
+    [TestMethod]
+    public void MissingDebugReproDirectory_IsReported()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator(static temporaryDirectory =>
+        {
+            string inputAssemblyPath = WinMDGeneratorTestHelper.CompileComponent("""
+                public interface IComponent
+                {
+                    int Method(int value);
+                }
+                """, temporaryDirectory);
+
+            string missingDebugReproDirectory = Path.Combine(temporaryDirectory, "does-not-exist");
+
+            return
+            [
+                $"--input-assembly-path {inputAssemblyPath}",
+                $"--reference-assembly-paths {inputAssemblyPath}",
+                $"--output-winmd-path {Path.Combine(temporaryDirectory, "out.winmd")}",
+                "--assembly-version 1.0.0.0",
+                "--use-windows-ui-xaml-projections False",
+                $"--debug-repro-directory {missingDebugReproDirectory}",
+            ];
+        });
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0008");
+    }
+}

--- a/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
@@ -20,30 +20,24 @@ public class Test_ParameterConventions
     [TestMethod]
     public void ValidComponent_GeneratesSuccessfully()
     {
-        // Smoke test: a valid component generates a '.winmd' (exit code 0). This validates the
-        // end-to-end harness so the failure assertions below are meaningful.
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+        // Smoke test: a valid component generates a '.winmd', validating the end-to-end harness
+        WinMDGeneratorRunner.AssertSuccess("""
             public interface IComponent
             {
                 int Method(int value);
             }
             """);
-
-        Assert.AreEqual(0, exitCode, output);
     }
 
     [TestMethod]
     public void RefArrayParameter_IsRejected()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+        WinMDGeneratorRunner.AssertFailure("""
             public interface IComponent
             {
                 void Method(ref int[] values);
             }
-            """);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0011");
+            """, error: "CSWINRTWINMDGEN0011");
     }
 
     [TestMethod]
@@ -51,44 +45,35 @@ public class Test_ParameterConventions
     {
         // 'in int[]' carries a 'modreq(InAttribute)' on interface members; the generator must still
         // see through it to detect the by-reference array.
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+        WinMDGeneratorRunner.AssertFailure("""
             public interface IComponent
             {
                 void Method(in int[] values);
             }
-            """);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0011");
+            """, error: "CSWINRTWINMDGEN0011");
     }
 
     [TestMethod]
     public void OutSpanParameter_IsRejected()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+        WinMDGeneratorRunner.AssertFailure("""
             using System;
             public interface IComponent
             {
                 void Method(out Span<int> values);
             }
-            """);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0012");
+            """, error: "CSWINRTWINMDGEN0012");
     }
 
     [TestMethod]
     public void OutReadOnlySpanParameter_IsRejected()
     {
-        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+        WinMDGeneratorRunner.AssertFailure("""
             using System;
             public interface IComponent
             {
                 void Method(out ReadOnlySpan<int> values);
             }
-            """);
-
-        Assert.AreNotEqual(0, exitCode, output);
-        StringAssert.Contains(output, "CSWINRTWINMDGEN0012");
+            """, error: "CSWINRTWINMDGEN0012");
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
@@ -37,7 +37,7 @@ public class Test_ParameterConventions
             {
                 void Method(ref int[] values);
             }
-            """, error: "CSWINRTWINMDGEN0011");
+            """, error: "CSWINRTWINMDGEN0013");
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class Test_ParameterConventions
             {
                 void Method(in int[] values);
             }
-            """, error: "CSWINRTWINMDGEN0011");
+            """, error: "CSWINRTWINMDGEN0013");
     }
 
     [TestMethod]
@@ -62,7 +62,7 @@ public class Test_ParameterConventions
             {
                 void Method(out Span<int> values);
             }
-            """, error: "CSWINRTWINMDGEN0012");
+            """, error: "CSWINRTWINMDGEN0014");
     }
 
     [TestMethod]
@@ -74,6 +74,6 @@ public class Test_ParameterConventions
             {
                 void Method(out ReadOnlySpan<int> values);
             }
-            """, error: "CSWINRTWINMDGEN0012");
+            """, error: "CSWINRTWINMDGEN0014");
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ParameterConventions.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using WinMDGeneratorTest.Helpers;
+
+namespace WinMDGeneratorTest;
+
+/// <summary>
+/// End-to-end tests for the WinMD generator's validation of unsupported method parameter conventions.
+/// </summary>
+/// <remarks>
+/// These tests run the actual <c>cswinrtwinmdgen</c> tool and assert that unsupported array/span
+/// parameter shapes are rejected with the expected error. Keeping the failure cases here lets us
+/// exercise them without breaking the build. The supported conventions that produce a valid
+/// <c>.winmd</c> (PassArray/FillArray/ReceiveArray) are covered by the authoring tests instead.
+/// </remarks>
+[TestClass]
+public class Test_ParameterConventions
+{
+    [TestMethod]
+    public void ValidComponent_GeneratesSuccessfully()
+    {
+        // Smoke test: a valid component generates a '.winmd' (exit code 0). This validates the
+        // end-to-end harness so the failure assertions below are meaningful.
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+            public interface IComponent
+            {
+                int Method(int value);
+            }
+            """);
+
+        Assert.AreEqual(0, exitCode, output);
+    }
+
+    [TestMethod]
+    public void RefArrayParameter_IsRejected()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+            public interface IComponent
+            {
+                void Method(ref int[] values);
+            }
+            """);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0011");
+    }
+
+    [TestMethod]
+    public void InArrayParameter_IsRejected()
+    {
+        // 'in int[]' carries a 'modreq(InAttribute)' on interface members; the generator must still
+        // see through it to detect the by-reference array.
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+            public interface IComponent
+            {
+                void Method(in int[] values);
+            }
+            """);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0011");
+    }
+
+    [TestMethod]
+    public void OutSpanParameter_IsRejected()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+            using System;
+            public interface IComponent
+            {
+                void Method(out Span<int> values);
+            }
+            """);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0012");
+    }
+
+    [TestMethod]
+    public void OutReadOnlySpanParameter_IsRejected()
+    {
+        (int exitCode, string output) = WinMDGeneratorTestHelper.RunGenerator("""
+            using System;
+            public interface IComponent
+            {
+                void Method(out ReadOnlySpan<int> values);
+            }
+            """);
+
+        Assert.AreNotEqual(0, exitCode, output);
+        StringAssert.Contains(output, "CSWINRTWINMDGEN0012");
+    }
+}

--- a/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
+++ b/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 
-    <!-- This project unit-tests the WinMD generator's managed logic directly; no CsWinRT processing needed -->
+    <!-- This project runs the WinMD generator tool end-to-end; it needs no CsWinRT processing itself -->
     <CsWinRTEnabled>false</CsWinRTEnabled>
   </PropertyGroup>
 

--- a/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
+++ b/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64;x86</Platforms>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 

--- a/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
+++ b/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
@@ -41,13 +41,19 @@
 
   <!--
     Build the WinMD generator tool, but do not reference its assembly: the tests invoke it as a
-    separate process (end-to-end), so the generator exposes no internals to this project. The
-    'RuntimeIdentifier' is removed so the tool always builds to 'bin/$(Configuration)/net10.0'.
+    separate process (end-to-end), so the generator exposes no internals to this project.
+    'UndefineProperties' drops the build-tool publishing properties ('BuildToolArch' and
+    'PublishBuildTool', plus 'RuntimeIdentifier' / 'SelfContained') from this reference so the
+    generator is always built framework-dependent for the build host (output under 'net10.0\',
+    with no 'win-<arch>' RID subfolder). Without this, the generator's 'PublishAot' build is
+    self-contained and cannot be referenced by this non self-contained test project (NETSDK1151).
   -->
   <ItemGroup>
     <ProjectReference Include="..\..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
                       ReferenceOutputAssembly="false"
-                      GlobalPropertiesToRemove="RuntimeIdentifier" />
+                      OutputItemType="_CsWinRTToolReference"
+                      UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained"
+                      Private="false" />
   </ItemGroup>
 
   <!-- Pass the built tool's path to the tests via assembly metadata -->

--- a/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
+++ b/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
@@ -1,0 +1,62 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Platforms>x64;x86</Platforms>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- This project unit-tests the WinMD generator's managed logic directly; no CsWinRT processing needed -->
+    <CsWinRTEnabled>false</CsWinRTEnabled>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'x86'">
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'x64'">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Used to compile the C# inputs that drive the generator end-to-end -->
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+
+    <!-- Core MSTest attributes/assertions -->
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest.Analyzers" />
+
+    <!-- MTP build integration + optional reporting -->
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+
+    <!-- MSTest runner and generators -->
+    <PackageReference Include="MSTest.Engine" />
+    <PackageReference Include="MSTest.SourceGeneration" />
+  </ItemGroup>
+
+  <!--
+    Build the WinMD generator tool, but do not reference its assembly: the tests invoke it as a
+    separate process (end-to-end), so the generator exposes no internals to this project. The
+    'RuntimeIdentifier' is removed so the tool always builds to 'bin/$(Configuration)/net10.0'.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
+                      ReferenceOutputAssembly="false"
+                      GlobalPropertiesToRemove="RuntimeIdentifier" />
+  </ItemGroup>
+
+  <!-- Pass the built tool's path to the tests via assembly metadata -->
+  <ItemGroup>
+    <AssemblyMetadata Include="WinMDGeneratorAssemblyPath"
+                      Value="$(MSBuildThisFileDirectory)..\..\WinRT.WinMD.Generator\bin\$(Configuration)\net10.0\cswinrtwinmdgen.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+</Project>

--- a/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
+++ b/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
@@ -108,7 +108,10 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
     /// </summary>
     public static Exception ByReferenceArrayParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
     {
-        return Exception(11, $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), 'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
+        return Exception(11,
+            $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. " +
+            $"Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), " +
+            $"'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
     }
 
     /// <summary>
@@ -116,7 +119,10 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
     /// </summary>
     public static Exception ByReferenceSpanParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
     {
-        return Exception(12, $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'. Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' (FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");
+        return Exception(12,
+            $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'." +
+            $"Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' " +
+            $"(FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
+++ b/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
@@ -73,6 +73,22 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
         return Exception(7, $"Failed to probe the .NET runtime version from the input assembly '{path}'.");
     }
 
+    /// <summary>
+    /// A method has a <c>ref</c> or <c>in</c> array parameter, which is not a valid Windows Runtime array convention.
+    /// </summary>
+    public static Exception ByReferenceArrayParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
+    {
+        return Exception(11, $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), 'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
+    }
+
+    /// <summary>
+    /// A method has a by-reference span parameter (e.g. <c>out Span&lt;T&gt;</c>), which has no Windows Runtime representation.
+    /// </summary>
+    public static Exception ByReferenceSpanParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
+    {
+        return Exception(12, $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'. Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' (FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");
+    }
+
     /// <inheritdoc cref="IGeneratorErrorFactory.DebugReproDirectoryDoesNotExist(string)"/>
     public static Exception DebugReproDirectoryDoesNotExist(string path)
     {

--- a/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
+++ b/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
@@ -108,7 +108,7 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
     /// </summary>
     public static Exception ByReferenceArrayParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
     {
-        return Exception(11,
+        return Exception(13,
             $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. " +
             $"Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), " +
             $"'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
@@ -119,7 +119,7 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
     /// </summary>
     public static Exception ByReferenceSpanParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
     {
-        return Exception(12,
+        return Exception(14,
             $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'." +
             $"Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' " +
             $"(FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");

--- a/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
+++ b/src/WinRT.WinMD.Generator/Errors/WellKnownWinMDExceptions.cs
@@ -73,22 +73,6 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
         return Exception(7, $"Failed to probe the .NET runtime version from the input assembly '{path}'.");
     }
 
-    /// <summary>
-    /// A method has a <c>ref</c> or <c>in</c> array parameter, which is not a valid Windows Runtime array convention.
-    /// </summary>
-    public static Exception ByReferenceArrayParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
-    {
-        return Exception(11, $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), 'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
-    }
-
-    /// <summary>
-    /// A method has a by-reference span parameter (e.g. <c>out Span&lt;T&gt;</c>), which has no Windows Runtime representation.
-    /// </summary>
-    public static Exception ByReferenceSpanParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
-    {
-        return Exception(12, $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'. Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' (FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");
-    }
-
     /// <inheritdoc cref="IGeneratorErrorFactory.DebugReproDirectoryDoesNotExist(string)"/>
     public static Exception DebugReproDirectoryDoesNotExist(string path)
     {
@@ -117,6 +101,22 @@ internal sealed class WellKnownWinMDExceptions : IGeneratorErrorFactory, IWindow
     public static Exception CannotReadWindowsSdkXml(string path)
     {
         return Exception(12, WellKnownGeneratorMessages.CannotReadWindowsSdkXml(path));
+    }
+
+    /// <summary>
+    /// A method has a <c>ref</c> or <c>in</c> array parameter, which is not a valid Windows Runtime array convention.
+    /// </summary>
+    public static Exception ByReferenceArrayParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
+    {
+        return Exception(11, $"Method '{declaringTypeName}.{methodName}' has by-reference array parameter '{parameterName}' passed by 'ref' or 'in'. Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>' for a read-only input array (PassArray), 'Span<T>' for a caller-allocated array (FillArray), or 'out T[]' for a callee-allocated array (ReceiveArray).");
+    }
+
+    /// <summary>
+    /// A method has a by-reference span parameter (e.g. <c>out Span&lt;T&gt;</c>), which has no Windows Runtime representation.
+    /// </summary>
+    public static Exception ByReferenceSpanParameterNotSupported(string declaringTypeName, string methodName, string parameterName)
+    {
+        return Exception(12, $"Method '{declaringTypeName}.{methodName}' has by-reference span parameter '{parameterName}'. Windows Runtime spans are passed by value: use 'ReadOnlySpan<T>' (PassArray) or 'Span<T>' (FillArray) by value, or 'out T[]' for a callee-allocated array (ReceiveArray).");
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Extensions/TypeSignatureExtensions.cs
+++ b/src/WinRT.WinMD.Generator/Extensions/TypeSignatureExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet.Signatures;
+
+namespace WindowsRuntime.WinMDGenerator;
+
+/// <summary>
+/// Extension methods for <see cref="TypeSignature"/>.
+/// </summary>
+internal static class TypeSignatureExtensions
+{
+    extension(TypeSignature signature)
+    {
+        /// <summary>
+        /// Strips any leading custom modifiers (<c>modreq</c>/<c>modopt</c>) from the signature.
+        /// </summary>
+        /// <remarks>
+        /// Custom modifiers carry no Windows Runtime meaning. They are emitted by the C# compiler in a few
+        /// cases, most notably the <c>modreq(System.Runtime.InteropServices.InAttribute)</c> applied to the
+        /// by-reference type of an <c>in</c> parameter on abstract, virtual, interface, or delegate members.
+        /// </remarks>
+        /// <returns>The underlying <see cref="TypeSignature"/> with all leading custom modifiers removed.</returns>
+        public TypeSignature StripCustomModifiers()
+        {
+            TypeSignature current = signature;
+
+            while (current is CustomModifierTypeSignature customModifier)
+            {
+                current = customModifier.BaseType;
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Checks whether the signature is some <see cref="System.Span{T}"/> type.
+        /// </summary>
+        /// <returns><see langword="true"/> if the signature is <see cref="System.Span{T}"/>; otherwise, <see langword="false"/>.</returns>
+        public bool IsTypeOfSpan()
+        {
+            return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.Span`1" };
+        }
+
+        /// <summary>
+        /// Checks whether the signature is some <see cref="System.ReadOnlySpan{T}"/> type.
+        /// </summary>
+        /// <returns><see langword="true"/> if the signature is <see cref="System.ReadOnlySpan{T}"/>; otherwise, <see langword="false"/>.</returns>
+        public bool IsTypeOfReadOnlySpan()
+        {
+            return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.ReadOnlySpan`1" };
+        }
+    }
+}

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -196,7 +196,7 @@ internal sealed partial class WinMDWriter
     {
         // Look through any custom modifiers (e.g. the 'modreq(InAttribute)' emitted for 'in' parameters
         // on abstract, virtual, interface, or delegate members) to inspect the real underlying signature
-        TypeSignature parameterType = StripCustomModifiers(inputParamType);
+        TypeSignature parameterType = inputParamType.StripCustomModifiers();
 
         // Validate by-reference parameters that wrap a span or array. Windows Runtime spans are always
         // passed by value, and Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>'
@@ -204,9 +204,9 @@ internal sealed partial class WinMDWriter
         // 'ref'/'in' array, has no Windows Runtime representation and is rejected here.
         if (parameterType is ByReferenceTypeSignature byReference)
         {
-            TypeSignature elementType = StripCustomModifiers(byReference.BaseType);
+            TypeSignature elementType = byReference.BaseType.StripCustomModifiers();
 
-            if (IsSpan(elementType) || IsReadOnlySpan(elementType))
+            if (elementType.IsTypeOfSpan() || elementType.IsTypeOfReadOnlySpan())
             {
                 throw WellKnownWinMDExceptions.ByReferenceSpanParameterNotSupported(
                     inputMethod.DeclaringType!.FullName,
@@ -234,7 +234,7 @@ internal sealed partial class WinMDWriter
         }
 
         // 'Span<T>' → 'FillArray' pattern: '[out]' without 'BYREF'
-        if (IsSpan(parameterType))
+        if (parameterType.IsTypeOfSpan())
         {
             return ParameterAttributes.Out;
         }
@@ -243,26 +243,6 @@ internal sealed partial class WinMDWriter
         // on a COM interop interface) default to '[in]', matching the MIDL convention for
         // 'ref const T' parameters. 'ReadOnlySpan<T>' and everything else also default to '[in]'.
         return ParameterAttributes.In;
-    }
-
-    /// <summary>
-    /// Determines whether a type signature is <see cref="System.Span{T}"/>.
-    /// </summary>
-    /// <param name="signature">The type signature to test.</param>
-    /// <returns><see langword="true"/> if <paramref name="signature"/> is <see cref="System.Span{T}"/>; otherwise, <see langword="false"/>.</returns>
-    private static bool IsSpan(TypeSignature signature)
-    {
-        return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.Span`1" };
-    }
-
-    /// <summary>
-    /// Determines whether a type signature is <see cref="System.ReadOnlySpan{T}"/>.
-    /// </summary>
-    /// <param name="signature">The type signature to test.</param>
-    /// <returns><see langword="true"/> if <paramref name="signature"/> is <see cref="System.ReadOnlySpan{T}"/>; otherwise, <see langword="false"/>.</returns>
-    private static bool IsReadOnlySpan(TypeSignature signature)
-    {
-        return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.ReadOnlySpan`1" };
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.WinMDGenerator.Errors;
 using MethodAttributes = AsmResolver.PE.DotNet.Metadata.Tables.MethodAttributes;
 using MethodImplAttributes = AsmResolver.PE.DotNet.Metadata.Tables.MethodImplAttributes;
 using MethodSemanticsAttributes = AsmResolver.PE.DotNet.Metadata.Tables.MethodSemanticsAttributes;
@@ -144,6 +145,11 @@ internal sealed partial class WinMDWriter
     ///   <item>Any other by-reference type (e.g. <c>ref Guid</c> on a COM interop interface) → <c>[in]</c>, matching the MIDL convention for <c>ref const T</c> parameters.</item>
     ///   <item>All other params → <c>[in]</c>.</item>
     /// </list>
+    /// <para>
+    /// Array and span shapes that have no Windows Runtime representation are rejected with a well-known
+    /// error: a by-reference span (e.g. <c>out Span&lt;T&gt;</c>), or a <c>ref</c>/<c>in</c> array (only
+    /// <c>out T[]</c> is a valid by-reference array). See <see cref="GetWinRTParameterAttributes"/>.
+    /// </para>
     /// </remarks>
     private static void AddParameterDefinitions(MethodDefinition outputMethod, MethodDefinition inputMethod)
     {
@@ -157,7 +163,7 @@ internal sealed partial class WinMDWriter
 
             if (sigIndex < inputParamTypes.Count)
             {
-                paramattributes = GetWinRTParameterAttributes(inputParam, inputParamTypes[sigIndex]);
+                paramattributes = GetWinRTParameterAttributes(inputMethod, inputParam, inputParamTypes[sigIndex]);
             }
 
             outputMethod.ParameterDefinitions.Add(new ParameterDefinition(
@@ -168,15 +174,57 @@ internal sealed partial class WinMDWriter
     }
 
     /// <summary>
-    /// Determines the Windows Runtime parameter attributes based on the input parameter and its type.
+    /// Determines the Windows Runtime parameter attributes based on the input parameter and its type,
+    /// validating that the parameter uses a supported Windows Runtime calling convention.
     /// </summary>
     /// <remarks>
     /// If the input parameter already has <see cref="ParameterAttributes.In"/> or
     /// <see cref="ParameterAttributes.Out"/> set, those flags are preserved unchanged. Otherwise,
     /// the type drives the default per the rules documented on <see cref="AddParameterDefinitions"/>.
+    /// By-reference spans (e.g. <c>out Span&lt;T&gt;</c>) and <c>ref</c>/<c>in</c> arrays have no
+    /// Windows Runtime representation and throw a <see cref="Errors.WellKnownWinMDException"/>.
     /// </remarks>
-    private static ParameterAttributes GetWinRTParameterAttributes(ParameterDefinition inputParam, TypeSignature inputParamType)
+    /// <param name="inputMethod">The method that declares the parameter (used for error context).</param>
+    /// <param name="inputParam">The input <see cref="ParameterDefinition"/> (provides the In/Out direction flags).</param>
+    /// <param name="inputParamType">The input parameter <see cref="TypeSignature"/>.</param>
+    /// <returns>The Windows Runtime <see cref="ParameterAttributes"/> for the parameter.</returns>
+    /// <exception cref="Errors.WellKnownWinMDException">Thrown if the parameter uses an unsupported array or span convention.</exception>
+    private static ParameterAttributes GetWinRTParameterAttributes(
+        MethodDefinition inputMethod,
+        ParameterDefinition inputParam,
+        TypeSignature inputParamType)
     {
+        // Look through any custom modifiers (e.g. the 'modreq(InAttribute)' emitted for 'in' parameters
+        // on abstract, virtual, interface, or delegate members) to inspect the real underlying signature
+        TypeSignature parameterType = StripCustomModifiers(inputParamType);
+
+        // Validate by-reference parameters that wrap a span or array. Windows Runtime spans are always
+        // passed by value, and Windows Runtime arrays use one of three conventions: 'ReadOnlySpan<T>'
+        // (PassArray), 'Span<T>' (FillArray), or 'out T[]' (ReceiveArray). A by-reference span, or a
+        // 'ref'/'in' array, has no Windows Runtime representation and is rejected here.
+        if (parameterType is ByReferenceTypeSignature byReference)
+        {
+            TypeSignature elementType = StripCustomModifiers(byReference.BaseType);
+
+            if (IsSpan(elementType) || IsReadOnlySpan(elementType))
+            {
+                throw WellKnownWinMDExceptions.ByReferenceSpanParameterNotSupported(
+                    inputMethod.DeclaringType!.FullName,
+                    inputMethod.Name!.Value,
+                    inputParam.Name!.Value);
+            }
+
+            // 'out T[]' (ReceiveArray) is valid, but 'ref T[]'/'in T[]' are not. By-reference non-array
+            // types (e.g. 'ref Guid riid' on a COM interop interface) are still allowed and handled below.
+            if (elementType is SzArrayTypeSignature && !inputParam.IsOut)
+            {
+                throw WellKnownWinMDExceptions.ByReferenceArrayParameterNotSupported(
+                    inputMethod.DeclaringType!.FullName,
+                    inputMethod.Name!.Value,
+                    inputParam.Name!.Value);
+            }
+        }
+
         // Preserve any 'In'/'Out' direction flags the input parameter already carries
         ParameterAttributes inputDirectionFlags = inputParam.Attributes & (ParameterAttributes.In | ParameterAttributes.Out);
 
@@ -186,8 +234,7 @@ internal sealed partial class WinMDWriter
         }
 
         // 'Span<T>' → 'FillArray' pattern: '[out]' without 'BYREF'
-        if (inputParamType is GenericInstanceTypeSignature genericInstanceSignature &&
-            genericInstanceSignature.GenericType.FullName == "System.Span`1")
+        if (IsSpan(parameterType))
         {
             return ParameterAttributes.Out;
         }
@@ -196,6 +243,26 @@ internal sealed partial class WinMDWriter
         // on a COM interop interface) default to '[in]', matching the MIDL convention for
         // 'ref const T' parameters. 'ReadOnlySpan<T>' and everything else also default to '[in]'.
         return ParameterAttributes.In;
+    }
+
+    /// <summary>
+    /// Determines whether a type signature is <see cref="System.Span{T}"/>.
+    /// </summary>
+    /// <param name="signature">The type signature to test.</param>
+    /// <returns><see langword="true"/> if <paramref name="signature"/> is <see cref="System.Span{T}"/>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsSpan(TypeSignature signature)
+    {
+        return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.Span`1" };
+    }
+
+    /// <summary>
+    /// Determines whether a type signature is <see cref="System.ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="signature">The type signature to test.</param>
+    /// <returns><see langword="true"/> if <paramref name="signature"/> is <see cref="System.ReadOnlySpan{T}"/>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsReadOnlySpan(TypeSignature signature)
+    {
+        return signature is GenericInstanceTypeSignature { GenericType.FullName: "System.ReadOnlySpan`1" };
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.TypeMapping.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.TypeMapping.cs
@@ -44,7 +44,7 @@ internal sealed partial class WinMDWriter
         // modifiers have no Windows Runtime representation, and without stripping them a modifier-wrapped
         // type would fall through to the 'System.Object' fallback at the end of this method, silently
         // erasing the real signature.
-        inputSignature = StripCustomModifiers(inputSignature);
+        inputSignature = inputSignature.StripCustomModifiers();
 
         // Handle 'CorLib' types
         if (inputSignature is CorLibTypeSignature corLib)
@@ -145,26 +145,6 @@ internal sealed partial class WinMDWriter
 
         // Fallback: import the type
         return _outputModule.CorLibTypeFactory.Object;
-    }
-
-    /// <summary>
-    /// Strips any leading custom modifiers (<c>modreq</c>/<c>modopt</c>) from a type signature.
-    /// </summary>
-    /// <remarks>
-    /// Custom modifiers carry no Windows Runtime meaning. They are emitted by the C# compiler in a few
-    /// cases, most notably the <c>modreq(System.Runtime.InteropServices.InAttribute)</c> applied to the
-    /// by-reference type of an <c>in</c> parameter on abstract, virtual, interface, or delegate members.
-    /// </remarks>
-    /// <param name="signature">The type signature to unwrap.</param>
-    /// <returns>The underlying <see cref="TypeSignature"/> with all leading custom modifiers removed.</returns>
-    private static TypeSignature StripCustomModifiers(TypeSignature signature)
-    {
-        while (signature is CustomModifierTypeSignature customModifier)
-        {
-            signature = customModifier.BaseType;
-        }
-
-        return signature;
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.TypeMapping.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.TypeMapping.cs
@@ -38,6 +38,14 @@ internal sealed partial class WinMDWriter
     /// <returns>The mapped <see cref="TypeSignature"/> for use in the output WinMD.</returns>
     private TypeSignature MapTypeSignatureToOutput(TypeSignature inputSignature)
     {
+        // Strip custom modifiers ('modreq'/'modopt') before dispatching on the underlying type.
+        // For example, 'in' parameters on abstract, virtual, interface, or delegate members carry a
+        // 'modreq(System.Runtime.InteropServices.InAttribute)' on their by-reference type. Custom
+        // modifiers have no Windows Runtime representation, and without stripping them a modifier-wrapped
+        // type would fall through to the 'System.Object' fallback at the end of this method, silently
+        // erasing the real signature.
+        inputSignature = StripCustomModifiers(inputSignature);
+
         // Handle 'CorLib' types
         if (inputSignature is CorLibTypeSignature corLib)
         {
@@ -137,6 +145,26 @@ internal sealed partial class WinMDWriter
 
         // Fallback: import the type
         return _outputModule.CorLibTypeFactory.Object;
+    }
+
+    /// <summary>
+    /// Strips any leading custom modifiers (<c>modreq</c>/<c>modopt</c>) from a type signature.
+    /// </summary>
+    /// <remarks>
+    /// Custom modifiers carry no Windows Runtime meaning. They are emitted by the C# compiler in a few
+    /// cases, most notably the <c>modreq(System.Runtime.InteropServices.InAttribute)</c> applied to the
+    /// by-reference type of an <c>in</c> parameter on abstract, virtual, interface, or delegate members.
+    /// </remarks>
+    /// <param name="signature">The type signature to unwrap.</param>
+    /// <returns>The underlying <see cref="TypeSignature"/> with all leading custom modifiers removed.</returns>
+    private static TypeSignature StripCustomModifiers(TypeSignature signature)
+    {
+        while (signature is CustomModifierTypeSignature customModifier)
+        {
+            signature = customModifier.BaseType;
+        }
+
+        return signature;
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
@@ -713,7 +713,7 @@ internal sealed partial class WinMDWriter
             for (int i = 0; i < paramNames.Length; i++)
             {
                 ParameterAttributes paramAttr = i < parameterTypes.Length && i < method.ParameterDefinitions.Count
-                    ? GetWinRTParameterAttributes(method.ParameterDefinitions[i], method.Signature!.ParameterTypes[i])
+                    ? GetWinRTParameterAttributes(method, method.ParameterDefinitions[i], method.Signature!.ParameterTypes[i])
                     : ParameterAttributes.In;
 
                 outputMethod.ParameterDefinitions.Add(new ParameterDefinition(

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -273,6 +273,14 @@
       <Platform Solution="*|x86" Project="x86" />
       <Build Solution="*|ARM64" Project="false" />
     </Project>
+    <Project Path="Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj">
+      <Platform Solution="*|ARM" Project="x86" />
+      <Platform Solution="*|ARM64" Project="x86" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x86" />
+      <Build Solution="*|ARM" Project="false" />
+      <Build Solution="*|ARM64" Project="false" />
+    </Project>
     <Project Path="TestWinRT/TestComponent/TestComponent.vcxproj" Id="2954f343-85a7-46f5-a3f3-f106fdd13900">
       <Platform Solution="*|ARM64" Project="Win32" />
       <Build Solution="*|ARM64" Project="false" />

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -274,11 +274,9 @@
       <Build Solution="*|ARM64" Project="false" />
     </Project>
     <Project Path="Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj">
-      <Platform Solution="*|ARM" Project="x86" />
-      <Platform Solution="*|ARM64" Project="x86" />
+      <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
       <Platform Solution="*|x86" Project="x86" />
-      <Build Solution="*|ARM" Project="false" />
       <Build Solution="*|ARM64" Project="false" />
     </Project>
     <Project Path="TestWinRT/TestComponent/TestComponent.vcxproj" Id="2954f343-85a7-46f5-a3f3-f106fdd13900">


### PR DESCRIPTION
## Summary

Fix several ways the WinMD generator (`cswinrtwinmdgen`) mishandled array/span method parameters when authoring a Windows Runtime component, add validation that rejects the shapes with no Windows Runtime representation, and stand up a new `WinMDGeneratorTest` project that exercises the generator's failure modes end-to-end.

## Motivation

When authoring a component, the WinMD generator maps each method parameter to a Windows Runtime array convention (`ReadOnlySpan<T>` → PassArray, `Span<T>` → FillArray, `out T[]` → ReceiveArray). A few parameter shapes were handled incorrectly:

- Custom modifiers were never stripped before dispatching on the parameter type, so any `modreq`-wrapped signature fell through to the `System.Object` fallback and was silently erased. This affected `in` parameters on abstract/virtual/interface/delegate members — most notably a COM interop `in Guid riid` was emitted as `[in] object` instead of `[in] Guid&`.
- `ref`/`in` arrays and `out` spans have no Windows Runtime representation, but were silently emitted as invalid metadata rather than reported as errors.

There was also no test coverage for the generator's failure behavior. Because these are build-time failures, they could not be asserted from the existing build-integrated test projects without breaking the build — so a dedicated end-to-end test project was needed.

## Changes

- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.TypeMapping.cs`**: strip custom modifiers (`modreq`/`modopt`) before mapping a type signature, so modifier-wrapped types are no longer erased to `object`.
- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs`**, **`WinMDWriter.Types.cs`**, **`Errors/WellKnownWinMDExceptions.cs`**: validate parameter conventions and reject the unsupported shapes with clear errors — `ref`/`in` arrays (`CSWINRTWINMDGEN0013`) and by-reference spans such as `out Span<T>` (`CSWINRTWINMDGEN0014`) — while preserving the deliberate COM interop `ref`/`in` scalar behavior (e.g. `ref Guid riid` → `[in]`).
- **`src/WinRT.WinMD.Generator/Extensions/TypeSignatureExtensions.cs`**: new extension file housing `StripCustomModifiers`, `IsTypeOfSpan`, and `IsTypeOfReadOnlySpan` (consistent with the interop generator's `IsTypeOf*` extensions), moved out of the writer partials.
- **`src/Tests/WinMDGeneratorTest/`**: new MSTest project that runs the actual `cswinrtwinmdgen` tool as a subprocess. `Test_ParameterConventions` covers the unsupported array/span shapes; `Test_InvalidInputs` covers invalid invocations (malformed/missing response files, bad arguments, missing/corrupt input assemblies, an unwritable output path, a missing debug-repro directory). The `WinMDGeneratorRunner` helper exposes single-call `AssertSuccess`/`AssertFailure` entry points; valid `.winmd` shapes remain covered by the authoring tests.
- **`src/cswinrt.slnx`**: register the new test project.
- **`.github/skills/testing/SKILL.md`**, **`.github/skills/update-testing-instructions/SKILL.md`**: document the new test project (new section, routing-table row, count bump) and add a matching per-project verification step to the update skill.
- **`.github/copilot-instructions.md`**: bump the documented WinMD generator error id range to `0001`–`0014` (it was already stale at `0001`–`0010` before this PR, as #2454 added `0011`/`0012`).
