### PR TITLE
Add missing [StructLayout] to ComCallData and HSTRING_HEADER

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Platform/ComCallData.cs
+++ b/src/WinRT.Runtime2/InteropServices/Platform/ComCallData.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Runtime.InteropServices;
+
 namespace WindowsRuntime.InteropServices;
 
 /// <see href="https://docs.rs/windows-sys/latest/windows_sys/Win32/System/Com/struct.ComCallData.html"/>
+[StructLayout(LayoutKind.Sequential)]
 internal unsafe struct ComCallData
 {
     public uint dwDispid;

--- a/src/WinRT.Runtime2/InteropServices/Platform/HSTRING_HEADER.cs
+++ b/src/WinRT.Runtime2/InteropServices/Platform/HSTRING_HEADER.cs
@@ -6,12 +6,15 @@
 
 #pragma warning disable IDE1006
 
+using System.Runtime.InteropServices;
+
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>
 /// Represents a header for an <c>HSTRING</c>.
 /// </summary>
 /// <see href="https://learn.microsoft.com/windows/win32/api/hstring/ns-hstring-hstring_header"/>
+[StructLayout(LayoutKind.Sequential)]
 internal struct HSTRING_HEADER
 {
     /// <summary>
@@ -24,6 +27,7 @@ internal struct HSTRING_HEADER
     // To avoid producing multiple builds of the managed bindings, we use a 16 byte buffer and a native int instead, preserving the same layout.
     // Using this strategy, trying to match the native definition of this union would be too contrived.
     // Since the contents of this structure are undefined, it is not important to provide the same definitions.
+    [StructLayout(LayoutKind.Sequential)]
     public unsafe partial struct _Reserved_e__Union
     {
         internal fixed byte Reserved1_0[16];


### PR DESCRIPTION
## Summary

Apply `[StructLayout(LayoutKind.Sequential)]` to the `ComCallData` and `HSTRING_HEADER` interop structs (including the nested `_Reserved_e__Union`), matching the convention used by every other ABI/interop struct in `WinRT.Runtime`.

## Motivation

`ComCallData` and `HSTRING_HEADER` were the only multi-field interop structs in `WinRT.Runtime2` missing the explicit `[StructLayout(LayoutKind.Sequential)]` annotation that all other ABI types carry. That inconsistency produced analyzer warnings. Applying the attribute fixes the inconsistency, resolves the warnings, and makes the expected sequential memory layout explicit, matching the native structure layout these P/Invoke and WinRT interop bindings rely on.

## Changes

- **`src/WinRT.Runtime2/InteropServices/Platform/ComCallData.cs`**: add the `System.Runtime.InteropServices` using directive and apply `[StructLayout(LayoutKind.Sequential)]` to the struct.
- **`src/WinRT.Runtime2/InteropServices/Platform/HSTRING_HEADER.cs`**: add the `System.Runtime.InteropServices` using directive and apply `[StructLayout(LayoutKind.Sequential)]` to both the `HSTRING_HEADER` struct and its nested `_Reserved_e__Union`.
