### PR TITLE
Stop relying on UB in 'IContextCallback' dispatch logic

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
@@ -105,10 +105,6 @@ internal static unsafe class ContextCallback
             comCallData.dwReserved = 0;
             comCallData.pUserDefined = &callbackData;
 
-            // Add a memory barrier to be extra safe that the target thread will be able to see
-            // the write we just did on 'LocalContextCallbackState' with the state to pass to the callback.
-            Thread.MemoryBarrier();
-
             // Marshal the supplied callback on the target context
             hresult = IContextCallbackVftbl.ContextCallbackUnsafe(
                 thisPtr: contextCallbackPtr,

--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
@@ -68,10 +68,14 @@ internal static unsafe class ContextCallback
         ref object? localContextCallbackState = ref LocalContextCallbackState;
 
         // Store the state object in the thread static to pass to the callback.
-        // We don't need a volatile write here, we have a memory barrier below.
         // A thread local is the most efficient solution for this, given that
         // we need the state to be somewhere on the managed heap to be valid.
         // The GC doesn't allow cross-thread access to managed stack variables.
+        // We're not using a volatile write, as it wouldn't actually help at all.
+        // Volatile writes disallow the write operations to be moved before memory
+        // operations that precede them, but they have nothing to say with respect
+        // to memory operations after them (whereas here we specifically need this
+        // write to not be reordered before following reads from that static field).
         if (localContextCallbackState is null)
         {
             localContextCallbackState = state;

--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace WindowsRuntime.InteropServices;
 
@@ -116,7 +115,7 @@ internal static unsafe class ContextCallback
         }
 
         // Reset the static field to avoid keeping the state alive for longer
-        Volatile.Write(ref LocalContextCallbackState, null);
+        LocalContextCallbackState = null;
 
         return hresult;
     }

--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace WindowsRuntime.InteropServices;
 
@@ -11,6 +12,12 @@ namespace WindowsRuntime.InteropServices;
 /// </summary>
 internal static unsafe class ContextCallback
 {
+    /// <summary>
+    /// Storage for the user-provided state for <see cref="CallInContextUnsafe"/>.
+    /// </summary>
+    [ThreadStatic]
+    private static object? LocalContextCallbackState;
+
     /// <summary>
     /// Calls the given callback in the right context, and returns the result of that invocation.
     /// </summary>
@@ -38,21 +45,10 @@ internal static unsafe class ContextCallback
             return WellKnownErrorCodes.S_OK;
         }
 
-        ComCallData comCallData;
-        comCallData.dwDispid = 0;
-        comCallData.dwReserved = 0;
-
-        CallbackData callbackData;
-        callbackData.Callback = callback;
-        callbackData.State = state;
-
-        // We can just store a pointer to the callback to invoke in the context,
-        // so we don't need to allocate another closure or anything. The callback
-        // will be kept alive automatically, because 'comCallData' is address exposed.
-        // In 'InvokeCallback' below, we then invoke the current caller-provided callback.
-        comCallData.pUserDefined = &callbackData;
-
-        // Stub to invoke on the target context
+        // Native method that invokes the callback on the target context. The state object is guaranteed to be pinned,
+        // so we can access it from a pointer. Note that the object will be stored in a static field, and it will not
+        // be on the stack of the original thread, so it's safe with respect to cross-thread access of managed objects.
+        // See: https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#cross-thread-access-to-local-variables.
         [UnmanagedCallersOnly]
         static int InvokeCallback(ComCallData* comCallData)
         {
@@ -60,7 +56,7 @@ internal static unsafe class ContextCallback
             {
                 CallbackData* callbackData = (CallbackData*)comCallData->pUserDefined;
 
-                callbackData->Callback(callbackData->State);
+                callbackData->Callback(*callbackData->StatePtr);
 
                 return WellKnownErrorCodes.S_OK;
             }
@@ -70,10 +66,49 @@ internal static unsafe class ContextCallback
             }
         }
 
