### PR TITLE
Centralize build properties and clean up project files

### DIFF
--- a/src/Authoring/WinRT.Host.Shim/Module.cs
+++ b/src/Authoring/WinRT.Host.Shim/Module.cs
@@ -1,4 +1,7 @@
-// TODO: consider embedding this as a resource into WinRT.Host.dll, 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// TODO: consider embedding this as a resource into WinRT.Host.dll,
 // to simplify deployment
 
 using System;
@@ -13,25 +16,34 @@ using WindowsRuntime.InteropServices.Marshalling;
 
 namespace WinRT.Host;
 
+/// <summary>
+/// Provides the activation factory entry point used by the native <c>WinRT.Host</c> shim to host managed Windows Runtime components.
+/// </summary>
 public static class Shim
 {
     private const int S_OK = 0;
     private const int E_NOINTERFACE = unchecked((int)0x80004002);
     private const int REGDB_E_READREGDB = unchecked((int)0x80040150);
-    private const int CLASS_E_CLASSNOTAVAILABLE = unchecked((int)(0x80040111));
+    private const int CLASS_E_CLASSNOTAVAILABLE = unchecked((int)0x80040111);
 
+    /// <summary>
+    /// Delegate matching the native signature used to retrieve an activation factory from a hosted component.
+    /// </summary>
     public unsafe delegate int GetActivationFactoryDelegate(IntPtr hstrTargetAssembly, IntPtr hstrRuntimeClassId, IntPtr* activationFactory);
 
     private unsafe delegate void* ManagedExportsGetActivationFactoryDelegate(ReadOnlySpan<char> activatableClassId);
 
     private static HashSet<string> _InitializedResolvers;
 
+    /// <summary>
+    /// Retrieves the activation factory for a runtime class from the specified target assembly, loading it into the default load context.
+    /// </summary>
     public static unsafe int GetActivationFactory(IntPtr hstrTargetAssembly, IntPtr hstrRuntimeClassId, IntPtr* activationFactory)
     {
         *activationFactory = IntPtr.Zero;
 
-        var targetAssembly = HStringMarshaller.ConvertToManaged((void*)hstrTargetAssembly);
-        var runtimeClassId = HStringMarshaller.ConvertToManaged((void*)hstrRuntimeClassId);
+        string targetAssembly = HStringMarshaller.ConvertToManaged((void*)hstrTargetAssembly);
+        string runtimeClassId = HStringMarshaller.ConvertToManaged((void*)hstrRuntimeClassId);
 
         try
         {
@@ -39,19 +51,19 @@ public static class Shim
 
             // ABI.<ModuleName>.ManagedExports.GetActivationFactory(ReadOnlySpan<char>) -> void*
             string moduleName = Path.GetFileNameWithoutExtension(targetAssembly);
-            var managedExportsType = assembly.GetType($"ABI.{moduleName}.ManagedExports");
+            Type managedExportsType = assembly.GetType($"ABI.{moduleName}.ManagedExports");
             if (managedExportsType == null)
             {
                 return REGDB_E_READREGDB;
             }
-            var GetActivationFactory = managedExportsType.GetMethod("GetActivationFactory", new Type[] { typeof(ReadOnlySpan<char>) });
+            MethodInfo GetActivationFactory = managedExportsType.GetMethod("GetActivationFactory", [typeof(ReadOnlySpan<char>)]);
             if (GetActivationFactory == null)
             {
                 return REGDB_E_READREGDB;
             }
             // ReadOnlySpan<char> is a ref struct and can't be used with MethodInfo.Invoke.
             // Use a delegate to call the method directly.
-            var del = GetActivationFactory.CreateDelegate<ManagedExportsGetActivationFactoryDelegate>();
+            ManagedExportsGetActivationFactoryDelegate del = GetActivationFactory.CreateDelegate<ManagedExportsGetActivationFactoryDelegate>();
             void* factory = del(runtimeClassId.AsSpan());
             if (factory == null)
             {
@@ -70,25 +82,21 @@ public static class Shim
     {
         if (_InitializedResolvers == null)
         {
-            Interlocked.CompareExchange(ref _InitializedResolvers, new HashSet<string>(StringComparer.OrdinalIgnoreCase), null);
+            _ = Interlocked.CompareExchange(ref _InitializedResolvers, new HashSet<string>(StringComparer.OrdinalIgnoreCase), null);
         }
 
         lock (_InitializedResolvers)
         {
             if (!_InitializedResolvers.Contains(targetAssembly))
             {
-                var resolver = new AssemblyDependencyResolver(targetAssembly);
-                AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName) =>
+                AssemblyDependencyResolver resolver = new(targetAssembly);
+                AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) =>
                 {
                     string assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
-                    if (assemblyPath != null)
-                    {
-                        return assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
-                    }
-                    return null;
+                    return assemblyPath != null ? assemblyLoadContext.LoadFromAssemblyPath(assemblyPath) : null;
                 };
 
-                _InitializedResolvers.Add(targetAssembly);
+                _ = _InitializedResolvers.Add(targetAssembly);
             }
         }
 

--- a/src/Authoring/WinRT.Host.Shim/WinRT.Host.Shim.csproj
+++ b/src/Authoring/WinRT.Host.Shim/WinRT.Host.Shim.csproj
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
+
+    <!--
+      This project is meant to be used for hosting scenarios with CoreCLR, so trimming and AOT
+      aren't supported by design. Opt out of the centralized 'IsAotCompatible' default so the
+      trim/AOT analyzers don't run on it.
+    -->
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Authoring/WinRT.Host.Shim/WinRT.Host.Shim.csproj
+++ b/src/Authoring/WinRT.Host.Shim/WinRT.Host.Shim.csproj
@@ -4,10 +4,6 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\WinRT.Runtime2\WinRT.Runtime.csproj" />
   </ItemGroup>

--- a/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
+++ b/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!--
       Suppress the following warning:

--- a/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
+++ b/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
@@ -27,28 +26,6 @@
       to the Roslyn code analysis process to try to debug the generators, forcing to pick the path manually.
     -->
     <DebugType>embedded</DebugType>
-
-    <!-- Treat all warnings as errors, only in release configurations (same as in the runtime) -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-
-    <!-- Enable the latest warning wave (same as in the runtime) -->
-    <AnalysisLevel>latest</AnalysisLevel>
-
-    <!-- Import the global configs from the CodeStyle package (enables all IDExxxx warnings)-->
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-
-    <!-- Enforce all code style rules during build (this replaces referencing Microsoft.CodeAnalysis.CSharp.CodeStyle) -->
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <!-- Suppress ref safety warnings in unsafe contexts (same as in the runtime) -->
-    <NoWarn>$(NoWarn);CS8500</NoWarn>
-
-    <!-- Enable the compiler strict mode (same as in the runtime) -->
-    <Features>strict</Features>
-
-    <!-- Generate documentation files (same workaround as in the runtime) -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Roslyn settings -->
     <IsRoslynComponent>true</IsRoslynComponent>

--- a/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
+++ b/src/Authoring/WinRT.SourceGenerator2/WinRT.SourceGenerator2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/Benchmarks/EventPerf.cs
+++ b/src/Benchmarks/EventPerf.cs
@@ -59,8 +59,8 @@ namespace Benchmarks
             ClassWithMarshalingRoutines instance = new ClassWithMarshalingRoutines();
             int z;
             System.EventHandler<int> s = (object sender, int value) => z = value;
-            return instance;
             GC.KeepAlive(s);
+            return instance;
         }
 
         [Benchmark]
@@ -134,8 +134,8 @@ namespace Benchmarks
             System.EventHandler<int> s = (object sender, int value) => z = value;
             instance.IntPropertyChanged += s;
             instance.IntPropertyChanged -= s;
-            return instance;
             GC.KeepAlive(s);
+            return instance;
         }
 
         [Benchmark]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,6 +41,14 @@
   <PropertyGroup Label="Globals" Condition="'$(MSBuildProjectExtension)' == '.csproj'">
 
     <!--
+      Classify "public" (product) projects, ie. the ones we actually ship, which are all named with a 'WinRT.'
+      prefix. This is used below to scope the repo's strict analysis (code-style enforcement and XML documentation)
+      to just those projects, leaving non-product projects (tests, samples, benchmarks, the local projection
+      projects, etc.) out of it. Note: 'StartsWith(...)' returns 'true'/'false', so compare against 'true' below.
+    -->
+    <IsPublicProject>$(MSBuildProjectName.StartsWith('WinRT.'))</IsPublicProject>
+
+    <!--
       Centralize the .NET version used by all projects. This makes it much easier to try out different
       .NET versions without touching every project file, as well as reverting any changes, if needed.
     -->
@@ -67,14 +75,14 @@
     <AnalysisLevel>latest</AnalysisLevel>
 
     <!--
-      Enable all IDExxxx code-style rules and enforce them during build, but only for the actual product
-      projects (ie. those with the 'WinRT.' prefix in their name). We don't want to impose the repo's strict
-      code-style rules on non-product projects (tests, samples, benchmarks, the local projection projects, etc.):
-      they would surface a large number of non-actionable IDExxxx warnings (and 'EnableGenerateDocumentationFile'
-      from IDE0005, which requires docs to be generated) on code we don't ship, including generated projection code.
+      Enable all IDExxxx code-style rules and enforce them during build, but only for the public (product) projects.
+      We don't want to impose the repo's strict code-style rules on non-product projects (tests, samples, benchmarks,
+      the local projection projects, etc.): they would surface a large number of non-actionable IDExxxx warnings (and
+      'EnableGenerateDocumentationFile' from IDE0005, which requires docs to be generated) on code we don't ship,
+      including generated projection code.
     -->
-    <AnalysisLevelStyle Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">true</EnforceCodeStyleInBuild>
+    <AnalysisLevelStyle Condition="'$(IsPublicProject)' == 'true'">latest-all</AnalysisLevelStyle>
+    <EnforceCodeStyleInBuild Condition="'$(IsPublicProject)' == 'true'">true</EnforceCodeStyleInBuild>
       
     <!--
       Suppress ref safety warnings in unsafe contexts (see https://github.com/dotnet/csharplang/issues/6476).
@@ -100,10 +108,9 @@
     <Features>$(Features);strict</Features>
 
     <!--
-      Generate documentation files, but only for the actual product projects (ie. those with the 'WinRT.' prefix
-      in their name). We don't care about XML docs for non-product projects (tests, samples, benchmarks, the local
-      projection projects, etc.), and enabling it there would also enforce 'CS1591' on all their public members and
-      on generated projection code, which isn't actionable.
+      Generate documentation files, but only for the public (product) projects. We don't care about XML docs for
+      non-product projects (tests, samples, benchmarks, the local projection projects, etc.), and enabling it there
+      would also enforce 'CS1591' on all their public members and on generated projection code, which isn't actionable.
 
       In theory this should only be enabled for published, non source generator projects. However, it's enabled for
       all product projects (including the source generator) to work around https://github.com/dotnet/roslyn/issues/41640.
@@ -111,7 +118,7 @@
       doesn't really impact NuGet packages, since the analyzer binaries are packed manually after build, so the .xml
       files aren't included. Once that issue is fixed, this should be restricted to published projects only.
     -->
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="'$(IsPublicProject)' == 'true'">true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Set overrides to point to folder where they are built in solution -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -66,11 +66,15 @@
     -->
     <AnalysisLevel>latest</AnalysisLevel>
 
-    <!-- Import the global configs from the CodeStyle package (enables all IDExxxx warnings)-->
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-
-    <!-- Enforce all code style rules during build (this replaces referencing Microsoft.CodeAnalysis.CSharp.CodeStyle) -->
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!--
+      Enable all IDExxxx code-style rules and enforce them during build, but only for the actual product
+      projects (ie. those with the 'WinRT.' prefix in their name). We don't want to impose the repo's strict
+      code-style rules on non-product projects (tests, samples, benchmarks, the local projection projects, etc.):
+      they would surface a large number of non-actionable IDExxxx warnings (and 'EnableGenerateDocumentationFile'
+      from IDE0005, which requires docs to be generated) on code we don't ship, including generated projection code.
+    -->
+    <AnalysisLevelStyle Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">latest-all</AnalysisLevelStyle>
+    <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">true</EnforceCodeStyleInBuild>
       
     <!--
       Suppress ref safety warnings in unsafe contexts (see https://github.com/dotnet/csharplang/issues/6476).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -96,14 +96,18 @@
     <Features>$(Features);strict</Features>
 
     <!--
-      Generate documentation files. In theory this should only be abled for published, non source generator projects.
-      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
-      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
-      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
-      When this workaround is no longer needed, the same property should also removed for the \samples directory.
-      Once that issue is fixed, this should be moved down to the src\ specific .props file again, and otherwise disabled.
+      Generate documentation files, but only for the actual product projects (ie. those with the 'WinRT.' prefix
+      in their name). We don't care about XML docs for non-product projects (tests, samples, benchmarks, the local
+      projection projects, etc.), and enabling it there would also enforce 'CS1591' on all their public members and
+      on generated projection code, which isn't actionable.
+
+      In theory this should only be enabled for published, non source generator projects. However, it's enabled for
+      all product projects (including the source generator) to work around https://github.com/dotnet/roslyn/issues/41640.
+      Until that's fixed, source generators will also produce an .xml file with their documentation. Note that this
+      doesn't really impact NuGet packages, since the analyzer binaries are packed manually after build, so the .xml
+      files aren't included. Once that issue is fixed, this should be restricted to published projects only.
     -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="$(MSBuildProjectName.StartsWith('WinRT.'))">true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Set overrides to point to folder where they are built in solution -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -49,6 +49,9 @@
     <!-- Enforce the same language version for all projects -->
     <LangVersion>14.0</LangVersion>
 
+    <!-- Allow unsafe code in all projects (the runtime and build tools rely heavily on pointers and other unsafe constructs for interop) -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
     <!--
       Treat all warnings as errors, only in release configurations. This allows the dev inner loop to remain
       convenient, without errors while testing things out and prototyping things, while still ensuring that

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,10 +11,11 @@
     <MicrosoftWinAppSDKIxpVersion>1.8.251104001</MicrosoftWinAppSDKIxpVersion>
     <MicrosoftWinAppSDKFoundationVersion>1.8.251104000</MicrosoftWinAppSDKFoundationVersion>
     <MicrosoftWebWebView2Version>1.0.3179.45</MicrosoftWebWebView2Version>
+
+    <!-- Debug symbol properties -->
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <LangVersion>preview</LangVersion>
-    <NoWarn>8305;0618</NoWarn>
+
     <GenerateTestProjection Condition="'$(GenerateTestProjection)$(Configuration)' == 'Release'">true</GenerateTestProjection>
     <GenerateTestProjection Condition="'$(GenerateTestProjection)' == ''">false</GenerateTestProjection>
     <CsWinRTGenerateProjection>$(GenerateTestProjection)</CsWinRTGenerateProjection>
@@ -35,6 +36,71 @@
     <FunctionalTestsBuildTFMs>net10.0</FunctionalTestsBuildTFMs>
     <WindowsAppSDKVerifyWinrtRuntimeVersion>false</WindowsAppSDKVerifyWinrtRuntimeVersion>
     <CsWinRTMessageImportance>high</CsWinRTMessageImportance>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Globals" Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+
+    <!--
+      Centralize the .NET version used by all projects. This makes it much easier to try out different
+      .NET versions without touching every project file, as well as reverting any changes, if needed.
+    -->
+    <DotNetVersion>net10.0</DotNetVersion>
+
+    <!-- Enforce the same language version for all projects -->
+    <LangVersion>14.0</LangVersion>
+
+    <!--
+      Treat all warnings as errors, only in release configurations. This allows the dev inner loop to remain
+      convenient, without errors while testing things out and prototyping things, while still ensuring that
+      all CI runs and official builds (including from PRs) will fail if any warnings are not addressed.
+    -->
+    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
+
+    <!--
+      Enable the latest warning wave, which shows additional warnings for invalid language features that are disabled by default.
+      For additional info, see https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-messages/warning-waves.
+    -->
+    <AnalysisLevel>latest</AnalysisLevel>
+
+    <!-- Import the global configs from the CodeStyle package (enables all IDExxxx warnings)-->
+    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
+
+    <!-- Enforce all code style rules during build (this replaces referencing Microsoft.CodeAnalysis.CSharp.CodeStyle) -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+      
+    <!--
+      Suppress ref safety warnings in unsafe contexts (see https://github.com/dotnet/csharplang/issues/6476).
+      This is used eg. to replace Unsafe.SizeOf<T>() calls with just sizeof(T), or to just use raw pointers to
+      reinterpret references to managed objects when it is safe to do so. The warnings are not necessary in this
+      context, since in order to use these APIs the caller already has to be in an unsafe context.
+    -->
+    <NoWarn>$(NoWarn);CS8500</NoWarn>
+
+    <!--
+      Temporarily suppress warnings about using CsWinRT 3.0 while in preview:
+      NETSDK1229: "Targeting a Windows SDK version with '1' as the revision number will reference CsWinRT 3.0, which is
+      currently in preview. The current project is targeting the Windows SDK version ''. If this is not intended, change
+      the revision number to '0' to use CsWinRT 2.x instead.".
+    -->
+    <NoWarn>$(NoWarn);NETSDK1229</NoWarn>
+
+    <!--
+      Enable the compiler strict mode (see https://www.meziantou.net/csharp-compiler-strict-mode.htm).
+      This (poorly documented) mode enables additional warnings for incorrect usages of some features.
+      For instance, this will warn when using the == operator to compare a struct with a null literal.
+    -->
+    <Features>$(Features);strict</Features>
+
+    <!--
+      Generate documentation files. In theory this should only be abled for published, non source generator projects.
+      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
+      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
+      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
+      When this workaround is no longer needed, the same property should also removed for the \samples directory.
+      Once that issue is fixed, this should be moved down to the src\ specific .props file again, and otherwise disabled.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Set overrides to point to folder where they are built in solution -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,7 +14,7 @@
       in the .csproj, because doing it here causes the property to not be visible early
       enough by the MSIX tooling, which causes the publishing to run incorrectly.
     -->
-    <IsAotCompatible Condition="'$(OutputType)' == 'Library'">true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(OutputType)' == 'Library' and '$(IsAotCompatible)' == ''">true</IsAotCompatible>
 
     <!-- Emit the [DisableRuntimeMarshalling] attribute (also enables the associated analyzer) -->
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -22,8 +22,11 @@
     <!--
       Emit the '[module: SkipLocalsInit]' attribute, to further reduce runtime overhead. This is especially useful when
       using 'stackalloc'. See: https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute.
+      The C# compiler requires unsafe code to be allowed in order to use '[SkipLocalsInit]' (otherwise it produces
+      CS0227), so this is only enabled for projects that opt into unsafe blocks. Projects that don't allow unsafe
+      code wouldn't benefit from it anyway (it's only meaningful in combination with eg. 'stackalloc').
     -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
+    <EmitSkipLocalsInitAttribute Condition="'$(AllowUnsafeBlocks)' == 'true'">true</EmitSkipLocalsInitAttribute>
   </PropertyGroup>
 
   <!-- NativeAOT and optimization options -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,15 +1,78 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <LangVersion>preview</LangVersion>
+  <!-- Properties for AOT and marshalling -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" >
+
+    <!--
+      Show full details for all trim/AOT warnings produced during builds.
+      Normally, the linker would only show a generic warning per assembly.
+    -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+
+    <!--
+      Enable AOT support for libraries. Note: for applications, we must enable AOT directly
+      in the .csproj, because doing it here causes the property to not be visible early
+      enough by the MSIX tooling, which causes the publishing to run incorrectly.
+    -->
+    <IsAotCompatible Condition="'$(OutputType)' == 'Library'">true</IsAotCompatible>
+
+    <!-- Emit the [DisableRuntimeMarshalling] attribute (also enables the associated analyzer) -->
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+
+    <!--
+      Emit the '[module: SkipLocalsInit]' attribute, to further reduce runtime overhead. This is especially useful when
+      using 'stackalloc'. See: https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute.
+    -->
+    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
   </PropertyGroup>
 
+  <!-- NativeAOT and optimization options -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) and '$(PublishAot)' == 'true'" >
+
+    <!-- Misc NativeAOT options to save size and maximize speed -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Speed</OptimizationPreference>
+    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
+    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
+
+    <!--
+      Enable CFG (Control Flow Guard), to make the resulting native binary more resilient to some exploit types.
+      Also see: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/security#control-flow-guard.
+      And: https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard#how-does-cfg-really-work.
+    -->
+    <ControlFlowGuard>Guard</ControlFlowGuard>
+
+    <!--
+      "It disables data dehydration. This is something we primarily added for linux because our data structures have lots of pointers in them
+      (e.g. vtables point to the method bodies) and on linux each such pointers costs 24 bytes of bookkeeping in the linux exe file format.
+      So this generates data structures in a dehydrated form on disk to avoid the penalty. The executables get smaller (much smaller on linux),
+      but we need to rehydrate them when the process starts.
+      [...]
+      Rehydrated data affects the size of private working set.
+      [...]
+      Setting IlcDehydrate=false might reduce private working set by about 30 MB."
+      (suggested by Michal Strehovsky, @michals, Native AOT lead)
+
+      In local testing, this results in a small launch performance improvement, and a small memory use reduction as well.
+    -->
+    <IlcDehydrate>false</IlcDehydrate>
+
+    <!--
+      By default, NativeAOT will ignore issues where assemblies fail to be resolved (eg. due to incorrect package authoring).
+      For any references to them, it will silently replace them with throwing stubs instead, without emitting any warnings.
+      Disabling this property changes this behavior and ensures publish builds will fail instead if this case is hit.
+    -->
+    <IlcResilient>false</IlcResilient>
+  </PropertyGroup>
+
+  <!-- Setup the generated folders -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'" >
     <GeneratedFilesRootDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'Generated Files'))</GeneratedFilesRootDir>
     <GeneratedFilesDir>$([MSBuild]::NormalizeDirectory('$(GeneratedFilesRootDir)', '$(TargetFramework)'))</GeneratedFilesDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(SimulateCsWinRTNugetReference)' == 'true'">
