### PR TITLE
Support [Deprecated] in 3.0 projections and authored components

### DIFF
--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -984,20 +984,19 @@ TEST(AuthoringTest, DeprecatedMembersClass)
     EXPECT_EQ(obj.OldProp(), L"OldProp");
     EXPECT_EQ(obj.NewProp(), L"NewProp");
 
-    // Members marked [Deprecated(DeprecationType.Remove)] keep their vtable slot and dispatch to the
-    // authored implementation, so existing callers compiled against them keep working.
-    obj.RemovedMethod();
-    EXPECT_EQ(obj.RemovedProp(), L"RemovedProp");
-
-    // The same applies to static members, which dispatch through the generated static factory.
     DeprecatedMembersClass::OldStatic();
-    DeprecatedMembersClass::RemovedStatic();
     DeprecatedMembersClass::NewStatic();
 
-    // Events of every deprecation kind can be subscribed to and revoked.
     auto oldToken = obj.OldEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
-    auto removedToken = obj.RemovedEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
     auto newToken = obj.NewEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
+
+    // Members marked [Deprecated(DeprecationType.Remove)] are omitted from the projection but keep their
+    // vtable slot, stubbed to return E_NOTIMPL. The new members above sit after the removed slots in
+    // vtable order and still dispatch correctly, which proves the removed slots remain in place.
+    EXPECT_THROW(obj.RemovedMethod(), hresult_not_implemented);
+    EXPECT_THROW(obj.RemovedProp(), hresult_not_implemented);
+    EXPECT_THROW(DeprecatedMembersClass::RemovedStatic(), hresult_not_implemented);
+    EXPECT_THROW(obj.RemovedEvent([](IInspectable const&, int32_t const&) {}), hresult_not_implemented);
 }
 
 TEST(AuthoringTest, FullFeaturedClass)

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -978,7 +978,11 @@ TEST(AuthoringTest, DeprecatedMembersClass)
 {
     DeprecatedMembersClass obj;
 
-    // Members marked [Deprecated(DeprecationType.Deprecate)] and the new members remain fully usable.
+    // Members marked [Deprecated(DeprecationType.Remove)] are omitted from the projection, so they are
+    // intentionally not referenced here. Their ABI vtable slot is still preserved (stubbed to E_NOTIMPL):
+    // the new members below sit after the removed slots in vtable order, so their correct dispatch confirms
+    // the removed slots remain in place and the layout did not shift. The deprecated members and the new
+    // members both remain projected and fully usable.
     obj.OldMethod();
     obj.NewMethod();
     EXPECT_EQ(obj.OldProp(), L"OldProp");
@@ -989,14 +993,6 @@ TEST(AuthoringTest, DeprecatedMembersClass)
 
     auto oldToken = obj.OldEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
     auto newToken = obj.NewEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
-
-    // Members marked [Deprecated(DeprecationType.Remove)] are omitted from the projection but keep their
-    // vtable slot, stubbed to return E_NOTIMPL. The new members above sit after the removed slots in
-    // vtable order and still dispatch correctly, which proves the removed slots remain in place.
-    EXPECT_THROW(obj.RemovedMethod(), hresult_not_implemented);
-    EXPECT_THROW(obj.RemovedProp(), hresult_not_implemented);
-    EXPECT_THROW(DeprecatedMembersClass::RemovedStatic(), hresult_not_implemented);
-    EXPECT_THROW(obj.RemovedEvent([](IInspectable const&, int32_t const&) {}), hresult_not_implemented);
 }
 
 TEST(AuthoringTest, FullFeaturedClass)

--- a/src/Tests/AuthoringConsumptionTest/test.cpp
+++ b/src/Tests/AuthoringConsumptionTest/test.cpp
@@ -977,10 +977,27 @@ TEST(AuthoringTest, AsyncMethodClass)
 TEST(AuthoringTest, DeprecatedMembersClass)
 {
     DeprecatedMembersClass obj;
+
+    // Members marked [Deprecated(DeprecationType.Deprecate)] and the new members remain fully usable.
     obj.OldMethod();
     obj.NewMethod();
-    EXPECT_EQ(obj.OldProp(), L"");
-    EXPECT_EQ(obj.NewProp(), L"");
+    EXPECT_EQ(obj.OldProp(), L"OldProp");
+    EXPECT_EQ(obj.NewProp(), L"NewProp");
+
+    // Members marked [Deprecated(DeprecationType.Remove)] keep their vtable slot and dispatch to the
+    // authored implementation, so existing callers compiled against them keep working.
+    obj.RemovedMethod();
+    EXPECT_EQ(obj.RemovedProp(), L"RemovedProp");
+
+    // The same applies to static members, which dispatch through the generated static factory.
+    DeprecatedMembersClass::OldStatic();
+    DeprecatedMembersClass::RemovedStatic();
+    DeprecatedMembersClass::NewStatic();
+
+    // Events of every deprecation kind can be subscribed to and revoked.
+    auto oldToken = obj.OldEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
+    auto removedToken = obj.RemovedEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
+    auto newToken = obj.NewEvent(auto_revoke, [](IInspectable const&, int32_t const&) {});
 }
 
 TEST(AuthoringTest, FullFeaturedClass)

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -2271,12 +2271,34 @@ namespace AuthoringTest
             [Windows.Foundation.Metadata.Deprecated("Use NewMethod instead", Windows.Foundation.Metadata.DeprecationType.Deprecate, 1u)]
             public void OldMethod() { }
 
+            [Windows.Foundation.Metadata.Deprecated("RemovedMethod is gone", Windows.Foundation.Metadata.DeprecationType.Remove, 2u)]
+            public void RemovedMethod() { }
+
             public void NewMethod() { }
 
-            [Windows.Foundation.Metadata.Deprecated("Use NewProp instead", Windows.Foundation.Metadata.DeprecationType.Deprecate, 1u)]
-            public string OldProp => "";
+            [Windows.Foundation.Metadata.Deprecated("Use NewStatic instead", Windows.Foundation.Metadata.DeprecationType.Deprecate, 1u)]
+            public static void OldStatic() { }
 
-            public string NewProp => "";
+            [Windows.Foundation.Metadata.Deprecated("RemovedStatic is gone", Windows.Foundation.Metadata.DeprecationType.Remove, 2u)]
+            public static void RemovedStatic() { }
+
+            public static void NewStatic() { }
+
+            [Windows.Foundation.Metadata.Deprecated("Use NewProp instead", Windows.Foundation.Metadata.DeprecationType.Deprecate, 1u)]
+            public string OldProp => "OldProp";
+
+            [Windows.Foundation.Metadata.Deprecated("RemovedProp is gone", Windows.Foundation.Metadata.DeprecationType.Remove, 2u)]
+            public string RemovedProp => "RemovedProp";
+
+            public string NewProp => "NewProp";
+
+            [Windows.Foundation.Metadata.Deprecated("Use NewEvent instead", Windows.Foundation.Metadata.DeprecationType.Deprecate, 1u)]
+            public event System.EventHandler<int> OldEvent;
+
+            [Windows.Foundation.Metadata.Deprecated("RemovedEvent is gone", Windows.Foundation.Metadata.DeprecationType.Remove, 2u)]
+            public event System.EventHandler<int> RemovedEvent;
+
+            public event System.EventHandler<int> NewEvent;
         }
 
         // Class implementing INotifyPropertyChanged + custom interface

--- a/src/Tests/TestComponentCSharp/DeprecatedClasses.cpp
+++ b/src/Tests/TestComponentCSharp/DeprecatedClasses.cpp
@@ -1,0 +1,60 @@
+#include "pch.h"
+#include "DeprecatedClasses.h"
+#include "DeprecatedConstructorClass.g.cpp"
+#include "RemovedActivationClass.g.cpp"
+#include "RemovedComposableClass.g.cpp"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    // The value encodes which constructor ran, so a test can prove the surviving constructor still
+    // dispatches through its original factory slot even though the one before it was removed.
+    DeprecatedConstructorClass::DeprecatedConstructorClass(int32_t first)
+    {
+        m_value = first;
+    }
+
+    DeprecatedConstructorClass::DeprecatedConstructorClass(int32_t first, int32_t second)
+    {
+        m_value = first + second;
+    }
+
+    DeprecatedConstructorClass::DeprecatedConstructorClass(int32_t first, int32_t second, int32_t third)
+    {
+        m_value = first + second + third;
+    }
+
+    int32_t DeprecatedConstructorClass::Value()
+    {
+        return m_value;
+    }
+
+    RemovedActivationClass::RemovedActivationClass(int32_t initialValue)
+    {
+        m_value = initialValue;
+    }
+
+    TestComponentCSharp::RemovedActivationClass RemovedActivationClass::Create(int32_t initialValue)
+    {
+        return winrt::make<RemovedActivationClass>(initialValue);
+    }
+
+    int32_t RemovedActivationClass::Value()
+    {
+        return m_value;
+    }
+
+    TestComponentCSharp::RemovedComposableClass RemovedComposableClass::Create(int32_t initialValue)
+    {
+        return winrt::make<RemovedComposableClass>(initialValue);
+    }
+
+    RemovedComposableClass::RemovedComposableClass(int32_t initialValue)
+    {
+        m_value = initialValue;
+    }
+
+    int32_t RemovedComposableClass::Value()
+    {
+        return m_value;
+    }
+}

