### PR TITLE
Package the WinRT.Runtime reference assembly

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -237,8 +237,37 @@ steps:
         Contents: |
           WinRT.Runtime.dll
           WinRT.Runtime.pdb
-          WinRT.Runtime.xml
         TargetFolder: $(StagingFolder)\net10.0
+
+    # Build the WinRT.Runtime reference assembly, with implementation-only types stripped out. Like the
+    # implementation assembly, it is built as AnyCPU (no platform), so its outputs land in the platform-less
+    # 'bin\<config>\net10.0' and 'obj\<config>\net10.0\ref' folders. It is staged after the implementation
+    # assembly (above), since the reference build overwrites the 'bin' outputs.
+    - task: VSBuild@1
+      displayName: Build WinRT.Runtime reference assembly
+      condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+      inputs:
+        solution: $(Build.SourcesDirectory)\src\WinRT.Runtime2\WinRT.Runtime.csproj
+        msbuildArgs: /restore /p:VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),CsWinRTBuildReferenceAssembly=true,ContinuousIntegrationBuild=true
+        configuration: $(BuildConfiguration)
+
+    # Stage WinRT.Runtime reference assembly (metadata-only assembly produced under 'obj\...\ref')
+    - task: CopyFiles@2
+      displayName: Stage WinRT.Runtime reference assembly
+      condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Runtime2\obj\$(BuildConfiguration)\net10.0\ref
+        Contents: WinRT.Runtime.dll
+        TargetFolder: $(StagingFolder)\net10.0\ref
+
+    # Stage WinRT.Runtime reference assembly XML documentation (stripped to the reference surface)
+    - task: CopyFiles@2
+      displayName: Stage WinRT.Runtime reference assembly XML
+      condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Runtime2\bin\$(BuildConfiguration)\net10.0
+        Contents: WinRT.Runtime.xml
+        TargetFolder: $(StagingFolder)\net10.0\ref
 
     # Stage WinRT.Host.Shim
     - task: CopyFiles@2 

--- a/build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml
@@ -99,7 +99,8 @@ steps:
         cswinrt_nuget_version=$(NugetVersion);\
         interop_winmd=$(Build.SourcesDirectory)\\release_x86\\native\\WindowsRuntime.Internal.winmd;\
         net10_runtime=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Runtime.dll;\
-        net10_runtime_xml=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Runtime.xml;\
+        net10_runtime_ref=$(Build.SourcesDirectory)\\release_x86\\net10.0\\ref\\WinRT.Runtime.dll;\
+        net10_runtime_ref_xml=$(Build.SourcesDirectory)\\release_x86\\net10.0\\ref\\WinRT.Runtime.xml;\
         source_generator=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.SourceGenerator.dll;\
         winrt_shim=$(Build.SourcesDirectory)\\release_x86\\net10.0\\WinRT.Host.Shim.dll;\
         winrt_host_x86=$(Build.SourcesDirectory)\\release_x86\\native\\WinRT.Host.dll;\

--- a/nuget/Microsoft.Windows.CsWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CsWinRT.nuspec
@@ -34,7 +34,8 @@
     <file src="$interop_winmd$" target="metadata"/>
     <file src="readme.txt"/>
     <file src="$net10_runtime$" target="lib\net10.0\"/>
-    <file src="$net10_runtime_xml$" target="lib\net10.0\"/>
+    <file src="$net10_runtime_ref$" target="ref\net10.0\"/>
+    <file src="$net10_runtime_ref_xml$" target="ref\net10.0\"/>
     <file src="$source_generator$" target="analyzers\dotnet\cs\"/>
     <file src="$winrt_host_x64$" target ="hosting\x64\native"/>
     <file src="$winrt_host_x86$" target ="hosting\x86\native"/>

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -118,6 +118,32 @@ if ErrorLevel 1 (
   exit /b !ErrorLevel!
 )
 