+
     <!-- Set in targets file to ensure we set it after .NET SDK sets it default based on TFM -->
     <_TargetPlatformVersionUsesCsWinRT3>true</_TargetPlatformVersionUsesCsWinRT3>      
   </PropertyGroup>
@@ -21,16 +84,18 @@
   </ItemGroup>
     
   <ItemGroup>
-    <!-- This repo builds the SDK projection assemblies from source, so remove
-         any SDK-injected ref packages. -->
+
+    <!-- This repo builds the SDK projection assemblies from source, so remove any SDK-injected ref packages -->
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Windows" />
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.Xaml" />
   </ItemGroup>
 
-  <!-- WinRT.Internal consumes the Windows SDK projection directly to compile
-       WindowsRuntime.Internal.idl bindings, so it must keep the CsWinRT3 ref
-       packs that the .NET SDK adds for the 'net*-windows*.*.1' TFMs. -->
+  <!--
+    WinRT.Internal consumes the Windows SDK projection directly to compile
+    WindowsRuntime.Internal.idl bindings, so it must keep the CsWinRT3 ref
+    packs that the .NET SDK adds for the 'net*-windows*.*.1' TFMs.
+  -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'WinRT.Internal'">
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.CsWinRT3.Windows" />
     <FrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref.CsWinRT3.Xaml" />
