### PR TITLE
Project IReference of TypeName/HResult as Type/Exception

### DIFF
--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1935,6 +1935,29 @@ namespace winrt::TestComponentCSharp::implementation
         return value;
     }
 
+    IVector<IReference<Windows::UI::Xaml::Interop::TypeName>> Class::GetReferenceTypeNameList()
+    {
+        return single_threaded_vector<IReference<Windows::UI::Xaml::Interop::TypeName>>({
+            winrt::box_value(winrt::xaml_typename<winrt::TestComponentCSharp::Class>()).as<IReference<Windows::UI::Xaml::Interop::TypeName>>(),
+            winrt::box_value(winrt::xaml_typename<int32_t>()).as<IReference<Windows::UI::Xaml::Interop::TypeName>>() });
+    }
+
+    int32_t Class::CountReferenceTypeNameList(IVector<IReference<Windows::UI::Xaml::Interop::TypeName>> const& value)
+    {
+        return value ? static_cast<int32_t>(value.Size()) : 0;
+    }
+
+    IVector<IReference<winrt::hresult>> Class::GetReferenceHResultList()
+    {
+        return single_threaded_vector<IReference<winrt::hresult>>({
+            winrt::box_value(winrt::hresult{ static_cast<int32_t>(0x80070057) }).as<IReference<winrt::hresult>>() });
+    }
+
+    int32_t Class::CountReferenceHResultList(IVector<IReference<winrt::hresult>> const& value)
+    {
+        return value ? static_cast<int32_t>(value.Size()) : 0;
+    }
+
     WF::IInspectable Class::EmptyString()
     {
         return winrt::box_value(hstring{});

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1914,6 +1914,27 @@ namespace winrt::TestComponentCSharp::implementation
         return type.Name;
     }
 
