### PR TITLE
[DO NOT MERGE] Validation build: fail-fast on IContextCallback dispatch recursion

### DIFF
--- a/src/WinRT.Runtime/Interop/IContextCallback.cs
+++ b/src/WinRT.Runtime/Interop/IContextCallback.cs
@@ -33,8 +33,30 @@ namespace ABI.WinRT.Interop
         private delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ComCallData*, Guid*, int, IntPtr, int> ContextCallback_4;
 #pragma warning restore CS0649
 
+        // Thread-static recursion guard used to validate the concern raised in
+        // https://github.com/microsoft/CsWinRT/pull/1865. It tracks the nesting depth of
+        // 'ContextCallback' invocations on the current thread, so we can detect whether the
+        // dispatch is ever reentered on the same thread (see 'ContextCallback' below).
+        [ThreadStatic]
+        private static int s_contextCallbackDepth;
+
         public static void ContextCallback(IntPtr contextCallbackPtr, delegate*<object, void> callback, delegate*<object, void> onFailCallback, object state)
         {
+            // Validation guard for https://github.com/microsoft/CsWinRT/pull/1865: detect whether the
+            // 'IContextCallback' dispatch can ever be reentered on the same thread (eg. if the native call
+            // below pumps messages on an STA thread while waiting for the callback to complete on the target
+            // context, and that pump dispatches another call that ends up back here on this same thread). If
+            // that ever happens, the thread-static state approach explored in that PR would be unsafe, so we
+            // fail fast with a useful message to surface how common this actually is in real world scenarios.
+            if (s_contextCallbackDepth > 0)
+            {
+                Environment.FailFast(
+                    "ABI.WinRT.Interop.IContextCallbackVftbl.ContextCallback was invoked recursively on the same thread " +
+                    "(managed thread id: " + Environment.CurrentManagedThreadId + ", depth: " + s_contextCallbackDepth + "). The " +
+                    "'IContextCallback' dispatch was reentered before a previous call on this thread returned, which would make " +
+                    "the thread-static state approach explored in https://github.com/microsoft/CsWinRT/pull/1865 unsafe.");
+            }
+
             ComCallData comCallData;
             comCallData.dwDispid = 0;
             comCallData.dwReserved = 0;
@@ -69,13 +91,27 @@ namespace ABI.WinRT.Interop
 
             Guid iid = IID.IID_ICallbackWithNoReentrancyToApplicationSTA;
 
-            int hresult = (*(IContextCallbackVftbl**)contextCallbackPtr)->ContextCallback_4(
-                contextCallbackPtr,
-                (IntPtr)(delegate* unmanaged<ComCallData*, int>)&InvokeCallback,
-                &comCallData,
-                &iid,
-                /* iMethod */ 5,
-                IntPtr.Zero);
+            // Mark that we're now dispatching on this thread. The reentrancy window is the native call
+            // below, so we only need to track recursion across it. We always reset the depth afterwards
+            // (even if the dispatch throws) so a later, legitimate call on this thread isn't misdetected.
+            s_contextCallbackDepth++;
+
+            int hresult;
+
+            try
+            {
+                hresult = (*(IContextCallbackVftbl**)contextCallbackPtr)->ContextCallback_4(
+                    contextCallbackPtr,
+                    (IntPtr)(delegate* unmanaged<ComCallData*, int>)&InvokeCallback,
+                    &comCallData,
+                    &iid,
+                    /* iMethod */ 5,
+                    IntPtr.Zero);
+            }
+            finally
+            {
+                s_contextCallbackDepth--;
+            }
 
             if (hresult < 0)
             {


### PR DESCRIPTION
## What this is

A **throwaway validation build** to answer the open question from #1865: *can the `IContextCallback` dispatch ever be reentered on the same thread?* (jkotas: "Are you sure that there cannot ever be recursion that would cause multiple recursive uses of `CallbackData` on the same thread?")

This instruments the existing dispatch in `ABI.WinRT.Interop.IContextCallbackVftbl.ContextCallback` with a `[ThreadStatic]` depth counter. If the dispatch is entered while a previous call on the **same thread** is still in progress (the reentrancy window is the native `ContextCallback_4` call, e.g. due to STA message pumping), it calls `Environment.FailFast` with a useful message instead of silently continuing.

The goal — per [this comment](https://github.com/microsoft/CsWinRT/pull/1865#issuecomment-4759768328) — is to ship a build with this assertion and run it through our tests and the Store to see how common (if ever) this recursion actually happens in real-world scenarios. If it never fires, then the thread-static state optimization from #1865 (without a slower fallback) would be safe.

## Notes

- Uses `Environment.FailFast` (not `Debug.Assert`) so it fires in Release/Store builds too.
- The counter is decremented in a `finally` so a legitimate later call on the same thread isn't misdetected if the dispatch throws.
- Only the `#if NET && CsWinRT_LANG_11_FEATURES` fast path (net8.0/net9.0) is instrumented — that's the path that matters for the Store.
- No public API surface changes (`IContextCallbackVftbl` is `internal`).

**Not intended to merge** — opened to get a preview package from CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>