@@ -86,8 +151,7 @@
     <ItemGroup>
       <Compile Include="$(GeneratedSkipLocalsInitFile)" />
     </ItemGroup>
-  </Target>
-    
+  </Target>    
 
   <!-- For C# projects, we use embedded pdbs, but we still need to submit symbols to the symbol server,
        so we extract the pdb to submit. -->
@@ -111,5 +175,4 @@
       <FileWrites Include="$(_OutputPdbPath)" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Perf/ResultsComparer/ResultsComparer.csproj
+++ b/src/Perf/ResultsComparer/ResultsComparer.csproj
@@ -4,6 +4,13 @@
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <TargetFramework Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+
+    <!--
+      This is a local-only benchmark results comparer tool (not shipped and not part of the
+      main solution), so XML docs and the repo's strict code-style enforcement aren't applied.
+    -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />

--- a/src/Projections/Directory.Build.props
+++ b/src/Projections/Directory.Build.props
@@ -19,6 +19,9 @@
     -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0108;CS0109;CS0114;CS0219;CS0628;CS0660;CA2257</WarningsNotAsErrors>
 
+    <!-- Generated projections surface evaluation-only ('[Experimental]') Windows Runtime APIs, so 'CS8305' is expected -->
+    <NoWarn>$(NoWarn);CS8305</NoWarn>
+
     <!-- Projections should not require runtime marshalling. -->
     <DisableRuntimeMarshalling>True</DisableRuntimeMarshalling>
     <CsWinRTAotOptimizerEnabled Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">Auto</CsWinRTAotOptimizerEnabled>

--- a/src/Projections/Directory.Build.props
+++ b/src/Projections/Directory.Build.props
@@ -7,13 +7,14 @@
       "CS0109: The member 'IChatMessage2.Status' does not hide an accessible member. The new keyword is not required."
       "CS0114: 'IUnSealedCustomEquals.GetHashCode()' hides inherited member 'object.GetHashCode()'. To make the current member
           override that implementation, add the override keyword. Otherwise add the new keyword."
+      "CS1591: Missing XML comment for publicly visible type or member 'CoreDragDropManager'."
       "CS0219: The variable '__retval' is assigned but its value is never used."
       "CS0628: 'ToggleSwitch.OnToggled()': new protected member declared in sealed type"
       "CS0660: 'CustomEquals2' defines operator == or operator != but does not override Object.Equals(object o)"
       "CA2257: The 'ABI.Windows.Foundation.Collections.IMapChangedEventArgs<K>.Vftbl' member on the 'ABI.Windows.Foundation.Collections.IMapChangedEventArgs<K>'
           type should be marked 'static' as 'ABI.Windows.Foundation.Collections.IMapChangedEventArgs<K>' has the 'DynamicInterfaceImplementationAttribute' applied"
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0108;CS0109;CS0114;CS0219;CS0628;CS0660;CA2257</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0108;CS0109;CS0114;CS1591;CS0219;CS0628;CS0660;CA2257</WarningsNotAsErrors>
 
     <!-- Generated projections surface evaluation-only ('[Experimental]') Windows Runtime APIs, so 'CS8305' is expected -->
     <NoWarn>$(NoWarn);CS8305</NoWarn>

