### PR TITLE
Add banned API analyzer to guard the reference assembly surface

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="coverlet.collector" Version="1.3.0" />
     <PackageVersion Include="MarkdownLog.NS20" Version="0.10.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />

--- a/src/WinRT.Runtime2/BannedSymbols.txt
+++ b/src/WinRT.Runtime2/BannedSymbols.txt
@@ -1,0 +1,7 @@
+# We use the '[WindowsRuntimeImplementationOnlyMember]' attribute to mark
+# all implementation-only types in 'WinRT.Runtime.dll'. These types are
+# only included when building the implementation assembly, while entirely
+# skipped when producing the reference assembly. This list of banned
+# symbols is only included when building the reference assembly, which
+# ensures that we never accidentally leak any of them in the public API.
+T:WindowsRuntime.WindowsRuntimeImplementationOnlyMemberAttribute

--- a/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationArgsReference.cs
+++ b/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationArgsReference.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;

--- a/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationFactoryCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationFactoryCallback.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE
+
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>

--- a/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationTypes.cs
+++ b/src/WinRT.Runtime2/InteropServices/Activation/WindowsRuntimeActivationTypes.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE
+
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -147,37 +147,38 @@
         at the top of the file. This provides a simple file-level opt-out for sources that reference internal types or members that
         are stripped from the reference assembly, and that would otherwise fail to compile in the reference assembly build.
       -->
-      <Compile Remove="@(Compile)" Condition="$([System.IO.File]::ReadAllText('%(FullPath)').Contains('#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE'))"/>
+      <Compile Remove="@(Compile)" Condition="$([System.IO.File]::ReadAllText('%(FullPath)').Contains('#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE'))" />
 
       <!--
         Also remove all ABI types, since none of these are needed for reference assemblies, and some might only contain
         internal types, meaning they wouldn't have the attribute (so they'd be kept), but would result in build errors.
       -->
-      <Compile Remove="ABI\**\*.cs"/>
+      <Compile Remove="ABI\**\*.cs" />
 
       <!-- Also remove other folders with implementation-only types, to minimize the number of code changes needed -->