--- a/src/Tests/TestComponentCSharp/DeprecatedClasses.h
+++ b/src/Tests/TestComponentCSharp/DeprecatedClasses.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "DeprecatedConstructorClass.g.h"
+#include "RemovedActivationClass.g.h"
+#include "RemovedComposableClass.g.h"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    // Each constructor stores a distinct value so a test can tell which factory slot was
+    // actually dispatched to (the removed overloads keep their slot, but are not projected).
+    struct DeprecatedConstructorClass : DeprecatedConstructorClassT<DeprecatedConstructorClass>
+    {
+        DeprecatedConstructorClass(int32_t first);
+        DeprecatedConstructorClass(int32_t first, int32_t second);
+        DeprecatedConstructorClass(int32_t first, int32_t second, int32_t third);
+
+        int32_t Value();
+
+    private:
+        int32_t m_value{ 0 };
+    };
+
+    struct RemovedActivationClass : RemovedActivationClassT<RemovedActivationClass>
+    {
+        RemovedActivationClass(int32_t initialValue);
+
+        static TestComponentCSharp::RemovedActivationClass Create(int32_t initialValue);
+
+        int32_t Value();
+
+    private:
+        int32_t m_value{ 0 };
+    };
+
+    struct RemovedComposableClass : RemovedComposableClassT<RemovedComposableClass>
+    {
+        // The parameterless constructor is the one the (removed) composable factory method uses;
+        // the other is implementation-only, for the static factory method below
+        RemovedComposableClass() = default;
+        explicit RemovedComposableClass(int32_t initialValue);
+
+        static TestComponentCSharp::RemovedComposableClass Create(int32_t initialValue);
+
+        int32_t Value();
+
+    private:
+        int32_t m_value{ 0 };
+    };
+}
+namespace winrt::TestComponentCSharp::factory_implementation
+{
+    struct DeprecatedConstructorClass : DeprecatedConstructorClassT<DeprecatedConstructorClass, implementation::DeprecatedConstructorClass>
+    {
+    };
+
+    struct RemovedActivationClass : RemovedActivationClassT<RemovedActivationClass, implementation::RemovedActivationClass>
+    {
+    };
+
+    struct RemovedComposableClass : RemovedComposableClassT<RemovedComposableClass, implementation::RemovedComposableClass>
+    {
+    };
+}

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -798,6 +798,56 @@ And this is another one"
         Int32 Value{ get; set; };
     }
 
+    // A constructor has no metadata row of its own: it is projected as a method on the activation
+    // (or composable) factory interface, and that method is where '[deprecated]' lives. These three
+    // classes cover the constructor cases the projection has to handle.
+
+    // A deprecated constructor is projected with '[Obsolete]'; a removed one is dropped from the
+    // projection while its factory vtable slot is preserved, so the constructor declared after it
+    // must still dispatch through the correct slot.
+    [default_interface]
+    runtimeclass DeprecatedConstructorClass
+    {
+        [deprecated("Use the three-argument constructor instead", deprecate, 1)]
+        DeprecatedConstructorClass(Int32 first);
+
+        [deprecated("The two-argument constructor is gone", remove, 1)]
+        DeprecatedConstructorClass(Int32 first, Int32 second);
+
+        DeprecatedConstructorClass(Int32 first, Int32 second, Int32 third);
+
+        Int32 Value{ get; };
+    }
+
+    // Every constructor is removed, so the (sealed, activatable) class cannot be constructed from the
+    // projection at all and instances come from the static factory method instead.
+    //
+    // Note: the constructor parameter cannot be named 'value'. MIDL projects a constructor as
+    // 'CreateInstance' on the activation factory interface and names its '[out, retval]' parameter
+    // 'value', so a user parameter of that name collides with it (MIDL5161).
+    [default_interface]
+    runtimeclass RemovedActivationClass
+    {
+        [deprecated("Use RemovedActivationClass.Create instead", remove, 1)]
+        RemovedActivationClass(Int32 initialValue);
+
+        static RemovedActivationClass Create(Int32 initialValue);
+
+        Int32 Value{ get; };
+    }
+
+    // As above, but unsealed, so its factory is composable rather than activatable.
+    [default_interface]
+    unsealed runtimeclass RemovedComposableClass
+    {
+        [deprecated("Use RemovedComposableClass.Create instead", remove, 1)]
+        RemovedComposableClass();
+
+        static RemovedComposableClass Create(Int32 initialValue);
+
+        Int32 Value{ get; };
+    }
+
     // Compile time test for sub windows namespace
     namespace Windows
     {

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -88,6 +88,7 @@
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
     <ClInclude Include="CustomExperimentClass.h" />
     <ClInclude Include="CustomEquals.h" />
+    <ClInclude Include="DeprecatedClasses.h" />
     <ClInclude Include="CustomIterableTest.h" />
     <ClInclude Include="CustomReadOnlyDictionaryTest.h" />
     <ClInclude Include="ManualProjectionTestClasses.h" />
@@ -111,6 +112,7 @@
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
     <ClCompile Include="CustomExperimentClass.cpp" />
     <ClCompile Include="CustomEquals.cpp" />
+    <ClCompile Include="DeprecatedClasses.cpp" />
     <ClCompile Include="CustomIterableTest.cpp" />
     <ClCompile Include="CustomReadOnlyDictionaryTest.cpp" />
     <ClCompile Include="pch.cpp">

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -21,6 +21,7 @@
     <ClCompile Include="AnotherAssembly.SetPropertyClass.cpp" />
     <ClCompile Include="CustomEquals.cpp" />
     <ClCompile Include="CustomExperimentClass.cpp" />
+    <ClCompile Include="DeprecatedClasses.cpp" />
     <ClCompile Include="WinRT.Class.cpp" />
     <ClCompile Include="ClassWithExplicitIUnknown.cpp" />
     <ClCompile Include="NonUniqueClass.cpp" />
@@ -40,6 +41,7 @@
     <ClInclude Include="AnotherAssembly.SetPropertyClass.h" />
     <ClInclude Include="CustomEquals.h" />
     <ClInclude Include="CustomExperimentClass.h" />
+    <ClInclude Include="DeprecatedClasses.h" />
     <ClInclude Include="WinRT.Class.h" />
     <ClInclude Include="ClassWithExplicitIUnknown.h" />
     <ClInclude Include="NonUniqueClass.h" />

--- a/src/Tests/UnitTest/ComInteropTests.cs
+++ b/src/Tests/UnitTest/ComInteropTests.cs
@@ -76,8 +76,13 @@ namespace UnitTest
         [TestMethod]
         public void TestPlayToManager()
         {
+            // 'PlayToManager' is deprecated in the Windows SDK, so it is projected with '[Obsolete]'. This
+            // test covers its interop extensions regardless, so suppress 'CS0618' to keep the intentional
+            // usage from breaking the build (warnings are treated as errors).
+#pragma warning disable CS0618
             Assert.ThrowsExactly<COMException>(() => PlayToManager.GetForWindow(new IntPtr(0)));
             PlayToManager.ShowPlayToUIForWindow(new IntPtr(0));
+#pragma warning restore CS0618
         }
 
         [TestMethod]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2001,6 +2001,74 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public void TestDeprecatedConstructors()
+        {
+            // A '[deprecated]' constructor is still projected, just with '[Obsolete]' on it
+#pragma warning disable CS0618
+            var deprecated = new DeprecatedConstructorClass(1);
+#pragma warning restore CS0618
+
+            Assert.AreEqual(1, deprecated.Value);
+
+            // The two-argument constructor is '[deprecated(remove)]', so it is not projected at all.
+            // Its factory vtable slot is preserved though, which is exactly what lets the three-argument
+            // constructor declared after it still dispatch through the right slot (it sums its arguments,
+            // so a wrong slot would either fail or produce a different value).
+            Assert.IsNull(typeof(DeprecatedConstructorClass).GetConstructor([typeof(int), typeof(int)]));
+
+            var live = new DeprecatedConstructorClass(1, 2, 3);
+
+            Assert.AreEqual(6, live.Value);
+
+            static bool IsObsolete(params Type[] parameterTypes)
+            {
+                ConstructorInfo constructor = typeof(DeprecatedConstructorClass).GetConstructor(parameterTypes);
+
+                Assert.IsNotNull(constructor);
+
+                return constructor.GetCustomAttribute<ObsoleteAttribute>() is not null;
+            }
+
+            Assert.IsTrue(IsObsolete(typeof(int)));
+            Assert.IsFalse(IsObsolete(typeof(int), typeof(int), typeof(int)));
+        }
+
+        [TestMethod]
+        public void TestRemovedConstructors()
+        {
+            // Every constructor of these two classes is '[deprecated(remove)]', so neither is
+            // constructible from the projection: the activatable (sealed) one and the composable
+            // (unsealed) one both have to drop their only constructor.
+            //
+            // 'HasPublicParameterlessConstructor' resolves the 'new()' constrained overload only when the
+            // type *as compiled against* really exposes a public parameterless constructor, so it asserts
+            // the reference projection's surface. That matters because dropping every constructor without
+            // emitting a non-public one in its place would let the C# compiler synthesize an implicit
+            // public parameterless constructor, which the implementation projection does not have.
+            Assert.IsTrue(HasPublicParameterlessConstructor<Class>());
+            Assert.IsFalse(HasPublicParameterlessConstructor<RemovedActivationClass>());
+            Assert.IsFalse(HasPublicParameterlessConstructor<RemovedComposableClass>());
+
+            // The implementation projection agrees with the reference projection above
+            Assert.AreEqual(0, typeof(RemovedActivationClass).GetConstructors().Length);
+            Assert.AreEqual(0, typeof(RemovedComposableClass).GetConstructors().Length);
+
+            // Both types are still fully usable through their static factory methods
+            Assert.AreEqual(42, RemovedActivationClass.Create(42).Value);
+            Assert.AreEqual(42, RemovedComposableClass.Create(42).Value);
+        }
+
+        /// <summary>
+        /// Compile-time probe for a public parameterless constructor: the <c>new()</c> constrained
+        /// overload is only a candidate when <typeparamref name="T"/> has one, so a call resolves to
+        /// the fallback overload otherwise.
+        /// </summary>
+        private static bool HasPublicParameterlessConstructor<T>() where T : new() => true;
+
+        /// <inheritdoc cref="HasPublicParameterlessConstructor{T}()"/>
+        private static bool HasPublicParameterlessConstructor<T>(int _ = 0) => false;
+
+        [TestMethod]
         public void TestStaticMembers()
         {
             Class.StaticIntProperty = 42;

--- a/src/WinRT.Projection.Writer/Builders/ProjectionFileBuilder.cs
+++ b/src/WinRT.Projection.Writer/Builders/ProjectionFileBuilder.cs
@@ -120,11 +120,18 @@ internal static class ProjectionFileBuilder
                     continue;
                 }
 
+                // Skip enum fields removed via '[Deprecated(..., DeprecationType.Remove, ...)]'
+                if (field.IsRemoved)
+                {
+                    continue;
+                }
+
                 string fieldName = field.GetRawName();
                 string constantValue = field.Constant.FormatLiteral();
 
                 // Emits per-enum-field '[SupportedOSPlatform]' when the field has a '[ContractVersion]'
                 CustomAttributeFactory.WritePlatformAttribute(writer, context, field);
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, field);
 
                 writer.WriteLine($"{fieldName} = unchecked(({enumUnderlyingType}){constantValue}),");
             }