--- a/src/Projections/Directory.Build.props
+++ b/src/Projections/Directory.Build.props
@@ -1,9 +1,5 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
-
   <PropertyGroup>
-    <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
     <!--
       Don't fail builds for well known warnings in projections that are lower priority:
 
@@ -22,16 +18,10 @@
     <!-- Generated projections surface evaluation-only ('[Experimental]') Windows Runtime APIs, so 'CS8305' is expected -->
     <NoWarn>$(NoWarn);CS8305</NoWarn>
 
-    <!-- Projections should not require runtime marshalling. -->
-    <DisableRuntimeMarshalling>True</DisableRuntimeMarshalling>
-    <CsWinRTAotOptimizerEnabled Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">Auto</CsWinRTAotOptimizerEnabled>
-
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <IsTrimmable>true</IsTrimmable>
-    <IsAotCompatible>true</IsAotCompatible>
+    <!-- Projection settings -->
     <CsWinRTGenerateReferenceProjection>true</CsWinRTGenerateReferenceProjection>
+    <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
 </Project>

--- a/src/Tests/BuildDeterminismTest/BuildDeterminismComponent/BuildDeterminismComponent.csproj
+++ b/src/Tests/BuildDeterminismTest/BuildDeterminismComponent/BuildDeterminismComponent.csproj
@@ -5,7 +5,6 @@
     <Platforms>x64;x86</Platforms>
     <ProjectName>BuildDeterminismComponent</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <CsWinRTGenerateInteropAssembly>true</CsWinRTGenerateInteropAssembly>
   </PropertyGroup>

--- a/src/Tests/BuildDeterminismTest/BuildDeterminismComponent/BuildDeterminismComponent.csproj
+++ b/src/Tests/BuildDeterminismTest/BuildDeterminismComponent/BuildDeterminismComponent.csproj
@@ -5,6 +5,15 @@
     <Platforms>x64;x86</Platforms>
     <ProjectName>BuildDeterminismComponent</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
+
+    <!--
+      This component uses Windows-only APIs (e.g. 'Windows.Foundation.Point/Rect', 'Microsoft.UI.Xaml'),
+      which trip 'CA1416' since the project targets a platform-agnostic 'net10.0' TFM. We can't switch to a
+      '-windows' TFM to satisfy the analyzer because the determinism test harness ('BuildDeterminismTest')
+      hard-codes the 'net10.0' TFM and output path, so suppress 'CA1416' instead. The component is only ever
+      built and run on Windows.
+    -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <CsWinRTGenerateInteropAssembly>true</CsWinRTGenerateInteropAssembly>
   </PropertyGroup>

--- a/src/Tests/DiagnosticTests/DiagnosticTests.csproj
+++ b/src/Tests/DiagnosticTests/DiagnosticTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(TestsBuildTFMs)</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/DiagnosticTests/Helpers.cs
+++ b/src/Tests/DiagnosticTests/Helpers.cs
@@ -28,7 +28,7 @@ namespace DiagnosticTests
         /// <param name="compilation"></param>
         /// <param name="generators"></param>
         /// <returns></returns>
-        private static GeneratorDriver CreateDriver(Compilation compilation, AnalyzerConfigOptionsProvider? options, params ISourceGenerator[] generators)
+        private static GeneratorDriver CreateDriver(Compilation compilation, AnalyzerConfigOptionsProvider options, params ISourceGenerator[] generators)
             => CSharpGeneratorDriver.Create(
                 generators: ImmutableArray.Create(generators),
                 additionalTexts: ImmutableArray<AdditionalText>.Empty,
@@ -42,7 +42,7 @@ namespace DiagnosticTests
         /// <param name="diagnostics"></param>
         /// <param name="generators"></param>
         /// <returns></returns>
-        private static Compilation RunGenerators(Compilation compilation, out ImmutableArray<Diagnostic> diagnostics, out GeneratorDriverRunResult result, AnalyzerConfigOptionsProvider? options, params ISourceGenerator[] generators)
+        private static Compilation RunGenerators(Compilation compilation, out ImmutableArray<Diagnostic> diagnostics, out GeneratorDriverRunResult result, AnalyzerConfigOptionsProvider options, params ISourceGenerator[] generators)
         {
             var driver = CreateDriver(compilation, options, generators).RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out diagnostics);
             result = driver.GetRunResult();

--- a/src/Tests/FunctionalTests/Directory.Build.props
+++ b/src/Tests/FunctionalTests/Directory.Build.props
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CsWinRTEnabled>false</CsWinRTEnabled>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/Tests/OOPExe/OOPExe.csproj
+++ b/src/Tests/OOPExe/OOPExe.csproj
@@ -12,6 +12,14 @@
       only contains lower-cased ascii characters"). This is generated code we don't control, so suppress it.
     -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
+
+    <!--
+      OOPExe is a Windows-only out-of-process COM/WinRT test harness (it calls 'CoCreateInstance' and uses
+      'Windows.Foundation' async APIs), but it targets plain 'net10.0' (no Windows platform), so the platform
+      compatibility analyzer flags these Windows-only call sites with 'CA1416'. Switching to a Windows TFM would
+      pull in the CsWinRT 2.x SDK projection and clash with the 3.0 'Test' projection it references, so suppress it.
+    -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/OOPExe/OOPExe.csproj
+++ b/src/Tests/OOPExe/OOPExe.csproj
@@ -6,6 +6,12 @@
     <Platforms>x64;x86</Platforms>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>
     <CsWinRTEnabled>false</CsWinRTEnabled>
+
+    <!--
+      The CsWin32 source generator emits a 'winmdroot' namespace/type that trips 'CS8981' ("the type name
+      only contains lower-cased ascii characters"). This is generated code we don't control, so suppress it.
+    -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.Lifted.csproj
@@ -18,6 +18,16 @@
         <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
         <UseRidGraph>true</UseRidGraph>
         <AppxIncludeWindowsMetadataReferenceFromProjectReferences>false</AppxIncludeWindowsMetadataReferenceFromProjectReferences>
+
+        <!--
+          The XAML compiler emits a backing field for every 'x:Name'-d element into the generated
+          '*.g.i.cs' files. 'ObjectLifetimePage' deliberately drops its strong references to some of
+          those elements ('MoveCanvas' and '_itemsControlLeakTest' are set to 'null' right after
+          'InitializeComponent()', since the leak tests need them to be collectable) and then looks
+          them back up with 'FindName(...)'. Those fields are therefore only ever assigned, which
+          trips 'CS0414'. This is generated code we don't control, so suppress it.
+        -->
+        <NoWarn>$(NoWarn);CS0414</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <None Remove="Images\LockScreenLogo.scale-200.png" />

--- a/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
+++ b/src/Tests/ObjectLifetimeTests/ObjectLifetimeTests.cs
@@ -182,7 +182,6 @@ namespace ObjectLifetimeTests
                 });
 
             _asyncQueue.Run();
-            Assert.IsTrue(true);
         }
 
         [TestMethod]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -4480,6 +4480,10 @@ namespace UnitTest
         //    }
         //}
 
+        // 'TestPnpPropertiesInLoop' is a manual stress helper kept 'private' so MSTest doesn't auto-run it
+        // (PnP enumeration is environment-dependent). The '[TestMethod]' is retained for easy ad-hoc runs, so
+        // suppress MSTEST0003 ("test method signature is invalid") for this intentionally-private method.
+#pragma warning disable MSTEST0003
         [TestMethod]
         private async Task TestPnpPropertiesInLoop()
         {
@@ -4488,6 +4492,7 @@ namespace UnitTest
                 await TestPnpPropertiesAsync();
             }
         }
+#pragma warning restore MSTEST0003
 
         private async Task TestPnpPropertiesAsync()
         {

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -52,7 +52,7 @@ namespace UnitTest
 
     public interface ITestCSharp<T>
     {
-        void TestMethod<T>();
+        void TestMethod<TMethod>();
     }
 
     [TestClass]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -64,7 +64,7 @@ namespace UnitTest
 
         public struct Estruct
         {
-            E value;
+            public E value;
         }
 
         [TestMethod]
@@ -777,7 +777,6 @@ namespace UnitTest
             var winRTBuffer = new Windows.Storage.Streams.Buffer(capacity: 0);
 
             await winRTStream.WriteAsync(winRTBuffer);
-            Assert.IsTrue(true);
         }
 
         [TestMethod]
@@ -806,7 +805,7 @@ namespace UnitTest
             stream.Seek(0, SeekOrigin.Begin);
 
             byte[] read = new byte[256];
-            await stream.ReadAsync(read, 0, read.Length);
+            await stream.ReadExactlyAsync(read, 0, read.Length);
             CollectionAssert.AreEqual(data, read);
             CollectionAssert.AreEqual(read, data);
         }
