### PR TITLE
Use the correct comparer for the interop generator visited-module set

### DIFF
--- a/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
@@ -70,46 +70,42 @@ internal static partial class ModuleDefinitionExtensions
         // Use a visited set to guard against cycles in the transitive assembly reference graph.
         // Such cycles are possible (eg. mutual references between assemblies) and would otherwise
         // cause this method to recurse infinitely, leading to a stack overflow.
-        return ReferencesAssembly(module, assemblyName, []);
-    }
-
-    /// <inheritdoc cref="ReferencesAssembly(ModuleDefinition, Utf8String)"/>
-    /// <param name="module"><inheritdoc cref="ReferencesAssembly(ModuleDefinition, Utf8String)" path="/param[@name='module']"/></param>
-    /// <param name="assemblyName"><inheritdoc cref="ReferencesAssembly(ModuleDefinition, Utf8String)" path="/param[@name='assemblyName']"/></param>
-    /// <param name="visitedModules">The set of modules that have already been traversed, to avoid cycles.</param>
-    private static bool ReferencesAssembly(ModuleDefinition module, Utf8String assemblyName, HashSet<ModuleDefinition> visitedModules)
-    {
-        // Skip modules we've already visited, to break reference cycles
-        if (!visitedModules.Add(module))
+        static bool ReferencesAssemblyCore(ModuleDefinition module, Utf8String assemblyName, HashSet<ModuleDefinition> visitedModules)
         {
-            return false;
-        }
-
-        // Check all direct assembly references and check if they match
-        foreach (AssemblyReference reference in module.AssemblyReferences)
-        {
-            if (reference.Name == assemblyName)
+            // Skip modules we've already visited, to break reference cycles
+            if (!visitedModules.Add(module))
             {
-                return true;
+                return false;
             }
 
-            // Try to resolve the current assembly, skip it if it fails
-            if (!reference.TryResolve(module.RuntimeContext, out AssemblyDefinition? assembly))
+            // Check all direct assembly references and check if they match
+            foreach (AssemblyReference reference in module.AssemblyReferences)
             {
-                continue;
-            }
-
-            // Also traverse the entire transitive dependency graph and check those assemblies
-            foreach (ModuleDefinition transitiveModule in assembly.Modules ?? [])
-            {
-                if (ReferencesAssembly(transitiveModule, assemblyName, visitedModules))
+                if (reference.Name == assemblyName)
                 {
                     return true;
                 }
+
+                // Try to resolve the current assembly, skip it if it fails
+                if (!reference.TryResolve(module.RuntimeContext, out AssemblyDefinition? assembly))
+                {
+                    continue;
+                }
+
+                // Also traverse the entire transitive dependency graph and check those assemblies
+                foreach (ModuleDefinition transitiveModule in assembly.Modules ?? [])
+                {
+                    if (ReferencesAssemblyCore(transitiveModule, assemblyName, visitedModules))
+                    {
+                        return true;
+                    }
+                }
             }
+
+            return false;
         }
 
-        return false;
+        return ReferencesAssemblyCore(module, assemblyName, []);
     }
 
     /// <summary>