+rem Build the WinRT.Runtime reference assembly. This recompiles WinRT.Runtime with all implementation-only
+rem types stripped out (via 'CsWinRTBuildReferenceAssembly=true'), producing a lightweight reference assembly
+rem (and its matching, stripped XML documentation) for packaging under 'ref\net10.0'. Like the implementation
+rem assembly, it is built as AnyCPU (no platform), so its outputs land in the platform-less 'bin\<config>\net10.0'
+rem and 'obj\<config>\net10.0\ref' folders. The reference build overwrites the implementation assembly in 'bin',
+rem so the implementation outputs are staged out first, and both are then packaged from the staging folder.
+set winrt_runtime_bin=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\
+set winrt_runtime_staging=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Runtime\
+
+echo Staging WinRT.Runtime implementation assembly for %cswinrt_platform% %cswinrt_configuration%
+if not exist "%winrt_runtime_staging%lib\" mkdir "%winrt_runtime_staging%lib\"
+copy /y "%winrt_runtime_bin%WinRT.Runtime.dll" "%winrt_runtime_staging%lib\WinRT.Runtime.dll"
+
+echo Building WinRT.Runtime reference assembly for %cswinrt_platform% %cswinrt_configuration%
+call :exec %msbuild_path%msbuild.exe %cswinrt_build_params% /restore /p:configuration=%cswinrt_configuration%;VersionNumber=%cswinrt_version_number%;VersionString=%cswinrt_version_string%;AssemblyVersionNumber=%cswinrt_assembly_version%;CsWinRTBuildReferenceAssembly=true %this_dir%WinRT.Runtime2\WinRT.Runtime.csproj
+if ErrorLevel 1 (
+  echo.
+  echo ERROR: Reference assembly build failed
+  exit /b !ErrorLevel!
+)
+
+echo Staging WinRT.Runtime reference assembly for %cswinrt_platform% %cswinrt_configuration%
+if not exist "%winrt_runtime_staging%ref\" mkdir "%winrt_runtime_staging%ref\"
+copy /y "%this_dir%WinRT.Runtime2\obj\%cswinrt_configuration%\net10.0\ref\WinRT.Runtime.dll" "%winrt_runtime_staging%ref\WinRT.Runtime.dll"
+copy /y "%winrt_runtime_bin%WinRT.Runtime.xml" "%winrt_runtime_staging%ref\WinRT.Runtime.xml"
+
 rem skip tests for now
 goto :package
 
@@ -270,8 +296,9 @@ if "%cswinrt_label%"=="functionaltest" exit /b 0
 rem We set the properties of the CsWinRT.nuspec here, and pass them as the -Properties option when we call `nuget pack`
 set cswinrt_bin_dir=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\cswinrt\bin\
 set interop_winmd=%this_dir%WinRT.Internal\bin\%cswinrt_configuration%\net10.0-windows10.0.26100.1\WindowsRuntime.Internal.winmd
-set net10_runtime=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.dll
-set net10_runtime_xml=%this_dir%WinRT.Runtime2\bin\%cswinrt_configuration%\net10.0\WinRT.Runtime.xml
+set net10_runtime=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Runtime\lib\WinRT.Runtime.dll
+set net10_runtime_ref=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Runtime\ref\WinRT.Runtime.dll
+set net10_runtime_ref_xml=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Runtime\ref\WinRT.Runtime.xml
 set source_generator_roslyn4120=%this_dir%Authoring\WinRT.SourceGenerator.Roslyn4120\bin\%cswinrt_configuration%\netstandard2.0\WinRT.SourceGenerator.dll
 set source_generator=%this_dir%Authoring\WinRT.SourceGenerator2\bin\%cswinrt_configuration%\net10.0\WinRT.SourceGenerator.dll
 set winrt_host_%cswinrt_platform%=%this_dir%_build\%cswinrt_platform%\%cswinrt_configuration%\WinRT.Host\bin\WinRT.Host.dll
@@ -286,7 +313,7 @@ set run_cswinrt_generator_task=%this_dir%WinRT.Generator.Tasks\bin\%cswinrt_conf
 
 rem Now call pack
 echo Creating nuget package