@@ -827,7 +826,11 @@ namespace UnitTest
         [TestMethod]
         public void TestDynamicInterfaceCastingOnInvalidInterface()
         {
+            // This test intentionally casts to a '[ComImport]' interface to verify it throws 'InvalidCastException',
+            // which is exactly the unsupported scenario that 'CSWINRT2009' flags, so suppress it just for this test.
+#pragma warning disable CSWINRT2009
             Assert.ThrowsExactly<System.InvalidCastException>(() => (IStringableInterop)(WindowsRuntimeObject)TestObject);
+#pragma warning restore CSWINRT2009
         }
 
         [TestMethod]
@@ -896,7 +899,7 @@ namespace UnitTest
             stream.Seek(0, SeekOrigin.Begin);
 
             byte[] read = new byte[256];
-            stream.Read(read, 0, read.Length);
+            stream.ReadExactly(read, 0, read.Length);
             CollectionAssert.AreEqual(data, read);
         }
 
@@ -981,7 +984,7 @@ namespace UnitTest
                 stream.Seek(0, SeekOrigin.Begin);
 
                 byte[] read = new byte[256];
-                await stream.ReadAsync(read, 0, read.Length);
+                await stream.ReadExactlyAsync(read, 0, read.Length);
                 CollectionAssert.AreEqual(data, read);
             }
 
@@ -1185,7 +1188,7 @@ namespace UnitTest
                 stream.Seek(0, SeekOrigin.Begin);
 
                 byte[] read = new byte[256];
-                await stream.ReadAsync(read, 0, read.Length);
+                await stream.ReadExactlyAsync(read, 0, read.Length);
                 CollectionAssert.AreEqual(data, read);
             }
 
@@ -2475,7 +2478,7 @@ namespace UnitTest
         }
 
         [TestMethod]
-        void TestInterfaceGeneric()
+        public void TestInterfaceGeneric()
         {
             var objs = TestObject.GetInterfaceVector();
             Assert.AreEqual(3, objs.Count);
@@ -2921,7 +2924,7 @@ namespace UnitTest
                 try
                 {
                     action();
-                    Assert.IsTrue(false);
+                    Assert.Fail();
                 }
                 catch (T ex)
                 {
@@ -2929,7 +2932,7 @@ namespace UnitTest
                 }
                 catch (Exception)
                 {
-                    Assert.IsTrue(false);
+                    Assert.Fail();
                 }
             }
         }
@@ -4002,7 +4005,7 @@ namespace UnitTest
             unsafe static (WeakReference<Class> winrt, WeakReference net, WindowsRuntimeObjectReference objRef) GetWeakReferences()
             {
                 var obj = new Class();
-                Assert.IsTrue(WindowsRuntimeComWrappersMarshal.TryUnwrapObjectReference(obj, out WindowsRuntimeObjectReference? objRef));
+                Assert.IsTrue(WindowsRuntimeComWrappersMarshal.TryUnwrapObjectReference(obj, out WindowsRuntimeObjectReference objRef));
                 return (new WeakReference<Class>(obj), new WeakReference(obj), objRef);
             }
 
@@ -4676,8 +4679,12 @@ namespace UnitTest
         // Manually verify warning for experimental.
         private void TestExperimentAttribute()
         {
+            // This method intentionally uses an '[Experimental]' API to manually verify the warning, so suppress
+            // 'CS8305' here to keep the intentional usage from breaking the build (warnings are treated as errors).
+#pragma warning disable CS8305
             CustomExperimentClass custom = new CustomExperimentClass();
             custom.f();
+#pragma warning restore CS8305
         }
 
         void OnDeviceAdded(DeviceWatcher sender, DeviceInformation args)

--- a/src/Tests/UnitTest/TestComponent_Tests.cs
+++ b/src/Tests/UnitTest/TestComponent_Tests.cs
@@ -604,12 +604,16 @@ namespace UnitTest
             {
             }
 
+            // These intentionally override private-implementation-detail base members that are marked
+            // obsolete (CSWINRT3001), to test 'IDynamicInterfaceCastable' behavior, so suppress CS0672.
+#pragma warning disable CS0672 // Member overrides obsolete member
             protected override bool HasUnwrappableNativeObjectReference => true;
 
             protected override bool IsOverridableInterface(in Guid iid)
             {
                 return false;
             }
+#pragma warning restore CS0672 // Member overrides obsolete member
         }
 
         // Workaround for .NET bug (https://github.com/dotnet/runtime/issues/125577) until it is resolved.

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -6,7 +6,6 @@
     <ProjectName>UnitTest</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
     <SelfContained>true</SelfContained>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <OutputType>exe</OutputType>
     <PublishAot>true</PublishAot>

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -5,6 +5,13 @@
     <Platforms>x64;x86</Platforms>
     <ProjectName>UnitTest</ProjectName>
     <NoWarn>1701;1702;0436;1658</NoWarn>
+
+    <!--
+      This project intentionally exercises private-implementation-detail APIs from 'WinRT.Runtime'
+      (e.g. 'HStringMarshaller', 'WellKnownInterfaceIIDs', 'WindowsRuntimeObjectReferenceValue'), which
+      are marked obsolete via the 'CSWINRT3001' diagnostic. We deliberately test these here, so suppress it.
+    -->
+    <NoWarn>$(NoWarn);CSWINRT3001</NoWarn>
     <SelfContained>true</SelfContained>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <OutputType>exe</OutputType>

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -27,6 +27,14 @@
       than raising the minimum target platform (which would defeat the purpose of those tests).
     -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+
+    <!--
+      The CsWin32 source generator emits a 'CoRegisterClassObject' P/Invoke (in 'Ole32') that uses COM
+      marshalling, which trips 'IL2050' (COM interop correctness under trimming) and 'CA1420' (requires
+      runtime marshalling, which is disabled repo-wide). This is generated code we don't control, so
+      suppress both here.
+    -->
+    <NoWarn>$(NoWarn);IL2050;CA1420</NoWarn>
     <SelfContained>true</SelfContained>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <OutputType>exe</OutputType>

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -12,6 +12,12 @@
       are marked obsolete via the 'CSWINRT3001' diagnostic. We deliberately test these here, so suppress it.
     -->
     <NoWarn>$(NoWarn);CSWINRT3001</NoWarn>
+
+    <!--
+      The CsWin32 source generator emits a 'winmdroot' namespace/type that trips 'CS8981' ("the type name
+      only contains lower-cased ascii characters"). This is generated code we don't control, so suppress it.
+    -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
     <SelfContained>true</SelfContained>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <OutputType>exe</OutputType>

--- a/src/Tests/UnitTest/UnitTest.csproj
+++ b/src/Tests/UnitTest/UnitTest.csproj
@@ -18,6 +18,15 @@
       only contains lower-cased ascii characters"). This is generated code we don't control, so suppress it.
     -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
+
+    <!--
+      This project intentionally calls Windows Runtime APIs annotated with '[SupportedOSPlatform]' for a
+      higher Windows version than the project's minimum (e.g. the 'Warning*' types exercised by
+      'TestSupportedOSPlatformWarnings', which exist specifically to verify the platform warnings, and the
+      'DisplayInformation' interop extensions). These deliberately trip 'CA1416', so suppress it here rather
+      than raising the minimum target platform (which would defeat the purpose of those tests).
+    -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <SelfContained>true</SelfContained>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <OutputType>exe</OutputType>

--- a/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
+++ b/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Generator core shared infrastructure v$(VersionString)</Description>

--- a/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
+++ b/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
@@ -19,15 +18,6 @@
 
     <!-- Set the root namespace (we ignore the '.Core' suffix) -->
     <RootNamespace>WindowsRuntime.Generator</RootNamespace>
-
-    <!-- Same settings as the other generator projects -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
+++ b/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsAotCompatible>true</IsAotCompatible>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Generator core shared infrastructure v$(VersionString)</Description>
@@ -12,9 +10,6 @@
     <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
-
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
 
     <!-- Set the root namespace (we ignore the '.Core' suffix) -->
     <RootNamespace>WindowsRuntime.Generator</RootNamespace>

--- a/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
+++ b/src/WinRT.Generator.Core/WinRT.Generator.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/WinRT.Generator.Tasks/RunCsWinRTForwarderImplGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTForwarderImplGenerator.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -154,7 +154,7 @@ public sealed class RunCsWinRTForwarderImplGenerator : ToolTask
         // This makes it easy to run the task against a local build of 'cswinrtimplgen'.
         if (effectiveArchitecture?.Equals("AnyCPU", StringComparison.OrdinalIgnoreCase) is true)
         {
-            return Path.Combine(CsWinRTToolsDirectory!, ToolName);
+            return Path.Combine(CsWinRTToolsDirectory, ToolName);
         }
 
         // If the architecture is not specified, determine it based on the current process architecture
@@ -168,7 +168,7 @@ public sealed class RunCsWinRTForwarderImplGenerator : ToolTask
         // The tool is inside an architecture-specific subfolder, as it's a native binary
         string architectureDirectory = $"win-{effectiveArchitecture}";
 
-        return Path.Combine(CsWinRTToolsDirectory!, architectureDirectory, ToolName);
+        return Path.Combine(CsWinRTToolsDirectory, architectureDirectory, ToolName);
     }
 
     /// <inheritdoc/>

