### PR TITLE
Fix constructor marshalling for non-blittable array element types

### DIFF
--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -230,6 +230,23 @@ namespace winrt::TestComponentCSharp::implementation
         _nonBlittableStruct = nonBlittableStruct;
     }
 
+    Class::Class(int32_t intProperty, array_view<TestComponentCSharp::ComposedNonBlittableStruct const> nonBlittableStructs, array_view<winrt::Windows::Foundation::DateTime const> dateTimes, array_view<winrt::hresult const> hresults) :
+        Class(intProperty, L"")
+    {
+        if (nonBlittableStructs.size() > 0)
+        {
+            _nonBlittableStruct = nonBlittableStructs[0];
+        }
+        if (dateTimes.size() > 0)
+        {
+            _dateTime = dateTimes[0];
+        }
+        if (hresults.size() > 0)
+        {
+            _hr = hresults[0];
+        }
+    }
+
     void Class::TypeProperty(Windows::UI::Xaml::Interop::TypeName val)
     {
         _typeProperty = val;

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -100,6 +100,7 @@ namespace winrt::TestComponentCSharp::implementation
         Class(int32_t intProperty);
         Class(int32_t intProperty, hstring const& stringProperty);
         Class(int32_t intProperty, hstring const& stringProperty, ComposedNonBlittableStruct const& nonBlittableStruct);
+        Class(int32_t intProperty, array_view<TestComponentCSharp::ComposedNonBlittableStruct const> nonBlittableStructs, array_view<winrt::Windows::Foundation::DateTime const> dateTimes, array_view<winrt::hresult const> hresults);
         static int32_t StaticIntProperty();
         static void StaticIntProperty(int32_t value);
         static winrt::event_token StaticIntPropertyChanged(Windows::Foundation::EventHandler<int32_t> const& handler);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -213,6 +213,8 @@ namespace TestComponentCSharp
         Class(Int32 intProperty, String stringProperty);
         // Activation factory taking a non-blittable struct by value.
         Class(Int32 intProperty, String stringProperty, ComposedNonBlittableStruct nonBlittableStruct);
+        // Activation factory taking arrays of non-blittable struct, mapped value-type, and HResult elements.
+        Class(Int32 intProperty, ComposedNonBlittableStruct[] nonBlittableStructs, Windows.Foundation.DateTime[] dateTimes, Windows.Foundation.HResult[] hresults);
 
         Windows.UI.Xaml.Interop.TypeName TypeProperty{ get; set; };
         String GetTypePropertyAbiName();

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2307,6 +2307,33 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public void TestNonBlittableArrayConstructor()
+        {
+            // Activation factory taking arrays of non-blittable struct, mapped value-type, and
+            // HResult/Exception elements by value (constructor PassArray marshalling).
+            var structVal = new ComposedNonBlittableStruct()
+            {
+                blittable = new BlittableStruct() { i32 = 42 },
+                strings = new NonBlittableStringStruct() { str = "I like tacos" },
+                bools = new NonBlittableBoolStruct() { w = true, x = false, y = true, z = false },
+                refs = TestObject.NonBlittableRefStructProperty
+            };
+            var dateTime = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var exception = new ArgumentException();
+
+            var instance = new Class(
+                9,
+                new[] { structVal },
+                new[] { dateTime },
+                new Exception[] { exception });
+
+            Assert.AreEqual(9, instance.IntProperty);
+            Assert.AreEqual("I like tacos", instance.ComposedNonBlittableStructProperty.strings.str);
+            Assert.AreEqual(dateTime, instance.DateTimeProperty);
+            Assert.IsNotNull(instance.HResultProperty);
+        }
+
+        [TestMethod]
         public void TestBlittableArrays()
         {
             int[] arr = new[] { 2, 4, 6, 8 };

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
@@ -65,6 +66,8 @@ internal static partial class ConstructorFactory
     /// <c>out void* innerInterface</c> params. Iteration over user params is bounded by
     /// <paramref name="userParamCount"/> (defaults to all params).</param>
     /// <param name="userParamCount">If &gt;= 0, only emit the first <paramref name="userParamCount"/> user params (used for composable factories).</param>
+    [SuppressMessage("Style", "IDE0045:Convert to conditional expression",
+        Justification = "if/else if chains over type-class predicates are more readable than nested ternaries.")]
     private static void EmitFactoryCallbackClass(IndentedTextWriter writer, ProjectionEmitContext context, MethodSignatureInfo sig, string callbackName, string argsName, string factoryObjRefName, int factoryMethodIndex, bool isComposable = false, int userParamCount = -1)
     {
         int paramCount = userParamCount >= 0 ? userParamCount : sig.Parameters.Count;
@@ -509,28 +512,22 @@ internal static partial class ConstructorFactory
 
                 // Data pointer type must match the array marshaller's CopyToUnmanaged signature.
                 string dataParamType;
-                string dataCastType;
 
                 if (context.AbiTypeKindResolver.IsMappedAbiValueType(szArr.BaseType))
                 {
                     dataParamType = AbiTypeHelpers.GetMappedAbiTypeName(szArr.BaseType) + "*";
-                    dataCastType = "(" + AbiTypeHelpers.GetMappedAbiTypeName(szArr.BaseType) + "*)";
                 }
                 else if (szArr.BaseType.IsHResultException())
                 {
                     dataParamType = "global::ABI.System.Exception*";
-                    dataCastType = "(global::ABI.System.Exception*)";
                 }
                 else if (context.AbiTypeKindResolver.IsNonBlittableStruct(szArr.BaseType))
                 {
-                    string abiStructName = AbiTypeHelpers.GetAbiStructTypeName(context, szArr.BaseType);
-                    dataParamType = abiStructName + "*";
-                    dataCastType = "(" + abiStructName + "*)";
+                    dataParamType = AbiTypeHelpers.GetAbiStructTypeName(context, szArr.BaseType) + "*";
                 }
                 else
                 {
                     dataParamType = "void**";
-                    dataCastType = "(void**)";
                 }
 
                 UnsafeAccessorFactory.EmitStaticMethod(
@@ -540,7 +537,7 @@ internal static partial class ConstructorFactory
                     functionName: $"CopyToUnmanaged_{raw}",
                     interopType: ArrayElementEncoder.GetArrayMarshallerInteropPath(szArr.BaseType),
                     parameterList: $"ReadOnlySpan<{elementProjected.Format()}> span, uint length, {dataParamType} data");
-                writer.WriteLine($"CopyToUnmanaged_{raw}(null, {pname}, (uint){pname}.Length, {dataCastType}_{raw});");
+                writer.WriteLine($"CopyToUnmanaged_{raw}(null, {pname}, (uint){pname}.Length, ({dataParamType})_{raw});");
             }
         }
 

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
@@ -296,13 +296,14 @@ internal static partial class ConstructorFactory
             string raw = p.GetRawName();
             string callName = IdentifierEscaping.EscapeIdentifier(raw);
             ArrayTempNames names = new(raw);
+            string storageT = AbiTypeHelpers.GetArrayElementStorageType(context, szArr.BaseType);
             writer.WriteLine();
             writer.WriteLine(isMultiline: true, $$"""
-                Unsafe.SkipInit(out InlineArray16<nint> {{names.InlineArray}});
-                nint[] {{names.ArrayFromPool}} = null;
-                Span<nint> {{names.Span}} = {{callName}}.Length <= 16
+                Unsafe.SkipInit(out InlineArray16<{{storageT}}> {{names.InlineArray}});
+                {{storageT}}[] {{names.ArrayFromPool}} = null;
+                Span<{{storageT}}> {{names.Span}} = {{callName}}.Length <= 16
                     ? {{names.InlineArray}}[..{{callName}}.Length]
-                    : ({{names.ArrayFromPool}} = global::System.Buffers.ArrayPool<nint>.Shared.Rent({{callName}}.Length));
+                    : ({{names.ArrayFromPool}} = global::System.Buffers.ArrayPool<{{storageT}}>.Shared.Rent({{callName}}.Length));
                 """);
 
             if (szArr.BaseType.IsString())
@@ -505,14 +506,41 @@ internal static partial class ConstructorFactory
             else
             {
                 IndentedTextWriterCallback elementProjected = TypedefNameWriter.WriteProjectionType(context, TypeSemanticsFactory.Get(szArr.BaseType));
+
+                // Data pointer type must match the array marshaller's CopyToUnmanaged signature.
+                string dataParamType;
+                string dataCastType;
+
+                if (context.AbiTypeKindResolver.IsMappedAbiValueType(szArr.BaseType))
+                {
+                    dataParamType = AbiTypeHelpers.GetMappedAbiTypeName(szArr.BaseType) + "*";
+                    dataCastType = "(" + AbiTypeHelpers.GetMappedAbiTypeName(szArr.BaseType) + "*)";
+                }
+                else if (szArr.BaseType.IsHResultException())
+                {
+                    dataParamType = "global::ABI.System.Exception*";
+                    dataCastType = "(global::ABI.System.Exception*)";
+                }
+                else if (context.AbiTypeKindResolver.IsNonBlittableStruct(szArr.BaseType))
+                {
+                    string abiStructName = AbiTypeHelpers.GetAbiStructTypeName(context, szArr.BaseType);
+                    dataParamType = abiStructName + "*";
+                    dataCastType = "(" + abiStructName + "*)";
+                }
+                else
+                {
+                    dataParamType = "void**";
+                    dataCastType = "(void**)";
+                }
+
                 UnsafeAccessorFactory.EmitStaticMethod(
                     writer,
                     accessName: "CopyToUnmanaged",
                     returnType: "void",
                     functionName: $"CopyToUnmanaged_{raw}",
                     interopType: ArrayElementEncoder.GetArrayMarshallerInteropPath(szArr.BaseType),
-                    parameterList: $"ReadOnlySpan<{elementProjected.Format()}> span, uint length, void** data");
-                writer.WriteLine($"CopyToUnmanaged_{raw}(null, {pname}, (uint){pname}.Length, (void**)_{raw});");
+                    parameterList: $"ReadOnlySpan<{elementProjected.Format()}> span, uint length, {dataParamType} data");
+                writer.WriteLine($"CopyToUnmanaged_{raw}(null, {pname}, (uint){pname}.Length, {dataCastType}_{raw});");
             }
         }
 
