### PR TITLE
Sort vtable types to match COM hierarchy and use TrustLevel consistently

### DIFF
--- a/src/WinRT.Projection.Writer/Resources/Base/InspectableVftbl.cs
+++ b/src/WinRT.Projection.Writer/Resources/Base/InspectableVftbl.cs
@@ -19,6 +19,14 @@ using Windows.Foundation;
 namespace WindowsRuntime.InteropServices;
 
 [StructLayout(LayoutKind.Sequential)]
+internal unsafe struct IUnknownVftbl
+{
+    public delegate* unmanaged[MemberFunction]<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged[MemberFunction]<void*, uint> AddRef;
+    public delegate* unmanaged[MemberFunction]<void*, uint> Release;
+}
+
+[StructLayout(LayoutKind.Sequential)]
 internal unsafe struct IInspectableVftbl
 {
     public delegate* unmanaged[MemberFunction]<void*, Guid*, void**, int> QueryInterface;
@@ -26,7 +34,7 @@ internal unsafe struct IInspectableVftbl
     public delegate* unmanaged[MemberFunction]<void*, uint> Release;
     public delegate* unmanaged[MemberFunction]<void*, uint*, Guid**, int> GetIids;
     public delegate* unmanaged[MemberFunction]<void*, void**, int> GetRuntimeClassName;
-    public delegate* unmanaged[MemberFunction]<void*, int*, int> GetTrustLevel;
+    public delegate* unmanaged[MemberFunction]<void*, TrustLevel*, int> GetTrustLevel;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -39,13 +47,5 @@ internal unsafe struct ReferenceVftbl
     public delegate* unmanaged[MemberFunction]<void*, void**, int> GetRuntimeClassName;
     public delegate* unmanaged[MemberFunction]<void*, TrustLevel*, int> GetTrustLevel;
     public delegate* unmanaged[MemberFunction]<void*, void*, int> get_Value;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-internal unsafe struct IUnknownVftbl
-{
-    public delegate* unmanaged[MemberFunction]<void*, Guid*, void**, int> QueryInterface;
-    public delegate* unmanaged[MemberFunction]<void*, uint> AddRef;
-    public delegate* unmanaged[MemberFunction]<void*, uint> Release;
 }
 #endif


### PR DESCRIPTION
## Summary

Minor cleanup to the baseline InspectableVftbl.cs emitted by the projection writer: the three vtable structs are reordered to follow the COM type hierarchy, and `IInspectableVftbl.GetTrustLevel` now uses `TrustLevel*` instead of `int*` for consistency.

## Motivation

The vtable struct definitions in this file represent the COM interface hierarchy (`IUnknown` -> `IInspectable` -> `IReference`), but they were declared out of order, with `IUnknownVftbl` appearing last. Ordering them to match the actual hierarchy makes the relationship between the structs obvious at a glance. Additionally, `IInspectableVftbl.GetTrustLevel` typed its trust-level argument as a raw `int*` while `ReferenceVftbl.GetTrustLevel` already used the strongly-typed `TrustLevel*`; aligning the two removes a needless inconsistency.

## Changes

- **`src/WinRT.Projection.Writer/Resources/Base/InspectableVftbl.cs`**: reorder `IUnknownVftbl`, `IInspectableVftbl`, and `ReferenceVftbl` to match the COM hierarchy, and change the `GetTrustLevel` slot in `IInspectableVftbl` from `delegate* unmanaged[MemberFunction]<void*, int*, int>` to `delegate* unmanaged[MemberFunction]<void*, TrustLevel*, int>`.
