### PR TITLE
Various fixes from WinUI testing

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -333,7 +333,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Message Condition="'$(_CsWinRTRunProjectionRefGenerator)' != 'true'"
              Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="Low" />
     <Message Condition="'$(_CsWinRTRunProjectionRefGenerator)' == 'true'"
-             Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="$(CsWinRTMessageImportance)" />
+             Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="Low" />
     <RunCsWinRTProjectionRefGenerator
         Condition="'$(_CsWinRTRunProjectionRefGenerator)' == 'true'"
         InputWinMDPaths="@(_CsWinRTRefInputs)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -332,8 +332,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <Message Condition="'$(_CsWinRTRunProjectionRefGen)' != 'true'"
              Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="$(CsWinRTMessageImportance)" />
-    <Message Condition="'$(_CsWinRTRunProjectionRefGen)' == 'true'"
-             Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="$(CsWinRTMessageImportance)" />
     <RunCsWinRTProjectionRefGenerator
         Condition="'$(_CsWinRTRunProjectionRefGen)' == 'true'"
         InputWinMDPaths="@(_CsWinRTRefInputs)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -332,6 +332,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <Message Condition="'$(_CsWinRTRunProjectionRefGenerator)' != 'true'"
              Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="Low" />
+    <Message Condition="'$(_CsWinRTRunProjectionRefGenerator)' == 'true'"
+             Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="$(CsWinRTMessageImportance)" />
     <RunCsWinRTProjectionRefGenerator
         Condition="'$(_CsWinRTRunProjectionRefGenerator)' == 'true'"
         InputWinMDPaths="@(_CsWinRTRefInputs)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -326,14 +326,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       In that case, running the tool is a pure no-op, so we skip launching it entirely.
     -->
     <PropertyGroup>
-      <_CsWinRTRunProjectionRefGen>false</_CsWinRTRunProjectionRefGen>
-      <_CsWinRTRunProjectionRefGen Condition="'@(_CsWinRTRefIncludes)' != ''">true</_CsWinRTRunProjectionRefGen>
+      <_CsWinRTRunProjectionRefGenerator>false</_CsWinRTRunProjectionRefGenerator>
+      <_CsWinRTRunProjectionRefGenerator Condition="'@(_CsWinRTRefIncludes)' != ''">true</_CsWinRTRunProjectionRefGenerator>
     </PropertyGroup>
 
-    <Message Condition="'$(_CsWinRTRunProjectionRefGen)' != 'true'"
-             Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="$(CsWinRTMessageImportance)" />
+    <Message Condition="'$(_CsWinRTRunProjectionRefGenerator)' != 'true'"
+             Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="Low" />
     <RunCsWinRTProjectionRefGenerator
-        Condition="'$(_CsWinRTRunProjectionRefGen)' == 'true'"
+        Condition="'$(_CsWinRTRunProjectionRefGenerator)' == 'true'"
         InputWinMDPaths="@(_CsWinRTRefInputs)"
         OutputDirectory="$(CsWinRTGeneratedFilesDir.TrimEnd('\'))"
         TargetFramework="$(CsWinRTExeTFM)"

--- a/nuget/Microsoft.Windows.CsWinRT.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.targets
@@ -319,8 +319,23 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_CsWinRTRefInputs Include="@(_CsWinRTRefInteropInputs)" />
     </ItemGroup>
 
-    <Message Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="$(CsWinRTMessageImportance)" />
+    <!--
+      Only run 'cswinrtprojectionrefgen' if there is actually something to project. With no
+      includes, the namespace filter excludes everything, so the generator emits no projection
+      sources (and no base files either, since those are only written alongside a projection).
+      In that case, running the tool is a pure no-op, so we skip launching it entirely.
+    -->
+    <PropertyGroup>
+      <_CsWinRTRunProjectionRefGen>false</_CsWinRTRunProjectionRefGen>
+      <_CsWinRTRunProjectionRefGen Condition="'@(_CsWinRTRefIncludes)' != ''">true</_CsWinRTRunProjectionRefGen>
+    </PropertyGroup>
+
+    <Message Condition="'$(_CsWinRTRunProjectionRefGen)' != 'true'"
+             Text="cswinrtprojectionrefgen: skipped (no namespaces to project)" Importance="$(CsWinRTMessageImportance)" />
+    <Message Condition="'$(_CsWinRTRunProjectionRefGen)' == 'true'"
+             Text="cswinrtprojectionrefgen: @(_CsWinRTRefInputs->Count()) input(s), @(_CsWinRTRefIncludes->Count()) include(s), @(_CsWinRTRefExcludes->Count()) exclude(s)" Importance="$(CsWinRTMessageImportance)" />
     <RunCsWinRTProjectionRefGenerator
