### PR TITLE
Refactor NuGet pack buildProperties to one property per line

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml
@@ -95,7 +95,32 @@ steps:
       command: pack
       searchPatternPack: nuget/Microsoft.Windows.CsWinRT.nuspec
       configurationToPack: Release
-      buildProperties: cswinrt_nuget_version=$(NugetVersion);interop_winmd=$(Build.SourcesDirectory)\release_x86\native\WindowsRuntime.Internal.winmd;net10_runtime=$(Build.SourcesDirectory)\release_x86\net10.0\WinRT.Runtime.dll;net10_runtime_xml=$(Build.SourcesDirectory)\release_x86\net10.0\WinRT.Runtime.xml;source_generator=$(Build.SourcesDirectory)\release_x86\net10.0\WinRT.SourceGenerator.dll;winrt_shim=$(Build.SourcesDirectory)\release_x86\net10.0\WinRT.Host.Shim.dll;winrt_host_x86=$(Build.SourcesDirectory)\release_x86\native\WinRT.Host.dll;winrt_host_x64=$(Build.SourcesDirectory)\release_x64\native\WinRT.Host.dll;winrt_host_arm64=$(Build.SourcesDirectory)\release_arm64\native\WinRT.Host.dll;winrt_host_resource_x86=$(Build.SourcesDirectory)\release_x86\native\WinRT.Host.dll.mui;winrt_host_resource_x64=$(Build.SourcesDirectory)\release_x64\native\WinRT.Host.dll.mui;winrt_host_resource_arm64=$(Build.SourcesDirectory)\release_arm64\native\WinRT.Host.dll.mui;cswinrtinteropgen_x64=$(Build.SourcesDirectory)\release_x64\net10.0\native\cswinrtinteropgen.exe;cswinrtinteropgen_arm64=$(Build.SourcesDirectory)\release_arm64\net10.0\native\cswinrtinteropgen.exe;cswinrtimplgen_x64=$(Build.SourcesDirectory)\release_x64\net10.0\native\cswinrtimplgen.exe;cswinrtimplgen_arm64=$(Build.SourcesDirectory)\release_arm64\net10.0\native\cswinrtimplgen.exe;cswinrtprojectiongen_x64=$(Build.SourcesDirectory)\release_x64\net10.0\native\cswinrtprojectiongen.exe;cswinrtprojectiongen_arm64=$(Build.SourcesDirectory)\release_arm64\net10.0\native\cswinrtprojectiongen.exe;cswinrtprojectionrefgen_x64=$(Build.SourcesDirectory)\release_x64\net10.0\native\cswinrtprojectionrefgen.exe;cswinrtprojectionrefgen_arm64=$(Build.SourcesDirectory)\release_arm64\net10.0\native\cswinrtprojectionrefgen.exe;cswinrtwinmdgen_x64=$(Build.SourcesDirectory)\release_x64\net10.0\native\cswinrtwinmdgen.exe;cswinrtwinmdgen_arm64=$(Build.SourcesDirectory)\release_arm64\net10.0\native\cswinrtwinmdgen.exe;run_cswinrt_generator_task=$(Build.SourcesDirectory)\release_x86\netstandard2.0\WinRT.Generator.Tasks.dll;branch=$(Build.SourceBranchName);commit=$(Build.SourceVersion)
+      buildProperties: "\
+        cswinrt_nuget_version=$(NugetVersion);\
+        interop_winmd=$(Build.SourcesDirectory)\\release_x86\\native\\WindowsRuntime.Internal.winmd;\
+        net10_runtime=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Runtime.dll;\
+        net10_runtime_xml=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Runtime.xml;\
+        source_generator=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.SourceGenerator.dll;\
+        winrt_shim=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Host.Shim.dll;\
+        winrt_host_x86=$(Build.SourcesDirectory)\\release_x86\\native\\WinRT.Host.dll;\
+        winrt_host_x64=$(Build.SourcesDirectory)\\release_x64\\native\\WinRT.Host.dll;\
+        winrt_host_arm64=$(Build.SourcesDirectory)\\release_arm64\\native\\WinRT.Host.dll;\
+        winrt_host_resource_x86=$(Build.SourcesDirectory)\\release_x86\\native\\WinRT.Host.dll.mui;\
+        winrt_host_resource_x64=$(Build.SourcesDirectory)\\release_x64\\native\\WinRT.Host.dll.mui;\
+        winrt_host_resource_arm64=$(Build.SourcesDirectory)\\release_arm64\\native\\WinRT.Host.dll.mui;\
+        cswinrtinteropgen_x64=$(Build.SourcesDirectory)\\release_x64\\net10.0\\native\\cswinrtinteropgen.exe;\
+        cswinrtinteropgen_arm64=$(Build.SourcesDirectory)\\release_arm64\\net10.0\\native\\cswinrtinteropgen.exe;\
+        cswinrtimplgen_x64=$(Build.SourcesDirectory)\\release_x64\\net10.0\\native\\cswinrtimplgen.exe;\
+        cswinrtimplgen_arm64=$(Build.SourcesDirectory)\\release_arm64\\net10.0\\native\\cswinrtimplgen.exe;\
+        cswinrtprojectiongen_x64=$(Build.SourcesDirectory)\\release_x64\\net10.0\\native\\cswinrtprojectiongen.exe;\
+        cswinrtprojectiongen_arm64=$(Build.SourcesDirectory)\\release_arm64\\net10.0\\native\\cswinrtprojectiongen.exe;\
+        cswinrtprojectionrefgen_x64=$(Build.SourcesDirectory)\\release_x64\\net10.0\\native\\cswinrtprojectionrefgen.exe;\
+        cswinrtprojectionrefgen_arm64=$(Build.SourcesDirectory)\\release_arm64\\net10.0\\native\\cswinrtprojectionrefgen.exe;\
+        cswinrtwinmdgen_x64=$(Build.SourcesDirectory)\\release_x64\\net10.0\\native\\cswinrtwinmdgen.exe;\
+        cswinrtwinmdgen_arm64=$(Build.SourcesDirectory)\\release_arm64\\net10.0\\native\\cswinrtwinmdgen.exe;\
+        run_cswinrt_generator_task=$(Build.SourcesDirectory)\\release_x86\\netstandard2.0\\WinRT.Generator.Tasks.dll;\
+        branch=$(Build.SourceBranchName);\
+        commit=$(Build.SourceVersion)"
       packDestination: $(ob_outputDirectory)\packages
 
   - ${{ if eq(parameters.IsGitHub, false) }}:


### PR DESCRIPTION
## Summary

Reformat the `buildProperties` input of the `NuGet pack` step in the publish pipeline so each MSBuild property is on its own line, while keeping the value passed to `nuget pack` byte-for-byte identical.

## Motivation

The `buildProperties` value was a single, very long line packing 25 `key=value` pairs separated by `;`. That made it hard to read and review, and any one-character edit showed the entire line as changed in diffs. Listing one property per line makes future edits and code review far easier, with no change to what the pipeline actually passes to `nuget pack`.

## Changes

- **`build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml`**: rewrite the `buildProperties` input as a double-quoted YAML scalar that uses backslash (`\`) line continuations, with one property per line (all left-aligned). The escaped line breaks join the lines with no added characters, so the `;` separators and every property value are preserved exactly. A folded scalar (`>-`) was deliberately not used because it inserts a space after each `;`, which would corrupt the property names that the nuspec consumes as `$key$`` tokens. Backslashes in the Windows paths are escaped as `\\` (which parse back to a single `\`).

Verified that the parsed scalar value is identical to the original (same length, same content) and that the file still parses as valid YAML. Line endings remain CRLF, consistent with the rest of the file.