--- a/src/WinRT.Generator.Tasks/RunCsWinRTInteropGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTInteropGenerator.cs
@@ -1,10 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -282,7 +279,7 @@ public sealed class RunCsWinRTInteropGenerator : ToolTask
         // This makes it easy to run the task against a local build of 'cswinrtinteropgen'.
         if (effectiveArchitecture?.Equals("AnyCPU", StringComparison.OrdinalIgnoreCase) is true)
         {
-            return Path.Combine(CsWinRTToolsDirectory!, ToolName);
+            return Path.Combine(CsWinRTToolsDirectory, ToolName);
         }
 
         // If the architecture is not specified, determine it based on the current process architecture
@@ -296,7 +293,7 @@ public sealed class RunCsWinRTInteropGenerator : ToolTask
         // The tool is inside an architecture-specific subfolder, as it's a native binary
         string architectureDirectory = $"win-{effectiveArchitecture}";
 
-        return Path.Combine(CsWinRTToolsDirectory!, architectureDirectory, ToolName);
+        return Path.Combine(CsWinRTToolsDirectory, architectureDirectory, ToolName);
     }
 
     /// <inheritdoc/>

--- a/src/WinRT.Generator.Tasks/RunCsWinRTMergedProjectionGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTMergedProjectionGenerator.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -179,7 +179,7 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
         // This makes it easy to run the task against a local build of 'cswinrtprojectiongen'.
         if (effectiveArchitecture?.Equals("AnyCPU", StringComparison.OrdinalIgnoreCase) is true)
         {
-            return Path.Combine(CsWinRTToolsDirectory!, ToolName);
+            return Path.Combine(CsWinRTToolsDirectory, ToolName);
         }
 
         // If the architecture is not specified, determine it based on the current process architecture
@@ -193,7 +193,7 @@ public sealed class RunCsWinRTMergedProjectionGenerator : ToolTask
         // The tool is inside an architecture-specific subfolder, as it's a native binary
         string architectureDirectory = $"win-{effectiveArchitecture}";
 
-        return Path.Combine(CsWinRTToolsDirectory!, architectureDirectory, ToolName);
+        return Path.Combine(CsWinRTToolsDirectory, architectureDirectory, ToolName);
     }
 
     /// <inheritdoc/>

--- a/src/WinRT.Generator.Tasks/RunCsWinRTProjectionRefGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTProjectionRefGenerator.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -186,7 +186,7 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
         // This makes it easy to run the task against a local build of 'cswinrtprojectionrefgen'.
         if (effectiveArchitecture?.Equals("AnyCPU", StringComparison.OrdinalIgnoreCase) is true)
         {
-            return Path.Combine(CsWinRTToolsDirectory!, ToolName);
+            return Path.Combine(CsWinRTToolsDirectory, ToolName);
         }
 
         // If the architecture is not specified, determine it based on the current process architecture
@@ -200,7 +200,7 @@ public sealed class RunCsWinRTProjectionRefGenerator : ToolTask
         // The tool is inside an architecture-specific subfolder, as it's a native binary
         string architectureDirectory = $"win-{effectiveArchitecture}";
 
-        return Path.Combine(CsWinRTToolsDirectory!, architectureDirectory, ToolName);
+        return Path.Combine(CsWinRTToolsDirectory, architectureDirectory, ToolName);
     }
 
     /// <inheritdoc/>

--- a/src/WinRT.Generator.Tasks/RunCsWinRTWinMDGenerator.cs
+++ b/src/WinRT.Generator.Tasks/RunCsWinRTWinMDGenerator.cs
@@ -1,9 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -140,7 +138,7 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
         // Special case for when 'AnyCPU' is specified (mostly for testing scenarios).
         if (effectiveArchitecture?.Equals("AnyCPU", StringComparison.OrdinalIgnoreCase) is true)
         {
-            return Path.Combine(CsWinRTToolsDirectory!, ToolName);
+            return Path.Combine(CsWinRTToolsDirectory, ToolName);
         }
 
         // If the architecture is not specified, determine it based on the current process architecture
@@ -153,7 +151,7 @@ public sealed class RunCsWinRTWinMDGenerator : ToolTask
 
         string architectureDirectory = $"win-{effectiveArchitecture}";
 
-        return Path.Combine(CsWinRTToolsDirectory!, architectureDirectory, ToolName);
+        return Path.Combine(CsWinRTToolsDirectory, architectureDirectory, ToolName);
     }
 
     /// <inheritdoc/>

--- a/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
+++ b/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
@@ -23,11 +23,6 @@
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
-
-    <!-- Suppress IDE0028 ('Collection initialization can be simplified'), which fires on the
-         'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
-         collection literal would drop the comparer, so the suggestion is not actually correct. -->
-    <NoWarn>$(NoWarn);IDE0028</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
+++ b/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
@@ -24,15 +23,6 @@
     <!-- This project produces a CLI tool, so we want a nice short name for it -->
     <AssemblyName>cswinrtimplgen</AssemblyName>
       
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!-- Used to enable publishing project in build -->
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>

--- a/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
+++ b/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Impl Generator v$(VersionString)</Description>
@@ -14,9 +13,6 @@
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
 
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.ImplGenerator</RootNamespace>
 
@@ -32,17 +28,6 @@
          'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
          collection literal would drop the comparer, so the suggestion is not actually correct. -->
     <NoWarn>$(NoWarn);IDE0028</NoWarn>
-  </PropertyGroup>
-
-  <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
-  <PropertyGroup>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
-    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
-    <ControlFlowGuard>Guard</ControlFlowGuard>
-    <IlcDehydrate>false</IlcDehydrate>
-    <IlcResilient>false</IlcResilient>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
+++ b/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
 
     <!-- Common metadata properties for publishing -->

--- a/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
+++ b/src/WinRT.Impl.Generator/WinRT.Impl.Generator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>

--- a/src/WinRT.Internal/ProjectionInternalAttribute.cs
+++ b/src/WinRT.Internal/ProjectionInternalAttribute.cs
@@ -13,6 +13,7 @@ namespace WindowsRuntime.Internal;
 /// CsWinRT generates an <see langword="internal"/> projection for any interface marked with this attribute
 /// (rather than the default <see langword="public"/> projection). User-friendly wrappers over the internal
 /// projection are exposed via hand-authored extension methods (see e.g. <c>ComInteropExtensions</c>).
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 public sealed class ProjectionInternalAttribute : Attribute;

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -8,7 +8,7 @@
       some of the C# source files in this project reference Windows Runtime types
       (e.g. 'Windows.UI.ApplicationSettings.AccountsSettingsPane') as well.
     -->
-    <TargetFramework>net10.0-windows10.0.26100.1</TargetFramework>
+    <TargetFramework>$(DotNetVersion)-windows10.0.26100.1</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 
     <!--

--- a/src/WinRT.Internal/WinRT.Internal.csproj
+++ b/src/WinRT.Internal/WinRT.Internal.csproj
@@ -45,13 +45,8 @@
     <!-- The produced '.dll' is just an intermediate artifact, only the generated '.winmd' is shipped -->
     <IsPackable>false</IsPackable>
 
-    <!--
-      Suppress XML doc warnings for parameters/return doc tags we omit on interop methods.
-      'NETSDK1229' is also suppressed: this project intentionally targets the CsWinRT 3.0
-      preview Windows SDK projections to author Windows Runtime metadata, so the preview
-      warning is not actionable.
-    -->
-    <NoWarn>$(NoWarn);CS1591;1701;CS1702;NETSDK1229</NoWarn>
+    <!-- Suppress XML doc warnings for parameters/return doc tags we omit on interop methods -->
+    <NoWarn>$(NoWarn);CS1591;1701;CS1702</NoWarn>
   </PropertyGroup>
 
   <!--

--- a/src/WinRT.Interop.Generator/Helpers/SignatureGenerator.cs
+++ b/src/WinRT.Interop.Generator/Helpers/SignatureGenerator.cs
@@ -175,7 +175,7 @@ internal static partial class SignatureGenerator
         if (type.IsComponentWindowsRuntimeType &&
             interopDefinitions.WindowsRuntimeComponentModule is { } componentModule)
         {
-            return InterfaceIIDResolver.TryGetIID(componentModule, type.FullName!, out iid);
+            return InterfaceIIDResolver.TryGetIID(componentModule, type.FullName, out iid);
         }
 
         iid = Guid.Empty;

--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -23,13 +23,6 @@
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
-
-    <!-- Suppress IDE0028 ('Collection initialization can be simplified'), which fires on the
-         'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
-         collection literal would drop the comparer, so the suggestion is not actually correct.
-         Also suppress IDE0370 ('Suppression is unnecessary') for null-forgiving operators on
-         properties that the analyzer can sometimes incorrectly determine are non-null. -->
-    <NoWarn>$(NoWarn);IDE0028;IDE0370</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
 
     <!-- Common metadata properties for publishing -->