+        ref object? localContextCallbackState = ref LocalContextCallbackState;
+
+        // Store the state object in the thread static to pass to the callback.
+        // We don't need a volatile write here, we have a memory barrier below.
+        // A thread local is the most efficient solution for this, given that
+        // we need the state to be somewhere on the managed heap to be valid.
+        // The GC doesn't allow cross-thread access to managed stack variables.
+        if (localContextCallbackState is null)
+        {
+            localContextCallbackState = state;
+        }
+        else
+        {
+            // In case we recursed on this thread, meaning the local storage already holds a state
+            // for some other caller above us in the stack, we can use a throwaway array to store
+            // the current state. This isn't very efficient, but in practice this case should not
+            // ever happen (it was validated in our entire test suite as well as in stress tests
+            // with the Microsoft Store app, and we never detected recursion on this code path).
+            // However just to be extra safe, we still want to keep this branch functional too.
+            object[] objects = [state];
+
+            localContextCallbackState = ref MemoryMarshal.GetArrayDataReference(objects)!;
+        }
+
         HRESULT hresult;
 
+        // Pin the state storage, which we can now safely pass to the target thread
+        fixed (object* statePtr = &localContextCallbackState)
         fixed (Guid* riid = &WellKnownWindowsInterfaceIIDs.IID_ICallbackWithNoReentrancyToApplicationSTA)
         {
+            CallbackData callbackData;
+            callbackData.Callback = callback;
+            callbackData.StatePtr = statePtr;
+
+            ComCallData comCallData;
+            comCallData.dwDispid = 0;
+            comCallData.dwReserved = 0;
+            comCallData.pUserDefined = &callbackData;
+
+            // Add a memory barrier to be extra safe that the target thread will be able to see
+            // the write we just did on 'LocalContextCallbackState' with the state to pass to the callback.
+            Thread.MemoryBarrier();
+
             // Marshal the supplied callback on the target context
             hresult = IContextCallbackVftbl.ContextCallbackUnsafe(
                 thisPtr: contextCallbackPtr,
@@ -83,6 +118,9 @@ internal static unsafe class ContextCallback
                 iMethod: 5,
                 pUnk: null);
         }
+
+        // Reset the static field to avoid keeping the state alive for longer
+        Volatile.Write(ref LocalContextCallbackState, null);
 
         return hresult;
     }
@@ -98,8 +136,8 @@ internal static unsafe class ContextCallback
         public delegate*<object, void> Callback;
 
         /// <summary>
-        /// The additional argument to supply to <see cref="Callback"/>.
+        /// A pointer to the additional argument to supply to <see cref="Callback"/>.
         /// </summary>
-        public object State;
+        public object* StatePtr;
     }
 }


### PR DESCRIPTION
## Summary

Port the cross-thread access fix from #1865 to the CsWinRT 3.0 runtime (`WinRT.Runtime2`). The context callback dispatch logic no longer stores the managed callback state in a stack local that is then dereferenced from the target thread, which is undefined behavior under the .NET memory model.

## Motivation

When dispatching a callback onto another context via `IContextCallback`, the previous code stored the user-provided state (a managed object) in a local variable on the *original* thread's stack and passed a pointer to it through `ComCallData`. The native `InvokeCallback` stub then dereferenced that pointer while running on the *target* thread. Reading a managed reference that lives on another thread's stack is explicitly undefined behavior, see the [.NET memory model spec on cross-thread access to local variables](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#cross-thread-access-to-local-variables). This is the same class of issue fixed for CsWinRT 2.x in #1865; this PR brings the fix to the 3.0 runtime.

## Changes

- **`src/WinRT.Runtime2/InteropServices/ObjectReference/ContextCallback.cs`**: rework `CallInContextUnsafe` to stop passing a stack-local managed reference across threads.
  - Add a `[ThreadStatic]` `LocalContextCallbackState` field so the state lives on the managed heap rather than on the calling thread's stack.
  - Write the state into that field, pin it, and pass a pointer (`CallbackData.StatePtr`) to the target context, with a `Thread.MemoryBarrier()` before the cross-context call and a `Volatile.Write(ref LocalContextCallbackState, null)` reset afterwards to avoid extending the state's lifetime.
  - Add a throwaway-array fallback for the recursion case (never observed in the test suite or in Store stress runs), so the path stays correct even if the thread-static slot is already occupied.
  - Change `CallbackData.State` (an `object`) to `CallbackData.StatePtr` (an `object*`).