@@ -677,8 +705,27 @@ internal static partial class ConstructorFactory
                     continue;
                 }
 
+                // Mapped value types (DateTime/TimeSpan) need no disposal or pool return.
+                if (context.AbiTypeKindResolver.IsMappedAbiValueType(szArr.BaseType))
+                {
+                    continue;
+                }
+
                 string raw = p.GetRawName();
                 ArrayTempNames names = new(raw);
+
+                if (szArr.BaseType.IsHResultException())
+                {
+                    // HResult ABI is just an int; no per-element Dispose, only the pool return.
+                    writer.WriteLine();
+                    writer.WriteLine(isMultiline: true, $$"""
+                        if ({{names.ArrayFromPool}} is not null)
+                        {
+                            global::System.Buffers.ArrayPool<global::ABI.System.Exception>.Shared.Return({{names.ArrayFromPool}});
+                        }
+                        """);
+                    continue;
+                }
 
                 if (szArr.BaseType.IsString())
                 {
@@ -699,6 +746,25 @@ internal static partial class ConstructorFactory
                 }
                 else
                 {
+                    // Complex structs use a typed <ABI struct>* (no cast); ref types use void**.
+                    string disposeDataParamType;
+                    string fixedPtrType;
+                    string disposeCastType;
+
+                    if (context.AbiTypeKindResolver.IsNonBlittableStruct(szArr.BaseType))
+                    {
+                        string abiStructName = AbiTypeHelpers.GetAbiStructTypeName(context, szArr.BaseType);
+                        disposeDataParamType = abiStructName + "* data";
+                        fixedPtrType = abiStructName + "*";
+                        disposeCastType = string.Empty;
+                    }
+                    else
+                    {
+                        disposeDataParamType = "void** data";
+                        fixedPtrType = "void*";
+                        disposeCastType = "(void**)";
+                    }
+
                     writer.WriteLine();
                     UnsafeAccessorFactory.EmitStaticMethod(
                         writer,
@@ -706,20 +772,23 @@ internal static partial class ConstructorFactory
                         returnType: "void",
                         functionName: $"Dispose_{raw}",
                         interopType: ArrayElementEncoder.GetArrayMarshallerInteropPath(szArr.BaseType),
-                        parameterList: "uint length, void** data");
+                        parameterList: $"uint length, {disposeDataParamType}");
                     writer.WriteLine();
                     writer.WriteLine(isMultiline: true, $$"""
-                        fixed(void* _{{raw}} = {{names.Span}})
+                        fixed({{fixedPtrType}} _{{raw}} = {{names.Span}})
                         {
-                            Dispose_{{raw}}(null, (uint) {{names.Span}}.Length, (void**)_{{raw}});
+                            Dispose_{{raw}}(null, (uint) {{names.Span}}.Length, {{disposeCastType}}_{{raw}});
                         }
                         """);
                 }