+        Condition="'$(_CsWinRTRunProjectionRefGen)' == 'true'"
         InputWinMDPaths="@(_CsWinRTRefInputs)"
         OutputDirectory="$(CsWinRTGeneratedFilesDir.TrimEnd('\'))"
         TargetFramework="$(CsWinRTExeTFM)"

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -224,6 +224,12 @@ namespace winrt::TestComponentCSharp::implementation
         _strings = winrt::single_threaded_vector<hstring>({ L"foo", L"bar" });
     }
 
+    Class::Class(int32_t intProperty, hstring const& stringProperty, ComposedNonBlittableStruct const& nonBlittableStruct) :
+        Class(intProperty, stringProperty)
+    {
+        _nonBlittableStruct = nonBlittableStruct;
+    }
+
     void Class::TypeProperty(Windows::UI::Xaml::Interop::TypeName val)
     {
         _typeProperty = val;

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -99,6 +99,7 @@ namespace winrt::TestComponentCSharp::implementation
 
         Class(int32_t intProperty);
         Class(int32_t intProperty, hstring const& stringProperty);
+        Class(int32_t intProperty, hstring const& stringProperty, ComposedNonBlittableStruct const& nonBlittableStruct);
         static int32_t StaticIntProperty();
         static void StaticIntProperty(int32_t value);
         static winrt::event_token StaticIntPropertyChanged(Windows::Foundation::EventHandler<int32_t> const& handler);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -211,6 +211,8 @@ namespace TestComponentCSharp
         Class();
         Class(Int32 intProperty);
         Class(Int32 intProperty, String stringProperty);
+        // Activation factory taking a non-blittable struct by value.
+        Class(Int32 intProperty, String stringProperty, ComposedNonBlittableStruct nonBlittableStruct);
 
         Windows.UI.Xaml.Interop.TypeName TypeProperty{ get; set; };
         String GetTypePropertyAbiName();

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2283,6 +2283,30 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public void TestNonBlittableStructConstructor()
+        {
+            // Activation factory taking a non-blittable struct by value. This exercises the
+            // projection's constructor marshalling for complex (non-blittable) struct inputs.
+            var val = new ComposedNonBlittableStruct()
+            {
+                blittable = new BlittableStruct() { i32 = 42 },
+                strings = new NonBlittableStringStruct() { str = "I like tacos" },
+                bools = new NonBlittableBoolStruct() { w = true, x = false, y = true, z = false },
+                refs = TestObject.NonBlittableRefStructProperty
+            };
+
+            var instance = new Class(5, "foo", val);
+
+            Assert.AreEqual(42, instance.ComposedNonBlittableStructProperty.blittable.i32);
+            Assert.AreEqual("I like tacos", instance.ComposedNonBlittableStructProperty.strings.str);
+            Assert.IsTrue(instance.ComposedNonBlittableStructProperty.bools.w);
+            Assert.IsFalse(instance.ComposedNonBlittableStructProperty.bools.x);
+            Assert.IsTrue(instance.ComposedNonBlittableStructProperty.bools.y);
+            Assert.IsFalse(instance.ComposedNonBlittableStructProperty.bools.z);
+            Assert.AreEqual(5, instance.IntProperty);
+        }
+
+        [TestMethod]
         public void TestBlittableArrays()
         {
             int[] arr = new[] { 2, 4, 6, 8 };

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
@@ -250,6 +250,28 @@ internal static partial class ConstructorFactory
             writer.WriteLine($"global::ABI.System.Exception __{raw} = global::ABI.System.ExceptionMarshaller.ConvertToUnmanaged({pname});");
         }
 
+        // For non-blittable struct params (structs with mapped value-type, string, Nullable<T>,
+        // or other reference-typed fields), emit an ABI struct local + per-field marshaller
+        // conversion. The factory function pointer signature expects the ABI struct by value, so
+        // the projected value must be marshalled before the call (and disposed after it).
+        bool hasNonBlittableStructInput = false;
+        for (int i = 0; i < paramCount; i++)
+        {
+            ParameterInfo p = sig.Parameters[i];
+
+            if (!context.AbiTypeKindResolver.IsNonBlittableStruct(p.Type))
+            {
+                continue;
+            }
+
+            hasNonBlittableStructInput = true;
+            string raw = p.GetRawName();
+            string pname = IdentifierEscaping.EscapeIdentifier(raw);
+            string abiType = AbiTypeHelpers.GetAbiStructTypeName(context, p.Type);
+            string marshaller = AbiTypeHelpers.GetMarshallerFullName(writer, context, p.Type);
+            writer.WriteLine($"{abiType} __{raw} = {marshaller}.ConvertToUnmanaged({pname});");
+        }
+
         // Declare InlineArray16 + ArrayPool fallback for non-blittable PassArray params
         // (runtime classes, objects, strings).
         bool hasNonBlittableArray = false;
@@ -307,7 +329,7 @@ internal static partial class ConstructorFactory
 
         writer.WriteLine("void* __retval = default;");
 
-        if (hasNonBlittableArray)
+        if (hasNonBlittableArray || hasNonBlittableStructInput)
         {
             writer.WriteLine(isMultiline: true, """
                 try
@@ -558,6 +580,10 @@ internal static partial class ConstructorFactory
             {
                 writer.Write($"__{raw}");
             }
+            else if (context.AbiTypeKindResolver.IsNonBlittableStruct(p.Type))
+            {
+                writer.Write($"__{raw}");
+            }
             else
             {
                 writer.Write(pname);
@@ -591,8 +617,9 @@ internal static partial class ConstructorFactory
             writer.WriteLine("}");
         }
 
-        // Close try and emit finally with cleanup for non-blittable PassArray params.
-        if (hasNonBlittableArray)
+        // Close try and emit finally with cleanup for non-blittable PassArray params and
+        // non-blittable struct input params.
+        if (hasNonBlittableArray || hasNonBlittableStructInput)
         {
             writer.DecreaseIndent();
             writer.WriteLine(isMultiline: true, """
@@ -601,6 +628,22 @@ internal static partial class ConstructorFactory
                 {
                 """);
             writer.IncreaseIndent();
+
+            // Dispose pre-marshalled ABI struct input locals (frees any HSTRING / boxed
+            // reference fields the per-field ConvertToUnmanaged may have allocated).
+            for (int i = 0; i < paramCount; i++)
+            {
+                ParameterInfo p = sig.Parameters[i];
+
+                if (!context.AbiTypeKindResolver.IsNonBlittableStruct(p.Type))
+                {
+                    continue;
+                }
+
+                string raw = p.GetRawName();
+                writer.WriteLine($"{AbiTypeHelpers.GetMarshallerFullName(writer, context, p.Type)}.Dispose(__{raw});");
+            }
+
             for (int i = 0; i < paramCount; i++)
             {
                 ParameterInfo p = sig.Parameters[i];

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
@@ -250,10 +250,9 @@ internal static partial class ConstructorFactory
             writer.WriteLine($"global::ABI.System.Exception __{raw} = global::ABI.System.ExceptionMarshaller.ConvertToUnmanaged({pname});");
         }
 
-        // For non-blittable struct params (structs with mapped value-type, string, Nullable<T>,
-        // or other reference-typed fields), emit an ABI struct local + per-field marshaller
-        // conversion. The factory function pointer signature expects the ABI struct by value, so
-        // the projected value must be marshalled before the call (and disposed after it).
+        // For non-blittable struct params, declare the ABI struct local default-initialized here;
+        // the marshaller conversion is emitted inside the try below, so a throwing
+        // ConvertToUnmanaged on a later param still hits the finally that disposes the others.
         bool hasNonBlittableStructInput = false;
         for (int i = 0; i < paramCount; i++)
         {
@@ -266,10 +265,8 @@ internal static partial class ConstructorFactory
 
             hasNonBlittableStructInput = true;
             string raw = p.GetRawName();
-            string pname = IdentifierEscaping.EscapeIdentifier(raw);
             string abiType = AbiTypeHelpers.GetAbiStructTypeName(context, p.Type);
-            string marshaller = AbiTypeHelpers.GetMarshallerFullName(writer, context, p.Type);
-            writer.WriteLine($"{abiType} __{raw} = {marshaller}.ConvertToUnmanaged({pname});");
+            writer.WriteLine($"{abiType} __{raw} = default;");
         }
 
         // Declare InlineArray16 + ArrayPool fallback for non-blittable PassArray params
@@ -336,6 +333,22 @@ internal static partial class ConstructorFactory
                 {
                 """);
             writer.IncreaseIndent();
+        }
+
+        // Marshal the non-blittable struct ABI locals inside the try (see declarations above).
+        for (int i = 0; i < paramCount; i++)
+        {
+            ParameterInfo p = sig.Parameters[i];
+
+            if (!context.AbiTypeKindResolver.IsNonBlittableStruct(p.Type))
+            {
+                continue;
+            }
+
+            string raw = p.GetRawName();
+            string pname = IdentifierEscaping.EscapeIdentifier(raw);
+            string marshaller = AbiTypeHelpers.GetMarshallerFullName(writer, context, p.Type);
+            writer.WriteLine($"__{raw} = {marshaller}.ConvertToUnmanaged({pname});");
         }
 
         // For System.Type params, pre-marshal to TypeReference (must be declared OUTSIDE the

--- a/src/WinRT.Projection.Writer/Helpers/TypeFilter.cs
+++ b/src/WinRT.Projection.Writer/Helpers/TypeFilter.cs
@@ -11,6 +11,17 @@ namespace WindowsRuntime.ProjectionWriter.Helpers;
 /// Include/exclude type filter using longest-prefix-match semantics: type/namespace is checked
 /// against each prefix in the include/exclude lists, and the longest matching prefix wins.
 /// </summary>
+/// <remarks>
+/// The semantics are:
+/// <list type="bullet">
+///   <item>If there are no include and no exclude rules at all, everything is included.</item>
+///   <item>Otherwise a type is included only if the longest matching rule is an include; if no
+///   rule matches (even when only exclude rules are present), the type is <b>excluded</b>.</item>
+///   <item>On an equal-length include/exclude tie, the <b>exclude</b> wins.</item>
+/// </list>
+/// In other words, once any rule exists the filter behaves as a whitelist: excludes only carve
+/// exceptions out of includes, they do not by themselves include everything else.
+/// </remarks>
 internal sealed class TypeFilter
 {
     private readonly List<string> _include;
@@ -19,8 +30,8 @@ internal sealed class TypeFilter
     /// <summary>
     /// Initializes a new <see cref="TypeFilter"/> with the given include and exclude prefix lists.
     /// </summary>
-    /// <param name="include">The include prefixes (a type matches if any prefix matches; empty means match-all).</param>
-    /// <param name="exclude">The exclude prefixes (a type is rejected if any prefix matches and no include prefix wins).</param>
+    /// <param name="include">The include prefixes (a type matches if any prefix matches).</param>
+    /// <param name="exclude">The exclude prefixes (a type is rejected if any prefix matches and no longer include prefix wins).</param>
     public TypeFilter(IEnumerable<string> include, IEnumerable<string> exclude)
     {
         _include = [.. include.OrderByDescending(s => s.Length)];
@@ -29,7 +40,7 @@ internal sealed class TypeFilter
 
     /// <summary>
     /// Returns whether the given type name passes the include/exclude filter.
-    /// Rules are sorted by descending prefix length (with includes winning ties over excludes);
+    /// Rules are sorted by descending prefix length (with excludes winning ties over includes);
     /// the first matching rule wins. Match semantics split the full type name into
     /// <c>namespace.typeName</c> parts and treat the rule prefix as either a namespace-prefix or
     /// a namespace + typename-prefix.
@@ -57,7 +68,7 @@ internal sealed class TypeFilter
             name = fullName[(dot + 1)..];
         }
 
-        // Walk both lists in descending length order; on tie, includes win over excludes.
+        // Walk both lists in descending length order; on tie, excludes win over includes.
         // (Both _include and _exclude are pre-sorted by descending length in the constructor.)
         int incIdx = 0;
         int excIdx = 0;
@@ -83,8 +94,8 @@ internal sealed class TypeFilter
             }
             else
             {
-                // Equal length: include wins (this is the documented tie-breaker).
-                pickInclude = incRule.Length >= excRule.Length;
+                // Equal length: exclude wins.
+                pickInclude = incRule.Length > excRule.Length;
             }
 
             string rule = pickInclude ? incRule! : excRule!;
@@ -104,8 +115,10 @@ internal sealed class TypeFilter
             }
         }
 
-        // No rule matched. If we have any include rules, default-exclude; else default-include.
-        return _include.Count == 0;
+        // No rule matched. Since at least one rule exists (the both-empty case returned true
+        // above), default to exclude. This means an excludes-only configuration (no includes)
+        // projects nothing rather than everything-but-excluded.
+        return false;
     }
 
     private static bool Match(string typeNamespace, string typeName, string rule)


### PR DESCRIPTION
- CsWinRTProjectionRefGen seems to be always running even if there is no projection to generate, for now scoping it running to when there are includes
- When there were CsWinRTExcludes but no includes, everything in CsWinRTInputs not excluded was being projected which isn't the behavior from before.  Types only in CsWinRTIncludes should be what is projected in that case.  Updating the TypeFilter logic in general to match what we had before.
- NonBlittable types passed in constructors were ending up failing to compile during merged projection generation as discovered by some Win2D types.  Addressing that and adding tests.