--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Interop Generator v$(VersionString)</Description>
@@ -14,9 +13,6 @@
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
 
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- Set the root namespace to match the runtime -->
     <RootNamespace>WindowsRuntime.InteropGenerator</RootNamespace>
 
@@ -34,43 +30,6 @@
          Also suppress IDE0370 ('Suppression is unnecessary') for null-forgiving operators on
          properties that the analyzer can sometimes incorrectly determine are non-null. -->
     <NoWarn>$(NoWarn);IDE0028;IDE0370</NoWarn>
-  </PropertyGroup>
-
-  <!-- NativeAOT and optimization options -->
-  <PropertyGroup>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
-    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
-
-    <!--
-      Enable CFG (Control Flow Guard), to make the resulting native binary more resilient to some exploit types.
-      Also see: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/security#control-flow-guard.
-      And: https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard#how-does-cfg-really-work.
-    -->
-    <ControlFlowGuard>Guard</ControlFlowGuard>
-
-    <!--
-      "It disables data dehydration. This is something we primarily added for linux because our data structures have lots of pointers in them
-      (e.g. vtables point to the method bodies) and on linux each such pointers costs 24 bytes of bookkeeping in the linux exe file format.
-      So this generates data structures in a dehydrated form on disk to avoid the penalty. The executables get smaller (much smaller on linux),
-      but we need to rehydrate them when the process starts.
-      [...]
-      Rehydrated data affects the size of private working set.
-      [...]
-      Setting IlcDehydrate=false might reduce private working set by about 30 MB."
-      (suggested by Michal Strehovsky, @michals, Native AOT lead)
-
-      In local testing, this results in a small launch performance improvement, and a small memory use reduction as well.
-    -->
-    <IlcDehydrate>false</IlcDehydrate>
-
-    <!--
-      By default, NativeAOT will ignore issues where assemblies fail to be resolved (eg. due to incorrect package authoring).
-      For any references to them, it will silently replace them with throwing stubs instead, without emitting any warnings.
-      Disabling this property changes this behavior and ensures publish builds will fail instead if this case is hit.
-    -->
-    <IlcResilient>false</IlcResilient>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
@@ -24,15 +23,6 @@
     <!-- This project produces a CLI tool, so we want a nice short name for it -->
     <AssemblyName>cswinrtinteropgen</AssemblyName>
       
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!-- Used to enable publishing project in build -->  
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>

--- a/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
+++ b/src/WinRT.Interop.Generator/WinRT.Interop.Generator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
 
     <!-- Common metadata properties for publishing -->

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -24,8 +24,8 @@
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
 
-    <!-- Temporarily suppress warnings for 'Microsoft.CodeAnalysis.CSharp' -->    
-    <NoWarn>$(NoWarn);IL2091;IL2050;IL2072;IL2075;IL2026;IDE0028</NoWarn>
+    <!-- Suppress trim/AOT analyzer warnings from the 'Microsoft.CodeAnalysis.CSharp' reference (Roslyn is not trim-safe) -->
+    <NoWarn>$(NoWarn);IL2091;IL2050;IL2072;IL2075;IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Projection Generator v$(VersionString)</Description>
@@ -14,9 +13,6 @@
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
 
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.ProjectionGenerator</RootNamespace>
 
@@ -30,17 +26,6 @@
 
     <!-- Temporarily suppress warnings for 'Microsoft.CodeAnalysis.CSharp' -->    
     <NoWarn>$(NoWarn);IL2091;IL2050;IL2072;IL2075;IL2026;IDE0028</NoWarn>
-  </PropertyGroup>
-
-  <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
-  <PropertyGroup>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
-    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
-    <ControlFlowGuard>Guard</ControlFlowGuard>
-    <IlcDehydrate>false</IlcDehydrate>
-    <IlcResilient>false</IlcResilient>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
+++ b/src/WinRT.Projection.Generator/WinRT.Projection.Generator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
@@ -24,15 +23,6 @@
     <!-- This project produces a CLI tool, so we want a nice short name for it -->
     <AssemblyName>cswinrtprojectiongen</AssemblyName>
       
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!-- Used to enable publishing project in build -->
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>

--- a/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
+++ b/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
@@ -24,15 +23,6 @@
     <!-- This project produces a CLI tool, so we want a nice short name for it -->
     <AssemblyName>cswinrtprojectionrefgen</AssemblyName>
       
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!-- Used to enable publishing project in build -->
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>

--- a/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
+++ b/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>

--- a/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
+++ b/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
 
     <!-- Common metadata properties for publishing -->

--- a/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
+++ b/src/WinRT.Projection.Ref.Generator/WinRT.Projection.Ref.Generator.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Reference Projection Generator v$(VersionString)</Description>
@@ -14,9 +13,6 @@
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
 
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.ReferenceProjectionGenerator</RootNamespace>
 
@@ -27,17 +23,6 @@
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
-  </PropertyGroup>
-
-  <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
-  <PropertyGroup>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
-    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
-    <ControlFlowGuard>Guard</ControlFlowGuard>
-    <IlcDehydrate>false</IlcDehydrate>
-    <IlcResilient>false</IlcResilient>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
@@ -19,15 +18,6 @@
     -->
     <InformationalVersion>$(VersionString)</InformationalVersion>
       
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!--
       The writer enables the strictest analysis posture (AnalysisLevel=latest +
       AnalysisLevelStyle=latest-all), matching WinRT.Interop.Generator. The five entries

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -3,12 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsAotCompatible>true</IsAotCompatible>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.ProjectionWriter</RootNamespace>
 

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
+++ b/src/WinRT.Projection.Writer/WinRT.Projection.Writer.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.ProjectionWriter</RootNamespace>

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
@@ -28,51 +27,6 @@
       the exact .dll name. For instance, the UWP XAML compiler special cases 'WinRT.Runtime.dll'.
     -->
     <AssemblyName>WinRT.Runtime</AssemblyName>