+
+                // Pool storage type matches the InlineArray16<storageT> setup.
+                string poolStorageT = AbiTypeHelpers.GetArrayElementStorageType(context, szArr.BaseType);
                 writer.WriteLine();
                 writer.WriteLine(isMultiline: true, $$"""
                     if ({{names.ArrayFromPool}} is not null)
                     {
-                        global::System.Buffers.ArrayPool<nint>.Shared.Return({{names.ArrayFromPool}});
+                        global::System.Buffers.ArrayPool<{{poolStorageT}}>.Shared.Return({{names.ArrayFromPool}});
                     }
                     """);
             }

--- a/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
+++ b/src/WinRT.Projection.Writer/Factories/ConstructorFactory.FactoryCallbacks.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
@@ -12,6 +11,8 @@ using WindowsRuntime.ProjectionWriter.Metadata;
 using WindowsRuntime.ProjectionWriter.Models;
 using WindowsRuntime.ProjectionWriter.Resolvers;
 using WindowsRuntime.ProjectionWriter.Writers;
+
+#pragma warning disable IDE0045
 
 namespace WindowsRuntime.ProjectionWriter.Factories;
 
@@ -66,8 +67,6 @@ internal static partial class ConstructorFactory
     /// <c>out void* innerInterface</c> params. Iteration over user params is bounded by
     /// <paramref name="userParamCount"/> (defaults to all params).</param>
     /// <param name="userParamCount">If &gt;= 0, only emit the first <paramref name="userParamCount"/> user params (used for composable factories).</param>