--- a/src/WinRT.Projection.Writer/Extensions/IHasCustomAttributeExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/IHasCustomAttributeExtensions.cs
@@ -94,5 +94,44 @@ internal static class IHasCustomAttributeExtensions
         {
             return member.GetAttribute(WellKnownNamespaces.WindowsFoundationMetadata, name);
         }
+
+        /// <summary>
+        /// Gets whether the member carries a <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute.
+        /// </summary>
+        public bool IsDeprecated => member.HasWindowsFoundationMetadataAttribute("DeprecatedAttribute");
+
+        /// <summary>
+        /// Gets whether the member is marked as removed: it carries a
+        /// <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute whose <c>DeprecationType</c>
+        /// is <c>Remove</c>. A removed member is omitted from the projection, while its ABI vtable
+        /// slot is preserved (stubbed to return <c>E_NOTIMPL</c>) for binary compatibility.
+        /// </summary>
+        /// <remarks>
+        /// <c>DeprecatedAttribute(string message, DeprecationType type, ...)</c>: the second fixed
+        /// argument is the <c>DeprecationType</c> enum, where <c>Deprecate</c> is 0 and <c>Remove</c> is 1.
+        /// </remarks>
+        public bool IsRemoved =>
+            member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is { Signature.FixedArguments: [_, { Element: int deprecationType }, ..] }
+            && deprecationType == 1;
+
+        /// <summary>
+        /// Gets whether the member is deprecated but not removed (i.e. it is projected with an
+        /// <c>[Obsolete]</c> attribute rather than being omitted).
+        /// </summary>
+        public bool IsDeprecatedNotRemoved => member.IsDeprecated && !member.IsRemoved;
+
+        /// <summary>
+        /// Gets the message from the member's <c>[Windows.Foundation.Metadata.Deprecated]</c>
+        /// attribute (the first fixed argument), or <see langword="null"/> if the member is not
+        /// deprecated or the attribute carries no message.
+        /// </summary>
+        /// <remarks>
+        /// <c>DeprecatedAttribute(string message, ...)</c>: the first fixed argument is the message.
+        /// AsmResolver returns <c>Utf8String</c> for string custom-attribute args, so it is converted.
+        /// </remarks>
+        public string? DeprecatedMessage =>
+            member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is { Signature.FixedArguments: [{ Element: { } message }, ..] }
+                ? message.ToString()
+                : null;
     }
 }

--- a/src/WinRT.Projection.Writer/Extensions/IHasCustomAttributeExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/IHasCustomAttributeExtensions.cs
@@ -110,9 +110,7 @@ internal static class IHasCustomAttributeExtensions
         /// <c>DeprecatedAttribute(string message, DeprecationType type, ...)</c>: the second fixed
         /// argument is the <c>DeprecationType</c> enum, where <c>Deprecate</c> is 0 and <c>Remove</c> is 1.
         /// </remarks>
-        public bool IsRemoved =>
-            member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is { Signature.FixedArguments: [_, { Element: int deprecationType }, ..] }
-            && deprecationType == 1;
+        public bool IsRemoved => member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is { Signature.FixedArguments: [_, { Element: 1 }, ..] };
 
         /// <summary>
         /// Gets whether the member is deprecated but not removed (i.e. it is projected with an
@@ -129,9 +127,17 @@ internal static class IHasCustomAttributeExtensions
         /// <c>DeprecatedAttribute(string message, ...)</c>: the first fixed argument is the message.
         /// AsmResolver returns <c>Utf8String</c> for string custom-attribute args, so it is converted.
         /// </remarks>
-        public string? DeprecatedMessage =>
-            member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is { Signature.FixedArguments: [{ Element: { } message }, ..] }
-                ? message.ToString()
-                : null;
+        public string? DeprecatedMessage
+        {
+            get
+            {
+                if (member.GetWindowsFoundationMetadataAttribute("DeprecatedAttribute") is not { Signature.FixedArguments: [{ Element: { } message }, ..] })
+                {
+                    return null;
+                }
+
+                return message.ToString();
+            }
+        }
     }
 }

--- a/src/WinRT.Projection.Writer/Extensions/ProjectionWriterExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/ProjectionWriterExtensions.cs
@@ -53,6 +53,7 @@ internal static class ProjectionWriterExtensions
                 #pragma warning disable CSWINRT3001 // "Type or member '...' is a private implementation detail"
                 #pragma warning disable CSWINRT3002 // "Type '...' is a private implementation detail"
                 #pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
+                #pragma warning disable CS0612, CS0618 // "'...' is obsolete" (deprecated Windows Runtime APIs are projected as '[Obsolete]', but generated code still has to reference them)
                 
                 """);
         }

--- a/src/WinRT.Projection.Writer/Extensions/TypeDefinitionExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/TypeDefinitionExtensions.cs
@@ -195,16 +195,22 @@ internal static class TypeDefinitionExtensions
         }
 
         /// <summary>
-        /// Returns whether the type declares a parameterless instance constructor.
+        /// Returns whether the type declares a parameterless instance constructor that is usable for
+        /// default activation, i.e. one that is not marked as removed (<c>[Deprecated(DeprecationType.Remove)]</c>).
         /// </summary>
-        /// <returns><see langword="true"/> if the type has a default constructor; otherwise <see langword="false"/>.</returns>
-        public bool HasDefaultConstructor()
+        /// <remarks>
+        /// A removed default constructor is omitted from the projection, so the type is no longer
+        /// default-activatable: the activation factory cannot emit <c>new T()</c> for it (the C# compiler
+        /// treats a call to a removed member as an error), and default activation returns <c>E_NOTIMPL</c> instead.
+        /// </remarks>
+        /// <returns><see langword="true"/> if the type has a non-removed default constructor; otherwise <see langword="false"/>.</returns>
+        public bool HasActivatableDefaultConstructor()
         {
             foreach (MethodDefinition m in type.Methods)
             {
                 if (m.IsDefaultConstructor)
                 {
-                    return true;
+                    return !m.IsRemoved;
                 }
             }
 

--- a/src/WinRT.Projection.Writer/Extensions/TypeDefinitionExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/TypeDefinitionExtensions.cs
@@ -218,6 +218,30 @@ internal static class TypeDefinitionExtensions
         }
 
         /// <summary>
+        /// Returns whether the type (an activation or composable factory interface) declares at least one
+        /// method that still projects to a constructor, i.e. one that is neither special nor marked as
+        /// removed (<c>[Deprecated(DeprecationType.Remove)]</c>).
+        /// </summary>
+        /// <remarks>
+        /// A factory interface with no such methods contributes no constructors to the projected class, so
+        /// (in reference-projection mode) the class needs a synthetic non-public parameterless constructor
+        /// to suppress the C# compiler's implicit public default constructor.
+        /// </remarks>
+        /// <returns><see langword="true"/> if the factory interface has a non-removed factory method; otherwise <see langword="false"/>.</returns>
+        public bool HasActivatableFactoryMethod()
+        {
+            foreach (MethodDefinition m in type.GetNonSpecialMethods())
+            {
+                if (!m.IsRemoved)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns whether the type has a base type that is not <see cref="object"/>
         /// (i.e. the type derives from a real WinRT/.NET class).
         /// </summary>

--- a/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
@@ -409,8 +409,14 @@ internal static class AbiInterfaceFactory
                 """);
 
             // A removed member (DeprecationType.Remove) keeps its vtable slot for ABI compatibility,