-      <Compile Remove="Exceptions\**\*.cs"/>
-      <Compile Remove="InteropServices\AsyncInfo\**\*.cs"/>
-      <Compile Remove="InteropServices\Bindables\**\*.cs"/>
-      <Compile Remove="InteropServices\Buffers\**\*.cs"/>
-      <Compile Remove="InteropServices\Callbacks\**\*.cs"/>
-      <Compile Remove="InteropServices\Collections\**\*.cs"/>
-      <Compile Remove="InteropServices\Dispatching\**\*.cs"/>
-      <Compile Remove="InteropServices\Events\**\*.cs"/>
-      <Compile Remove="InteropServices\Exceptions\**\*.cs"/>
-      <Compile Remove="InteropServices\InteropDllImports\**\*.cs"/>
-      <Compile Remove="InteropServices\Marshalers\**\*.cs"/>
-      <Compile Remove="InteropServices\Marshalling\**\*.cs"/>
-      <Compile Remove="InteropServices\ObjectReference\**\*.cs"/>
-      <Compile Remove="InteropServices\Placeholders\**\*.cs"/>
-      <Compile Remove="InteropServices\ProjectionDllExports\**\*.cs"/>
-      <Compile Remove="InteropServices\ProjectionImpls\**\*.cs"/>
-      <Compile Remove="InteropServices\Streams\**\*.cs"/>
-      <Compile Remove="InteropServices\TypeMapGroups\**\*.cs"/>
-      <Compile Remove="InteropServices\TypeMapInfo\**\*.cs"/>
-      <Compile Remove="InteropServices\Vtables\**\*.cs"/>
-      <Compile Remove="InteropServices\WeakReferences\**\*.cs"/>
-      <Compile Remove="NativeObjects\**\*.cs"/>
+      <Compile Remove="Exceptions\**\*.cs" />
+      <Compile Remove="InteropServices\AsyncInfo\**\*.cs" />
+      <Compile Remove="InteropServices\Bindables\**\*.cs" />
+      <Compile Remove="InteropServices\Buffers\**\*.cs" />
+      <Compile Remove="InteropServices\Callbacks\**\*.cs" />
+      <Compile Remove="InteropServices\Collections\**\*.cs" />
+      <Compile Remove="InteropServices\Dispatching\**\*.cs" />
+      <Compile Remove="InteropServices\Events\**\*.cs" />
+      <Compile Remove="InteropServices\Exceptions\**\*.cs" />
+      <Compile Remove="InteropServices\InteropDllImports\**\*.cs" />
+      <Compile Remove="InteropServices\Marshalers\**\*.cs" />
+      <Compile Remove="InteropServices\Marshalling\**\*.cs" />
+      <Compile Remove="InteropServices\ObjectReference\**\*.cs" />
+      <Compile Remove="InteropServices\Placeholders\**\*.cs" />
+      <Compile Remove="InteropServices\ProjectionDllExports\**\*.cs" />
+      <Compile Remove="InteropServices\ProjectionImpls\**\*.cs" />
+      <Compile Remove="InteropServices\Streams\**\*.cs" />
+      <Compile Remove="InteropServices\TypeMapGroups\**\*.cs" />
+      <Compile Remove="InteropServices\TypeMapInfo\**\*.cs" />
+      <Compile Remove="InteropServices\Vtables\**\*.cs" />
+      <Compile Remove="InteropServices\WeakReferences\**\*.cs" />
+      <Compile Remove="NativeObjects\**\*.cs" />
+      <Compile Remove="Windows.UI.Xaml.Interop\**\*.cs" />
     </ItemGroup>
   </Target>
     

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -79,28 +79,32 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <!--
-    Disable the default 'ProduceReferenceAssembly' behavior. WinRT.Runtime provides its own custom
-    reference assembly (built with 'CsWinRTBuildReferenceAssembly=true') that strips private implementation
-    detail types via '#if WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY'. The SDK-generated ref assembly would
-    include those types (since 'WINDOWS_RUNTIME_REFERENCE_ASSEMBLY' is not defined in normal builds), which
-    would leak abstract members to downstream ProjectReference consumers and break reference projections.
-  -->
+  <!-- Settings for the implementation assembly -->
   <PropertyGroup Condition="'$(CsWinRTBuildReferenceAssembly)' != 'true'">
+
+    <!--
+      Disable the default 'ProduceReferenceAssembly' behavior. WinRT.Runtime provides its own custom
+      reference assembly (built with 'CsWinRTBuildReferenceAssembly=true') that strips private implementation
+      detail types via '#if WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY'. The SDK-generated ref assembly would
+      include those types (since 'WINDOWS_RUNTIME_REFERENCE_ASSEMBLY' is not defined in normal builds), which
+      would leak abstract members to downstream ProjectReference consumers and break reference projections.
+    -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 
     <!-- Build constant to simplify '#ifdef'-s, so they don't need negation expressions -->
     <DefineConstants>$(DefineConstants);WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY</DefineConstants>
   </PropertyGroup>
 
-  <!--
-    When producing a reference assembly for packaging, define 'WINDOWS_RUNTIME_REFERENCE_ASSEMBLY'. This is used
-    to completely strip out the private implementation detail types from the reference assembly, so they're
-    further hidden. This is conditioned on 'CsWinRTBuildReferenceAssembly' (and NOT 'ProduceReferenceAssembly'),
-    because 'ProduceReferenceAssembly' is set to 'true' by default by the .NET SDK for library projects. The
-    stripping should only happen during the explicit reference assembly build step for NuGet packaging.
-  -->
+  <!-- Settings for the reference assembly -->
   <PropertyGroup Condition="'$(CsWinRTBuildReferenceAssembly)' == 'true'">