-    [SuppressMessage("Style", "IDE0045:Convert to conditional expression",
-        Justification = "if/else if chains over type-class predicates are more readable than nested ternaries.")]
     private static void EmitFactoryCallbackClass(IndentedTextWriter writer, ProjectionEmitContext context, MethodSignatureInfo sig, string callbackName, string argsName, string factoryObjRefName, int factoryMethodIndex, bool isComposable = false, int userParamCount = -1)
     {
         int paramCount = userParamCount >= 0 ? userParamCount : sig.Parameters.Count;
@@ -471,7 +470,7 @@ internal static partial class ConstructorFactory
             }
         }
 
-        // Emit CopyToUnmanaged for non-blittable PassArray params.
+        // Emit 'CopyToUnmanaged' for non-blittable PassArray params
         for (int i = 0; i < paramCount; i++)
         {
             ParameterInfo p = sig.Parameters[i];
@@ -510,7 +509,7 @@ internal static partial class ConstructorFactory
             {
                 IndentedTextWriterCallback elementProjected = TypedefNameWriter.WriteProjectionType(context, TypeSemanticsFactory.Get(szArr.BaseType));
 
-                // Data pointer type must match the array marshaller's CopyToUnmanaged signature.
+                // Data pointer type must match the array marshaller's 'CopyToUnmanaged' signature
                 string dataParamType;
 
                 if (context.AbiTypeKindResolver.IsMappedAbiValueType(szArr.BaseType))
@@ -559,7 +558,7 @@ internal static partial class ConstructorFactory
 
         if (isComposable)
         {
-            // Composable extras: baseInterface (void*), out innerInterface (void**)
+            // Composable extras: 'baseInterface (void*), out innerInterface (void**)'
             writer.Write("void*, void**, ");
         }
 
@@ -580,12 +579,12 @@ internal static partial class ConstructorFactory
                 continue;
             }
 
-            // For enums, cast to underlying type. For bool, cast to byte. For char, cast to ushort.
-            // For string params, use the marshalled HString from the fixed block.
-            // For runtime class / object / generic instance params, use __<name>.GetThisPtrUnsafe().
+            // For enums, cast to underlying type. For 'bool', cast to 'byte'. For 'char', cast to 'ushort'.
+            // For 'string' params, use the marshalled 'HSTRING' from the fixed block.
+            // For runtime class / 'object' / generic instance params, use '__<name>.GetThisPtrUnsafe()'.
             if (context.AbiTypeKindResolver.IsEnumType(p.Type))
             {
-                // No cast needed: function pointer signature uses the projected enum type.
+                // No cast needed: function pointer signature uses the projected enum type
                 writer.Write(pname);
             }
             else if (p.Type is CorLibTypeSignature corlibBool &&
@@ -630,7 +629,7 @@ internal static partial class ConstructorFactory
 
         if (isComposable)
         {
-            // Pass __baseInterface.GetThisPtrUnsafe() and &__innerInterface.
+            // Pass '__baseInterface.GetThisPtrUnsafe()' and '&__innerInterface'
             writer.Write(isMultiline: true, """
                 ,
                   __baseInterface.GetThisPtrUnsafe(),
@@ -648,7 +647,7 @@ internal static partial class ConstructorFactory
 
         writer.WriteLine("retval = __retval;");
 
-        // Close fixed blocks (innermost first).
+        // Close fixed blocks (innermost first)
         for (int i = 0; i < fixedNesting; i++)
         {
             writer.DecreaseIndent();
@@ -667,8 +666,8 @@ internal static partial class ConstructorFactory
                 """);
             writer.IncreaseIndent();
 
-            // Dispose pre-marshalled ABI struct input locals (frees any HSTRING / boxed
-            // reference fields the per-field ConvertToUnmanaged may have allocated).
+            // Dispose pre-marshalled ABI struct input locals (frees any 'HSTRING' / boxed
+            // reference fields the per-field 'ConvertToUnmanaged' may have allocated).
             for (int i = 0; i < paramCount; i++)
             {
                 ParameterInfo p = sig.Parameters[i];
@@ -702,7 +701,7 @@ internal static partial class ConstructorFactory
                     continue;
                 }
 
-                // Mapped value types (DateTime/TimeSpan) need no disposal or pool return.
+                // Mapped value types ('DateTime'/'TimeSpan') need no disposal or pool return
                 if (context.AbiTypeKindResolver.IsMappedAbiValueType(szArr.BaseType))
                 {
                     continue;
@@ -713,7 +712,7 @@ internal static partial class ConstructorFactory
 
                 if (szArr.BaseType.IsHResultException())
                 {
-                    // HResult ABI is just an int; no per-element Dispose, only the pool return.
+                    // 'HResult' ABI is just an 'int': no per-element 'Dispose', only the pool return
                     writer.WriteLine();
                     writer.WriteLine(isMultiline: true, $$"""
                         if ({{names.ArrayFromPool}} is not null)
@@ -743,7 +742,7 @@ internal static partial class ConstructorFactory
                 }
                 else
                 {
-                    // Complex structs use a typed <ABI struct>* (no cast); ref types use void**.
+                    // Complex structs use a typed <ABI struct>* (no cast), ref types use 'void**'
                     string disposeDataParamType;
                     string fixedPtrType;
                     string disposeCastType;
@@ -779,7 +778,7 @@ internal static partial class ConstructorFactory
                         """);
                 }
 
-                // Pool storage type matches the InlineArray16<storageT> setup.
+                // Pool storage type matches the 'InlineArray16<storageT>' setup
                 string poolStorageT = AbiTypeHelpers.GetArrayElementStorageType(context, szArr.BaseType);
                 writer.WriteLine();
                 writer.WriteLine(isMultiline: true, $$"""


### PR DESCRIPTION
Activation-factory constructors taking arrays of non-blittable structs, mapped value types (DateTime/TimeSpan), or HResult/Exception elements hardcoded nint InlineArray storage and void** CopyToUnmanaged/Dispose data pointers, so the array marshaller's UnsafeAccessor failed to bind at runtime (Method not found: ...ArrayMarshaller.Dispose).

Route the constructor's PassArray storage, CopyToUnmanaged, and finally cleanup through the element-kind-aware helpers (GetArrayElementStorageType and typed data-pointer/cast selection), mirroring the RCW caller. Add a TestComponentCSharp constructor and TestNonBlittableArrayConstructor test covering all three element kinds.