-            // but is no longer on the projected interface, so its CCW entry returns E_NOTIMPL.
-            if (IsAbiMemberRemoved(method, eventMap, propertyMap))
+            // but is no longer on the projected interface. When consuming a Windows Runtime type, a
+            // managed object implementing the interface cannot supply the removed member (it is not on
+            // the projected interface), so its CCW entry returns E_NOTIMPL. In component (authoring) mode
+            // the dispatch target is the authored implementation (the authored class for instance
+            // members, or the generated activation/static factory that forwards to it), which still
+            // defines the member, so the entry keeps dispatching to that implementation to preserve
+            // binary compatibility for existing native callers.
+            if (!context.Settings.Component && IsAbiMemberRemoved(method, eventMap, propertyMap))
             {
                 writer.WriteLine();
                 writer.WriteLine("""

--- a/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
@@ -395,9 +395,17 @@ internal static class AbiInterfaceFactory
             MethodSignatureInfo sig = new(method);
             string mname = method.GetRawName();
 
-            // If this method is an event add accessor, emit the per-event ConditionalWeakTable
-            // before the Do_Abi method.
-            if (eventMap is not null && eventMap.TryGetValue(method, out EventDefinition? evt) && evt.AddMethod == method)
+            // A removed member (DeprecationType.Remove) keeps its vtable slot for ABI compatibility, but
+            // is no longer part of the projection, so its CCW entry returns E_NOTIMPL. This applies in
+            // both consuming and component (authoring) mode: the projected interface omits the member, and
+            // generated code cannot dispatch to it even in component mode, because the C# compiler treats a
+            // call to a '[Deprecated(Remove)]' member as an obsolete-as-error (CS0619). The vtable slot is
+            // preserved so the layout stays stable for existing native callers.
+            bool removed = IsAbiMemberRemoved(method, eventMap, propertyMap);
+
+            // If this method is an event add accessor, emit the per-event ConditionalWeakTable before the
+            // Do_Abi method. Removed events are stubbed to E_NOTIMPL and never use the table, so it is skipped.
+            if (!removed && eventMap is not null && eventMap.TryGetValue(method, out EventDefinition? evt) && evt.AddMethod == method)
             {
                 EventTableFactory.EmitEventTableField(writer, context, evt, ifaceFullName);
             }
@@ -408,15 +416,7 @@ internal static class AbiInterfaceFactory
                 private static unsafe int Do_Abi_{{vm}}({{doAbiParams}})
                 """);
 
-            // A removed member (DeprecationType.Remove) keeps its vtable slot for ABI compatibility,
-            // but is no longer on the projected interface. When consuming a Windows Runtime type, a
-            // managed object implementing the interface cannot supply the removed member (it is not on
-            // the projected interface), so its CCW entry returns E_NOTIMPL. In component (authoring) mode
-            // the dispatch target is the authored implementation (the authored class for instance
-            // members, or the generated activation/static factory that forwards to it), which still
-            // defines the member, so the entry keeps dispatching to that implementation to preserve
-            // binary compatibility for existing native callers.
-            if (!context.Settings.Component && IsAbiMemberRemoved(method, eventMap, propertyMap))
+            if (removed)
             {
                 writer.WriteLine();
                 writer.WriteLine("""

--- a/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiInterfaceFactory.cs
@@ -371,6 +371,23 @@ internal static class AbiInterfaceFactory
         // this order: methods first, then properties (setter before getter), then events.
         HashSet<MethodDefinition> propertyAccessors = [.. type.GetPropertyAccessors()];
 
+        // Map each property accessor (getter/setter) to its property, so a removed property (whose
+        // removal marker is on the getter per the MIDL convention) can stub both accessor bodies.
+        Dictionary<MethodDefinition, PropertyDefinition> propertyMap = [];
+
+        foreach (PropertyDefinition prop in type.Properties)
+        {
+            if (prop.GetMethod is { } propertyGetter)
+            {
+                propertyMap[propertyGetter] = prop;
+            }
+
+            if (prop.SetMethod is { } propertySetter)
+            {
+                propertyMap[propertySetter] = prop;
+            }
+        }
+
         // Local helper to emit a single Do_Abi method body for a given MethodDefinition.
         void EmitOneDoAbi(MethodDefinition method)
         {
@@ -390,6 +407,20 @@ internal static class AbiInterfaceFactory
                 [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
                 private static unsafe int Do_Abi_{{vm}}({{doAbiParams}})
                 """);
+
+            // A removed member (DeprecationType.Remove) keeps its vtable slot for ABI compatibility,
+            // but is no longer on the projected interface, so its CCW entry returns E_NOTIMPL.
+            if (IsAbiMemberRemoved(method, eventMap, propertyMap))
+            {
+                writer.WriteLine();
+                writer.WriteLine("""
+                    {
+                        return unchecked((int)0x80004001);
+                    }
+                    """);
+
+                return;
+            }
 
             if (eventMap is not null && eventMap.TryGetValue(method, out EventDefinition? evt2))
             {
@@ -451,6 +482,27 @@ internal static class AbiInterfaceFactory
                 EmitOneDoAbi(r);
             }
         }
+    }
+
+    /// <summary>
+    /// Determines whether the CCW entry for <paramref name="method"/> must be stubbed because the
+    /// member is removed (<c>DeprecationType.Remove</c>). The removal marker lives on the property
+    /// getter / event add accessor (MIDL convention), so both accessors of a removed property or
+    /// event are reported as removed.
+    /// </summary>
+    private static bool IsAbiMemberRemoved(MethodDefinition method, Dictionary<MethodDefinition, EventDefinition>? eventMap, Dictionary<MethodDefinition, PropertyDefinition> propertyMap)
+    {
+        if (eventMap is not null && eventMap.TryGetValue(method, out EventDefinition? evt))
+        {
+            return evt.AddMethod is { IsRemoved: true };
+        }
+
+        if (propertyMap.TryGetValue(method, out PropertyDefinition? prop))
+        {
+            return (prop.GetMethod ?? prop.SetMethod) is { IsRemoved: true };
+        }
+
+        return method.IsRemoved;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Factories/AbiInterfaceIDicFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiInterfaceIDicFactory.cs
@@ -246,6 +246,12 @@ internal static class AbiInterfaceIDicFactory
 
         foreach (MethodDefinition method in type.GetNonSpecialMethods())
         {
+            // Removed members are omitted from the projected interface, so emit no DIM forwarder
+            if (method.IsRemoved)
+            {
+                continue;
+            }
+
             MethodSignatureInfo sig = new(method);
             string mname = method.GetRawName();
 
@@ -259,6 +265,13 @@ internal static class AbiInterfaceIDicFactory
         foreach (PropertyDefinition prop in type.Properties)
         {
             (MethodDefinition? getter, MethodDefinition? setter) = prop.GetMethods();
+
+            // MIDL places '[Deprecated]' on the accessor (the getter for read/write properties)
+            if ((getter ?? setter) is { IsRemoved: true })
+            {
+                continue;
+            }
+
             string pname = prop.GetRawName();
             string propType = InterfaceFactory.WritePropType(context, prop);
 
@@ -290,6 +303,11 @@ internal static class AbiInterfaceIDicFactory
 
         foreach (EventDefinition evt in type.Events)
         {
+            if (evt.AddMethod is { IsRemoved: true })
+            {
+                continue;
+            }
+
             string evtName = evt.GetRawName();
             writer.WriteLine();
             IndentedTextWriterCallback eventType = TypedefNameWriter.WriteEventType(context, evt);
@@ -367,6 +385,12 @@ internal static class AbiInterfaceIDicFactory
 
         foreach (MethodDefinition method in type.GetNonSpecialMethods())
         {
+            // Removed members are omitted from the projected interface, so emit no DIM forwarder
+            if (method.IsRemoved)
+            {
+                continue;
+            }
+
             MethodSignatureInfo sig = new(method);
             string mname = method.GetRawName();
             IndentedTextWriterCallback ret = MethodFactory.WriteProjectionReturnType(context, sig);
@@ -388,6 +412,13 @@ internal static class AbiInterfaceIDicFactory
         foreach (PropertyDefinition prop in type.Properties)
         {
             (MethodDefinition? getter, MethodDefinition? setter) = prop.GetMethods();
+
+            // MIDL places '[Deprecated]' on the accessor (the getter for read/write properties)
+            if ((getter ?? setter) is { IsRemoved: true })
+            {
+                continue;
+            }
+
             string pname = prop.GetRawName();
             string propType = InterfaceFactory.WritePropType(context, prop);
 
@@ -446,6 +477,11 @@ internal static class AbiInterfaceIDicFactory
         // dispatch through the static ABI Methods class's event accessor (returns an EventSource).
         foreach (EventDefinition evt in type.Events)
         {
+            if (evt.AddMethod is { IsRemoved: true })
+            {
+                continue;
+            }
+
             string evtName = evt.GetRawName();
             writer.WriteLine();
             IndentedTextWriterCallback eventType = TypedefNameWriter.WriteEventType(context, evt);

--- a/src/WinRT.Projection.Writer/Factories/ClassFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ClassFactory.cs
@@ -636,23 +636,11 @@ internal static class ClassFactory
             //
             // Sealed classes can never be a base, so they only need case 1; unsealed classes need a
             // parameterless ctor whenever they don't already emit one (which also covers case 1).
+            // Both checks live in 'ConstructorFactory' so they stay in sync with what it actually emits
+            // (in particular, they must agree on which factories and overloads are skipped as removed).
             if (type.IsSealed)
             {
-                bool hasRefModeCtors = false;
-                foreach (KeyValuePair<string, AttributedType> kv in AttributedTypes.Get(type, context.Cache))
-                {
-                    AttributedType factory = kv.Value;
-
-                    // Activatable always emits at least one ctor; a composable factory only emits ctors
-                    // when it has methods (a composable factory with no methods emits none).
-                    if (factory.Activatable || (factory.Composable && factory.Type is not null && factory.Type.Methods.Count > 0))
-                    {
-                        hasRefModeCtors = true;
-                        break;
-                    }
-                }
-
-                if (!hasRefModeCtors)
+                if (!ConstructorFactory.EmitsAnyConstructor(type, context.Cache))
                 {
                     RefModeStubFactory.EmitSyntheticPrivateCtor(writer, typeName, isSealed: true);
                 }

--- a/src/WinRT.Projection.Writer/Factories/ClassFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ClassFactory.cs
@@ -265,6 +265,13 @@ internal static class ClassFactory
 
             TypeDefinition staticIface = factory.Type;
 
+            // Skip static members from a removed static factory interface: the interface is omitted
+            // from the projection and ABI, so its IID / ABI Methods class would not exist to dispatch to.
+            if (staticIface.IsRemoved)
+            {
+                continue;
+            }
+
             // Compute the objref name for this static factory interface.
             string objRef = ObjRefNameGenerator.GetObjRefName(context, staticIface);
 
@@ -284,9 +291,17 @@ internal static class ClassFactory
             // Methods
             foreach (MethodDefinition method in staticIface.GetNonSpecialMethods())
             {
+                // Skip removed static methods (omitted from the projection)
+                if (method.IsRemoved)
+                {
+                    continue;
+                }
+
                 MethodSignatureInfo sig = new(method);
                 string mname = method.GetRawName();
                 writer.WriteLine();
+
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
 
                 writer.WriteIf(!string.IsNullOrEmpty(platformAttribute), platformAttribute);
 
@@ -309,8 +324,19 @@ internal static class ClassFactory
             // Events: dispatch via static ABI class which returns an event source.
             foreach (EventDefinition evt in staticIface.Events)
             {
+                // MIDL places '[Deprecated]' on the event 'add' accessor, not on the Event row.
+                if (evt.AddMethod is { IsRemoved: true })
+                {
+                    continue;
+                }
+
                 string evtName = evt.GetRawName();
                 writer.WriteLine();
+
+                if (evt.AddMethod is { } addMethod)
+                {
+                    CustomAttributeFactory.WriteObsoleteAttribute(writer, addMethod);
+                }
 
                 writer.WriteIf(!string.IsNullOrEmpty(platformAttribute), platformAttribute);
 
@@ -343,6 +369,16 @@ internal static class ClassFactory
             {
                 string propName = prop.GetRawName();
                 (MethodDefinition? getter, MethodDefinition? setter) = prop.GetMethods();
+
+                // MIDL places '[Deprecated]' on the accessor (the getter for read/write properties),
+                // not on the Property row, so removal/deprecation is checked on the accessor.
+                MethodDefinition? accessor = getter ?? setter;
+
+                if (accessor is { IsRemoved: true })
+                {
+                    continue;
+                }
+
                 string propType = InterfaceFactory.WritePropType(context, prop);
 
                 if (!properties.TryGetValue(propName, out StaticPropertyAccessorState? state))
@@ -350,8 +386,13 @@ internal static class ClassFactory
                     state = new StaticPropertyAccessorState
                     {
                         PropTypeText = propType,
+                        DeprecationAccessor = accessor,
                     };
                     properties[propName] = state;
+                }
+                else
+                {
+                    state.DeprecationAccessor ??= accessor;
                 }
 
                 if (getter is not null && !state.HasGetter)
@@ -377,6 +418,11 @@ internal static class ClassFactory
         {
             StaticPropertyAccessorState s = kv.Value;
             writer.WriteLine();
+
+            if (s.DeprecationAccessor is { } deprecationAccessor)
+            {
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, deprecationAccessor);
+            }
 
             // when getter and setter platforms match; otherwise emit per-accessor.
             string getterPlat = s.GetterPlatformAttribute;

--- a/src/WinRT.Projection.Writer/Factories/ClassMembersFactory.WriteClassMembers.cs
+++ b/src/WinRT.Projection.Writer/Factories/ClassMembersFactory.WriteClassMembers.cs
@@ -86,6 +86,11 @@ internal static partial class ClassMembersFactory
                 setterPlat = string.Empty;
             }
 
+            if (s.DeprecationAccessor is { } deprecationAccessor)
+            {
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, deprecationAccessor);
+            }
+
             writer.WriteIf(!string.IsNullOrEmpty(propertyPlat), propertyPlat);
 
             writer.Write($"{s.Access}{s.MethodSpec}{s.PropTypeText} {kvp.Key}");

--- a/src/WinRT.Projection.Writer/Factories/ClassMembersFactory.WriteInterfaceMembers.cs
+++ b/src/WinRT.Projection.Writer/Factories/ClassMembersFactory.WriteInterfaceMembers.cs
@@ -267,6 +267,13 @@ internal static partial class ClassMembersFactory
                 continue;
             }
 
+            // Skip members removed via '[Deprecated(..., DeprecationType.Remove, ...)]': the ABI
+            // vtable slot is preserved separately, but they are omitted from the projected class.
+            if (method.IsRemoved)
+            {
+                continue;
+            }
+
             // Detect a 'string ToString()' that overrides Object.ToString() and force the
             // 'override' modifier on the emitted member.
             string methodSpecForThis = methodSpec;
@@ -331,6 +338,8 @@ internal static partial class ClassMembersFactory
                         parameterList: $"WindowsRuntimeObjectReference thisReference{accessorParams}");
                 }
 
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
+
                 writer.WriteLine(isMultiline: true, $$"""
                     {{platformTrimmed}}
                     {{access}}{{methodSpecForThis}}{{ret}} {{name}}({{parms}}) => {{body}}
@@ -339,6 +348,8 @@ internal static partial class ClassMembersFactory
             else
             {
                 writer.WriteLine();
+
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
 
                 writer.WriteIf(!string.IsNullOrEmpty(platformAttribute), platformAttribute);
 
@@ -381,6 +392,15 @@ internal static partial class ClassMembersFactory
             string name = prop.GetRawName();
             (MethodDefinition? getter, MethodDefinition? setter) = prop.GetMethods();
 
+            // MIDL places '[Deprecated]' on the property accessor (the getter for read/write
+            // properties), not on the Property row, so removal/deprecation is checked on the accessor.
+            MethodDefinition? accessor = getter ?? setter;
+
+            if (accessor is { IsRemoved: true })
+            {
+                continue;
+            }
+
             if (!propertyState.TryGetValue(name, out PropertyAccessorState? state))
             {
                 state = new PropertyAccessorState
@@ -390,8 +410,13 @@ internal static partial class ClassMembersFactory
                     MethodSpec = methodSpec,
                     IsOverridable = isOverridable,
                     OverridableInterface = isOverridable ? originalInterface : null,
+                    DeprecationAccessor = accessor,
                 };
                 propertyState[name] = state;
+            }
+            else
+            {
+                state.DeprecationAccessor ??= accessor;
             }
 
             if (getter is not null && !state.HasGetter)
@@ -427,6 +452,13 @@ internal static partial class ClassMembersFactory
             string name = evt.GetRawName();
 
             if (!writtenEvents.Add(name))
+            {
+                continue;
+            }
+
+            // MIDL places '[Deprecated]' on the event 'add' accessor, not on the Event row.
+            // Skip events removed via 'DeprecationType.Remove' (the ABI slot is preserved separately).
+            if (evt.AddMethod is { IsRemoved: true })
             {
                 continue;
             }
@@ -542,6 +574,12 @@ internal static partial class ClassMembersFactory
 
             // Emit the public/protected event with Subscribe/Unsubscribe.
             writer.WriteLine();
+
+            // MIDL places '[Deprecated]' on the event 'add' accessor, not on the Event row.
+            if (evt.AddMethod is { } addMethod)
+            {
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, addMethod);
+            }
 
             // string to each event emission. In ref mode this produces e.g.
             // [global::System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.16299.0")].

--- a/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
@@ -172,7 +172,11 @@ internal static class ComponentFactory
             {
                 foreach (MethodDefinition method in info.Type.Methods)
                 {
-                    if (method.IsConstructor)
+                    // Removed members (DeprecationType.Remove) are omitted from the factory class: the
+                    // projected factory/static interface drops them, their vtable slot is stubbed to
+                    // E_NOTIMPL, and generated code cannot call the authored member anyway (the C#
+                    // compiler treats a call to a '[Deprecated(Remove)]' member as an error).
+                    if (method.IsConstructor || method.IsRemoved)
                     {
                         continue;
                     }
@@ -184,7 +188,7 @@ internal static class ComponentFactory
             {
                 foreach (MethodDefinition method in info.Type.Methods)
                 {
-                    if (method.IsConstructor)
+                    if (method.IsConstructor || method.IsRemoved)
                     {
                         continue;
                     }
@@ -193,10 +197,20 @@ internal static class ComponentFactory
                 }
                 foreach (PropertyDefinition prop in info.Type.Properties)
                 {
+                    if ((prop.GetMethod ?? prop.SetMethod) is { IsRemoved: true })
+                    {
+                        continue;
+                    }
+
                     WriteStaticFactoryProperty(writer, context, prop, projectedTypeName);
                 }
                 foreach (EventDefinition evt in info.Type.Events)
                 {
+                    if (evt.AddMethod is { IsRemoved: true })
+                    {
+                        continue;
+                    }
+
                     WriteStaticFactoryEvent(writer, context, evt, projectedTypeName);
                 }
             }

--- a/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
@@ -86,7 +86,10 @@ internal static class ComponentFactory
         // Writes the body of the 'ActivateInstance' method (it throws for non-activatable types)
         void WriteActivateInstanceBody(IndentedTextWriter writer)
         {
-            bool isActivatable = !type.IsStatic && type.HasDefaultConstructor();
+            // A type whose default constructor is removed ([Deprecated(DeprecationType.Remove)]) is no longer
+            // default-activatable: 'new T()' cannot be emitted (it would call the removed authored member),
+            // so default activation falls through to the 'throw' below, which marshals to E_NOTIMPL.
+            bool isActivatable = !type.IsStatic && type.HasActivatableDefaultConstructor();
 
             if (isActivatable)
             {

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.AttributedTypes.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.AttributedTypes.cs
@@ -64,6 +64,13 @@ internal static partial class ConstructorFactory
         {
             AttributedType factory = kv.Value;
 
+            // Skip constructors generated from a removed factory interface: the interface is omitted
+            // from the projection and ABI, so its IID / ABI Methods class would not exist to dispatch to.
+            if (factory.Type is { IsRemoved: true })
+            {
+                continue;
+            }
+
             if (factory.Activatable)
             {
                 WriteFactoryConstructors(writer, context, factory.Type, classType);
@@ -106,12 +113,23 @@ internal static partial class ConstructorFactory
                     continue;
                 }
 
+                // Skip removed constructor overloads; the factory vtable slot is preserved (methodIndex
+                // still advances) so the remaining constructors dispatch through the correct slot.
+                if (method.IsRemoved)
+                {
+                    methodIndex++;
+
+                    continue;
+                }
+
                 MethodSignatureInfo sig = new(method);
                 string callbackName = (method.Name?.Value ?? "Create") + "_" + sig.Parameters.Count.ToString(CultureInfo.InvariantCulture);
                 string argsName = callbackName + "Args";
 
                 // Emit the public constructor.
                 writer.WriteLine();
+
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
 
                 writer.WriteIf(!string.IsNullOrEmpty(platformAttribute), platformAttribute);
 

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.AttributedTypes.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.AttributedTypes.cs
@@ -226,6 +226,47 @@ internal static partial class ConstructorFactory
     }
 
     /// <summary>
+    /// Determines whether <see cref="WriteAttributedTypes"/> emits at least one public constructor for
+    /// the given runtime class.
+    /// </summary>
+    /// <remarks>
+    /// Used in reference-projection mode to decide whether a sealed class needs a synthetic non-public
+    /// parameterless constructor to suppress the C# compiler's implicit public default constructor
+    /// (see <see cref="RefModeStubFactory.EmitSyntheticPrivateCtor"/>). Emitting it matters for more than
+    /// tidiness: the implementation projection never emits an implicit public default constructor, so
+    /// leaving one on the reference surface would let consumers compile a <c>new T()</c> call that fails
+    /// at runtime against the implementation projection.
+    /// </remarks>
+    public static bool EmitsAnyConstructor(TypeDefinition classType, MetadataCache cache)
+    {
+        foreach (KeyValuePair<string, AttributedType> kv in AttributedTypes.Get(classType, cache))
+        {
+            AttributedType factory = kv.Value;
+
+            // A removed factory interface is skipped entirely by 'WriteAttributedTypes', so it emits nothing
+            if (factory.Type is { IsRemoved: true })
+            {
+                continue;
+            }
+
+            // A default '[Activatable(uint version)]' (no factory interface) always emits 'public TypeName()'
+            if (factory.Activatable && factory.Type is null)
+            {
+                return true;
+            }
+
+            // Both activation and composable factories emit one constructor per factory method, so a factory
+            // whose methods are all special or removed (or which has none at all) emits no constructors.
+            if ((factory.Activatable || factory.Composable) && factory.Type is { } factoryType && factoryType.HasActivatableFactoryMethod())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Determines whether <see cref="WriteAttributedTypes"/> emits at least one parameterless public
     /// constructor for the given runtime class (a default <c>[Activatable]</c> ctor, an activation-factory
     /// method with no parameters, or a composable-factory method with no user parameters).
@@ -240,6 +281,12 @@ internal static partial class ConstructorFactory
         foreach (KeyValuePair<string, AttributedType> kv in AttributedTypes.Get(classType, cache))
         {
             AttributedType factory = kv.Value;
+
+            // A removed factory interface is skipped entirely by 'WriteAttributedTypes', so it emits nothing
+            if (factory.Type is { IsRemoved: true })
+            {
+                continue;
+            }
 
             // A default '[Activatable(uint version)]' (no factory interface) emits 'public TypeName()'.
             if (factory.Activatable && factory.Type is null)
@@ -259,7 +306,8 @@ internal static partial class ConstructorFactory
             {
                 foreach (MethodDefinition method in factory.Type.Methods)
                 {
-                    if (method.IsSpecial)
+                    // Special methods and removed overloads emit no constructor
+                    if (method.IsSpecial || method.IsRemoved)
                     {
                         continue;
                     }

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.Composable.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.Composable.cs
@@ -56,6 +56,15 @@ internal static partial class ConstructorFactory
                 continue;
             }
 
+            // Skip removed composable constructor overloads; the factory vtable slot is preserved
+            // (methodIndex still advances) so the remaining constructors dispatch through the correct slot.
+            if (method.IsRemoved)
+            {
+                methodIndex++;
+
+                continue;
+            }
+
             // Composable factory methods have signature like:
             //   T CreateInstance(args, object baseInterface, out object innerInterface)
             // For the constructor on the projected class, we exclude the trailing two params.
@@ -71,6 +80,8 @@ internal static partial class ConstructorFactory
             bool isParameterless = userParamCount == 0;
 
             writer.WriteLine();
+
+            CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
 
             writer.WriteIf(!string.IsNullOrEmpty(platformAttribute), platformAttribute);
 

--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -485,6 +485,31 @@ internal static class CustomAttributeFactory
     }
 
     /// <summary>
+    /// Writes a <c>[System.Obsolete]</c> attribute when <paramref name="member"/> is deprecated but
+    /// not removed. Removed members are omitted from the projection entirely, so they get no attribute.
+    /// </summary>
+    /// <param name="writer">The writer to emit to.</param>
+    /// <param name="member">The member to inspect for <c>[Windows.Foundation.Metadata.Deprecated]</c>.</param>
+    public static void WriteObsoleteAttribute(IndentedTextWriter writer, IHasCustomAttribute member)
+    {
+        if (!member.IsDeprecatedNotRemoved)
+        {
+            return;
+        }
+
+        string? message = member.DeprecatedMessage;
+
+        if (string.IsNullOrEmpty(message))
+        {
+            writer.WriteLine("[global::System.Obsolete]");
+        }
+        else
+        {
+            writer.WriteLine($"[global::System.Obsolete(@\"{EscapeVerbatimString(message)}\")]");
+        }
+    }
+
+    /// <summary>
     /// Returns whether a Windows Runtime metadata attribute application should be carried over to the projection.
     /// </summary>
     /// <param name="context">The active emit context.</param>
@@ -542,6 +567,7 @@ internal static class CustomAttributeFactory
     public static void WriteTypeCustomAttributes(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type, bool enablePlatformAttrib)
     {
         WriteCustomAttributes(writer, context, type, enablePlatformAttrib);
+        WriteObsoleteAttribute(writer, type);
     }
 
     /// <inheritdoc cref="WriteTypeCustomAttributes(IndentedTextWriter, ProjectionEmitContext, TypeDefinition, bool)"/>
@@ -562,6 +588,7 @@ internal static class CustomAttributeFactory
         int before = writer.Length;
 
         WriteCustomAttributes(writer, context, type, enablePlatformAttrib);
+        WriteObsoleteAttribute(writer, type);
 
         // If anything was written, the buffer ends with a trailing newline that came from the
         // last attribute's WriteLine. Trim it so the callback can be inlined into a multiline

--- a/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
@@ -218,11 +218,19 @@ internal static class InterfaceFactory
     {
         foreach (MethodDefinition method in type.GetNonSpecialMethods())
         {
+            // Skip members removed via '[Deprecated(..., DeprecationType.Remove, ...)]': their ABI
+            // vtable slot is preserved separately, but they are omitted from the projected interface.
+            if (method.IsRemoved)
+            {
+                continue;
+            }
+
             MethodSignatureInfo sig = new(method);
 
             // Carried-over metadata attributes ([Overload], [DefaultOverload], [Experimental]) are
             // reference-projection-only.
             WriteMethodCustomAttributes(writer, context, method);
+            CustomAttributeFactory.WriteObsoleteAttribute(writer, method);
             IndentedTextWriterCallback ret = MethodFactory.WriteProjectionReturnType(context, sig);
             IndentedTextWriterCallback parms = MethodFactory.WriteParameterList(context, sig);
             writer.WriteLine($"{ret} {method.GetRawName()}({parms});");
@@ -232,6 +240,15 @@ internal static class InterfaceFactory
         {
             (MethodDefinition? getter, MethodDefinition? setter) = prop.GetMethods();
 
+            // MIDL places '[Deprecated]' on the property accessor (the getter for read/write
+            // properties), not on the Property row, so deprecation is checked on the accessor.
+            MethodDefinition? accessor = getter ?? setter;
+
+            if (accessor is { IsRemoved: true })
+            {
+                continue;
+            }
+
             // Add 'new' when this interface has a setter-only property AND a property of the same
             // name exists on a base interface (typically the getter-only counterpart). This hides
             // the inherited member.
@@ -239,6 +256,12 @@ internal static class InterfaceFactory
                 && TryFindPropertyInBaseInterfaces(context.Cache, type, prop.GetRawName(), out _))
                 ? "new " : string.Empty;
             string propType = WritePropType(context, prop);
+
+            if (accessor is not null)
+            {
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, accessor);
+            }
+
             writer.Write($"{newKeyword}{propType} {prop.GetRawName()} {{");
 
             writer.WriteIf(getter is not null || setter is not null, " get;");
@@ -250,6 +273,19 @@ internal static class InterfaceFactory
 
         foreach (EventDefinition evt in type.Events)
         {
+            // MIDL places '[Deprecated]' on the event 'add' accessor, not on the Event row.
+            MethodDefinition? addMethod = evt.AddMethod;
+
+            if (addMethod is { IsRemoved: true })
+            {
+                continue;
+            }
+
+            if (addMethod is not null)
+            {
+                CustomAttributeFactory.WriteObsoleteAttribute(writer, addMethod);
+            }
+
             IndentedTextWriterCallback eventType = TypedefNameWriter.WriteEventType(context, evt);
             writer.WriteLine($"event {eventType} {evt.Name?.Value};");
         }

--- a/src/WinRT.Projection.Writer/Factories/MetadataAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/MetadataAttributeFactory.cs
@@ -605,6 +605,7 @@ internal static class MetadataAttributeFactory
             using WindowsRuntime;
 
             #pragma warning disable CSWINRT3001
+            #pragma warning disable CS0612, CS0618
 
             namespace ABI;
 
@@ -653,6 +654,7 @@ internal static class MetadataAttributeFactory
             using WindowsRuntime;
 
             #pragma warning disable CSWINRT3001
+            #pragma warning disable CS0612, CS0618
 
             namespace ABI;
 

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.GeneratedIids.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.GeneratedIids.cs
@@ -84,6 +84,12 @@ internal sealed partial class ProjectionGenerator
                     continue;
                 }
 
+                // Skip fully removed types (omitted from both the projection and the ABI)
+                if (type.IsRemoved)
+                {
+                    continue;
+                }
+
                 if (type.IsGeneric)
                 {
                     continue;

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
@@ -48,6 +48,12 @@ internal sealed partial class ProjectionGenerator
                     continue;
                 }
 
+                // Skip fully removed types (omitted from both the projection and the ABI)
+                if (type.IsRemoved)
+                {
+                    continue;
+                }
+
                 if (type.IsGeneric)
                 {
                     continue;
@@ -116,6 +122,12 @@ internal sealed partial class ProjectionGenerator
                 continue;
             }
 
+            // Skip fully removed types (omitted from both the projection and the ABI)
+            if (type.IsRemoved)
+            {
+                continue;
+            }
+
             (string ns2, string nm2) = type.Names();
 
             // Skip generic types and mapped types
@@ -176,6 +188,12 @@ internal sealed partial class ProjectionGenerator
                     continue;
                 }
 
+                // Skip fully removed types (omitted from both the projection and the ABI)
+                if (type.IsRemoved)
+                {
+                    continue;
+                }
+
                 if (TypeKindResolver.Resolve(type) != TypeKind.Class)
                 {
                     continue;
@@ -200,6 +218,12 @@ internal sealed partial class ProjectionGenerator
                 bool isFactoryInterface = factoryInterfacesInThisNs.Contains(type);
 
                 if (!_settings.Filter.Includes(type.FullName) && !isFactoryInterface)
+                {
+                    continue;
+                }
+
+                // Skip fully removed types (omitted from both the projection and the ABI)
+                if (type.IsRemoved)
                 {
                     continue;
                 }

--- a/src/WinRT.Projection.Writer/Models/PropertyAccessorState.cs
+++ b/src/WinRT.Projection.Writer/Models/PropertyAccessorState.cs
@@ -29,6 +29,13 @@ internal sealed class PropertyAccessorState
     public bool HasSetter { get; set; }
 
     /// <summary>
+    /// Gets or sets the accessor method used to determine whether the property is deprecated (the
+    /// getter when present, otherwise the setter). MIDL places <c>[Deprecated]</c> on the accessor,
+    /// not on the Property row, so the projected property's <c>[Obsolete]</c> is derived from it.
+    /// </summary>
+    public MethodDefinition? DeprecationAccessor { get; set; }
+
+    /// <summary>
     /// Gets or sets the projected C# type text of the property (for the unified getter+setter declaration).
     /// </summary>
     public string PropTypeText { get; set; } = string.Empty;

--- a/src/WinRT.Projection.Writer/Models/StaticPropertyAccessorState.cs
+++ b/src/WinRT.Projection.Writer/Models/StaticPropertyAccessorState.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AsmResolver.DotNet;
+
 namespace WindowsRuntime.ProjectionWriter.Models;
 
 /// <summary>
@@ -18,6 +20,13 @@ internal sealed class StaticPropertyAccessorState
     /// Gets or sets whether a static setter accessor has been seen for this property.
     /// </summary>
     public bool HasSetter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the accessor method used to determine whether the static property is deprecated
+    /// (the getter when present, otherwise the setter). MIDL places <c>[Deprecated]</c> on the
+    /// accessor, not on the Property row.
+    /// </summary>
+    public MethodDefinition? DeprecationAccessor { get; set; }
 
     /// <summary>
     /// Gets or sets the projected C# type text of the property (for the unified getter+setter declaration).

--- a/src/WinRT.Projection.Writer/Resources/Base/ComInteropExtensions.cs
+++ b/src/WinRT.Projection.Writer/Resources/Base/ComInteropExtensions.cs
@@ -25,6 +25,11 @@
 // minimum Windows SDK that is currently supported. See this mapping
 // in the Windows SDK projection project. The two should be kept in sync.
 
+// Some of the types wrapped below are deprecated in the Windows SDK, so they are projected with
+// '[Obsolete]'. That is guidance for consumers of these extensions, not for the extensions
+// themselves, which have to name those types to wrap them.
+#pragma warning disable CS0612, CS0618
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
@@ -331,24 +331,80 @@ internal sealed partial class WinMDWriter
     /// </summary>
     /// <param name="source">The source element to copy attributes from.</param>
     /// <param name="target">The target element to copy attributes to.</param>
-    private void CopyCustomAttributes(IHasCustomAttribute source, IHasCustomAttribute target)
+    /// <param name="skipDeprecated">
+    /// Whether to skip the <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute. This is set when
+    /// copying to a property or event row, because the deprecation attribute is emitted on the accessor
+    /// method instead (see <see cref="CopyDeprecatedAttributeToAccessor"/>).
+    /// </param>
+    private void CopyCustomAttributes(IHasCustomAttribute source, IHasCustomAttribute target, bool skipDeprecated = false)
     {
         foreach (CustomAttribute attribute in source.CustomAttributes)
         {
-            if (!ShouldCopyAttribute(attribute, _runtimeContext))
+            // The '[Deprecated]' attribute on properties and events is emitted on the accessor method
+            // (matching MIDL), so it is skipped here when copying attributes to the property or event row
+            if (skipDeprecated && IsDeprecatedAttribute(attribute))
             {
                 continue;
             }
 
-            if (ImportAttributeConstructor(attribute.Constructor) is not MemberReference importedCtor)
-            {
-                continue;
-            }
-
-            CustomAttributeSignature clonedSignature = CloneAttributeSignature(attribute.Signature);
-
-            target.CustomAttributes.Add(new CustomAttribute(importedCtor, clonedSignature));
+            CopyCustomAttribute(attribute, target);
         }
+    }
+
+    /// <summary>
+    /// Copies a single custom attribute from a source element to a target element, applying the same
+    /// filtering and import logic as <see cref="CopyCustomAttributes"/>.
+    /// </summary>
+    /// <param name="attribute">The custom attribute to copy.</param>
+    /// <param name="target">The target element to copy the attribute to.</param>
+    private void CopyCustomAttribute(CustomAttribute attribute, IHasCustomAttribute target)
+    {
+        if (!ShouldCopyAttribute(attribute, _runtimeContext))
+        {
+            return;
+        }
+
+        if (ImportAttributeConstructor(attribute.Constructor) is not MemberReference importedCtor)
+        {
+            return;
+        }
+
+        CustomAttributeSignature clonedSignature = CloneAttributeSignature(attribute.Signature);
+
+        target.CustomAttributes.Add(new CustomAttribute(importedCtor, clonedSignature));
+    }
+
+    /// <summary>
+    /// Copies the <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute (if any) from a property or
+    /// event onto its accessor method (the getter for properties, the <c>add</c> accessor for events).
+    /// </summary>
+    /// <remarks>
+    /// Windows Runtime metadata places the deprecation attribute on the accessor method rather than the
+    /// property or event row (this is the placement MIDL produces). Emitting it on the accessor keeps
+    /// authored components consistent with the Windows SDK, so that both CsWinRT and other consumers
+    /// (e.g. <c>windows-rs</c>) resolve member deprecation the same way.
+    /// </remarks>
+    /// <param name="source">The source property or event to read the attribute from.</param>
+    /// <param name="accessor">The accessor method (or fallback element) to copy the attribute to.</param>
+    private void CopyDeprecatedAttributeToAccessor(IHasCustomAttribute source, IHasCustomAttribute accessor)
+    {
+        foreach (CustomAttribute attribute in source.CustomAttributes)
+        {
+            if (IsDeprecatedAttribute(attribute))
+            {
+                CopyCustomAttribute(attribute, accessor);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns whether the given custom attribute is a <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute.
+    /// </summary>
+    /// <param name="attribute">The custom attribute to evaluate.</param>
+    /// <returns><see langword="true"/> if the attribute is the deprecation attribute; otherwise, <see langword="false"/>.</returns>
+    private static bool IsDeprecatedAttribute(CustomAttribute attribute)
+    {
+        return attribute.Constructor?.DeclaringType?.FullName == "Windows.Foundation.Metadata.DeprecatedAttribute";
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -274,6 +274,9 @@ internal sealed partial class WinMDWriter
             attributes: PropertyAttributes.None,
             signature: isStatic ? PropertySignature.CreateStatic(propertyType) : PropertySignature.CreateInstance(propertyType));
 
+        MethodDefinition? getter = null;
+        MethodDefinition? setter = null;
+
         // Add getter
         if (inputProperty.GetMethod is not null)
         {
@@ -295,7 +298,7 @@ internal sealed partial class WinMDWriter
                 ? MethodSignature.CreateStatic(propertyType)
                 : MethodSignature.CreateInstance(propertyType);
 
-            MethodDefinition getter = new("get_" + inputProperty.Name.Value, attributes, getSignature);
+            getter = new("get_" + inputProperty.Name.Value, attributes, getSignature);
             if (!isInterfaceParent)
             {
                 getter.ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
@@ -325,7 +328,7 @@ internal sealed partial class WinMDWriter
                 ? MethodSignature.CreateStatic(_outputModule.CorLibTypeFactory.Void, [propertyType])
                 : MethodSignature.CreateInstance(_outputModule.CorLibTypeFactory.Void, [propertyType]);
 
-            MethodDefinition setter = new("put_" + inputProperty.Name.Value, attributes, setSignature);
+            setter = new("put_" + inputProperty.Name.Value, attributes, setSignature);
             if (!isInterfaceParent)
             {
                 setter.ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
@@ -340,8 +343,11 @@ internal sealed partial class WinMDWriter
 
         outputType.Properties.Add(outputProperty);
 
-        // Copy custom attributes from the input property
-        CopyCustomAttributes(inputProperty, outputProperty);
+        // Copy custom attributes from the input property. The '[Deprecated]' attribute is emitted on the
+        // accessor (the getter, or the setter for write-only properties) rather than the property row,
+        // matching the placement used by MIDL so that property deprecation resolves consistently
+        CopyCustomAttributes(inputProperty, outputProperty, skipDeprecated: true);
+        CopyDeprecatedAttributeToAccessor(inputProperty, getter ?? setter ?? (IHasCustomAttribute)outputProperty);
     }
 
     /// <summary>
@@ -369,7 +375,10 @@ internal sealed partial class WinMDWriter
 
         outputType.Properties.Add(outputProperty);
 
-        CopyCustomAttributes(inputProperty, outputProperty);
+        // Copy custom attributes from the input property. The '[Deprecated]' attribute is emitted on the
+        // setter accessor rather than the property row, matching the placement used by MIDL
+        CopyCustomAttributes(inputProperty, outputProperty, skipDeprecated: true);
+        CopyDeprecatedAttributeToAccessor(inputProperty, setter);
     }
 
     /// <summary>
@@ -403,6 +412,8 @@ internal sealed partial class WinMDWriter
         // For interface parents (synthesized interfaces), always use instance signatures
         bool isStatic = !isInterfaceParent && inputEvent.AddMethod?.IsStatic == true;
 
+        MethodDefinition adder;
+
         // Add method
         {
             MethodAttributes attributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName;
@@ -426,7 +437,7 @@ internal sealed partial class WinMDWriter
                 ? MethodSignature.CreateStatic(tokenSignature, [handlerSignature])
                 : MethodSignature.CreateInstance(tokenSignature, [handlerSignature]);
 
-            MethodDefinition adder = new("add_" + inputEvent.Name.Value, attributes, addSignature);
+            adder = new("add_" + inputEvent.Name.Value, attributes, addSignature);
             if (!isInterfaceParent)
             {
                 adder.ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
@@ -472,7 +483,9 @@ internal sealed partial class WinMDWriter
 
         outputType.Events.Add(outputEvent);
 
-        // Copy custom attributes from the input event
-        CopyCustomAttributes(inputEvent, outputEvent);
+        // Copy custom attributes from the input event. The '[Deprecated]' attribute is emitted on the
+        // 'add' accessor rather than the event row, matching the placement used by MIDL
+        CopyCustomAttributes(inputEvent, outputEvent, skipDeprecated: true);
+        CopyDeprecatedAttributeToAccessor(inputEvent, adder);
     }
 }


### PR DESCRIPTION
## Summary

Port `[Windows.Foundation.Metadata.Deprecated]` handling to the CsWinRT 3.0 projection writer and WinMD generator. Deprecated Windows Runtime APIs are now projected with `[System.Obsolete]`, and APIs marked `DeprecationType.Remove` are omitted from the projected surface while their ABI vtable slot is preserved (stubbed to return `E_NOTIMPL`) for binary compatibility. The same attribute is supported when authoring Windows Runtime components.

## Motivation

Honoring `[Deprecated]` was supported in CsWinRT 2.x (in `cswinrt.exe`) but had not yet been ported to the 3.0 C# generators. Without it, deprecated Windows Runtime APIs are projected as regular members (no `[Obsolete]` guidance for consumers), and APIs the platform has removed would either reappear on the projected surface or shift the ABI vtable layout, breaking binary compatibility with existing native callers.

The attribute carries a `DeprecationType`: `Deprecate` (0) means the API still works but should be replaced, and `Remove` (1) means it is gone from the projected surface but its vtable slot must remain. `[Deprecated]` is not exclusive to the Windows SDK: authored components can apply it to their own members too, so support has to span both the consuming projection and the authoring pipeline.

## Changes

### Projection writer (consuming side)

- **`Extensions/IHasCustomAttributeExtensions.cs`**: adds `IsDeprecated`, `IsRemoved`, `IsDeprecatedNotRemoved`, and `DeprecatedMessage` helpers that read the `[Deprecated]` attribute arguments (message and `DeprecationType`).
- **`Factories/CustomAttributeFactory.cs`**: emits `[System.Obsolete(message)]` for members and types that are deprecated but not removed.
- **`Generation/ProjectionGenerator.Namespace.cs`** and **`Generation/ProjectionGenerator.GeneratedIids.cs`**: skip removed types entirely so they never appear in the projection.
- **`Factories/InterfaceFactory.cs`**, **`Factories/ClassMembersFactory.WriteInterfaceMembers.cs`**, **`Factories/ClassMembersFactory.WriteClassMembers.cs`**, **`Factories/ClassFactory.cs`**, **`Factories/ConstructorFactory.AttributedTypes.cs`**, **`Factories/ConstructorFactory.Composable.cs`**, **`Factories/AbiInterfaceIDicFactory.cs`**, and **`Builders/ProjectionFileBuilder.cs`** (enum fields): skip removed members (and removed factory/static interfaces) and annotate deprecated ones with `[Obsolete]`, following the MIDL convention that a property's marker lives on its getter and an event's on its `add` accessor.
- **`Models/PropertyAccessorState.cs`** and **`Models/StaticPropertyAccessorState.cs`**: track the accessor that carries the deprecation marker so the `[Obsolete]` attribute is emitted on the projected property.
- **`Factories/AbiInterfaceFactory.cs`** and **`Factories/ComponentFactory.cs`**: a removed member keeps its CCW vtable slot but the slot is stubbed to return `E_NOTIMPL` in both consuming and component (authoring) mode. Generated code cannot dispatch to a removed authored member, because the C# compiler treats a call to a `[Deprecated(Remove)]` member as an obsolete-as-error (`CS0619`) that cannot be suppressed; the activation/static factory likewise omits forwarders for removed members, and a type whose parameterless constructor is removed is treated as non-default-activatable (its `ActivateInstance` returns `E_NOTIMPL` instead of emitting `new T()`). The vtable slot is preserved so the layout stays stable for existing native callers.
- **`Factories/ConstructorFactory.AttributedTypes.cs`**, **`Factories/ClassFactory.cs`**, and **`Extensions/TypeDefinitionExtensions.cs`**: the two predicates that decide whether a reference projection needs a synthetic non-public parameterless constructor now agree with what `WriteAttributedTypes` actually emits, i.e. they skip removed factory interfaces and removed factory overloads. Without this, a class whose activation or composable factory was entirely removed emitted no constructor at all and the C# compiler synthesized an implicit public parameterless one in its place, putting a constructor on the reference surface that the implementation projection does not have (so a consumer's `new T()` would compile and then fail at run time). `ClassFactory`'s inline `hasRefModeCtors` loop is replaced by a new `ConstructorFactory.EmitsAnyConstructor` next to the existing `EmitsParameterlessConstructor`, and the per-factory-interface part is exposed as `HasActivatableFactoryMethod` alongside `HasActivatableDefaultConstructor`.
- **`Extensions/ProjectionWriterExtensions.cs`**, **`Factories/MetadataAttributeFactory.cs`**, and **`Resources/Base/ComInteropExtensions.cs`**: generated projection files suppress `CS0612`/`CS0618`, alongside the diagnostics they already suppress. `[Obsolete]` is guidance for consumers of a projection, not for the projection itself, which has to name a deprecated type in order to project it at all — without this the Windows SDK projection does not build, because `ComInteropExtensions.cs` wraps `IPlayToManagerInterop` in terms of the deprecated `Windows.Media.PlayTo.PlayToManager`. The suppressions are per-file, so user code calling a deprecated API still gets the warning.

### WinMD generator (authoring side)

- **`Writers/WinMDWriter.Members.cs`** and **`Writers/WinMDWriter.Attributes.cs`**: when generating a component `.winmd`, the `[Deprecated]` attribute for properties and events is emitted on the accessor (the getter for properties, the `add` accessor for events) rather than the property/event metadata row, matching the placement MIDL produces for the Windows SDK. This keeps authored components consistent with the SDK so both CsWinRT and other consumers (e.g. `windows-rs`) resolve member deprecation the same way. Methods and types continue to carry the attribute directly.

> Constructors are deliberately not covered here: `Windows.Foundation.Metadata.DeprecatedAttribute` has no `AttributeTargets.Constructor`, so a C# component author cannot apply it to a constructor in the first place.

### Tests

- **`Tests/AuthoringTest/Program.cs`**: extends `DeprecatedMembersClass` to cover `Deprecate` and `Remove` across instance methods, static methods, properties, and events. Building it exercises both the WinMD generator and the component projection.
- **`Tests/AuthoringConsumptionTest/test.cpp`**: exercises the deprecated and new members of each kind (method, property, event, static), and asserts that the removed instance, static, and event members throw `E_NOTIMPL`. The new members sit after the removed slots in vtable order and still dispatch correctly, proving the removed slots remain in place.
- **`Tests/TestComponentCSharp/`**: adds `DeprecatedConstructorClass` (a deprecated constructor, a removed one, and a live one declared after it), plus `RemovedActivationClass` (sealed/activatable) and `RemovedComposableClass` (unsealed/composable) whose only constructor is removed. Building `Projections/Test` generates a reference projection for them, and the unit test publish generates the implementation projection.
- **`Tests/UnitTest/TestComponentCSharp_Tests.cs`**: asserts both projections. The reference projection is checked at compile time via an overload pair whose `new()` constrained member is only a candidate when the type really exposes a public parameterless constructor, which is what catches a class that dropped every constructor without emitting a non-public one in its place. The implementation projection is checked at run time through reflection, and by constructing the types and calling their static factory methods (the surviving three-argument constructor sums its arguments, so it only produces the expected value if the removed constructor's factory slot is still in place).