+
+    <!--
+      When producing a reference assembly for packaging, define 'WINDOWS_RUNTIME_REFERENCE_ASSEMBLY'. This is used
+      to completely strip out the private implementation detail types from the reference assembly, so they're
+      further hidden. This is conditioned on 'CsWinRTBuildReferenceAssembly' (and NOT 'ProduceReferenceAssembly'),
+      because 'ProduceReferenceAssembly' is set to 'true' by default by the .NET SDK for library projects. The
+      stripping should only happen during the explicit reference assembly build step for NuGet packaging.
+    -->
     <DefineConstants>$(DefineConstants);WINDOWS_RUNTIME_REFERENCE_ASSEMBLY</DefineConstants>
 
     <!--
@@ -111,7 +115,22 @@
         - IDE0380: 'unsafe' modifier is unnecessary (some types have 'unsafe' for excluded members).
     -->
     <NoWarn>$(NoWarn);CS8597;IDE0005;IDE0380</NoWarn>
+
+    <!--
+      Always fail the build if we're leaking private APIs, even if just prototyping in local builds.
+      This is something that would never be allowed, so it's better to catch it as early as possible.
+    -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0030</WarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup Condition="'$(CsWinRTBuildReferenceAssembly)' == 'true'">
+
+    <!-- Include the banned API list, for the implementation-only marker attribute -->
+    <None Remove="BannedSymbols.txt" />
+    <AdditionalFiles Include="BannedSymbols.txt" />
+
+    <!-- Include the banned API analyzer, which we use to block implementation-only types in the reference assembly -->
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
 
   <!--
     Remove all source files containing just implementation-only types.

--- a/src/WinRT.Runtime2/Windows.Foundation/TrustLevel.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/TrustLevel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE
+
 using WindowsRuntime;
 
 namespace Windows.Foundation;


### PR DESCRIPTION
## Summary

Adds the `Microsoft.CodeAnalysis.BannedApiAnalyzers` analyzer to the reference assembly build of `WinRT.Runtime`, to enforce that no implementation-only types can leak into the public API surface. Also marks several implementation-only types that had been missed, so they are correctly stripped from the reference assembly.

## Motivation

`WinRT.Runtime` ships a custom reference assembly that strips out all private implementation detail types. Implementation-only types are marked with `[WindowsRuntimeImplementationOnlyMember]` and live in source files that opt out of the reference assembly build via `#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE`. Until now this relied entirely on manual discipline: if a type was not correctly marked or excluded, it would silently leak into the public reference assembly, leaking abstract members to downstream consumers and breaking reference projections.

The banned API analyzer turns this into a compile-time guarantee. The marker attribute itself is added to the banned symbols list, so any implementation-only type that survives into the reference assembly build is immediately flagged. The diagnostic (`RS0030`) is promoted to an error for the reference assembly build, so a leak fails the build even during local prototyping, catching the problem as early as possible.

While enabling the analyzer, it surfaced a few implementation-only types that had been missed; those are now correctly excluded.

## Changes

- **`src/Directory.Packages.props`**: add the `Microsoft.CodeAnalysis.BannedApiAnalyzers` package version.
- **`WinRT.Runtime.csproj`**: reference the banned API analyzer and include `BannedSymbols.txt` (both only for the reference assembly build), promote `RS0030` to an error in that build, and add `Windows.UI.Xaml.Interop\**` to the excluded implementation-only folders. The two configuration `PropertyGroup`s are also reorganized under clearer `Settings for the implementation/reference assembly` headers.
- **`BannedSymbols.txt`**: new file banning `WindowsRuntime.WindowsRuntimeImplementationOnlyMemberAttribute` in the reference assembly.
- **`WindowsRuntimeActivationArgsReference.cs`**, **`WindowsRuntimeActivationFactoryCallback.cs`**, **`WindowsRuntimeActivationTypes.cs`**, **`TrustLevel.cs`**: mark these previously-missed implementation-only sources with `#define WINDOWS_RUNTIME_IMPLEMENTATION_ONLY_FILE` so they are excluded from the reference assembly.
