### PR TITLE
Optimize generated activation factories for authored components

### DIFF
--- a/src/WinRT.Generator.Core/Extensions/SignatureComparerExtensions.cs
+++ b/src/WinRT.Generator.Core/Extensions/SignatureComparerExtensions.cs
@@ -3,19 +3,17 @@
 
 using AsmResolver.DotNet.Signatures;
 
-namespace WindowsRuntime.ProjectionWriter;
+namespace WindowsRuntime.Generator;
 
 /// <summary>
 /// Extensions for <see cref="SignatureComparer"/>.
 /// </summary>
 internal static class SignatureComparerExtensions
 {
-#pragma warning disable IDE0052 // TODO: remove this once Roslyn bug is fixed
     /// <summary>
     /// Backing field for the <see cref="IgnoreVersion"/> extension property.
     /// </summary>
     private static readonly SignatureComparer IgnoreVersion = new(SignatureComparisonFlags.VersionAgnostic);
-#pragma warning restore IDE0052
 
     extension(SignatureComparer)
     {

--- a/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
+++ b/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
@@ -24,5 +24,8 @@
     <InternalsVisibleTo Include="cswinrtprojectiongen" />
     <InternalsVisibleTo Include="cswinrtprojectionrefgen" />
     <InternalsVisibleTo Include="cswinrtwinmdgen" />
+
+    <!-- The projection writer library consumes shared helpers (e.g. SignatureComparer.IgnoreVersion). -->
+    <InternalsVisibleTo Include="WinRT.Projection.Writer" />
   </ItemGroup>
 </Project>

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableMap2.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Factories;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.IObservableVector1.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Factories;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.Generics.cs
+++ b/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.Generics.cs
@@ -3,6 +3,7 @@
 
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
+++ b/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Extensions/ComExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ComExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.References;
 
 namespace WindowsRuntime.InteropGenerator;

--- a/src/WinRT.Interop.Generator/Extensions/IHasCustomAttributeExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/IHasCustomAttributeExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 
 namespace WindowsRuntime.InteropGenerator;
 

--- a/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/ModuleDefinitionExtensions.cs
@@ -9,6 +9,7 @@ using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Helpers;
 using WindowsRuntime.InteropGenerator.Visitors;
 

--- a/src/WinRT.Interop.Generator/Extensions/SignatureComparerExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/SignatureComparerExtensions.cs
@@ -12,20 +12,8 @@ namespace WindowsRuntime.InteropGenerator;
 /// </summary>
 internal static class SignatureComparerExtensions
 {
-#pragma warning disable IDE0052 // TODO: remove this once Roslyn bug is fixed
-    /// <summary>
-    /// Backing field for <see cref="get_IgnoreVersion"/>.
-    /// </summary>
-    private static readonly SignatureComparer IgnoreVersion = new(SignatureComparisonFlags.VersionAgnostic);
-#pragma warning restore IDE0052
-
     extension(SignatureComparer comparer)
     {
-        /// <summary>
-        /// An immutable default instance of <see cref="SignatureComparer"/>, with <see cref="SignatureComparisonFlags.VersionAgnostic"/>.
-        /// </summary>
-        public static SignatureComparer IgnoreVersion => IgnoreVersion;
-
         /// <summary>
         /// Creates an <see cref="IEqualityComparer{T}"/> instance for a pair of <see cref="TypeSignature"/> values.
         /// </summary>

--- a/src/WinRT.Interop.Generator/Extensions/TypeDefinitionExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/TypeDefinitionExtensions.cs
@@ -8,6 +8,7 @@ using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 
 #pragma warning disable IDE0046
 

--- a/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
@@ -8,6 +8,7 @@ using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.Generator.References;
 using WindowsRuntime.InteropGenerator.References;
 

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IReadOnlyDictionary2Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IReadOnlyDictionary2Impl.cs
@@ -6,6 +6,7 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;
 using static AsmResolver.PE.DotNet.Cil.CilOpCodes;

--- a/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IReadOnlyList1Impl.cs
+++ b/src/WinRT.Interop.Generator/Factories/InteropMethodDefinitionFactory.IReadOnlyList1Impl.cs
@@ -6,6 +6,7 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;
 using static AsmResolver.PE.DotNet.Cil.CilOpCodes;

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
@@ -11,6 +11,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE;
 using ConsoleAppFramework;
+using WindowsRuntime.Generator;
 using WindowsRuntime.Generator.Errors;
 using WindowsRuntime.Generator.Extensions;
 using WindowsRuntime.Generator.References;

--- a/src/WinRT.Interop.Generator/Generation/InteropGeneratorDiscoveryState.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGeneratorDiscoveryState.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Models;
 

--- a/src/WinRT.Interop.Generator/Generation/InteropGeneratorEmitState.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGeneratorEmitState.cs
@@ -8,6 +8,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Models;
 

--- a/src/WinRT.Interop.Generator/Helpers/TypeExclusions.cs
+++ b/src/WinRT.Interop.Generator/Helpers/TypeExclusions.cs
@@ -4,6 +4,7 @@
 using System;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.References;
 
 namespace WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
+++ b/src/WinRT.Interop.Generator/Helpers/WindowsRuntimeTypeAnalyzer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.References;
 
 namespace WindowsRuntime.InteropGenerator.Helpers;

--- a/src/WinRT.Interop.Generator/Models/TypeSignatureEquatableSet.Builder.cs
+++ b/src/WinRT.Interop.Generator/Models/TypeSignatureEquatableSet.Builder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 
 namespace WindowsRuntime.InteropGenerator.Models;
 

--- a/src/WinRT.Interop.Generator/Models/TypeSignatureEquatableSet.cs
+++ b/src/WinRT.Interop.Generator/Models/TypeSignatureEquatableSet.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Helpers;
 
 namespace WindowsRuntime.InteropGenerator.Models;

--- a/src/WinRT.Interop.Generator/References/WellKnownInterfaceIIDs.cs
+++ b/src/WinRT.Interop.Generator/References/WellKnownInterfaceIIDs.cs
@@ -6,6 +6,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Factories;
 

--- a/src/WinRT.Interop.Generator/Resolvers/InteropImplTypeResolver.cs
+++ b/src/WinRT.Interop.Generator/Resolvers/InteropImplTypeResolver.cs
@@ -5,6 +5,7 @@ using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Factories;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Interop.Generator/Resolvers/InteropInterfaceEntriesResolver.cs
+++ b/src/WinRT.Interop.Generator/Resolvers/InteropInterfaceEntriesResolver.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.Models;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ManagedParameter.cs
+++ b/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ManagedParameter.cs
@@ -6,6 +6,7 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ManagedValue.cs
+++ b/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ManagedValue.cs
@@ -5,6 +5,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.NativeParameter.cs
+++ b/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.NativeParameter.cs
@@ -7,6 +7,7 @@ using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Collections;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ReturnValue.cs
+++ b/src/WinRT.Interop.Generator/Rewriters/InteropMethodRewriter.ReturnValue.cs
@@ -5,6 +5,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
+using WindowsRuntime.Generator;
 using WindowsRuntime.InteropGenerator.Errors;
 using WindowsRuntime.InteropGenerator.Generation;
 using WindowsRuntime.InteropGenerator.References;

--- a/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.Generate.cs
+++ b/src/WinRT.Projection.Generator/Generation/ProjectionGenerator.Generate.cs
@@ -109,6 +109,11 @@ internal partial class ProjectionGenerator
         List<string> excludes = [];
         List<string> winmdInputs = [];
 
+        // Paths to the managed implementation assemblies of the component(s) being projected, scanned
+        // by the projection writer for implementation details (e.g. the static fields backing XAML
+        // dependency properties) that are not present in the .winmd metadata
+        List<string> componentImplementationAssemblies = [];
+
         // Filter out .winmd files from the resolver paths
         string[] resolverPaths = [.. args.ReferenceAssemblyPaths
             .Where(p => !p.EndsWith(".winmd", StringComparison.OrdinalIgnoreCase))];
@@ -141,9 +146,15 @@ internal partial class ProjectionGenerator
 
                 ModuleDefinition refModule = ModuleDefinition.FromFile(refPath, resolver.ReaderParameters);
 
-                if (IsComponentAssembly(refModule) && refModule.Assembly?.Name is Utf8String name)
+                if (IsComponentAssembly(refModule))
                 {
-                    _ = componentAssemblyNameSet.Add(name.Value);
+                    // Keep the path so the projection writer can inspect the managed implementation
+                    componentImplementationAssemblies.Add(refPath);
+
+                    if (refModule.Assembly?.Name is Utf8String name)
+                    {
+                        _ = componentAssemblyNameSet.Add(name.Value);
+                    }
                 }
             }
 
@@ -276,6 +287,7 @@ internal partial class ProjectionGenerator
             Include = includes,
             Exclude = excludes,
             Component = componentMode,
+            ComponentImplementationAssemblyPaths = componentImplementationAssemblies,
             MaxDegreesOfParallelism = args.MaxDegreesOfParallelism,
             CancellationToken = args.Token,
         };

--- a/src/WinRT.Projection.Writer/Extensions/SignatureComparerExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/SignatureComparerExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet.Signatures;
+
+namespace WindowsRuntime.ProjectionWriter;
+
+/// <summary>
+/// Extensions for <see cref="SignatureComparer"/>.
+/// </summary>
+internal static class SignatureComparerExtensions
+{
+#pragma warning disable IDE0052 // TODO: remove this once Roslyn bug is fixed
+    /// <summary>
+    /// Backing field for the <see cref="IgnoreVersion"/> extension property.
+    /// </summary>
+    private static readonly SignatureComparer IgnoreVersion = new(SignatureComparisonFlags.VersionAgnostic);
+#pragma warning restore IDE0052
+
+    extension(SignatureComparer)
+    {
+        /// <summary>
+        /// Gets a shared, version-agnostic <see cref="SignatureComparer"/>, suitable for comparing
+        /// AsmResolver entities (e.g. as the <see cref="System.Collections.Generic.IEqualityComparer{T}"/>
+        /// for a <see cref="System.Collections.Generic.HashSet{T}"/> of <see cref="AsmResolver.DotNet.TypeDefinition"/>).
+        /// </summary>
+        public static SignatureComparer IgnoreVersion => IgnoreVersion;
+    }
+}

--- a/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
@@ -53,16 +53,16 @@ internal static class ComponentFactory
     /// <param name="writer">The writer to emit the factory class to.</param>
     /// <param name="context">The active projection emit context.</param>
     /// <param name="type">The activatable runtime class to emit a factory for.</param>
-    /// <param name="emitStaticConstructor">
-    /// Whether to emit the static constructor that forces the authored type's class constructor to
-    /// run before activation. Only needed when the type registers dependency properties (see
-    /// <see cref="Metadata.ComponentStaticConstructorAnalyzer.RequiresStaticConstructor(string)"/>).
-    /// </param>
-    public static void WriteFactoryClass(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type, bool emitStaticConstructor)
+    public static void WriteFactoryClass(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type)
     {
         (string typeNs, string typeName) = type.Names();
         string projectedTypeName = TypedefNameWriter.BuildGlobalQualifiedName(typeNs, typeName);
         string factoryTypeName = $"{IdentifierEscaping.StripBackticks(typeName)}ServerActivationFactory";
+
+        // The static constructor that forces the authored type's class constructor to run before
+        // activation is only needed when the type registers dependency properties, so consult the
+        // component's managed implementation assemblies (the .winmd doesn't carry those fields).
+        bool emitStaticConstructor = context.StaticConstructorAnalyzer.RequiresStaticConstructor(type.FullName);
 
         // Writes the set of interfaces implemented by the factory class ('IActivationFactory' is always included)
         void WriteBaseInterfaceList(IndentedTextWriter writer)

--- a/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
@@ -56,7 +56,7 @@ internal static class ComponentFactory
     /// <param name="emitStaticConstructor">
     /// Whether to emit the static constructor that forces the authored type's class constructor to
     /// run before activation. Only needed when the type registers dependency properties (see
-    /// <see cref="Metadata.ComponentImplementationMetadata.RequiresStaticConstructor"/>).
+    /// <see cref="Metadata.ComponentStaticConstructorAnalyzer.RequiresStaticConstructor(string)"/>).
     /// </param>
     public static void WriteFactoryClass(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type, bool emitStaticConstructor)
     {

--- a/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/ComponentFactory.cs
@@ -50,7 +50,15 @@ internal static class ComponentFactory
     /// <summary>
     /// Writes the per-runtime-class server-activation-factory type for component mode.
     /// </summary>
-    public static void WriteFactoryClass(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type)
+    /// <param name="writer">The writer to emit the factory class to.</param>
+    /// <param name="context">The active projection emit context.</param>
+    /// <param name="type">The activatable runtime class to emit a factory for.</param>
+    /// <param name="emitStaticConstructor">
+    /// Whether to emit the static constructor that forces the authored type's class constructor to
+    /// run before activation. Only needed when the type registers dependency properties (see
+    /// <see cref="Metadata.ComponentImplementationMetadata.RequiresStaticConstructor"/>).
+    /// </param>
+    public static void WriteFactoryClass(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type, bool emitStaticConstructor)
     {
         (string typeNs, string typeName) = type.Names();
         string projectedTypeName = TypedefNameWriter.BuildGlobalQualifiedName(typeNs, typeName);
@@ -90,6 +98,27 @@ internal static class ComponentFactory
             }
         }
 
+        // Writes the static constructor that forces the projected type's class constructor to run
+        // before activation, so any dependency properties it registers (as static fields) are set
+        // up in time. Types that don't register any don't need it, so the callback emits nothing
+        // for them and the factory omits the constructor entirely, keeping the factory body a
+        // single interpolated template in either case
+        void WriteStaticConstructor(IndentedTextWriter writer)
+        {
+            if (!emitStaticConstructor)
+            {
+                return;
+            }
+
+            writer.WriteLine();
+            writer.WriteLine(isMultiline: true, $$"""
+                static {{factoryTypeName}}()
+                {
+                    global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof({{projectedTypeName}}).TypeHandle);
+                }
+                """);
+        }
+
         // Helper wrapper to write additional methods
         void WriteAdditionalActivationFactoryMethods(IndentedTextWriter writer)
         {
@@ -101,12 +130,8 @@ internal static class ComponentFactory
             internal sealed class {{factoryTypeName}} : {{WriteBaseInterfaceList}}
             {
                 private static readonly {{factoryTypeName}} _factory = new();
+                {{WriteStaticConstructor}}
 
-                static {{factoryTypeName}}()
-                {
-                    global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof({{projectedTypeName}}).TypeHandle);
-                }
-            
                 public static unsafe void* Make()
                 {
                     return global::WindowsRuntime.InteropServices.Marshalling.WindowsRuntimeInterfaceMarshaller<global::WindowsRuntime.InteropServices.IActivationFactory>

--- a/src/WinRT.Projection.Writer/Generation/ProjectionEmitContext.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionEmitContext.cs
@@ -15,11 +15,13 @@ namespace WindowsRuntime.ProjectionWriter.Generation;
 /// <param name="settings">The active projection settings.</param>
 /// <param name="cache">The metadata cache for the current generation.</param>
 /// <param name="currentNamespace">The namespace currently being emitted (or <see cref="string.Empty"/> when not in a per-namespace pass).</param>
+/// <param name="staticConstructorAnalyzer">The analyzer over the component's managed implementation assemblies (component mode).</param>
 /// <param name="windowsRuntimeMetadataTypeEntries">The (projected-type-name -> source <c>.winmd</c> stem) map to record into while emitting per-type markers, or <see langword="null"/> outside the per-namespace type-emission pass.</param>
 internal sealed class ProjectionEmitContext(
     Settings settings,
     MetadataCache cache,
     string currentNamespace,
+    ComponentStaticConstructorAnalyzer staticConstructorAnalyzer,
     ConcurrentDictionary<string, string>? windowsRuntimeMetadataTypeEntries = null)
 {
     /// <summary>
@@ -65,6 +67,14 @@ internal sealed class ProjectionEmitContext(
     /// Gets the resolver used to classify type signatures by their ABI marshalling shape.
     /// </summary>
     public AbiTypeKindResolver AbiTypeKindResolver { get; } = new AbiTypeKindResolver(cache);
+
+    /// <summary>
+    /// Gets the analyzer over the component's managed implementation assemblies (component mode).
+    /// It exposes implementation details that are absent from the <c>.winmd</c> metadata (e.g. the
+    /// <c>static</c> fields backing XAML dependency properties), computed on demand as types are
+    /// emitted. The same instance is shared by every emit context, so its memoization is reused.
+    /// </summary>
+    public ComponentStaticConstructorAnalyzer StaticConstructorAnalyzer { get; } = staticConstructorAnalyzer;
 
     /// <summary>
     /// Gets a value indicating whether platform-attribute computation should suppress platforms

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Factories;
 using WindowsRuntime.ProjectionWriter.Metadata;
 using WindowsRuntime.ProjectionWriter.Writers;

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
@@ -44,6 +44,7 @@ internal sealed partial class ProjectionGenerator
         // so consult the authored component's managed implementation assemblies to decide which
         // activation factories actually need to force the authored type's class constructor to run
         ComponentImplementationMetadata implementationMetadata = ComponentImplementationMetadata.Load(_settings.ComponentImplementationAssemblies);
+        ComponentStaticConstructorAnalyzer staticConstructorAnalyzer = new(implementationMetadata);
 
         foreach ((_, NamespaceMembers members) in _cache.Namespaces)
         {
@@ -68,7 +69,7 @@ internal sealed partial class ProjectionGenerator
 
                     _ = set.Add(type);
 
-                    if (implementationMetadata.RequiresStaticConstructor(type.FullName))
+                    if (staticConstructorAnalyzer.RequiresStaticConstructor(type.FullName))
                     {
                         _ = requiringStaticConstructor.Add(type);
                     }

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
 using WindowsRuntime.ProjectionWriter.Factories;
 using WindowsRuntime.ProjectionWriter.Metadata;
 using WindowsRuntime.ProjectionWriter.Writers;
@@ -24,17 +25,24 @@ internal sealed partial class ProjectionGenerator
     /// <list type="bullet">
     /// <item><description><c>ComponentActivatable</c> -- the flat set of all activatable classes</description></item>
     /// <item><description><c>ByModule</c> -- the same set keyed by source module name (used to emit per-module activation-factory entry points in <see cref="WriteComponentModuleFile"/>)</description></item>
+    /// <item><description><c>RequiringStaticConstructor</c> -- the subset of activatable classes whose activation factory must force the authored type's class constructor to run (because the type, or an authored base type, registers a dependency property)</description></item>
     /// </list>
     /// </returns>
-    private (HashSet<TypeDefinition> ComponentActivatable, Dictionary<string, HashSet<TypeDefinition>> ByModule) DiscoverComponentActivatableTypes()
+    private (HashSet<TypeDefinition> ComponentActivatable, Dictionary<string, HashSet<TypeDefinition>> ByModule, HashSet<TypeDefinition> RequiringStaticConstructor) DiscoverComponentActivatableTypes()
     {
-        HashSet<TypeDefinition> componentActivatable = [];
+        HashSet<TypeDefinition> componentActivatable = new(SignatureComparer.IgnoreVersion);
         Dictionary<string, HashSet<TypeDefinition>> componentByModule = [];
+        HashSet<TypeDefinition> requiringStaticConstructor = new(SignatureComparer.IgnoreVersion);
 
         if (!_settings.Component)
         {
-            return (componentActivatable, componentByModule);
+            return (componentActivatable, componentByModule, requiringStaticConstructor);
         }
+
+        // The .winmd metadata does not carry the static fields backing XAML dependency properties,
+        // so consult the authored component's managed implementation assemblies to decide which
+        // activation factories actually need to force the authored type's class constructor to run
+        ComponentImplementationMetadata implementationMetadata = ComponentImplementationMetadata.Load(_settings.ComponentImplementationAssemblies);
 
         foreach ((_, NamespaceMembers members) in _cache.Namespaces)
         {
@@ -53,16 +61,21 @@ internal sealed partial class ProjectionGenerator
 
                     if (!componentByModule.TryGetValue(moduleName, out HashSet<TypeDefinition>? set))
                     {
-                        set = [];
+                        set = new(SignatureComparer.IgnoreVersion);
                         componentByModule[moduleName] = set;
                     }
 
                     _ = set.Add(type);
+
+                    if (implementationMetadata.RequiresStaticConstructor(type.FullName))
+                    {
+                        _ = requiringStaticConstructor.Add(type);
+                    }
                 }
             }
         }
 
-        return (componentActivatable, componentByModule);
+        return (componentActivatable, componentByModule, requiringStaticConstructor);
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Component.cs
@@ -26,25 +26,17 @@ internal sealed partial class ProjectionGenerator
     /// <list type="bullet">
     /// <item><description><c>ComponentActivatable</c> -- the flat set of all activatable classes</description></item>
     /// <item><description><c>ByModule</c> -- the same set keyed by source module name (used to emit per-module activation-factory entry points in <see cref="WriteComponentModuleFile"/>)</description></item>
-    /// <item><description><c>RequiringStaticConstructor</c> -- the subset of activatable classes whose activation factory must force the authored type's class constructor to run (because the type, or an authored base type, registers a dependency property)</description></item>
     /// </list>
     /// </returns>
-    private (HashSet<TypeDefinition> ComponentActivatable, Dictionary<string, HashSet<TypeDefinition>> ByModule, HashSet<TypeDefinition> RequiringStaticConstructor) DiscoverComponentActivatableTypes()
+    private (HashSet<TypeDefinition> ComponentActivatable, Dictionary<string, HashSet<TypeDefinition>> ByModule) DiscoverComponentActivatableTypes()
     {
         HashSet<TypeDefinition> componentActivatable = new(SignatureComparer.IgnoreVersion);
         Dictionary<string, HashSet<TypeDefinition>> componentByModule = [];
-        HashSet<TypeDefinition> requiringStaticConstructor = new(SignatureComparer.IgnoreVersion);
 
         if (!_settings.Component)
         {
-            return (componentActivatable, componentByModule, requiringStaticConstructor);
+            return (componentActivatable, componentByModule);
         }
-
-        // The .winmd metadata does not carry the static fields backing XAML dependency properties,
-        // so consult the authored component's managed implementation assemblies to decide which
-        // activation factories actually need to force the authored type's class constructor to run
-        ComponentImplementationMetadata implementationMetadata = ComponentImplementationMetadata.Load(_settings.ComponentImplementationAssemblies);
-        ComponentStaticConstructorAnalyzer staticConstructorAnalyzer = new(implementationMetadata);
 
         foreach ((_, NamespaceMembers members) in _cache.Namespaces)
         {
@@ -68,16 +60,11 @@ internal sealed partial class ProjectionGenerator
                     }
 
                     _ = set.Add(type);
-
-                    if (staticConstructorAnalyzer.RequiresStaticConstructor(type.FullName))
-                    {
-                        _ = requiringStaticConstructor.Add(type);
-                    }
                 }
             }
         }
 
-        return (componentActivatable, componentByModule, requiringStaticConstructor);
+        return (componentActivatable, componentByModule);
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.GeneratedIids.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.GeneratedIids.cs
@@ -62,7 +62,7 @@ internal sealed partial class ProjectionGenerator
 
         bool iidWritten = false;
         HashSet<TypeDefinition> interfacesFromClassesEmitted = [];
-        ProjectionEmitContext guidContext = new(_settings, _cache, "ABI");
+        ProjectionEmitContext guidContext = new(_settings, _cache, "ABI", _staticConstructorAnalyzer);
         using IndentedTextWriterOwner guidIndentedOwner = IndentedTextWriterPool.GetOrCreate();
         IndentedTextWriter guidIndented = guidIndentedOwner.Writer;
         IidExpressionGenerator.WriteInterfaceIidsBegin(guidIndented);

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
@@ -27,7 +27,7 @@ internal sealed partial class ProjectionGenerator
         ConcurrentBag<KeyValuePair<string, string>> exclusiveToInterfaceEntries = state.ExclusiveToInterfaceEntries;
         ConcurrentDictionary<string, string> authoredTypeNameToMetadataMap = state.AuthoredTypeNameToMetadataMap;
         HashSet<TypeDefinition> componentActivatable = state.ComponentActivatable;
-        ProjectionEmitContext context = new(_settings, _cache, ns, state.WindowsRuntimeMetadataTypeEntries);
+        ProjectionEmitContext context = new(_settings, _cache, ns, _staticConstructorAnalyzer, state.WindowsRuntimeMetadataTypeEntries);
         using IndentedTextWriterOwner writerOwner = IndentedTextWriterPool.GetOrCreate();
         IndentedTextWriter writer = writerOwner.Writer;
 
@@ -137,7 +137,7 @@ internal sealed partial class ProjectionGenerator
 
                 if (_settings.Component && componentActivatable.Contains(type))
                 {
-                    ComponentFactory.WriteFactoryClass(writer, context, type, state.ComponentActivatableRequiringStaticConstructor.Contains(type));
+                    ComponentFactory.WriteFactoryClass(writer, context, type);
                 }
             }
             else if (kind is TypeKind.Delegate or TypeKind.Enum or TypeKind.Interface)

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
@@ -137,7 +137,7 @@ internal sealed partial class ProjectionGenerator
 
                 if (_settings.Component && componentActivatable.Contains(type))
                 {
-                    ComponentFactory.WriteFactoryClass(writer, context, type);
+                    ComponentFactory.WriteFactoryClass(writer, context, type, state.ComponentActivatableRequiringStaticConstructor.Contains(type));
                 }
             }
             else if (kind is TypeKind.Delegate or TypeKind.Enum or TypeKind.Interface)

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.cs
@@ -55,11 +55,12 @@ internal sealed partial class ProjectionGenerator(Settings settings, MetadataCac
     {
         HashSet<TypeDefinition> componentActivatable;
         Dictionary<string, HashSet<TypeDefinition>> componentByModule;
+        HashSet<TypeDefinition> componentActivatableRequiringStaticConstructor;
 
         // Phase 1: discover the activatable runtime classes (component mode only).
         try
         {
-            (componentActivatable, componentByModule) = DiscoverComponentActivatableTypes();
+            (componentActivatable, componentByModule, componentActivatableRequiringStaticConstructor) = DiscoverComponentActivatableTypes();
         }
         catch (Exception e) when (!e.IsWellKnown)
         {
@@ -68,7 +69,7 @@ internal sealed partial class ProjectionGenerator(Settings settings, MetadataCac
 
         _token.ThrowIfCancellationRequested();
 
-        ProjectionGeneratorRunState state = new(componentActivatable, componentByModule);
+        ProjectionGeneratorRunState state = new(componentActivatable, componentByModule, componentActivatableRequiringStaticConstructor);
 
         // Phase 2: parallel emission. All file writes happen below; wrap the whole emission
         // pipeline in a single try/catch so any unexpected failure surfaces as an

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.cs
@@ -49,18 +49,26 @@ internal sealed partial class ProjectionGenerator(Settings settings, MetadataCac
     private readonly CancellationToken _token = token;
 
     /// <summary>
+    /// Analyzes the component's managed implementation assemblies to decide which activation
+    /// factories must force the authored type's class constructor to run. Created once and shared
+    /// by every emit context, so its memoization cache is reused across namespaces. Empty (and
+    /// unused) outside component mode, where no implementation assemblies are provided.
+    /// </summary>
+    private readonly ComponentStaticConstructorAnalyzer _staticConstructorAnalyzer =
+        new(ComponentImplementationMetadata.Load(settings.ComponentImplementationAssemblies));
+
+    /// <summary>
     /// Runs the projection-generation pipeline end-to-end.
     /// </summary>
     public void Run()
     {
         HashSet<TypeDefinition> componentActivatable;
         Dictionary<string, HashSet<TypeDefinition>> componentByModule;
-        HashSet<TypeDefinition> componentActivatableRequiringStaticConstructor;
 
         // Phase 1: discover the activatable runtime classes (component mode only).
         try
         {
-            (componentActivatable, componentByModule, componentActivatableRequiringStaticConstructor) = DiscoverComponentActivatableTypes();
+            (componentActivatable, componentByModule) = DiscoverComponentActivatableTypes();
         }
         catch (Exception e) when (!e.IsWellKnown)
         {
@@ -69,7 +77,7 @@ internal sealed partial class ProjectionGenerator(Settings settings, MetadataCac
 
         _token.ThrowIfCancellationRequested();
 
-        ProjectionGeneratorRunState state = new(componentActivatable, componentByModule, componentActivatableRequiringStaticConstructor);
+        ProjectionGeneratorRunState state = new(componentActivatable, componentByModule);
 
         // Phase 2: parallel emission. All file writes happen below; wrap the whole emission
         // pipeline in a single try/catch so any unexpected failure surfaces as an

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGeneratorRunState.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGeneratorRunState.cs
@@ -30,6 +30,14 @@ internal sealed class ProjectionGeneratorRunState
     public Dictionary<string, HashSet<TypeDefinition>> ComponentByModule { get; }
 
     /// <summary>
+    /// Gets the subset of <see cref="ComponentActivatable"/> whose activation factory must force the
+    /// authored type's class constructor to run before activation (because the type, or an authored
+    /// base type, registers a dependency property). Read-only after construction; safe for concurrent
+    /// reads from any work item.
+    /// </summary>
+    public HashSet<TypeDefinition> ComponentActivatableRequiringStaticConstructor { get; }
+
+    /// <summary>
     /// Gets the (projected-type-name -> default-interface-name) map populated by namespace
     /// work items via <see cref="Factories.MetadataAttributeFactory.AddDefaultInterfaceEntry"/>.
     /// </summary>
@@ -69,12 +77,15 @@ internal sealed class ProjectionGeneratorRunState
     /// </summary>
     /// <param name="componentActivatable">The flat set of activatable runtime classes.</param>
     /// <param name="componentByModule">The activatable classes grouped by source module name.</param>
+    /// <param name="componentActivatableRequiringStaticConstructor">The subset of activatable classes whose activation factory must force the authored type's class constructor to run.</param>
     public ProjectionGeneratorRunState(
         HashSet<TypeDefinition> componentActivatable,
-        Dictionary<string, HashSet<TypeDefinition>> componentByModule)
+        Dictionary<string, HashSet<TypeDefinition>> componentByModule,
+        HashSet<TypeDefinition> componentActivatableRequiringStaticConstructor)
     {
         ComponentActivatable = componentActivatable;
         ComponentByModule = componentByModule;
+        ComponentActivatableRequiringStaticConstructor = componentActivatableRequiringStaticConstructor;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Generation/ProjectionGeneratorRunState.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGeneratorRunState.cs
@@ -30,14 +30,6 @@ internal sealed class ProjectionGeneratorRunState
     public Dictionary<string, HashSet<TypeDefinition>> ComponentByModule { get; }
 
     /// <summary>
-    /// Gets the subset of <see cref="ComponentActivatable"/> whose activation factory must force the
-    /// authored type's class constructor to run before activation (because the type, or an authored
-    /// base type, registers a dependency property). Read-only after construction; safe for concurrent
-    /// reads from any work item.
-    /// </summary>
-    public HashSet<TypeDefinition> ComponentActivatableRequiringStaticConstructor { get; }
-
-    /// <summary>
     /// Gets the (projected-type-name -> default-interface-name) map populated by namespace
     /// work items via <see cref="Factories.MetadataAttributeFactory.AddDefaultInterfaceEntry"/>.
     /// </summary>
@@ -77,15 +69,12 @@ internal sealed class ProjectionGeneratorRunState
     /// </summary>
     /// <param name="componentActivatable">The flat set of activatable runtime classes.</param>
     /// <param name="componentByModule">The activatable classes grouped by source module name.</param>
-    /// <param name="componentActivatableRequiringStaticConstructor">The subset of activatable classes whose activation factory must force the authored type's class constructor to run.</param>
     public ProjectionGeneratorRunState(
         HashSet<TypeDefinition> componentActivatable,
-        Dictionary<string, HashSet<TypeDefinition>> componentByModule,
-        HashSet<TypeDefinition> componentActivatableRequiringStaticConstructor)
+        Dictionary<string, HashSet<TypeDefinition>> componentByModule)
     {
         ComponentActivatable = componentActivatable;
         ComponentByModule = componentByModule;
-        ComponentActivatableRequiringStaticConstructor = componentActivatableRequiringStaticConstructor;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Generation/Settings.cs
+++ b/src/WinRT.Projection.Writer/Generation/Settings.cs
@@ -103,6 +103,14 @@ internal sealed class Settings
     public bool Component { get; init; }
 
     /// <summary>
+    /// Gets the paths to the managed implementation assemblies of the authored Windows Runtime
+    /// component(s) being projected. Used in component mode to inspect implementation details that
+    /// are absent from the input <c>.winmd</c> metadata (e.g. the <c>static</c> fields backing XAML
+    /// dependency properties). May be empty when those assemblies are not available.
+    /// </summary>
+    public HashSet<string> ComponentImplementationAssemblies { get; } = [];
+
+    /// <summary>
     /// Gets or sets a value indicating whether <c>[ExclusiveTo]</c> interfaces are emitted as <c>public</c> rather than <c>internal</c>.
     /// </summary>
     public bool PublicExclusiveTo { get; init; }

--- a/src/WinRT.Projection.Writer/Metadata/ComponentImplementationMetadata.cs
+++ b/src/WinRT.Projection.Writer/Metadata/ComponentImplementationMetadata.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.ProjectionWriter.References;
+
+namespace WindowsRuntime.ProjectionWriter.Metadata;
+
+/// <summary>
+/// Indexes implementation details of the authored Windows Runtime component(s) being projected,
+/// read from their managed implementation assemblies (<c>.dll</c>). These details are not present
+/// in the <c>.winmd</c> metadata, so they have to be read from the compiled assemblies directly.
+/// </summary>
+/// <remarks>
+/// The only detail currently tracked is whether an authored type registers any XAML dependency
+/// properties (modelled as <c>static</c> fields of type <c>DependencyProperty</c>), which drives
+/// whether the generated activation factory needs to force the authored type's class constructor
+/// to run before the type is activated.
+/// </remarks>
+internal sealed class ComponentImplementationMetadata
+{
+    /// <summary>
+    /// Per-type record: whether the type itself declares a <c>static</c> <c>DependencyProperty</c>
+    /// field, and the full name of its base type (used to walk authored base types).
+    /// </summary>
+    private readonly record struct TypeRecord(bool DeclaresDependencyProperty, string? BaseTypeFullName);
+
+    /// <summary>The authored types indexed by full name.</summary>
+    private readonly Dictionary<string, TypeRecord> _typesByFullName;
+
+    private ComponentImplementationMetadata(Dictionary<string, TypeRecord> typesByFullName)
+    {
+        _typesByFullName = typesByFullName;
+    }
+
+    /// <summary>
+    /// Loads the metadata for the given managed implementation assemblies. When the input is empty,
+    /// the returned instance is empty and <see cref="RequiresStaticConstructor"/> conservatively
+    /// reports that every type needs its class constructor.
+    /// </summary>
+    /// <param name="assemblyPaths">The managed implementation assembly paths to scan.</param>
+    /// <returns>The loaded metadata.</returns>
+    public static ComponentImplementationMetadata Load(IEnumerable<string> assemblyPaths)
+    {
+        // Type full names are compared ordinally, which is the default string equality used here
+        Dictionary<string, TypeRecord> typesByFullName = [];
+
+        foreach (string assemblyPath in assemblyPaths)
+        {
+            ModuleDefinition module = ModuleDefinition.FromFile(assemblyPath);
+
+            foreach (TypeDefinition type in module.GetAllTypes())
+            {
+                string fullName = type.FullName;
+
+                // Skip the '<Module>' pseudo-type and only index the first definition for a given
+                // full name (multiple component assemblies should never define the same type)
+                if (string.IsNullOrEmpty(fullName) || type.Name?.Value is "<Module>")
+                {
+                    continue;
+                }
+
+                _ = typesByFullName.TryAdd(fullName, new TypeRecord(DeclaresDependencyProperty(type), type.BaseType?.FullName));
+            }
+        }
+
+        return new ComponentImplementationMetadata(typesByFullName);
+    }
+
+    /// <summary>
+    /// Determines whether the activation factory for the authored type identified by
+    /// <paramref name="typeFullName"/> must force the type's class constructor to run before
+    /// activation, i.e. whether the type (or any authored base type) registers a dependency property.
+    /// </summary>
+    /// <param name="typeFullName">The full name of the authored type.</param>
+    /// <returns><see langword="true"/> if the static constructor is required; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// If the type is not found among the scanned implementation assemblies, this returns
+    /// <see langword="true"/>: we cannot prove the constructor is unnecessary, so it is kept (this
+    /// preserves the previous behavior whenever no implementation assemblies are available). The
+    /// hierarchy walk stops at the first base type outside the scanned assemblies (e.g. a framework
+    /// base type), because framework dependency properties are registered by the framework itself.
+    /// </remarks>
+    public bool RequiresStaticConstructor(string typeFullName)
+    {
+        if (!_typesByFullName.ContainsKey(typeFullName))
+        {
+            return true;
+        }
+
+        HashSet<string> visited = [];
+        string? current = typeFullName;
+
+        while (current is not null && visited.Add(current) && _typesByFullName.TryGetValue(current, out TypeRecord record))
+        {
+            if (record.DeclaresDependencyProperty)
+            {
+                return true;
+            }
+
+            current = record.BaseTypeFullName;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="type"/> declares any <c>static</c> field whose type is the
+    /// XAML <c>DependencyProperty</c> (in either <c>Microsoft.UI.Xaml</c> or <c>Windows.UI.Xaml</c>).
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><see langword="true"/> if the type declares such a field; otherwise, <see langword="false"/>.</returns>
+    private static bool DeclaresDependencyProperty(TypeDefinition type)
+    {
+        foreach (FieldDefinition field in type.Fields)
+        {
+            if (!field.IsStatic)
+            {
+                continue;
+            }
+
+            TypeSignature? fieldType = field.Signature?.FieldType;
+
+            if (fieldType is null)
+            {
+                continue;
+            }
+
+            (string ns, string name) = fieldType.Names();
+
+            if (name == WellKnownTypeNames.DependencyProperty &&
+                (ns == WellKnownNamespaces.MicrosoftUIXaml || ns == WellKnownNamespaces.WindowsUIXaml))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/WinRT.Projection.Writer/Metadata/ComponentImplementationMetadata.cs
+++ b/src/WinRT.Projection.Writer/Metadata/ComponentImplementationMetadata.cs
@@ -3,49 +3,41 @@
 
 using System.Collections.Generic;
 using AsmResolver.DotNet;
-using AsmResolver.DotNet.Signatures;
-using WindowsRuntime.ProjectionWriter.References;
 
 namespace WindowsRuntime.ProjectionWriter.Metadata;
 
 /// <summary>
-/// Indexes implementation details of the authored Windows Runtime component(s) being projected,
-/// read from their managed implementation assemblies (<c>.dll</c>). These details are not present
-/// in the <c>.winmd</c> metadata, so they have to be read from the compiled assemblies directly.
+/// Resolves authored Windows Runtime types from the managed implementation assemblies (<c>.dll</c>)
+/// of the component(s) being projected, by full name. The managed assemblies carry implementation
+/// details (such as the <c>static</c> fields backing XAML dependency properties) that are not
+/// present in the <c>.winmd</c> metadata, so consumers resolve the managed type here and inspect it
+/// directly.
 /// </summary>
 /// <remarks>
-/// The only detail currently tracked is whether an authored type registers any XAML dependency
-/// properties (modelled as <c>static</c> fields of type <c>DependencyProperty</c>), which drives
-/// whether the generated activation factory needs to force the authored type's class constructor
-/// to run before the type is activated.
+/// Loading only builds a name index over the assemblies' types. No per-type analysis is performed
+/// up front: callers resolve just the types they care about (see
+/// <see cref="ComponentStaticConstructorAnalyzer"/>), keeping the cost proportional to what is used.
 /// </remarks>
 internal sealed class ComponentImplementationMetadata
 {
-    /// <summary>
-    /// Per-type record: whether the type itself declares a <c>static</c> <c>DependencyProperty</c>
-    /// field, and the full name of its base type (used to walk authored base types).
-    /// </summary>
-    private readonly record struct TypeRecord(bool DeclaresDependencyProperty, string? BaseTypeFullName);
+    /// <summary>The authored types indexed by full name (ordinal, the default string equality).</summary>
+    private readonly Dictionary<string, TypeDefinition> _typesByFullName;
 
-    /// <summary>The authored types indexed by full name.</summary>
-    private readonly Dictionary<string, TypeRecord> _typesByFullName;
-
-    private ComponentImplementationMetadata(Dictionary<string, TypeRecord> typesByFullName)
+    private ComponentImplementationMetadata(Dictionary<string, TypeDefinition> typesByFullName)
     {
         _typesByFullName = typesByFullName;
     }
 
     /// <summary>
-    /// Loads the metadata for the given managed implementation assemblies. When the input is empty,
-    /// the returned instance is empty and <see cref="RequiresStaticConstructor"/> conservatively
-    /// reports that every type needs its class constructor.
+    /// Loads the managed implementation assemblies and indexes their types by full name. When the
+    /// input is empty, the returned instance resolves nothing and <see cref="Resolve"/> always
+    /// returns <see langword="null"/>.
     /// </summary>
-    /// <param name="assemblyPaths">The managed implementation assembly paths to scan.</param>
+    /// <param name="assemblyPaths">The managed implementation assembly paths to load.</param>
     /// <returns>The loaded metadata.</returns>
     public static ComponentImplementationMetadata Load(IEnumerable<string> assemblyPaths)
     {
-        // Type full names are compared ordinally, which is the default string equality used here
-        Dictionary<string, TypeRecord> typesByFullName = [];
+        Dictionary<string, TypeDefinition> typesByFullName = [];
 
         foreach (string assemblyPath in assemblyPaths)
         {
@@ -62,7 +54,7 @@ internal sealed class ComponentImplementationMetadata
                     continue;
                 }
 
-                _ = typesByFullName.TryAdd(fullName, new TypeRecord(DeclaresDependencyProperty(type), type.BaseType?.FullName));
+                _ = typesByFullName.TryAdd(fullName, type);
             }
         }
 
@@ -70,73 +62,14 @@ internal sealed class ComponentImplementationMetadata
     }
 
     /// <summary>
-    /// Determines whether the activation factory for the authored type identified by
-    /// <paramref name="typeFullName"/> must force the type's class constructor to run before
-    /// activation, i.e. whether the type (or any authored base type) registers a dependency property.
+    /// Resolves the authored type with the given full name from the loaded implementation
+    /// assemblies, or <see langword="null"/> if no such type is present (e.g. a framework type, or
+    /// when no implementation assemblies were loaded).
     /// </summary>
-    /// <param name="typeFullName">The full name of the authored type.</param>
-    /// <returns><see langword="true"/> if the static constructor is required; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>
-    /// If the type is not found among the scanned implementation assemblies, this returns
-    /// <see langword="true"/>: we cannot prove the constructor is unnecessary, so it is kept (this
-    /// preserves the previous behavior whenever no implementation assemblies are available). The
-    /// hierarchy walk stops at the first base type outside the scanned assemblies (e.g. a framework
-    /// base type), because framework dependency properties are registered by the framework itself.
-    /// </remarks>
-    public bool RequiresStaticConstructor(string typeFullName)
+    /// <param name="fullName">The full name of the type to resolve.</param>
+    /// <returns>The resolved <see cref="TypeDefinition"/>, or <see langword="null"/>.</returns>
+    public TypeDefinition? Resolve(string fullName)
     {
-        if (!_typesByFullName.ContainsKey(typeFullName))
-        {
-            return true;
-        }
-
-        HashSet<string> visited = [];
-        string? current = typeFullName;
-
-        while (current is not null && visited.Add(current) && _typesByFullName.TryGetValue(current, out TypeRecord record))
-        {
-            if (record.DeclaresDependencyProperty)
-            {
-                return true;
-            }
-
-            current = record.BaseTypeFullName;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Returns whether <paramref name="type"/> declares any <c>static</c> field whose type is the
-    /// XAML <c>DependencyProperty</c> (in either <c>Microsoft.UI.Xaml</c> or <c>Windows.UI.Xaml</c>).
-    /// </summary>
-    /// <param name="type">The type to inspect.</param>
-    /// <returns><see langword="true"/> if the type declares such a field; otherwise, <see langword="false"/>.</returns>
-    private static bool DeclaresDependencyProperty(TypeDefinition type)
-    {
-        foreach (FieldDefinition field in type.Fields)
-        {
-            if (!field.IsStatic)
-            {
-                continue;
-            }
-
-            TypeSignature? fieldType = field.Signature?.FieldType;
-
-            if (fieldType is null)
-            {
-                continue;
-            }
-
-            (string ns, string name) = fieldType.Names();
-
-            if (name == WellKnownTypeNames.DependencyProperty &&
-                (ns == WellKnownNamespaces.MicrosoftUIXaml || ns == WellKnownNamespaces.WindowsUIXaml))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return _typesByFullName.GetValueOrDefault(fullName);
     }
 }

--- a/src/WinRT.Projection.Writer/Metadata/ComponentStaticConstructorAnalyzer.cs
+++ b/src/WinRT.Projection.Writer/Metadata/ComponentStaticConstructorAnalyzer.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
+using WindowsRuntime.ProjectionWriter.References;
+
+namespace WindowsRuntime.ProjectionWriter.Metadata;
+
+/// <summary>
+/// Decides whether the activation factory generated for an authored Windows Runtime class must
+/// force the class constructor to run before activation, i.e. whether the class (or an authored
+/// base class) registers any XAML dependency properties.
+/// </summary>
+/// <remarks>
+/// Dependency properties are registered in <c>static</c> fields of type <c>DependencyProperty</c>,
+/// so they only exist in the managed implementation assemblies, not in the <c>.winmd</c> metadata.
+/// The analyzer resolves each queried type lazily via <see cref="ComponentImplementationMetadata"/>
+/// and walks its base chain on demand, memoizing the result per visited type so that shared
+/// hierarchies (e.g. several controls deriving from a common authored base) are traversed once.
+/// </remarks>
+internal sealed class ComponentStaticConstructorAnalyzer
+{
+    /// <summary>The resolver used to look up authored types (and their base types) by full name.</summary>
+    private readonly ComponentImplementationMetadata _metadata;
+
+    /// <summary>
+    /// Memoizes, per visited type, whether it requires the class constructor to run. Keyed with the
+    /// version-agnostic <see cref="SignatureComparer"/>, the standard comparer for AsmResolver entities.
+    /// </summary>
+    private readonly Dictionary<TypeDefinition, bool> _cache = new(SignatureComparer.IgnoreVersion);
+
+    /// <summary>
+    /// Creates a new <see cref="ComponentStaticConstructorAnalyzer"/> over the given metadata.
+    /// </summary>
+    /// <param name="metadata">The resolver for the component's managed implementation types.</param>
+    public ComponentStaticConstructorAnalyzer(ComponentImplementationMetadata metadata)
+    {
+        _metadata = metadata;
+    }
+
+    /// <summary>
+    /// Determines whether the activation factory for the authored type identified by
+    /// <paramref name="typeFullName"/> must force the type's class constructor to run before
+    /// activation.
+    /// </summary>
+    /// <param name="typeFullName">The full name of the authored type.</param>
+    /// <returns><see langword="true"/> if the static constructor is required; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// If the type cannot be resolved from the scanned implementation assemblies, this returns
+    /// <see langword="true"/>: we cannot prove the constructor is unnecessary, so it is kept (this
+    /// also covers the case where no implementation assemblies are available).
+    /// </remarks>
+    public bool RequiresStaticConstructor(string typeFullName)
+    {
+        TypeDefinition? type = _metadata.Resolve(typeFullName);
+
+        return type is null || RequiresStaticConstructor(type);
+    }
+
+    /// <summary>
+    /// Memoized core: whether <paramref name="type"/> (or an authored base type) registers a
+    /// dependency property.
+    /// </summary>
+    /// <param name="type">The resolved authored type to inspect.</param>
+    /// <returns><see langword="true"/> if the static constructor is required; otherwise, <see langword="false"/>.</returns>
+    private bool RequiresStaticConstructor(TypeDefinition type)
+    {
+        if (_cache.TryGetValue(type, out bool cached))
+        {
+            return cached;
+        }
+
+        // The type itself registers a dependency property, or an authored base type does. The base
+        // walk stops at the first type outside the scanned assemblies (e.g. a framework base type),
+        // because framework dependency properties are registered by the framework itself. Inheritance
+        // can't cycle, so a plain recursion (memoized below) always terminates.
+        bool result =
+            DeclaresDependencyProperty(type) ||
+            (type.BaseType is { } baseType &&
+             _metadata.Resolve(baseType.FullName) is { } baseDefinition &&
+             RequiresStaticConstructor(baseDefinition));
+
+        _cache[type] = result;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="type"/> declares any <c>static</c> field whose type is the
+    /// XAML <c>DependencyProperty</c> (in either <c>Microsoft.UI.Xaml</c> or <c>Windows.UI.Xaml</c>).
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><see langword="true"/> if the type declares such a field; otherwise, <see langword="false"/>.</returns>
+    private static bool DeclaresDependencyProperty(TypeDefinition type)
+    {
+        foreach (FieldDefinition field in type.Fields)
+        {
+            if (!field.IsStatic)
+            {
+                continue;
+            }
+
+            TypeSignature? fieldType = field.Signature?.FieldType;
+
+            if (fieldType is null)
+            {
+                continue;
+            }
+
+            (string ns, string name) = fieldType.Names();
+
+            if (name == WellKnownTypeNames.DependencyProperty &&
+                (ns == WellKnownNamespaces.MicrosoftUIXaml || ns == WellKnownNamespaces.WindowsUIXaml))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/WinRT.Projection.Writer/Metadata/ComponentStaticConstructorAnalyzer.cs
+++ b/src/WinRT.Projection.Writer/Metadata/ComponentStaticConstructorAnalyzer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using WindowsRuntime.Generator;
@@ -19,7 +19,9 @@ namespace WindowsRuntime.ProjectionWriter.Metadata;
 /// so they only exist in the managed implementation assemblies, not in the <c>.winmd</c> metadata.
 /// The analyzer resolves each queried type lazily via <see cref="ComponentImplementationMetadata"/>
 /// and walks its base chain on demand, memoizing the result per visited type so that shared
-/// hierarchies (e.g. several controls deriving from a common authored base) are traversed once.
+/// hierarchies (e.g. several controls deriving from a common authored base) are traversed once. A
+/// single instance is shared by all per-namespace emit contexts and queried from the parallel
+/// emission work items, so the memoization cache is concurrent.
 /// </remarks>
 internal sealed class ComponentStaticConstructorAnalyzer
 {
@@ -27,10 +29,11 @@ internal sealed class ComponentStaticConstructorAnalyzer
     private readonly ComponentImplementationMetadata _metadata;
 
     /// <summary>
-    /// Memoizes, per visited type, whether it requires the class constructor to run. Keyed with the
+    /// Memoizes, per visited type, whether it requires the class constructor to run. Concurrent
+    /// because the analyzer is queried from the parallel emission work items. Keyed with the
     /// version-agnostic <see cref="SignatureComparer"/>, the standard comparer for AsmResolver entities.
     /// </summary>
-    private readonly Dictionary<TypeDefinition, bool> _cache = new(SignatureComparer.IgnoreVersion);
+    private readonly ConcurrentDictionary<TypeDefinition, bool> _cache = new(SignatureComparer.IgnoreVersion);
 
     /// <summary>
     /// Creates a new <see cref="ComponentStaticConstructorAnalyzer"/> over the given metadata.

--- a/src/WinRT.Projection.Writer/ProjectionWriter.cs
+++ b/src/WinRT.Projection.Writer/ProjectionWriter.cs
@@ -57,6 +57,7 @@ public static class ProjectionWriter
             settings.Include.UnionWith(options.Include);
             settings.Exclude.UnionWith(options.Exclude);
             settings.AdditionExclude.UnionWith(options.AdditionExclude);
+            settings.ComponentImplementationAssemblies.UnionWith(options.ComponentImplementationAssemblyPaths);
 
             settings.MakeReadOnly();
 

--- a/src/WinRT.Projection.Writer/ProjectionWriterOptions.cs
+++ b/src/WinRT.Projection.Writer/ProjectionWriterOptions.cs
@@ -47,6 +47,19 @@ public sealed class ProjectionWriterOptions
     public bool Component { get; init; }
 
     /// <summary>
+    /// Optional paths to the managed implementation assemblies (<c>.dll</c>) of the authored
+    /// Windows Runtime component(s) being projected. Only meaningful in <see cref="Component"/> mode.
+    /// </summary>
+    /// <remarks>
+    /// The input <c>.winmd</c> metadata does not carry implementation details such as the
+    /// <c>static</c> fields backing XAML dependency properties, so the writer consults these
+    /// managed assemblies to decide whether each generated activation factory needs to force the
+    /// authored type's class constructor to run before activation. When the list is empty (e.g. the
+    /// managed assembly is not available yet), the writer conservatively keeps that constructor.
+    /// </remarks>
+    public IReadOnlyList<string> ComponentImplementationAssemblyPaths { get; init; } = [];
+
+    /// <summary>
     /// Make exclusive-to interfaces public in the projection (default is internal).
     /// </summary>
     public bool PublicExclusiveTo { get; init; }

--- a/src/WinRT.Projection.Writer/References/WellKnownNamespaces.cs
+++ b/src/WinRT.Projection.Writer/References/WellKnownNamespaces.cs
@@ -37,4 +37,14 @@ internal static class WellKnownNamespaces
     /// The <c>Windows.UI.Xaml.Interop</c> namespace.
     /// </summary>
     public const string WindowsUIXamlInterop = "Windows.UI.Xaml.Interop";
+
+    /// <summary>
+    /// The <c>Windows.UI.Xaml</c> namespace (UWP XAML, where <c>DependencyProperty</c> lives in that mode).
+    /// </summary>
+    public const string WindowsUIXaml = "Windows.UI.Xaml";
+
+    /// <summary>
+    /// The <c>Microsoft.UI.Xaml</c> namespace (WinUI, where <c>DependencyProperty</c> lives in that mode).
+    /// </summary>
+    public const string MicrosoftUIXaml = "Microsoft.UI.Xaml";
 }

--- a/src/WinRT.Projection.Writer/References/WellKnownTypeNames.cs
+++ b/src/WinRT.Projection.Writer/References/WellKnownTypeNames.cs
@@ -52,4 +52,11 @@ internal static class WellKnownTypeNames
     /// The Windows SDK XAML <c>TypeName</c> struct (the WinMD source for <see cref="System.Type"/>).
     /// </summary>
     public const string TypeName = "TypeName";
+
+    /// <summary>
+    /// The XAML <c>DependencyProperty</c> type (in either <c>Microsoft.UI.Xaml</c> for WinUI or
+    /// <c>Windows.UI.Xaml</c> for UWP XAML). Authored types register dependency properties as
+    /// <c>static</c> fields of this type.
+    /// </summary>
+    public const string DependencyProperty = "DependencyProperty";
 }

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WinRT.Generator.Core\WinRT.Generator.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="WinRT.Projection.Writer.TestRunner" />
   </ItemGroup>
 

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -14,7 +14,7 @@
       
     <!--
       The writer enables the strictest analysis posture (AnalysisLevel=latest +
-      AnalysisLevelStyle=latest-all), matching WinRT.Interop.Generator. The five entries
+      AnalysisLevelStyle=latest-all), matching WinRT.Interop.Generator. The six entries
       below are intentional permanent suppressions. They are scoped at the project level
       because each one fires across many sites where the writer's emission patterns
       can't reasonably comply with the IDE rule the analyzer surfaces (most recent
@@ -24,9 +24,10 @@
     -->
     <!-- IDE0010 / IDE0072: Add missing cases to switch over a large enum (ElementType etc.) — too noisy to enumerate every case. -->
     <!-- IDE0022: Use expression body for method — writer prefers block bodies for emission helpers, even when short, for visual consistency with surrounding multi-statement methods. -->
+    <!-- IDE0028: Collection initialization can be simplified — fires on the 'new(SignatureComparer.IgnoreVersion)' pattern, but simplifying to a collection literal would drop the comparer, so the suggestion is not correct. -->
     <!-- IDE0046: 'if' statement can be simplified — early-return guards are more readable than nested ternaries when the branch produces a literal/sentinel and the rest of the method continues. -->
     <!-- IDE0060: Remove unused parameter — keep for API consistency across factory helpers. -->
-    <NoWarn>$(NoWarn);IDE0010;IDE0022;IDE0046;IDE0060;IDE0072</NoWarn>
+    <NoWarn>$(NoWarn);IDE0010;IDE0022;IDE0028;IDE0046;IDE0060;IDE0072</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -14,7 +14,7 @@
       
     <!--
       The writer enables the strictest analysis posture (AnalysisLevel=latest +
-      AnalysisLevelStyle=latest-all), matching WinRT.Interop.Generator. The six entries
+      AnalysisLevelStyle=latest-all), matching WinRT.Interop.Generator. The five entries
       below are intentional permanent suppressions. They are scoped at the project level
       because each one fires across many sites where the writer's emission patterns
       can't reasonably comply with the IDE rule the analyzer surfaces (most recent
@@ -24,10 +24,9 @@
     -->
     <!-- IDE0010 / IDE0072: Add missing cases to switch over a large enum (ElementType etc.) — too noisy to enumerate every case. -->
     <!-- IDE0022: Use expression body for method — writer prefers block bodies for emission helpers, even when short, for visual consistency with surrounding multi-statement methods. -->
-    <!-- IDE0028: Collection initialization can be simplified — fires on the 'new(SignatureComparer.IgnoreVersion)' pattern, but simplifying to a collection literal would drop the comparer, so the suggestion is not correct. -->
     <!-- IDE0046: 'if' statement can be simplified — early-return guards are more readable than nested ternaries when the branch produces a literal/sentinel and the rest of the method continues. -->
     <!-- IDE0060: Remove unused parameter — keep for API consistency across factory helpers. -->
-    <NoWarn>$(NoWarn);IDE0010;IDE0022;IDE0028;IDE0046;IDE0060;IDE0072</NoWarn>
+    <NoWarn>$(NoWarn);IDE0010;IDE0022;IDE0046;IDE0060;IDE0072</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Optimize the `*ServerActivationFactory` classes generated for authored Windows Runtime components: the static constructor that forces the authored type's class constructor to run before activation is now emitted only when the type actually needs it (i.e. when it, or an authored base type, registers XAML dependency properties). For all other authored types it is pure overhead and is now omitted.

## Motivation

Every generated activation factory used to emit a static constructor calling `RuntimeHelpers.RunClassConstructor(typeof(T).TypeHandle)`. That is only required when the authored type registers XAML dependency properties (declared as `static DependencyProperty` fields), so they are registered before the type is first activated. For every other type the static constructor is unnecessary work at activation time, so making it pay-for-play removes that overhead.

Whether a type registers dependency properties cannot be answered from the `.winmd` metadata (it does not carry static fields), so the change also threads the component's compiled implementation assemblies into the projection writer and adds the infrastructure to answer that question on demand while emitting each factory. Along the way it consolidates a small shared helper (`SignatureComparer.IgnoreVersion`) into the shared generator core so both the projection writer and the interop generator use a single copy.

## Changes

The PR is organised into focused commits:

- **Plumb the managed implementation assemblies into the projection writer** — `ProjectionWriterOptions.ComponentImplementationAssemblyPaths` (carried through `Settings`) exposes the authored component's compiled `.dll`(s) to the writer, and the projection generator host collects, in component mode, the reference assemblies marked `[WindowsRuntimeComponentAssembly]`.
- **Skip the activation factory static constructor when not needed** — `ComponentFactory.WriteFactoryClass` emits the static constructor only when required, via a callback so the factory body stays a single interpolated template; adds `DependencyProperty` and the `Microsoft.UI.Xaml` / `Windows.UI.Xaml` namespaces to the well-known name references.
- **Move `SignatureComparer.IgnoreVersion` to the shared generator core** — promotes the version-agnostic comparer to `WinRT.Generator.Core` and migrates both the projection writer and the interop generator to consume the single shared copy, removing the interop generator's duplicate.
- **Make the dependency-property analysis lazy** — `ComponentImplementationMetadata` is a thin resolver that indexes the managed assemblies' types by name, and a new `ComponentStaticConstructorAnalyzer` computes the requirement on demand, walking base types lazily and memoizing per visited type so shared hierarchies are traversed once.
- **Compute the requirement on the fly via the emit context** — `ProjectionEmitContext` carries the shared analyzer, so `WriteFactoryClass` derives the answer from the type and context instead of taking a pre-computed flag; the analyzer's cache is concurrent since it is queried from the parallel emission work items.

Backward compatible: when the implementation assemblies are not available (e.g. reference-projection generation), the analysis conservatively keeps the static constructor, matching the previous always-emit behavior.