+    IReference<Windows::UI::Xaml::Interop::TypeName> Class::BoxedTypeName()
+    {
+        return winrt::box_value(winrt::xaml_typename<winrt::TestComponentCSharp::Class>()).as<IReference<Windows::UI::Xaml::Interop::TypeName>>();
+    }
+
+    IReference<Windows::UI::Xaml::Interop::TypeName> Class::RoundtripTypeName(IReference<Windows::UI::Xaml::Interop::TypeName> const& value)
+    {
+        return value;
+    }
+
+    IReference<winrt::hresult> Class::BoxedHResult()
+    {
+        // Box a known failure 'HRESULT' ('E_INVALIDARG') as 'IReference<HResult>'
+        return winrt::box_value(winrt::hresult{ static_cast<int32_t>(0x80070057) }).as<IReference<winrt::hresult>>();
+    }
+
+    IReference<winrt::hresult> Class::RoundtripHResult(IReference<winrt::hresult> const& value)
+    {
+        return value;
+    }
+
     WF::IInspectable Class::EmptyString()
     {
         return winrt::box_value(hstring{});

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -449,6 +449,11 @@ namespace winrt::TestComponentCSharp::implementation
         static Windows::Foundation::IReference<winrt::hresult> BoxedHResult();
         static Windows::Foundation::IReference<winrt::hresult> RoundtripHResult(Windows::Foundation::IReference<winrt::hresult> const& value);
 
+        static Windows::Foundation::Collections::IVector<Windows::Foundation::IReference<Windows::UI::Xaml::Interop::TypeName>> GetReferenceTypeNameList();
+        static int32_t CountReferenceTypeNameList(Windows::Foundation::Collections::IVector<Windows::Foundation::IReference<Windows::UI::Xaml::Interop::TypeName>> const& value);
+        static Windows::Foundation::Collections::IVector<Windows::Foundation::IReference<winrt::hresult>> GetReferenceHResultList();
+        static int32_t CountReferenceHResultList(Windows::Foundation::Collections::IVector<Windows::Foundation::IReference<winrt::hresult>> const& value);
+
         static Windows::Foundation::IInspectable EmptyString();
         static Windows::Foundation::IInspectable BoxedDelegate();
         static Windows::Foundation::IInspectable BoxedEnum();

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -443,6 +443,12 @@ namespace winrt::TestComponentCSharp::implementation
         static bool VerifyTypeIsThisClassType(Windows::UI::Xaml::Interop::TypeName const& type_name);
         static hstring GetTypeNameForType(Windows::UI::Xaml::Interop::TypeName const& type);
 
+        static Windows::Foundation::IReference<Windows::UI::Xaml::Interop::TypeName> BoxedTypeName();
+        static Windows::Foundation::IReference<Windows::UI::Xaml::Interop::TypeName> RoundtripTypeName(Windows::Foundation::IReference<Windows::UI::Xaml::Interop::TypeName> const& value);
+
+        static Windows::Foundation::IReference<winrt::hresult> BoxedHResult();
+        static Windows::Foundation::IReference<winrt::hresult> RoundtripHResult(Windows::Foundation::IReference<winrt::hresult> const& value);
+
         static Windows::Foundation::IInspectable EmptyString();
         static Windows::Foundation::IInspectable BoxedDelegate();
         static Windows::Foundation::IInspectable BoxedEnum();

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -534,6 +534,15 @@ namespace TestComponentCSharp
         static Windows.Foundation.IReference<Windows.Foundation.HResult> BoxedHResult{ get; };
         static Windows.Foundation.IReference<Windows.Foundation.HResult> RoundtripHResult(Windows.Foundation.IReference<Windows.Foundation.HResult> value);
 
+        // Generic collections of these reference-projected types: 'IVector<IReference<TypeName>>' and
+        // 'IVector<IReference<HResult>>' both project to 'IList<Type>' / 'IList<Exception>', which collide
+        // with the canonical 'IVector<TypeName>' / 'IVector<HResult>' IIDs. These members exist to verify the
+        // projection still compiles; the matching unit tests document the (broken) runtime behavior.
+        static Windows.Foundation.Collections.IVector<Windows.Foundation.IReference<Windows.UI.Xaml.Interop.TypeName> > GetReferenceTypeNameList();
+        static Int32 CountReferenceTypeNameList(Windows.Foundation.Collections.IVector<Windows.Foundation.IReference<Windows.UI.Xaml.Interop.TypeName> > value);
+        static Windows.Foundation.Collections.IVector<Windows.Foundation.IReference<Windows.Foundation.HResult> > GetReferenceHResultList();
+        static Int32 CountReferenceHResultList(Windows.Foundation.Collections.IVector<Windows.Foundation.IReference<Windows.Foundation.HResult> > value);
+
         // Other
         static Object EmptyString { get; };
 

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -524,6 +524,16 @@ namespace TestComponentCSharp
 
         static String GetTypeNameForType(Windows.UI.Xaml.Interop.TypeName type);
 
+        // 'IReference<WUX.Interop.TypeName>' projects to 'System.Type' ('TypeName' is a Windows Runtime value type
+        // but projects to the reference type 'System.Type', so it must project as 'Type', not 'Nullable<Type>').
+        static Windows.Foundation.IReference<Windows.UI.Xaml.Interop.TypeName> BoxedTypeName{ get; };
+        static Windows.Foundation.IReference<Windows.UI.Xaml.Interop.TypeName> RoundtripTypeName(Windows.Foundation.IReference<Windows.UI.Xaml.Interop.TypeName> value);
+
+        // 'IReference<HResult>' projects to 'System.Exception' ('HResult' is a Windows Runtime value type but
+        // projects to the reference type 'System.Exception', so it must project as 'Exception', not 'Nullable<Exception>').
+        static Windows.Foundation.IReference<Windows.Foundation.HResult> BoxedHResult{ get; };
+        static Windows.Foundation.IReference<Windows.Foundation.HResult> RoundtripHResult(Windows.Foundation.IReference<Windows.Foundation.HResult> value);
+
         // Other
         static Object EmptyString { get; };
 

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3912,6 +3912,50 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public void ReferenceTypeNameListProjectsAsTypeList()
+        {
+            // 'IVector<IReference<TypeName>>' projects to the public 'IList<Type>', but the ABI marshaller keeps
+            // the 'Nullable<Type>' element marker, so it targets the correct 'IVector<IReference<TypeName>>' IID
+            // and boxes/unboxes each element via 'TypeMarshaller'. The list returned from native round-trips with
+            // usable 'Type' elements (this is the return-only direction, created entirely in C++).
+            IList<Type> list = Class.GetReferenceTypeNameList();
+
+            Assert.AreEqual(2, list.Count);
+            Assert.AreEqual(typeof(Class), list[0]);
+            Assert.AreEqual(typeof(int), list[1]);
+        }
+
+        [TestMethod]
+        public void ReferenceTypeNameListAsParameter()
+        {
+            // Passing a managed 'IList<Type>' to a native 'IVector<IReference<TypeName>>' parameter (the native
+            // side only reads the count here, which is element-agnostic)
+            Assert.AreEqual(2, Class.CountReferenceTypeNameList(new List<Type> { typeof(Class), typeof(int) }));
+        }
+
+        [TestMethod]
+        public void ReferenceHResultListProjectsAsExceptionList()
+        {
+            // 'IVector<IReference<HResult>>' projects to the public 'IList<Exception>', but the ABI marshaller keeps
+            // the 'Nullable<Exception>' element marker, so it targets the correct 'IVector<IReference<HResult>>' IID
+            // and boxes/unboxes each element via 'ExceptionMarshaller'. The list returned from native round-trips
+            // with usable 'Exception' elements (this is the return-only direction, created entirely in C++).
+            IList<Exception> list = Class.GetReferenceHResultList();
+
+            Assert.AreEqual(1, list.Count);
+            Assert.IsNotNull(list[0]);
+            Assert.AreEqual(unchecked((int)0x80070057), list[0].HResult); // 'E_INVALIDARG'
+        }
+
+        [TestMethod]
+        public void ReferenceHResultListAsParameter()
+        {
+            // Passing a managed 'IList<Exception>' to a native 'IVector<IReference<HResult>>' parameter (the native
+            // side only reads the count here, which is element-agnostic)
+            Assert.AreEqual(2, Class.CountReferenceHResultList(new List<Exception> { new ArgumentException(), new InvalidOperationException() }));
+        }
+
+        [TestMethod]
         public void TypeInfoGenerics()
         {
             var typeName = Class.GetTypeNameForType(typeof(IList<int>));

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3884,6 +3884,34 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public void ReferenceTypeNameProjectsAsType()
+        {
+            // 'IReference<WUX.Interop.TypeName>' projects to 'System.Type', not the invalid 'Nullable<Type>'
+            // ('TypeName' is a Windows Runtime value type, but it projects to the reference type 'System.Type'). The boxed
+            // value round-trips through the native boundary as a 'Type', including the null case.
+            Assert.AreEqual(typeof(Class), Class.BoxedTypeName);
+
+            Assert.AreEqual(typeof(int), Class.RoundtripTypeName(typeof(int)));
+            Assert.AreEqual(typeof(Class), Class.RoundtripTypeName(typeof(Class)));
+            Assert.IsNull(Class.RoundtripTypeName(null));
+        }
+
+        [TestMethod]
+        public void ReferenceHResultProjectsAsException()
+        {
+            // 'IReference<HResult>' projects to 'System.Exception', not the invalid 'Nullable<Exception>'
+            // ('HResult' is a Windows Runtime value type, but it projects to the reference type 'System.Exception'). The
+            // boxed value round-trips through the native boundary as an 'Exception', including the null case.
+            Exception boxed = Class.BoxedHResult;
+
+            Assert.IsNotNull(boxed);
+            Assert.AreEqual(unchecked((int)0x80070057), boxed.HResult); // 'E_INVALIDARG'
+
+            Assert.IsInstanceOfType<ArgumentOutOfRangeException>(Class.RoundtripHResult(new ArgumentOutOfRangeException()));
+            Assert.IsNull(Class.RoundtripHResult(null));
+        }
+
+        [TestMethod]
         public void TypeInfoGenerics()
         {
             var typeName = Class.GetTypeNameForType(typeof(IList<int>));

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3912,47 +3912,39 @@ namespace UnitTest
         }
 
         [TestMethod]
-        public void ReferenceTypeNameListProjectsAsTypeList()
+        public void ReferenceTypeNameListReturnThrowsNotSupported()
         {
-            // 'IVector<IReference<TypeName>>' projects to the public 'IList<Type>', but the ABI marshaller keeps
-            // the 'Nullable<Type>' element marker, so it targets the correct 'IVector<IReference<TypeName>>' IID
-            // and boxes/unboxes each element via 'TypeMarshaller'. The list returned from native round-trips with
-            // usable 'Type' elements (this is the return-only direction, created entirely in C++).
-            IList<Type> list = Class.GetReferenceTypeNameList();
-
-            Assert.AreEqual(2, list.Count);
-            Assert.AreEqual(typeof(Class), list[0]);
-            Assert.AreEqual(typeof(int), list[1]);
+            // 'IVector<IReference<TypeName>>' projects its public surface as 'IList<Type>', but it cannot be
+            // marshalled: 'System.Type' is a reference type, so there is no valid 'Nullable<Type>' collection
+            // marshaller for the interop generator to produce. The projected member throws 'NotSupportedException'
+            // instead of referencing a marshaller that does not exist (return-only direction, created in C++)
+            Assert.ThrowsExactly<NotSupportedException>(() => Class.GetReferenceTypeNameList());
         }
 
         [TestMethod]
-        public void ReferenceTypeNameListAsParameter()
+        public void ReferenceTypeNameListParameterThrowsNotSupported()
         {
-            // Passing a managed 'IList<Type>' to a native 'IVector<IReference<TypeName>>' parameter (the native
-            // side only reads the count here, which is element-agnostic)
-            Assert.AreEqual(2, Class.CountReferenceTypeNameList(new List<Type> { typeof(Class), typeof(int) }));
+            // Same limitation as the return direction: passing a managed 'IList<Type>' to a native
+            // 'IVector<IReference<TypeName>>' parameter throws 'NotSupportedException'
+            Assert.ThrowsExactly<NotSupportedException>(() => Class.CountReferenceTypeNameList(new List<Type> { typeof(Class), typeof(int) }));
         }
 
         [TestMethod]
-        public void ReferenceHResultListProjectsAsExceptionList()
+        public void ReferenceHResultListReturnThrowsNotSupported()
         {
-            // 'IVector<IReference<HResult>>' projects to the public 'IList<Exception>', but the ABI marshaller keeps
-            // the 'Nullable<Exception>' element marker, so it targets the correct 'IVector<IReference<HResult>>' IID
-            // and boxes/unboxes each element via 'ExceptionMarshaller'. The list returned from native round-trips
-            // with usable 'Exception' elements (this is the return-only direction, created entirely in C++).
-            IList<Exception> list = Class.GetReferenceHResultList();
-
-            Assert.AreEqual(1, list.Count);
-            Assert.IsNotNull(list[0]);
-            Assert.AreEqual(unchecked((int)0x80070057), list[0].HResult); // 'E_INVALIDARG'
+            // 'IVector<IReference<HResult>>' projects its public surface as 'IList<Exception>', but it cannot be
+            // marshalled: 'System.Exception' is a reference type, so there is no valid 'Nullable<Exception>' collection
+            // marshaller for the interop generator to produce. The projected member throws 'NotSupportedException'
+            // instead of referencing a marshaller that does not exist (return-only direction, created in C++)
+            Assert.ThrowsExactly<NotSupportedException>(() => Class.GetReferenceHResultList());
         }
 
         [TestMethod]
-        public void ReferenceHResultListAsParameter()
+        public void ReferenceHResultListParameterThrowsNotSupported()
         {
-            // Passing a managed 'IList<Exception>' to a native 'IVector<IReference<HResult>>' parameter (the native
-            // side only reads the count here, which is element-agnostic)
-            Assert.AreEqual(2, Class.CountReferenceHResultList(new List<Exception> { new ArgumentException(), new InvalidOperationException() }));
+            // Same limitation as the return direction: passing a managed 'IList<Exception>' to a native
+            // 'IVector<IReference<HResult>>' parameter throws 'NotSupportedException'
+            Assert.ThrowsExactly<NotSupportedException>(() => Class.CountReferenceHResultList(new List<Exception> { new ArgumentException(), new InvalidOperationException() }));
         }
 
         [TestMethod]

--- a/src/WinRT.Projection.Writer/Extensions/TypeSignatureExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/TypeSignatureExtensions.cs
@@ -120,6 +120,63 @@ internal static class TypeSignatureExtensions
         }
 
         /// <summary>
+        /// Returns whether the signature is a <c>Windows.Foundation.IReference`1</c> instantiation whose
+        /// argument is a Windows Runtime value type that projects to a .NET reference type, namely
+        /// <c>Windows.UI.Xaml.Interop.TypeName</c> (projected as <see cref="System.Type"/>) or
+        /// <c>Windows.Foundation.HResult</c> (projected as <see cref="System.Exception"/>).
+        /// </summary>
+        /// <remarks>
+        /// Unlike other <c>IReference&lt;T&gt;</c> shapes, these two project to a bare reference type
+        /// rather than a <see cref="System.Nullable{T}"/>, because <see cref="System.Type"/> and
+        /// <see cref="System.Exception"/> are reference types. They marshal correctly as a scalar
+        /// (via <c>ABI.System.TypeMarshaller</c> / <c>ABI.System.ExceptionMarshaller</c>), but cannot
+        /// appear inside a generic instantiation (see <see cref="ContainsNestedNullableTOfReferenceType"/>).
+        /// </remarks>
+        /// <returns><see langword="true"/> if the signature is <c>IReference&lt;TypeName&gt;</c> or <c>IReference&lt;HResult&gt;</c>; otherwise <see langword="false"/>.</returns>
+        public bool IsNullableTOfReferenceType()
+        {
+            if (!sig.IsNullableT())
+            {
+                return false;
+            }
+
+            TypeSignature? inner = sig.GetNullableInnerType();
+
+            return inner is not null && (inner.IsSystemType() || inner.IsHResultException());
+        }
+
+        /// <summary>
+        /// Returns whether the signature is a generic instantiation whose type-argument tree
+        /// (recursively) contains an <see cref="IsNullableTOfReferenceType"/> shape.
+        /// </summary>
+        /// <remarks>
+        /// Such instantiations (e.g. <c>IVector&lt;IReference&lt;TypeName&gt;&gt;</c>) cannot be
+        /// marshalled: the <c>WinRT.Interop</c> marshaller name would embed a <c>Nullable&lt;Type&gt;</c>
+        /// or <c>Nullable&lt;Exception&gt;</c>, which is not a constructible type, so the interop generator
+        /// never produces a matching marshaller. The scalar <see cref="IsNullableTOfReferenceType"/> case
+        /// is intentionally excluded: it appears only as a (nested) type argument here, never as the
+        /// top-level signature, which still projects and marshals correctly on its own.
+        /// </remarks>
+        /// <returns><see langword="true"/> if a reference-projected <c>IReference&lt;T&gt;</c> is nested as a type argument; otherwise <see langword="false"/>.</returns>
+        public bool ContainsNestedNullableTOfReferenceType()
+        {
+            if (sig is not GenericInstanceTypeSignature gi)
+            {
+                return false;
+            }
+
+            foreach (TypeSignature arg in gi.TypeArguments)
+            {
+                if (arg.IsNullableTOfReferenceType() || arg.ContainsNestedNullableTOfReferenceType())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns whether the signature has the "ABI reference-pointer" shape: it crosses the
         /// ABI as a <c>void*</c> / <c>IInspectable*</c>. That covers <see cref="string"/> (HSTRING),
         /// any WinRT runtime class or interface (resolved via <paramref name="resolver"/>),

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
@@ -49,6 +49,21 @@ internal static partial class AbiMethodBodyFactory
                 $"on '{ifaceFullName}'. Events should dispatch through EmitDoAbiAddEvent / EmitDoAbiRemoveEvent.");
         }
 
+        // Generic instantiations over 'IReference<TypeName>' / 'IReference<HResult>' have no valid
+        // 'WinRT.Interop' marshaller (see 'RequiresUnsupportedNullableTOfReferenceTypeMarshalling'), so
+        // the CCW body throws instead of referencing a marshaller the interop generator cannot produce
+        if (RequiresUnsupportedNullableTOfReferenceTypeMarshalling(sig))
+        {
+            writer.WriteLine();
+            writer.WriteLine(isMultiline: true, """
+                {
+                    throw new global::System.NotSupportedException();
+                }
+                """);
+
+            return;
+        }
+
         writer.WriteLine();
         using (writer.WriteBlock())
         {

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
@@ -42,6 +42,23 @@ internal static partial class AbiMethodBodyFactory
         Justification = "if/else if chains over type-class predicates are more readable than nested ternaries.")]
     public static void EmitAbiMethodBodyIfSimple(IndentedTextWriter writer, ProjectionEmitContext context, MethodSignatureInfo sig, int slot, string? paramNameOverride = null, bool isNoExcept = false)
     {
+        // Generic instantiations over 'IReference<TypeName>' / 'IReference<HResult>' cannot be marshalled:
+        // 'System.Type' and 'System.Exception' are reference types with no 'Nullable<T>' shape, so the
+        // 'WinRT.Interop' marshaller they would reference does not exist. Emit a throwing body instead
+        if (RequiresUnsupportedNullableTOfReferenceTypeMarshalling(sig))
+        {
+            writer.WriteLine();
+            writer.IncreaseIndent();
+            writer.WriteLine(isMultiline: true, """
+                {
+                    throw new global::System.NotSupportedException();
+                }
+                """);
+            writer.DecreaseIndent();
+
+            return;
+        }
+
         TypeSignature? rt = sig.ReturnType;
 
         MethodSignatureMarshallingFacts facts = MethodSignatureMarshallingFacts.From(sig, context.AbiTypeKindResolver);

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using WindowsRuntime.ProjectionWriter.Models;
+
 namespace WindowsRuntime.ProjectionWriter.Factories;
 
 /// <summary>
@@ -16,4 +18,32 @@ namespace WindowsRuntime.ProjectionWriter.Factories;
 ///   <item><description><c>AbiMethodBodyFactory.MarshallerDispatch.cs</c> - Per-marshaller ConvertToManaged/Unmanaged dispatch helpers.</description></item>
 /// </list>
 /// </remarks>
-internal static partial class AbiMethodBodyFactory;
+internal static partial class AbiMethodBodyFactory
+{
+    /// <summary>
+    /// Returns whether the method's return type or any parameter type involves a generic
+    /// instantiation over <c>IReference&lt;TypeName&gt;</c> / <c>IReference&lt;HResult&gt;</c>, which
+    /// cannot be marshalled (see <see cref="TypeSignatureExtensions.ContainsNestedNullableTOfReferenceType"/>).
+    /// When this is the case, the projected member's body is replaced with a <c>throw</c> instead of
+    /// emitting a reference to a <c>WinRT.Interop</c> marshaller that the interop generator cannot produce.
+    /// </summary>
+    /// <param name="sig">The interface method signature being emitted.</param>
+    /// <returns><see langword="true"/> if the method cannot be marshalled; otherwise <see langword="false"/>.</returns>
+    private static bool RequiresUnsupportedNullableTOfReferenceTypeMarshalling(MethodSignatureInfo sig)
+    {
+        if (sig.ReturnType is { } rt && rt.ContainsNestedNullableTOfReferenceType())
+        {
+            return true;
+        }
+
+        foreach (ParameterInfo p in sig.Parameters)
+        {
+            if (p.Type.StripByRefAndCustomModifiers().ContainsNestedNullableTOfReferenceType())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/WinRT.Projection.Writer/Helpers/TypedefNameWriter.cs
+++ b/src/WinRT.Projection.Writer/Helpers/TypedefNameWriter.cs
@@ -9,6 +9,7 @@ using WindowsRuntime.ProjectionWriter.Metadata;
 using WindowsRuntime.ProjectionWriter.Writers;
 using static WindowsRuntime.ProjectionWriter.References.ProjectionNames;
 using static WindowsRuntime.ProjectionWriter.References.WellKnownNamespaces;
+using static WindowsRuntime.ProjectionWriter.References.WellKnownTypeNames;
 
 namespace WindowsRuntime.ProjectionWriter.Helpers;
 
@@ -227,6 +228,21 @@ internal static class TypedefNameWriter
             case TypeSemantics.GenericInstanceRef gir:
                 {
                     (string ns, string name) = gir.GenericType.Names();
+
+                    // 'IReference<T>' normally projects to 'System.Nullable<T>', but a couple of Windows Runtime
+                    // value types project to .NET reference types ('Windows.UI.Xaml.Interop.TypeName' -> 'System.Type'
+                    // and 'Windows.Foundation.HResult' -> 'System.Exception'). For those, 'Nullable<Type>' /
+                    // 'Nullable<Exception>' would be invalid C#, so drop the nullability and project the inner type
+                    // directly (a reference type is already nullable).
+                    if (ns == WindowsFoundation &&
+                        name == IReferenceGeneric &&
+                        gir.GenericArgs is [{ } innerArg] &&
+                        ProjectsToReferenceType(innerArg))
+                    {
+                        WriteTypeName(writer, context, innerArg, nameType, forceWriteNamespace);
+                        break;
+                    }
+
                     _ = MappedTypes.ApplyMapping(ref ns, ref name);
 
                     if (nameType == TypedefNameType.EventSource && ns == "System")
@@ -311,6 +327,37 @@ internal static class TypedefNameWriter
     public static void WriteProjectionType(IndentedTextWriter writer, ProjectionEmitContext context, TypeSemantics semantics)
     {
         WriteTypeName(writer, context, semantics, TypedefNameType.Projected, false);
+    }
+
+    /// <summary>
+    /// Returns whether the projected form of the supplied <paramref name="semantics"/> is a .NET reference type.
+    /// Most Windows Runtime value types project to .NET value types (so <c>IReference&lt;T&gt;</c> projects to
+    /// <see cref="System.Nullable{T}"/>), but two Windows Runtime value types project to .NET <em>reference</em> types:
+    /// <c>Windows.UI.Xaml.Interop.TypeName</c> -&gt; <see cref="System.Type"/> and <c>Windows.Foundation.HResult</c>
+    /// -&gt; <see cref="System.Exception"/>. For those, the <see cref="System.Nullable{T}"/> wrapper is invalid C#,
+    /// so <c>IReference&lt;T&gt;</c> must project the inner type directly (a reference type is already nullable).
+    /// </summary>
+    /// <param name="semantics">The semantic representation of the type argument.</param>
+    /// <returns><see langword="true"/> if the projected type is a .NET reference type; otherwise <see langword="false"/>.</returns>
+    private static bool ProjectsToReferenceType(TypeSemantics semantics)
+    {
+        // A literal 'System.Type' reference (e.g. from attribute-blob-encoded 'Type' arguments)
+        if (semantics is TypeSemantics.SystemType)
+        {
+            return true;
+        }
+
+        if (semantics is TypeSemantics.Reference reference)
+        {
+            (string ns, string name) = reference.Type.Names();
+
+            _ = MappedTypes.ApplyMapping(ref ns, ref name);
+
+            // The only Windows Runtime value types that map to a .NET reference type: 'TypeName' -> 'Type', 'HResult' -> 'Exception'
+            return ns == "System" && name is "Type" or "Exception";
+        }
+
+        return false;
     }
 
     /// <inheritdoc cref="WriteTypeName(IndentedTextWriter, ProjectionEmitContext, TypeSemantics, TypedefNameType, bool)"/>


### PR DESCRIPTION
## Summary

Fix the C# projection of `IReference<T>` for the two Windows Runtime value types that map to .NET *reference* types: `Windows.UI.Xaml.Interop.TypeName` -> `System.Type` and `Windows.Foundation.HResult` -> `System.Exception`. These now project to `Type` / `Exception` instead of the invalid `System.Nullable<Type>` / `System.Nullable<Exception>`.

## Motivation

`IReference<T>` normally projects to `System.Nullable<T>`, which is correct for value-type inners. But `TypeName` and `HResult` are Windows Runtime value types that project to the .NET reference types `System.Type` and `System.Exception`. `Nullable<Type>` / `Nullable<Exception>` are not valid C# (the type argument of `Nullable<T>` must be a non-nullable value type), so any metadata containing `IReference<TypeName>` or `IReference<HResult>` produced a projection that failed to compile. A reference type is already nullable, so the projection should simply be the inner type. This mirrors the equivalent CsWinRT 2.x fix (#2103).

The marshalling itself was already fully supported by the runtime (`TypeMarshaller` / `ExceptionMarshaller` `BoxToUnmanaged` / `UnboxToManaged` via `IID_IReferenceOfType` / `IID_IReferenceOfException`); only the projected type name was wrong.

## Changes

- **`src/WinRT.Projection.Writer/Helpers/TypedefNameWriter.cs`**: when projecting `Windows.Foundation.IReference<T>`, detect inners whose projection is a .NET reference type (`TypeName` -> `Type`, `HResult` -> `Exception`, plus a literal `System.Type`) and emit the inner type directly instead of wrapping it in `System.Nullable<>`.
- **`src/Tests/TestComponentCSharp/`** (`TestComponentCSharp.idl`, `Class.h`, `Class.cpp`): add scalar `IReference<TypeName>` and `IReference<HResult>` members - a native-boxed property (`BoxedTypeName` / `BoxedHResult`) and a round-trip method (`RoundtripTypeName` / `RoundtripHResult`).
- **`src/Tests/UnitTest/TestComponentCSharp_Tests.cs`**: add `ReferenceTypeNameProjectsAsType` and `ReferenceHResultProjectsAsException`, covering both marshalling directions and the null case.

## Notes

The test members and the projection-writer fix are committed separately so CI can demonstrate the tests failing to build (invalid `Nullable<Type>` / `Nullable<Exception>`) before the fix lands, then passing afterward. Collections of these types (`IVector<IReference<TypeName>>` etc.) are intentionally out of scope: since `Type` / `Exception` are reference types there is no distinct `Nullable<>` managed shape, so such a collection is indistinguishable from `IVector<TypeName>` / `IVector<HResult>` at the interop layer.