-call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinRT.nuspec -Properties interop_winmd=%interop_winmd%;net10_runtime=%net10_runtime%;net10_runtime_xml=%net10_runtime_xml%;source_generator=%source_generator%;cswinrt_nuget_version=%cswinrt_version_string%;winrt_host_x86=%winrt_host_x86%;winrt_host_x64=%winrt_host_x64%;winrt_host_arm=%winrt_host_arm%;winrt_host_arm64=%winrt_host_arm64%;winrt_host_resource_x86=%winrt_host_resource_x86%;winrt_host_resource_x64=%winrt_host_resource_x64%;winrt_host_resource_arm=%winrt_host_resource_arm%;winrt_host_resource_arm64=%winrt_host_resource_arm64%;winrt_shim=%winrt_shim%;cswinrtinteropgen_x64=%cswinrtinteropgen_x64%;cswinrtinteropgen_arm64=%cswinrtinteropgen_arm64%;cswinrtimplgen_x64=%cswinrtimplgen_x64%;cswinrtimplgen_arm64=%cswinrtimplgen_arm64%;cswinrtprojectiongen_x64=%cswinrtprojectiongen_x64%;cswinrtprojectiongen_arm64=%cswinrtprojectiongen_arm64%;cswinrtprojectionrefgen_x64=%cswinrtprojectionrefgen_x64%;cswinrtprojectionrefgen_arm64=%cswinrtprojectionrefgen_arm64%;cswinrtwinmdgen_x64=%cswinrtwinmdgen_x64%;cswinrtwinmdgen_arm64=%cswinrtwinmdgen_arm64%;run_cswinrt_generator_task=%run_cswinrt_generator_task%; -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
+call :exec %nuget_dir%\nuget pack %this_dir%..\nuget\Microsoft.Windows.CsWinRT.nuspec -Properties interop_winmd=%interop_winmd%;net10_runtime=%net10_runtime%;net10_runtime_ref=%net10_runtime_ref%;net10_runtime_ref_xml=%net10_runtime_ref_xml%;source_generator=%source_generator%;cswinrt_nuget_version=%cswinrt_version_string%;winrt_host_x86=%winrt_host_x86%;winrt_host_x64=%winrt_host_x64%;winrt_host_arm=%winrt_host_arm%;winrt_host_arm64=%winrt_host_arm64%;winrt_host_resource_x86=%winrt_host_resource_x86%;winrt_host_resource_x64=%winrt_host_resource_x64%;winrt_host_resource_arm=%winrt_host_resource_arm%;winrt_host_resource_arm64=%winrt_host_resource_arm64%;winrt_shim=%winrt_shim%;cswinrtinteropgen_x64=%cswinrtinteropgen_x64%;cswinrtinteropgen_arm64=%cswinrtinteropgen_arm64%;cswinrtimplgen_x64=%cswinrtimplgen_x64%;cswinrtimplgen_arm64=%cswinrtimplgen_arm64%;cswinrtprojectiongen_x64=%cswinrtprojectiongen_x64%;cswinrtprojectiongen_arm64=%cswinrtprojectiongen_arm64%;cswinrtprojectionrefgen_x64=%cswinrtprojectionrefgen_x64%;cswinrtprojectionrefgen_arm64=%cswinrtprojectionrefgen_arm64%;cswinrtwinmdgen_x64=%cswinrtwinmdgen_x64%;cswinrtwinmdgen_arm64=%cswinrtwinmdgen_arm64%;run_cswinrt_generator_task=%run_cswinrt_generator_task%; -OutputDirectory %cswinrt_bin_dir% -NonInteractive -Verbosity Detailed -NoPackageAnalysis
 goto :eof
 
 :exec


### PR DESCRIPTION
## Summary

Package the `WinRT.Runtime` reference assembly into the CsWinRT NuGet package under `ref\net10.0`, alongside the implementation assembly under `lib\net10.0`. This wires up both the Azure Pipelines CI build and the local `build.cmd` to build the reference assembly (with implementation-only types stripped out via `CsWinRTBuildReferenceAssembly=true`) and stage its `.dll` plus its stripped XML documentation.

## Motivation

This is the final piece of the work to enable a reference assembly for `WinRT.Runtime`. The earlier work introduced the `CsWinRTBuildReferenceAssembly` build option that recompiles `WinRT.Runtime` with all implementation-only types stripped out. This PR makes that reference assembly actually ship: it builds it during packaging and places it under `ref\net10.0` in the NuGet package, so consumers compile against the trimmed public surface while the full implementation assembly is delivered under `lib\net10.0`. The XML documentation is moved to the reference folder as well, so it matches the reference surface that consumers see.

## Changes

- **`build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml`**: stop staging `WinRT.Runtime.xml` alongside the implementation assembly; add a `VSBuild` step to build the reference assembly (`CsWinRTBuildReferenceAssembly=true`, x86/release only) and `CopyFiles` steps to stage the reference `WinRT.Runtime.dll` (from `obj\...\ref`) and its stripped `WinRT.Runtime.xml` into `net10.0\ref`.
- **`build/AzurePipelineTemplates/CsWinRT-PublishToNuGet-Steps.yml`**: replace the `net10_runtime_xml` nuspec property with `net10_runtime_ref` and `net10_runtime_ref_xml`, pointing at the staged `net10.0\ref` outputs.
- **`nuget/Microsoft.Windows.CsWinRT.nuspec`**: package the reference assembly and its XML under `ref\net10.0\` instead of placing the XML under `lib\net10.0\`.
- **`src/build.cmd`**: stage the implementation assembly first (the reference build overwrites the `bin` outputs), build the reference assembly, stage the reference `.dll` and XML, and pass the new `net10_runtime_ref` / `net10_runtime_ref_xml` properties to `nuget pack`.