-
-    <!--
-      Treat all warnings as errors, only in release configurations. This allows the dev inner loop to remain
-      convenient, without errors while testing things out and prototyping things, while still ensuring that
-      all CI runs and official builds (including from PRs) will fail if any warnings are not addressed.
-    -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-
-    <!--
-      Enable the latest warning wave, which shows additional warnings for invalid language features that are disabled by default.
-      For additional info, see https://docs.microsoft.com/dotnet/csharp/language-reference/compiler-messages/warning-waves.
-    -->
-    <AnalysisLevel>latest</AnalysisLevel>
-
-    <!-- Import the global configs from the CodeStyle package (enables all IDExxxx warnings)-->
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-
-    <!-- Enforce all code style rules during build (this replaces referencing Microsoft.CodeAnalysis.CSharp.CodeStyle) -->
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-      
-    <!--
-      Suppress ref safety warnings in unsafe contexts (see https://github.com/dotnet/csharplang/issues/6476).
-      This is used eg. to replace Unsafe.SizeOf<T>() calls with just sizeof(T), or to just use raw pointers to
-      reinterpret references to managed objects when it is safe to do so. The warnings are not necessary in this
-      context, since in order to use these APIs the caller already has to be in an unsafe context.
-    -->
-    <NoWarn>$(NoWarn);CS8500</NoWarn>
-
-    <!--
-      Enable the compiler strict mode (see https://www.meziantou.net/csharp-compiler-strict-mode.htm).
-      This (poorly documented) mode enables additional warnings for incorrect usages of some features.
-      For instance, this will warn when using the == operator to compare a struct with a null literal.
-    -->
-    <Features>strict</Features>
-
-    <!--
-      Generate documentation files. In theory this should only be abled for published, non source generator projects.
-      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
-      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
-      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
-      When this workaround is no longer needed, the same property should also removed for the \samples directory.
-      Once that issue is fixed, this should be moved down to the src\ specific .props file again, and otherwise disabled.
-    -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Enable strong name signing -->
     <SignAssembly>true</SignAssembly>

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsAotCompatible>true</IsAotCompatible>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Runtime v$(VersionString)</Description>
@@ -13,12 +11,6 @@
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
 
-    <!--
-      Emit the '[module: SkipLocalsInit]' attribute, to further reduce runtime overhead. This is especially useful when
-      using 'stackalloc'. See: https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute.
-    -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
-      
     <!-- 'WindowsRuntime' is the root namespace, with the name being consistent with eg. 'System.Runtime.InteropServices.WindowsRuntime' -->
     <RootNamespace>WindowsRuntime</RootNamespace>
       

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/WinRT.Runtime2/WinRT.Runtime.csproj
+++ b/src/WinRT.Runtime2/WinRT.Runtime.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT Runtime v$(VersionString)</Description>

--- a/src/WinRT.Sdk.Projection/WinRT.Sdk.Projection.csproj
+++ b/src/WinRT.Sdk.Projection/WinRT.Sdk.Projection.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <IsAotCompatible>true</IsAotCompatible>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!--
       When WindowsSdkXaml=true, generate WinRT.Sdk.Xaml.Projection.dll (the Windows.UI.Xaml projection)

--- a/src/WinRT.Sdk.Projection/WinRT.Sdk.Projection.csproj
+++ b/src/WinRT.Sdk.Projection/WinRT.Sdk.Projection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
 
     <!--
       When WindowsSdkXaml=true, generate WinRT.Sdk.Xaml.Projection.dll (the Windows.UI.Xaml projection)

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -23,11 +23,6 @@
     <IsBuildTool>true</IsBuildTool>
     <RuntimeIdentifier Condition="'$(PublishBuildTool)' == 'true'">win-$(BuildToolArch)</RuntimeIdentifier>
     <SelfContained Condition="'$(PublishBuildTool)' == 'true'">true</SelfContained>
-
-    <!-- Suppress IDE0028 ('Collection initialization can be simplified'), which fires on the
-         'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
-         collection literal would drop the comparer, so the suggestion is not actually correct. -->
-    <NoWarn>$(NoWarn);IDE0028</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
 
     <!-- Common metadata properties for publishing -->

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
 
     <!-- Common metadata properties for publishing -->
     <Description>C#/WinRT WinMD Generator v$(VersionString)</Description>
@@ -13,9 +12,6 @@
     <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyVersion>$(AssemblyVersionNumber)</AssemblyVersion>
     <FileVersion>$(VersionNumber)</FileVersion>
-
-    <!-- Emit the '[module: SkipLocalsInit]' attribute (same as the runtime) -->
-    <EmitSkipLocalsInitAttribute>true</EmitSkipLocalsInitAttribute>
 
     <!-- Set the root namespace to match the other projects -->
     <RootNamespace>WindowsRuntime.WinMDGenerator</RootNamespace>
@@ -32,17 +28,6 @@
          'new(StringComparer.Ordinal)' pattern with later analyzer versions. Simplifying to a
          collection literal would drop the comparer, so the suggestion is not actually correct. -->
     <NoWarn>$(NoWarn);IDE0028</NoWarn>
-  </PropertyGroup>
-
-  <!-- NativeAOT and optimization options (same as 'WinRT.Interop.Generator') -->
-  <PropertyGroup>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <OptimizationPreference>Speed</OptimizationPreference>
-    <StackTraceSupport Condition="'$(Configuration)' == 'Release'">false</StackTraceSupport>
-    <UseSystemResourceKeys Condition="'$(Configuration)' == 'Release'">true</UseSystemResourceKeys>
-    <ControlFlowGuard>Guard</ControlFlowGuard>
-    <IlcDehydrate>false</IlcDehydrate>
-    <IlcResilient>false</IlcResilient>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
@@ -23,15 +22,6 @@
 
     <!-- This project produces a CLI tool, so we want a nice short name for it -->
     <AssemblyName>cswinrtwinmdgen</AssemblyName>
-
-    <!-- Same settings as 'WinRT.Runtime' -->
-    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisLevelStyle>latest-all</AnalysisLevelStyle>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Features>strict</Features>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Used to enable publishing project in build -->
     <IsBuildTool>true</IsBuildTool>

--- a/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
+++ b/src/WinRT.WinMD.Generator/WinRT.WinMD.Generator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.cs
@@ -95,7 +95,7 @@ internal sealed partial class WinMDWriter
     /// during finalization by <see cref="AddOverloadAttributesForType"/> to honor author-specified overload
     /// names instead of auto-generating sequential ones.
     /// </remarks>
-    private readonly Dictionary<MethodDefinition, string> _userSpecifiedOverloadNames = new();
+    private readonly Dictionary<MethodDefinition, string> _userSpecifiedOverloadNames = [];
 
     /// <summary>
     /// Creates a new <see cref="WinMDWriter"/> instance.


### PR DESCRIPTION
## Summary

Centralize the common MSBuild properties for all C# projects into `Directory.Build.props`/`Directory.Build.targets`, then remove the now-redundant per-project copies, fix the C# language version that was accidentally pinned to `preview` everywhere, and point the core projects at a single shared `$(DotNetVersion)`.

## Motivation

Properties such as `LangVersion`, `AllowUnsafeBlocks`, warnings-as-errors, analysis levels, code-style enforcement, and the AOT/NativeAOT settings were copy-pasted across roughly a dozen project files, which is noisy and easy to drift. A stray `LangVersion=preview` in `Directory.Build.targets` (imported after each project body) was also silently overriding every project back to the preview language version, even the ones that explicitly set `14.0`. Centralizing these settings removes the duplication, makes it possible to try a different .NET version or language version from one place, and fixes the accidental `preview` language version. While validating the result, the centralization also surfaced two latent build breaks that are fixed here.

## Changes

### Centralized build configuration

- **`src/Directory.Build.props`**: add a `Globals` property group (scoped to `.csproj`) that defines `DotNetVersion` (`net10.0`), `LangVersion=14.0`, `AllowUnsafeBlocks=true`, Release-only `TreatWarningsAsErrors`/`CodeAnalysisTreatWarningsAsErrors`, `AnalysisLevel`/`AnalysisLevelStyle`, `EnforceCodeStyleInBuild`, `Features=strict`, `GenerateDocumentationFile`, and the common `NoWarn` entries (`CS8500`, `NETSDK1229`).
- **`src/Directory.Build.targets`**: apply the AOT/marshalling settings (`IsAotCompatible` for libraries, `DisableRuntimeMarshalling`, `EmitSkipLocalsInitAttribute`, `TrimmerSingleWarn`) to net10.0 projects, and the NativeAOT publish options (`InvariantGlobalization`, `OptimizationPreference`, `StackTraceSupport`, `UseSystemResourceKeys`, `ControlFlowGuard`, `IlcDehydrate`, `IlcResilient`) to net10.0 `PublishAot` projects.

### Project file cleanup

- Removed the redundant properties listed above from `WinRT.Runtime2`, `WinRT.Generator.Core`, `WinRT.Projection.Writer`, `WinRT.SourceGenerator2`, `WinRT.Sdk.Projection`, `WinRT.Internal`, and the five build tools (`cswinrtinteropgen`, `cswinrtimplgen`, `cswinrtprojectiongen`, `cswinrtprojectionrefgen`, `cswinrtwinmdgen`). This also drops the leftover `LangVersion=preview` override in `WinRT.Impl.Generator`.
- Removed the now-redundant `AllowUnsafeBlocks=true` copies from the core projects plus `UnitTest`, `DiagnosticTests`, `BuildDeterminismComponent`, `WinRT.Host.Shim`, and the `FunctionalTests` `Directory.Build.props`. The `NonWinRT` test keeps its conditional `AllowUnsafeBlocks=false` (when `TestUnsafeDisabled`) since it still overrides the centralized default for that scenario.
- Pointed the core projects' `TargetFramework` at `$(DotNetVersion)` (`WinRT.Internal` uses `$(DotNetVersion)-windows10.0.26100.1`). The resolved framework is unchanged (`net10.0`), so output folders and existing `HintPath`/tool-directory references are unaffected.

### Suppressions no longer necessary

- Removed project `NoWarn` entries that no longer fire, verified with `Release --no-incremental` builds (where warnings are errors): `IDE0028` from `cswinrtinteropgen`/`cswinrtimplgen`/`cswinrtwinmdgen`/`cswinrtprojectiongen`, and `IDE0370` from `cswinrtinteropgen`.
- **`WinRT.Interop.Generator/Helpers/SignatureGenerator.cs`**: `IDE0370` was firing on a redundant null-forgiving operator `type.FullName!` (`FullName` is a non-nullable `string`); removed the `!` so the suppression is genuinely unnecessary. The Writer's IDE suppressions and the projection generator's `IL*` (Roslyn trim/AOT) suppressions are retained because they still apply.

### Build-break fixes surfaced by the centralization

- **`src/Directory.Build.targets`**: only emit `[module: SkipLocalsInit]` for projects that set `AllowUnsafeBlocks` (the C# compiler requires unsafe code for `[SkipLocalsInit]` or it produces `CS0227`). This matches the pre-centralization behavior and unbreaks non-unsafe net10.0 projects such as `WinRT.Internal`. (With `AllowUnsafeBlocks` now centralized to `true`, this guard continues to do the right thing for any project that opts back out.)
- **`src/WinRT.Internal/ProjectionInternalAttribute.cs`**: fix a malformed XML doc comment (a `<para>` closed by `</remarks>`, `CS1570`) that became an error once `GenerateDocumentationFile` was enabled under Release warnings-as-errors.

## Validation

All core projects plus `WinRT.Internal` build green in Release (`--no-incremental`, warnings-as-errors active). `WinRT.Sdk.Projection` cannot be restored locally (`NU1102` for `Microsoft.Windows.SDK.Contracts`, which CI supplies via an explicit `SdkPackageVersion`); this is pre-existing and unrelated to these changes. Test and sample project `TargetFramework` values were intentionally left untouched, so a CI Release run is worth doing to confirm nothing else relies on the previously per-project settings.