### PR TITLE
Remove stale C# 11 and modern .NET comments in ContextCallback

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
@@ -49,8 +49,7 @@ internal static unsafe class ContextCallback
         // We can just store a pointer to the callback to invoke in the context,
         // so we don't need to allocate another closure or anything. The callback
         // will be kept alive automatically, because 'comCallData' is address exposed.
-        // We only do this if we can use C# 11, and if we're on modern .NET, to be safe.
-        // In the callback below, we can then just retrieve the Action again to invoke it.
+        // In 'InvokeCallback' below, we then invoke the current caller-provided callback.
         comCallData.pUserDefined = &callbackData;
 
         // Stub to invoke on the target context


### PR DESCRIPTION
## Summary

Remove stale code comments in `ContextCallback` that referenced C# 11 and "modern .NET" version checks. These were leftovers from CsWinRT 2.x and no longer reflect how the 3.0 code works.

## Motivation

CsWinRT 2.x had to support multiple runtimes and language versions, so several comments were qualified with conditions like "only do this if we can use C# 11, and if we're on modern .NET". CsWinRT 3.0 targets .NET 10 and C# 14 unconditionally, so those qualifications are inaccurate and misleading. The original comment also described the callback being invoked by retrieving an `Action` "in the callback below", which no longer matches the current code (the callback is stored as a function pointer and invoked from the `InvokeCallback` local function).

## Changes

- **`src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs`**: replace the stale two-line comment about C# 11 / modern .NET with a single accurate line describing how the caller-provided callback is invoked from `InvokeCallback`.