@@ -121,39 +117,36 @@ internal static partial class ModuleDefinitionExtensions
     {
         // Use a visited set to guard against cycles in the transitive assembly reference graph,
         // which would otherwise cause infinite recursion and a stack overflow (see 'ReferencesAssembly').
-        return EnumerateAssemblyReferences(module, []);
-    }
-
-    /// <inheritdoc cref="EnumerateAssemblyReferences(ModuleDefinition)"/>
-    /// <param name="module"><inheritdoc cref="EnumerateAssemblyReferences(ModuleDefinition)" path="/param[@name='module']"/></param>
-    /// <param name="visitedModules">The set of modules that have already been traversed, to avoid cycles.</param>
-    private static IEnumerable<AssemblyReference> EnumerateAssemblyReferences(ModuleDefinition module, HashSet<ModuleDefinition> visitedModules)
-    {
-        // Skip modules we've already visited, to break reference cycles
-        if (!visitedModules.Add(module))
+        static IEnumerable<AssemblyReference> EnumerateAssemblyReferencesCore(ModuleDefinition module, HashSet<ModuleDefinition> visitedModules)
         {
-            yield break;
-        }
-
-        foreach (AssemblyReference reference in module.AssemblyReferences)
-        {
-            yield return reference;
-
-            // Try to resolve the current assembly, skip it if it fails
-            if (!reference.TryResolve(module.RuntimeContext, out AssemblyDefinition? assembly))
+            // Skip modules we've already visited, to break reference cycles
+            if (!visitedModules.Add(module))
             {
-                continue;
+                yield break;
             }
 
-            // Also enumerate all transitive references as well
-            foreach (ModuleDefinition transitiveModule in assembly.Modules ?? [])
+            foreach (AssemblyReference reference in module.AssemblyReferences)
             {
-                foreach (AssemblyReference transitiveReference in EnumerateAssemblyReferences(transitiveModule, visitedModules))
+                yield return reference;
+
+                // Try to resolve the current assembly, skip it if it fails
+                if (!reference.TryResolve(module.RuntimeContext, out AssemblyDefinition? assembly))
                 {
-                    yield return transitiveReference;
+                    continue;
+                }
+
+                // Also enumerate all transitive references as well
+                foreach (ModuleDefinition transitiveModule in assembly.Modules ?? [])
+                {
+                    foreach (AssemblyReference transitiveReference in EnumerateAssemblyReferencesCore(transitiveModule, visitedModules))
+                    {
+                        yield return transitiveReference;
+                    }
                 }
             }
         }
+
+        return EnumerateAssemblyReferencesCore(module, []);
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
@@ -105,7 +105,7 @@ internal static partial class ModuleDefinitionExtensions
             return false;
         }
 
-        return ReferencesAssemblyCore(module, assemblyName, []);
+        return ReferencesAssemblyCore(module, assemblyName, new HashSet<ModuleDefinition>(SignatureComparer.IgnoreVersion));
     }
 
     /// <summary>
@@ -146,7 +146,7 @@ internal static partial class ModuleDefinitionExtensions
             }
         }
 
-        return EnumerateAssemblyReferencesCore(module, []);
+        return EnumerateAssemblyReferencesCore(module, new HashSet<ModuleDefinition>(SignatureComparer.IgnoreVersion));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Follow-up to #2465. Make the visited-module set used by the interop generator's transitive assembly-reference traversal compare modules by their semantic identity (via `SignatureComparer.IgnoreVersion`) instead of by reference, and refactor the two traversal helpers into local static functions.

## Motivation

#2465 added a visited-module `HashSet<ModuleDefinition>` to `ModuleDefinitionExtensions.ReferencesAssembly` and `EnumerateAssemblyReferences` to break cycles in the transitive assembly-reference graph (e.g. mutual references) and prevent the infinite recursion / stack overflow that those cycles caused.

That set was constructed with the default comparer, which compares `ModuleDefinition` instances by reference. With AsmResolver, resolving an assembly reference can return a distinct `ModuleDefinition` instance for the same logical module depending on the resolution path, so reference equality can fail to recognize a module that has already been visited, weakening the cycle guard. Using `SignatureComparer.IgnoreVersion` compares modules by their assembly identity, which is the comparer already used for module-keyed collections elsewhere in the interop generator (e.g. `InteropGeneratorDiscoveryState` and `EnumerateTypeSignatures`). This makes cycle detection reliable and consistent with the rest of the codebase.

## Changes

- **`src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs`**: construct the visited `HashSet<ModuleDefinition>` with `SignatureComparer.IgnoreVersion` in both `ReferencesAssembly` and `EnumerateAssemblyReferences` so modules are compared semantically rather than by reference.
- **`src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs`**: refactor the recursive traversal helpers from separate private method overloads into local static functions nested within their respective public methods (behavior-preserving).
