### PR TITLE
Add opt-in CCW marshalling for projected Windows Runtime types

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -24,3 +24,6 @@ CSWINRT2014 | WindowsRuntime.SourceGenerator | Warning | API contract type missi
 CSWINRT2015 | WindowsRuntime.SourceGenerator | Info | Public authored type missing version metadata
 CSWINRT2016 | WindowsRuntime.SourceGenerator | Warning | Public authored type missing 'ContractVersionAttribute'
 CSWINRT2017 | WindowsRuntime.SourceGenerator | Warning | Public authored type mixing '[ContractVersion]' and '[Version]'
+CSWINRT2018 | WindowsRuntime.SourceGenerator | Warning | '[WindowsRuntimeNativeExposedType]' target type cannot be instantiated
+CSWINRT2019 | WindowsRuntime.SourceGenerator | Warning | '[WindowsRuntimeNativeExposedType]' target type is not a projected class
+CSWINRT2020 | WindowsRuntime.SourceGenerator | Warning | Duplicate '[WindowsRuntimeNativeExposedType]' target type

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
@@ -45,14 +45,12 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            IAssemblySymbol assemblySymbol = context.Compilation.Assembly;
+            List<ITypeSymbol> validTargetTypes = [];
 
             // Collect the valid target types across all applications of the attribute in the assembly (including
             // the ones in generated code), so that a type used both in user code and in generated code is still
             // detected as a duplicate. This list is only used to report duplicate applications of the attribute.
-            List<ITypeSymbol> validTargetTypes = [];
-
-            foreach (AttributeData attribute in assemblySymbol.GetAttributes(nativeExposedTypeAttributeType))
+            foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes(nativeExposedTypeAttributeType))
             {
                 if (attribute is { ConstructorArguments: [{ Value: ITypeSymbol targetType }] } &&
                     Classify(targetType, windowsRuntimeMetadataAttributeType) is NativeExposedTypeKind.Valid)
@@ -64,7 +62,7 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
             // Classify and report each application of the attribute. Applications in generated code are
             // suppressed by the analysis framework, because this analyzer opts out of generated code analysis,
             // so only applications authored in user code are ever reported.
-            foreach (AttributeData attribute in assemblySymbol.GetAttributes(nativeExposedTypeAttributeType))
+            foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes(nativeExposedTypeAttributeType))
             {
                 // Skip malformed applications, eg. where the argument does not bind to a type
                 if (attribute is not { ConstructorArguments: [{ Value: ITypeSymbol targetType }] })
@@ -84,19 +82,17 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
                         location,
                         targetType));
                 }
-
-                // The type is not a projected class, so CCW marshalling code is already generated for it
                 else if (kind is NativeExposedTypeKind.NotProjectedClass)
                 {
+                    // The type is not a projected class, so CCW marshalling code is already generated for it
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.NativeExposedTypeNotProjectedClass,
                         location,
                         targetType));
                 }
-
-                // The type is valid, but it is also targeted by another application of the attribute
                 else if (CountOccurrences(validTargetTypes, targetType) > 1)
                 {
+                    // The type is valid, but it is also targeted by another application of the attribute
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.NativeExposedTypeDuplicate,
                         location,
@@ -122,10 +118,14 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
 
         // A valid target is a non generic projected Windows Runtime class. CCW marshalling code is generated
         // automatically for every other kind of type, so the attribute is only ever needed for projected classes.
-        return type is INamedTypeSymbol { TypeKind: TypeKind.Class, IsGenericType: false } namedType &&
-               namedType.HasAttributeWithType(windowsRuntimeMetadataAttributeType)
-            ? NativeExposedTypeKind.Valid
-            : NativeExposedTypeKind.NotProjectedClass;
+        if (type is not INamedTypeSymbol { TypeKind: TypeKind.Class, IsGenericType: false } namedType ||
+            !namedType.HasAttributeWithType(windowsRuntimeMetadataAttributeType))
+        {
+            return NativeExposedTypeKind.NotProjectedClass;
+        }
+
+        // The type is a valid, non-generic and projected runtime class
+        return NativeExposedTypeKind.Valid;
     }
 
     /// <summary>
@@ -134,7 +134,7 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
     /// <param name="types">The sequence of types to search.</param>
     /// <param name="type">The type to count occurrences of.</param>
     /// <returns>The number of times <paramref name="type"/> appears in <paramref name="types"/>.</returns>
-    private static int CountOccurrences(List<ITypeSymbol> types, ITypeSymbol type)
+    private static int CountOccurrences(IEnumerable<ITypeSymbol> types, ITypeSymbol type)
     {
         int count = 0;
 

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
@@ -39,11 +39,15 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            // Get the '[WindowsRuntimeMetadata]' symbol, which is used to detect projected Windows Runtime types
-            if (context.Compilation.GetTypeByMetadataName("WindowsRuntime.WindowsRuntimeMetadataAttribute") is not { } windowsRuntimeMetadataAttributeType)
+            // Get the '[WindowsRuntimeReferenceAssembly]' symbol, which is used to detect projected Windows Runtime types
+            if (context.Compilation.GetTypeByMetadataName("WindowsRuntime.InteropServices.WindowsRuntimeReferenceAssemblyAttribute") is not { } referenceAssemblyAttributeType)
             {
                 return;
             }
+
+            // Also get the '[WindowsRuntimeType]' symbol, if available. This is only used as a fallback for the rare
+            // case of compiling directly against an implementation projection (see 'IsProjectedWindowsRuntimeType').
+            INamedTypeSymbol? windowsRuntimeTypeAttributeType = context.Compilation.GetTypeByMetadataName("WindowsRuntime.WindowsRuntimeTypeAttribute");
 
             List<ITypeSymbol> validTargetTypes = [];
 
@@ -53,7 +57,7 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
             foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes(nativeExposedTypeAttributeType))
             {
                 if (attribute is { ConstructorArguments: [{ Value: ITypeSymbol targetType }] } &&
-                    Classify(targetType, windowsRuntimeMetadataAttributeType) is NativeExposedTypeKind.Valid)
+                    Classify(targetType, referenceAssemblyAttributeType, windowsRuntimeTypeAttributeType) is NativeExposedTypeKind.Valid)
                 {
                     validTargetTypes.Add(targetType);
                 }
@@ -72,7 +76,7 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
 
                 Location? location = attribute.GetArgumentLocation(0, context.CancellationToken) ?? attribute.GetLocation(context.CancellationToken);
 
-                NativeExposedTypeKind kind = Classify(targetType, windowsRuntimeMetadataAttributeType);
+                NativeExposedTypeKind kind = Classify(targetType, referenceAssemblyAttributeType, windowsRuntimeTypeAttributeType);
 
                 // The type cannot be instantiated, so no CCW would ever be created for it
                 if (kind is NativeExposedTypeKind.NotInstantiable)
@@ -106,9 +110,13 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
     /// Classifies a target type used with <c>[WindowsRuntimeNativeExposedType]</c>.
     /// </summary>
     /// <param name="type">The target type to classify.</param>
-    /// <param name="windowsRuntimeMetadataAttributeType">The <c>[WindowsRuntimeMetadata]</c> symbol.</param>
+    /// <param name="referenceAssemblyAttributeType">The <c>[WindowsRuntimeReferenceAssembly]</c> symbol.</param>
+    /// <param name="windowsRuntimeTypeAttributeType">The <c>[WindowsRuntimeType]</c> symbol, if it is available.</param>
     /// <returns>The <see cref="NativeExposedTypeKind"/> classification for <paramref name="type"/>.</returns>
-    private static NativeExposedTypeKind Classify(ITypeSymbol type, INamedTypeSymbol windowsRuntimeMetadataAttributeType)
+    private static NativeExposedTypeKind Classify(
+        ITypeSymbol type,
+        INamedTypeSymbol referenceAssemblyAttributeType,
+        INamedTypeSymbol? windowsRuntimeTypeAttributeType)
     {
         // A type that cannot be instantiated can never have a CCW created for it, so the attribute is meaningless
         if (!IsInstantiable(type))
@@ -119,13 +127,43 @@ public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
         // A valid target is a non generic projected Windows Runtime class. CCW marshalling code is generated
         // automatically for every other kind of type, so the attribute is only ever needed for projected classes.
         if (type is not INamedTypeSymbol { TypeKind: TypeKind.Class, IsGenericType: false } namedType ||
-            !namedType.HasAttributeWithType(windowsRuntimeMetadataAttributeType))
+            !IsProjectedWindowsRuntimeType(namedType, referenceAssemblyAttributeType, windowsRuntimeTypeAttributeType))
         {
             return NativeExposedTypeKind.NotProjectedClass;
         }
 
         // The type is a valid, non-generic and projected runtime class
         return NativeExposedTypeKind.Valid;
+    }
+
+    /// <summary>
+    /// Checks whether a given type is a projected Windows Runtime type.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="referenceAssemblyAttributeType">The <c>[WindowsRuntimeReferenceAssembly]</c> symbol.</param>
+    /// <param name="windowsRuntimeTypeAttributeType">The <c>[WindowsRuntimeType]</c> symbol, if it is available.</param>
+    /// <returns>Whether <paramref name="type"/> is a projected Windows Runtime type.</returns>
+    private static bool IsProjectedWindowsRuntimeType(
+        INamedTypeSymbol type,
+        INamedTypeSymbol referenceAssemblyAttributeType,
+        INamedTypeSymbol? windowsRuntimeTypeAttributeType)
+    {
+        // Projections are consumed as reference projection assemblies, which are marked with
+        // '[assembly: WindowsRuntimeReferenceAssembly]'. All types they contain are projected
+        // Windows Runtime types, so this is the check being used to detect them. Note that the
+        // per-type markers are not visible here, as they are implementation details that are
+        // stripped from reference projections (the same is true for the centralized metadata
+        // lookup type that carries all '[WindowsRuntimeMetadata]' entries).
+        if (type.ContainingAssembly is { } containingAssembly &&
+            containingAssembly.HasAttributeWithType(referenceAssemblyAttributeType))
+        {
+            return true;
+        }
+
+        // Fallback for the rare case of compiling directly against an implementation projection (eg. a local
+        // project reference to a projection project that is not producing a reference projection). Those types
+        // do not have the assembly-level marker, but they do carry the per-type '[WindowsRuntimeType]' marker.
+        return windowsRuntimeTypeAttributeType is not null && type.HasAttributeWithType(windowsRuntimeTypeAttributeType);
     }
 
     /// <summary>

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that validates uses of <c>[WindowsRuntimeNativeExposedType]</c>. The attribute is only
+/// meaningful when applied with a concrete, non generic projected Windows Runtime class type, as CCW marshalling
+/// code is generated automatically for every other kind of type. It also reports redundant applications of the
+/// attribute that target a type already used by another application in the same assembly.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WindowsRuntimeNativeExposedTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+    [
+        DiagnosticDescriptors.NativeExposedTypeNotInstantiable,
+        DiagnosticDescriptors.NativeExposedTypeNotProjectedClass,
+        DiagnosticDescriptors.NativeExposedTypeDuplicate
+    ];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(static context =>
+        {
+            // Get the '[WindowsRuntimeNativeExposedType]' symbol
+            if (context.Compilation.GetTypeByMetadataName("WindowsRuntime.InteropServices.WindowsRuntimeNativeExposedTypeAttribute") is not { } nativeExposedTypeAttributeType)
+            {
+                return;
+            }
+
+            // Get the '[WindowsRuntimeMetadata]' symbol, which is used to detect projected Windows Runtime types
+            if (context.Compilation.GetTypeByMetadataName("WindowsRuntime.WindowsRuntimeMetadataAttribute") is not { } windowsRuntimeMetadataAttributeType)
+            {
+                return;
+            }
+
+            IAssemblySymbol assemblySymbol = context.Compilation.Assembly;
+
+            // Collect the valid target types across all applications of the attribute in the assembly (including
+            // the ones in generated code), so that a type used both in user code and in generated code is still
+            // detected as a duplicate. This list is only used to report duplicate applications of the attribute.
+            List<ITypeSymbol> validTargetTypes = [];
+
+            foreach (AttributeData attribute in assemblySymbol.GetAttributes(nativeExposedTypeAttributeType))
+            {
+                if (attribute is { ConstructorArguments: [{ Value: ITypeSymbol targetType }] } &&
+                    Classify(targetType, windowsRuntimeMetadataAttributeType) is NativeExposedTypeKind.Valid)
+                {
+                    validTargetTypes.Add(targetType);
+                }
+            }
+
+            // Classify and report each application of the attribute. Applications in generated code are
+            // suppressed by the analysis framework, because this analyzer opts out of generated code analysis,
+            // so only applications authored in user code are ever reported.
+            foreach (AttributeData attribute in assemblySymbol.GetAttributes(nativeExposedTypeAttributeType))
+            {
+                // Skip malformed applications, eg. where the argument does not bind to a type
+                if (attribute is not { ConstructorArguments: [{ Value: ITypeSymbol targetType }] })
+                {
+                    continue;
+                }
+
+                Location? location = attribute.GetArgumentLocation(0, context.CancellationToken) ?? attribute.GetLocation(context.CancellationToken);
+
+                NativeExposedTypeKind kind = Classify(targetType, windowsRuntimeMetadataAttributeType);
+
+                // The type cannot be instantiated, so no CCW would ever be created for it
+                if (kind is NativeExposedTypeKind.NotInstantiable)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.NativeExposedTypeNotInstantiable,
+                        location,
+                        targetType));
+                }
+
+                // The type is not a projected class, so CCW marshalling code is already generated for it
+                else if (kind is NativeExposedTypeKind.NotProjectedClass)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.NativeExposedTypeNotProjectedClass,
+                        location,
+                        targetType));
+                }
+
+                // The type is valid, but it is also targeted by another application of the attribute
+                else if (CountOccurrences(validTargetTypes, targetType) > 1)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.NativeExposedTypeDuplicate,
+                        location,
+                        targetType));
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Classifies a target type used with <c>[WindowsRuntimeNativeExposedType]</c>.
+    /// </summary>
+    /// <param name="type">The target type to classify.</param>
+    /// <param name="windowsRuntimeMetadataAttributeType">The <c>[WindowsRuntimeMetadata]</c> symbol.</param>
+    /// <returns>The <see cref="NativeExposedTypeKind"/> classification for <paramref name="type"/>.</returns>
+    private static NativeExposedTypeKind Classify(ITypeSymbol type, INamedTypeSymbol windowsRuntimeMetadataAttributeType)
+    {
+        // A type that cannot be instantiated can never have a CCW created for it, so the attribute is meaningless
+        if (!IsInstantiable(type))
+        {
+            return NativeExposedTypeKind.NotInstantiable;
+        }
+
+        // A valid target is a non generic projected Windows Runtime class. CCW marshalling code is generated
+        // automatically for every other kind of type, so the attribute is only ever needed for projected classes.
+        return type is INamedTypeSymbol { TypeKind: TypeKind.Class, IsGenericType: false } namedType &&
+               namedType.HasAttributeWithType(windowsRuntimeMetadataAttributeType)
+            ? NativeExposedTypeKind.Valid
+            : NativeExposedTypeKind.NotProjectedClass;
+    }
+
+    /// <summary>
+    /// Counts how many times a given type appears in a sequence of types.
+    /// </summary>
+    /// <param name="types">The sequence of types to search.</param>
+    /// <param name="type">The type to count occurrences of.</param>
+    /// <returns>The number of times <paramref name="type"/> appears in <paramref name="types"/>.</returns>
+    private static int CountOccurrences(List<ITypeSymbol> types, ITypeSymbol type)
+    {
+        int count = 0;
+
+        foreach (ITypeSymbol candidate in types)
+        {
+            if (SymbolEqualityComparer.Default.Equals(candidate, type))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Checks whether a given type can be instantiated.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>Whether <paramref name="type"/> can be instantiated.</returns>
+    private static bool IsInstantiable(ITypeSymbol type)
+    {
+        // Array types can always be instantiated
+        if (type is IArrayTypeSymbol)
+        {
+            return true;
+        }
+
+        // Any other non named type (eg. a pointer type or a type parameter) cannot be instantiated
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        // An unbound generic type definition (eg. 'typeof(List<>)') cannot be instantiated
+        if (namedType.IsUnboundGenericType)
+        {
+            return false;
+        }
+
+        // Interfaces, abstract classes, and static classes cannot be instantiated
+        if (namedType.TypeKind is TypeKind.Interface || namedType.IsAbstract || namedType.IsStatic)
+        {
+            return false;
+        }
+
+        // Classes, structs, enums, and delegates can be instantiated
+        return namedType.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Enum or TypeKind.Delegate;
+    }
+
+    /// <summary>
+    /// The classification of a target type used with <c>[WindowsRuntimeNativeExposedType]</c>.
+    /// </summary>
+    private enum NativeExposedTypeKind
+    {
+        /// <summary>
+        /// The target type cannot be instantiated (eg. an interface, an abstract class, or a generic type definition).
+        /// </summary>
+        NotInstantiable,
+
+        /// <summary>
+        /// The target type can be instantiated, but it is not a projected Windows Runtime class.
+        /// </summary>
+        NotProjectedClass,
+
+        /// <summary>
+        /// The target type is a valid, non generic projected Windows Runtime class.
+        /// </summary>
+        Valid
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -244,4 +244,46 @@ internal static partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Public types in a Windows Runtime component should not mix '[ContractVersion]' and '[Version]', as these represent two different versioning schemes. Pick one and apply it consistently across the public API surface of the component.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[WindowsRuntimeNativeExposedType]</c> attribute applied with a target type that cannot be instantiated.
+    /// </summary>
+    public static readonly DiagnosticDescriptor NativeExposedTypeNotInstantiable = new(
+        id: "CSWINRT2018",
+        title: "'[WindowsRuntimeNativeExposedType]' target type cannot be instantiated",
+        messageFormat: """The type '{0}' is used as the target of a '[WindowsRuntimeNativeExposedType]' attribute, but it cannot be instantiated. Only concrete, non generic projected Windows Runtime class types can be used with this attribute, as no CCW would ever be created for a type that cannot be instantiated.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The '[WindowsRuntimeNativeExposedType]' attribute should only be applied with concrete, non generic projected Windows Runtime class types. Types that cannot be instantiated, such as interfaces, abstract classes, static classes, and generic type definitions, have no effect when used as the target of the attribute.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[WindowsRuntimeNativeExposedType]</c> attribute applied with a target type that is not a projected Windows Runtime class.
+    /// </summary>
+    public static readonly DiagnosticDescriptor NativeExposedTypeNotProjectedClass = new(
+        id: "CSWINRT2019",
+        title: "'[WindowsRuntimeNativeExposedType]' target type is not a projected class",
+        messageFormat: """The type '{0}' is used as the target of a '[WindowsRuntimeNativeExposedType]' attribute, but it is not a projected Windows Runtime class type. CCW marshalling code is already generated automatically for all other types (such as user defined types, value types, delegates, arrays, and generic instantiations), so applying the attribute to '{0}' has no effect.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The '[WindowsRuntimeNativeExposedType]' attribute should only be applied with projected Windows Runtime class types. CCW marshalling code is generated automatically for all other types, so applying the attribute to them has no effect.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <c>[WindowsRuntimeNativeExposedType]</c> attribute applied with a target type that is already used by another application of the attribute in the same assembly.
+    /// </summary>
+    public static readonly DiagnosticDescriptor NativeExposedTypeDuplicate = new(
+        id: "CSWINRT2020",
+        title: "Duplicate '[WindowsRuntimeNativeExposedType]' target type",
+        messageFormat: """The type '{0}' is used as the target of more than one '[WindowsRuntimeNativeExposedType]' attribute in the same assembly. CCW marshalling code is only generated once per type, so the additional applications of the attribute for '{0}' have no effect and can be removed.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A given type should only be used as the target of a single '[WindowsRuntimeNativeExposedType]' attribute in an assembly. CCW marshalling code is only generated once per type, so additional applications of the attribute for the same type have no effect.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 }

--- a/src/Tests/FunctionalTests/NativeExposedType/NativeExposedType.csproj
+++ b/src/Tests/FunctionalTests/NativeExposedType/NativeExposedType.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(FunctionalTestsBuildTFMs)</TargetFrameworks>
+    <Platforms>x86;x64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    <PublishProfileFullPath>$(MSBuildProjectDirectory)\..\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Authoring\WinRT.SourceGenerator2\WinRT.SourceGenerator2.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetPlatform="Platform=AnyCPU" />
+    <ProjectReference Include="..\..\..\Projections\Windows\Windows.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/FunctionalTests/NativeExposedType/Program.cs
+++ b/src/Tests/FunctionalTests/NativeExposedType/Program.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Windows.Data.Json;
+using WindowsRuntime.InteropServices;
+
+#pragma warning disable CSWINRT3001 // Type or member is obsolete
+
+// The interop generator normally skips projected types when generating CCW marshalling code, as they are backed
+// by native objects and never need to be exposed to native code through a CCW. Opting 'JsonArray' in via the
+// '[WindowsRuntimeNativeExposedType]' attribute forces the interop generator to also emit CCW marshalling code
+// for it, just like it does for any user defined type. This registers a proxy type map association for the type,
+// which the checks below then verify is present (and absent for a projected type that was not opted in).
+[assembly: WindowsRuntimeNativeExposedType(typeof(JsonArray))]
+
+namespace NativeExposedType;
+
+internal static class Program
+{
+    private static int Main()
+    {
+        IReadOnlyDictionary<Type, Type> proxyTypeMapping = GetComWrappersProxyTypeMapping();
+
+        // 'JsonArray' was explicitly opted into CCW marshalling code generation, so the interop generator must
+        // have generated a proxy for it and registered the associated proxy type map entry.
+        if (!proxyTypeMapping.TryGetValue(typeof(JsonArray), out _))
+        {
+            return 101;
+        }
+
+        // 'JsonObject' is a projected type that was not opted into CCW marshalling code generation. The interop
+        // generator must have skipped it, as projected types are backed by native objects and never need CCW
+        // marshalling code generated for them by default.
+        if (proxyTypeMapping.TryGetValue(typeof(JsonObject), out _))
+        {
+            return 102;
+        }
+
+        return 100;
+    }
+
+    // Retrieves the proxy type map used by CsWinRT to resolve CCW marshalling info for managed objects
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The proxy type map is always preserved by the interop generator.")]
+    private static IReadOnlyDictionary<Type, Type> GetComWrappersProxyTypeMapping()
+    {
+        return TypeMapping.GetOrCreateProxyTypeMapping<WindowsRuntimeComWrappersTypeMapGroup>();
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
+++ b/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
@@ -22,6 +22,11 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     /// <summary>
+    /// The name of the additional project standing in for a Windows Runtime reference projection assembly.
+    /// </summary>
+    private const string ReferenceProjectionName = "ReferenceProjection";
+
+    /// <summary>
     /// Whether to enable unsafe blocks.
     /// </summary>
     private readonly bool _allowUnsafeBlocks;
@@ -61,13 +66,20 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
     /// <param name="languageVersion">The language version to use to run the test.</param>
     /// <param name="isCsWinRTComponent">Whether to set the <c>"CsWinRTComponent"</c> MSBuild property to <see langword="true"/>.</param>
     /// <param name="generatedSource">An additional source file to add to the compilation as generated code, or <see langword="null"/> to not add one.</param>
+    /// <param name="referenceProjectionSource">
+    /// An additional source file to compile into a separate project that is marked as a Windows Runtime reference projection
+    /// (via <c>[assembly: WindowsRuntimeReferenceAssembly]</c>) and referenced by the test project, or <see langword="null"/>
+    /// to not add one. This is used to validate scenarios involving projected Windows Runtime types, which are always
+    /// consumed from reference projections.
+    /// </param>
     public static Task VerifyAnalyzerAsync(
         string source,
         ReadOnlySpan<DiagnosticResult> expectedDiagnostics = default,
         bool allowUnsafeBlocks = true,
         LanguageVersion languageVersion = LanguageVersion.CSharp14,
         bool isCsWinRTComponent = false,
-        string generatedSource = null)
+        string generatedSource = null,
+        string referenceProjectionSource = null)
     {
         CSharpAnalyzerTest<TAnalyzer> test = new(allowUnsafeBlocks, languageVersion) { TestCode = source };
 
@@ -83,6 +95,24 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
         if (generatedSource is not null)
         {
             test.TestState.Sources.Add(("NativeExposedTypes.g.cs", generatedSource));
+        }
+
+        // Add a separate project standing in for a Windows Runtime reference projection assembly, which is how all
+        // projected types are actually consumed. Such assemblies are marked with '[assembly: WindowsRuntimeReferenceAssembly]',
+        // and they do not carry any of the per-type markers (those are implementation details that are stripped from them).
+        if (referenceProjectionSource is not null)
+        {
+            ProjectState projectState = test.TestState.AdditionalProjects[ReferenceProjectionName];
+
+            projectState.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
+            projectState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(WindowsRuntimeObject).Assembly.Location));
+            projectState.Sources.Add(($"{ReferenceProjectionName}.cs", $"""
+                [assembly: WindowsRuntime.InteropServices.WindowsRuntimeReferenceAssembly]
+
+                {referenceProjectionSource}
+                """));
+
+            test.TestState.AdditionalProjectReferences.Add(ReferenceProjectionName);
         }
 
         // Configure the desired MSBuild properties via a global analyzer config file

--- a/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
+++ b/src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
@@ -60,12 +60,14 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
     /// <param name="allowUnsafeBlocks">Whether to enable unsafe blocks.</param>
     /// <param name="languageVersion">The language version to use to run the test.</param>
     /// <param name="isCsWinRTComponent">Whether to set the <c>"CsWinRTComponent"</c> MSBuild property to <see langword="true"/>.</param>
+    /// <param name="generatedSource">An additional source file to add to the compilation as generated code, or <see langword="null"/> to not add one.</param>
     public static Task VerifyAnalyzerAsync(
         string source,
         ReadOnlySpan<DiagnosticResult> expectedDiagnostics = default,
         bool allowUnsafeBlocks = true,
         LanguageVersion languageVersion = LanguageVersion.CSharp14,
-        bool isCsWinRTComponent = false)
+        bool isCsWinRTComponent = false,
+        string generatedSource = null)
     {
         CSharpAnalyzerTest<TAnalyzer> test = new(allowUnsafeBlocks, languageVersion) { TestCode = source };
 
@@ -74,6 +76,14 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(CoreApplication).Assembly.Location));
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Button).Assembly.Location));
         test.TestState.ExpectedDiagnostics.AddRange([.. expectedDiagnostics]);
+
+        // Add an additional source file that is treated as generated code (the '.g.cs' suffix is recognized by the
+        // analysis framework). This is used to validate that diagnostics are suppressed for applications of the
+        // attribute that appear in generated code, when the analyzer opts out of generated code analysis.
+        if (generatedSource is not null)
+        {
+            test.TestState.Sources.Add(("NativeExposedTypes.g.cs", generatedSource));
+        }
 
         // Configure the desired MSBuild properties via a global analyzer config file
         if (isCsWinRTComponent)

--- a/src/Tests/SourceGenerator2Test/Test_WindowsRuntimeNativeExposedTypeAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WindowsRuntimeNativeExposedTypeAnalyzer.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<WindowsRuntimeNativeExposedTypeAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="WindowsRuntimeNativeExposedTypeAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_WindowsRuntimeNativeExposedTypeAnalyzer
+{
+    [TestMethod]
+    public async Task ProjectedClass_DoesNotWarn()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType(typeof(Microsoft.UI.Xaml.DependencyObjectCollection))]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task Interface_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2018:typeof(IMyInterface)|})]
+
+            public interface IMyInterface;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task AbstractClass_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2018:typeof(MyClass)|})]
+
+            public abstract class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task StaticClass_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2018:typeof(MyClass)|})]
+
+            public static class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task GenericTypeDefinition_Warns()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2018:typeof(List<>)|})]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task UserDefinedClass_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyClass)|})]
+
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ValueType_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyStruct)|})]
+
+            public struct MyStruct;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task Delegate_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyDelegate)|})]
+
+            public delegate void MyDelegate();
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ArrayType_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(int[])|})]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ClosedGenericType_Warns()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(List<int>)|})]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ProjectedStruct_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(Windows.Foundation.Point)|})]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task DuplicateProjectedClass_BothWarn()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2020:typeof(Microsoft.UI.Xaml.DependencyObjectCollection)|})]
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2020:typeof(Microsoft.UI.Xaml.DependencyObjectCollection)|})]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task DuplicateNonProjectedClass_WarnsAsNotProjectedClass()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyClass)|})]
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyClass)|})]
+
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task DuplicateAcrossUserAndGeneratedCode_OnlyUserWarns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2020:typeof(Microsoft.UI.Xaml.DependencyObjectCollection)|})]
+            """;
+
+        const string generatedSource = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType(typeof(Microsoft.UI.Xaml.DependencyObjectCollection))]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, generatedSource: generatedSource);
+    }
+
+    [TestMethod]
+    public async Task ApplicationInGeneratedCodeOnly_DoesNotWarn()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType(typeof(Microsoft.UI.Xaml.DependencyObjectCollection))]
+            """;
+
+        const string generatedSource = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType(typeof(MyClass))]
+
+            public sealed class MyClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, generatedSource: generatedSource);
+    }
+}

--- a/src/Tests/SourceGenerator2Test/Test_WindowsRuntimeNativeExposedTypeAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_WindowsRuntimeNativeExposedTypeAnalyzer.cs
@@ -208,6 +208,55 @@ public sealed class Test_WindowsRuntimeNativeExposedTypeAnalyzer
     }
 
     [TestMethod]
+    public async Task ProjectedClassFromReferenceProjection_DoesNotWarn()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType(typeof(MyProjectedClass))]
+            """;
+
+        const string referenceProjectionSource = """
+            public sealed class MyProjectedClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, referenceProjectionSource: referenceProjectionSource);
+    }
+
+    [TestMethod]
+    public async Task ProjectedStructFromReferenceProjection_Warns()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2019:typeof(MyProjectedStruct)|})]
+            """;
+
+        const string referenceProjectionSource = """
+            public struct MyProjectedStruct;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, referenceProjectionSource: referenceProjectionSource);
+    }
+
+    [TestMethod]
+    public async Task DuplicateProjectedClassFromReferenceProjection_BothWarn()
+    {
+        const string source = """
+            using WindowsRuntime.InteropServices;
+
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2020:typeof(MyProjectedClass)|})]
+            [assembly: WindowsRuntimeNativeExposedType({|CSWINRT2020:typeof(MyProjectedClass)|})]
+            """;
+
+        const string referenceProjectionSource = """
+            public sealed class MyProjectedClass;
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, referenceProjectionSource: referenceProjectionSource);
+    }
+
+    [TestMethod]
     public async Task ApplicationInGeneratedCodeOnly_DoesNotWarn()
     {
         const string source = """

--- a/src/Tests/UnitTest/NativeExposedTypeTests.cs
+++ b/src/Tests/UnitTest/NativeExposedTypeTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using TestComponentCSharp;
+using Windows.Data.Json;
+using WindowsRuntime.InteropServices;
+
+#pragma warning disable CSWINRT3001 // Type or member is obsolete
+
+// The interop generator normally skips projected types when generating CCW marshalling code, as they are backed
+// by native objects and never need to be exposed to native code through a CCW. Opting 'CustomIterableTest' in via
+// the '[WindowsRuntimeNativeExposedType]' attribute forces the interop generator to also emit CCW marshalling code
+// for it, just like it does for any user defined type. This registers a proxy type map association for the type,
+// which the tests below then verify is present (and absent for a projected type that was not opted in).
+[assembly: WindowsRuntimeNativeExposedType(typeof(CustomIterableTest))]
+
+namespace UnitTest
+{
+    [TestClass]
+    public class NativeExposedTypeTests
+    {
+        [TestMethod]
+        public void NativeExposedType_IsRegisteredInComWrappersProxyTypeMapping()
+        {
+            IReadOnlyDictionary<Type, Type> proxyTypeMapping = GetComWrappersProxyTypeMapping();
+
+            // 'CustomIterableTest' was explicitly opted into CCW marshalling code generation, so the interop
+            // generator must have generated a proxy for it and registered the associated proxy type map entry.
+            Assert.IsTrue(proxyTypeMapping.TryGetValue(typeof(CustomIterableTest), out _));
+        }
+
+        [TestMethod]
+        public void ProjectedType_WithoutOptIn_IsNotRegisteredInComWrappersProxyTypeMapping()
+        {
+            IReadOnlyDictionary<Type, Type> proxyTypeMapping = GetComWrappersProxyTypeMapping();
+
+            // 'JsonObject' is a projected type that was not opted into CCW marshalling code generation. The interop
+            // generator must have skipped it, as projected types are backed by native objects and never need CCW
+            // marshalling code generated for them by default.
+            Assert.IsFalse(proxyTypeMapping.TryGetValue(typeof(JsonObject), out _));
+        }
+
+        // Retrieves the proxy type map used by CsWinRT to resolve CCW marshalling info for managed objects
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The proxy type map is always preserved by the interop generator.")]
+        private static IReadOnlyDictionary<Type, Type> GetComWrappersProxyTypeMapping()
+        {
+            return TypeMapping.GetOrCreateProxyTypeMapping<WindowsRuntimeComWrappersTypeMapGroup>();
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
+++ b/src/WinRT.Interop.Generator/Discovery/InteropTypeDiscovery.cs
@@ -82,6 +82,11 @@ internal static partial class InteropTypeDiscovery
     /// <param name="interopDefinitions">The <see cref="InteropDefinitions"/> instance to use.</param>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="module">The module currently being analyzed.</param>
+    /// <param name="isNativeExposedType">
+    /// Whether the type was explicitly opted into CCW marshalling code generation via
+    /// <c>[WindowsRuntimeNativeExposedType]</c>. When this is <see langword="true"/>, projected Windows
+    /// Runtime types are not skipped, as they would otherwise never get CCW marshalling code generated.
+    /// </param>
     /// <remarks>
     /// This method expects <paramref name="typeDefinition"/> to either be non-generic, or
     /// to have <paramref name="typeSignature"/> be a fully constructed signature for it.
@@ -93,7 +98,8 @@ internal static partial class InteropTypeDiscovery
         InteropGeneratorDiscoveryState discoveryState,
         InteropDefinitions interopDefinitions,
         InteropReferences interopReferences,
-        ModuleDefinition module)
+        ModuleDefinition module,
+        bool isNativeExposedType = false)
     {
         // Ignore types that should explicitly be excluded
         if (TypeExclusions.IsExcluded(typeSignature, interopReferences))
@@ -114,8 +120,10 @@ internal static partial class InteropTypeDiscovery
             return;
         }
 
-        // We can skip all projected Windows Runtime types early, as they don't need CCW support
-        if (typeDefinition.IsProjectedWindowsRuntimeType)
+        // We can skip all projected Windows Runtime types early, as they don't need CCW support. The only
+        // exception is when a type has been explicitly opted into CCW marshalling code generation, in which
+        // case we do want to process it as any other user-defined type (see the analyzer for more details).
+        if (typeDefinition.IsProjectedWindowsRuntimeType && !isNativeExposedType)
         {
             return;
         }

--- a/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
+++ b/src/WinRT.Interop.Generator/Errors/WellKnownInteropExceptions.cs
@@ -879,6 +879,22 @@ internal sealed class WellKnownInteropExceptions : IGeneratorErrorFactory
     }
 
     /// <summary>
+    /// Failed to discover native exposed types.
+    /// </summary>
+    public static WellKnownInteropException DiscoverNativeExposedTypesError(string? name, Exception exception)
+    {
+        return Exception(101, $"Failed to discover native exposed types (from '[WindowsRuntimeNativeExposedType]' attributes) for module '{name}'.", exception);
+    }
+
+    /// <summary>
+    /// Failed to resolve a type specified in a '[WindowsRuntimeNativeExposedType]' attribute.
+    /// </summary>
+    public static WellKnownInteropWarning NativeExposedTypeNotResolvedWarning(TypeSignature typeSignature, ModuleDefinition module)
+    {
+        return Warning(102, $"Failed to resolve the type '{typeSignature}' specified in a '[WindowsRuntimeNativeExposedType]' attribute while processing module '{module}': CCW marshalling code for it will not be generated.");
+    }
+
+    /// <summary>
     /// Creates a new exception with the specified id and message.
     /// </summary>
     /// <param name="id">The exception id.</param>

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.Discover.cs
@@ -289,6 +289,11 @@ internal partial class InteropGenerator
 
         args.Token.ThrowIfCancellationRequested();
 
+        // Discover all types explicitly opted into CCW marshalling code generation
+        DiscoverNativeExposedTypes(args, discoveryState, module);
+
+        args.Token.ThrowIfCancellationRequested();
+
         // Discover all generic type instantiations
         DiscoverGenericTypeInstantiations(args, discoveryState, module);
 
@@ -446,6 +451,79 @@ internal partial class InteropGenerator
         catch (Exception e)
         {
             WellKnownInteropExceptions.DiscoverExposedUserDefinedTypesError(module.Name, e).ThrowOrAttach(e);
+        }
+    }
+
+    /// <summary>
+    /// Discovers all types explicitly opted into CCW marshalling code generation via <c>[WindowsRuntimeNativeExposedType]</c>.
+    /// </summary>
+    /// <param name="args">The arguments for this invocation.</param>
+    /// <param name="discoveryState">The discovery state for this invocation.</param>
+    /// <param name="module">The module currently being analyzed.</param>
+    /// <remarks>
+    /// Projected Windows Runtime types are normally skipped when discovering exposed user-defined types, as they are backed
+    /// by native objects and never need CCW marshalling code. This method handles the niche cases where a projected type
+    /// does need such code, by processing the types explicitly requested through the attribute as any other user-defined type.
+    /// </remarks>
+    private static void DiscoverNativeExposedTypes(
+        InteropGeneratorArgs args,
+        InteropGeneratorDiscoveryState discoveryState,
+        ModuleDefinition module)
+    {
+        try
+        {
+            // Optimization: only implementation assemblies can carry the attribute, as Windows Runtime
+            // reference assemblies only contain projections and no user authored assembly metadata.
+            if (module.Assembly is not { IsWindowsRuntimeReferenceAssembly: false } assembly)
+            {
+                return;
+            }
+
+            InteropReferences interopReferences = CreateDiscoveryInteropReferences(module);
+            InteropDefinitions interopDefinitions = new(
+                interopReferences: interopReferences,
+                windowsRuntimeSdkProjectionModule: discoveryState.WindowsRuntimeSdkProjectionModule!,
+                windowsRuntimeSdkXamlProjectionModule: discoveryState.WindowsRuntimeSdkXamlProjectionModule,
+                windowsRuntimeProjectionModule: discoveryState.WindowsRuntimeProjectionModule,
+                windowsRuntimeComponentModule: discoveryState.WindowsRuntimeComponentModule);
+
+            // Enumerate all '[assembly: WindowsRuntimeNativeExposedType(typeof(<TYPE>))]' attributes on the module
+            foreach (CustomAttribute attribute in assembly.FindCustomAttributes("WindowsRuntime.InteropServices"u8, "WindowsRuntimeNativeExposedTypeAttribute"u8))
+            {
+                args.Token.ThrowIfCancellationRequested();
+
+                // Match '[WindowsRuntimeNativeExposedType(typeof(<TYPE>))]' and extract the exposed type
+                if (attribute.Signature is not { FixedArguments: [{ Element: TypeSignature exposedType }] })
+                {
+                    continue;
+                }
+
+                // Resolve the exposed type to its definition. If we can't, it likely means a reference is
+                // missing. We just warn and move on, as the rest of the discovery can still be completed.
+                if (!exposedType.TryResolve(interopReferences.RuntimeContext, out TypeDefinition? typeDefinition))
+                {
+                    WellKnownInteropExceptions.NativeExposedTypeNotResolvedWarning(exposedType, module).LogOrThrow(args.TreatWarningsAsErrors);
+
+                    continue;
+                }
+
+                // Track the exposed type as a user-defined type, bypassing the check that would normally skip
+                // projected types. All other filters still apply, so if the type is not actually a projected
+                // type that would benefit from CCW support (e.g. it's an interface), this will just be a no-op.
+                InteropTypeDiscovery.TryTrackExposedUserDefinedType(
+                    typeDefinition: typeDefinition,
+                    typeSignature: typeDefinition.ToTypeSignature(),
+                    args: args,
+                    discoveryState: discoveryState,
+                    interopDefinitions: interopDefinitions,
+                    interopReferences: interopReferences,
+                    module: module,
+                    isNativeExposedType: true);
+            }
+        }
+        catch (Exception e)
+        {
+            WellKnownInteropExceptions.DiscoverNativeExposedTypesError(module.Name, e).ThrowOrAttach(e);
         }
     }
 

--- a/src/WinRT.Interop.Generator/References/InteropReferences.cs
+++ b/src/WinRT.Interop.Generator/References/InteropReferences.cs
@@ -741,6 +741,11 @@ internal sealed class InteropReferences
     public TypeReference WindowsRuntimeMappedTypeAttribute => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeMappedTypeAttribute"u8);
 
     /// <summary>
+    /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeNativeExposedTypeAttribute</c>.
+    /// </summary>
+    public TypeReference WindowsRuntimeNativeExposedTypeAttribute => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeNativeExposedTypeAttribute"u8);
+
+    /// <summary>
     /// Gets the <see cref="AsmResolver.DotNet.TypeReference"/> for <c>WindowsRuntime.InteropServices.WindowsRuntimeComWrappersTypeMapGroup</c>.
     /// </summary>
     public TypeReference WindowsRuntimeComWrappersTypeMapGroup => field ??= _windowsRuntimeModule.CreateTypeReference("WindowsRuntime.InteropServices"u8, "WindowsRuntimeComWrappersTypeMapGroup"u8);

--- a/src/WinRT.Interop.Generator/References/WellKnownInterfaceIIDs.cs
+++ b/src/WinRT.Interop.Generator/References/WellKnownInterfaceIIDs.cs
@@ -90,6 +90,8 @@ internal static class WellKnownInterfaceIIDs
                 => "Windows_Foundation_IAsyncAction",
             _ when SignatureComparer.IgnoreVersion.Equals(interfaceType, interopReferences.IVectorChangedEventArgs)
                 => "Windows_Foundation_Collections_IVectorChangedEventArgs",
+            _ when SignatureComparer.IgnoreVersion.Equals(interfaceType, interopReferences.IStringable)
+                => "IStringable",
             _ when SignatureComparer.IgnoreVersion.Equals(interfaceType, interopReferences.IBuffer)
                 => "Windows_Storage_Streams_IBuffer",
             _ when SignatureComparer.IgnoreVersion.Equals(interfaceType, interopReferences.IInputStream)

--- a/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeComWrappersMarshallerAttribute.cs
+++ b/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeComWrappersMarshallerAttribute.cs
@@ -72,8 +72,8 @@ public abstract unsafe class WindowsRuntimeComWrappersMarshallerAttribute : Attr
     public virtual void* GetOrCreateComInterfaceForObject(object value)
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static NotSupportedException GetNotSupportedException()
-            => new($"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation does not support '{nameof(GetOrCreateComInterfaceForObject)}'.");
+        NotSupportedException GetNotSupportedException()
+            => new($"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation ('{GetType()}') does not support '{nameof(GetOrCreateComInterfaceForObject)}'.");
 
         throw GetNotSupportedException();
     }
@@ -106,11 +106,12 @@ public abstract unsafe class WindowsRuntimeComWrappersMarshallerAttribute : Attr
     /// <seealso cref="ComWrappers.ComputeVtables"/>
     public virtual ComWrappers.ComInterfaceEntry* ComputeVtables(out int count)
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static NotSupportedException GetNotSupportedException()
-            => new($"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation does not support '{nameof(ComputeVtables)}'.");
+        // This method does not throw an exception like the others in this type. In case of failure,
+        // the code in 'WindowsRuntimeMarshallingInfo' will detect the returned 'null' value and
+        // throw an exception from there, so additional debugging info can be included as well.
+        count = 0;
 
-        throw GetNotSupportedException();
+        return null;
     }
 
     /// <summary>
@@ -132,8 +133,8 @@ public abstract unsafe class WindowsRuntimeComWrappersMarshallerAttribute : Attr
     public virtual object CreateObject(void* value, out CreatedWrapperFlags wrapperFlags)
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static NotSupportedException GetNotSupportedException()
-            => new($"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation does not support '{nameof(CreateObject)}'.");
+        NotSupportedException GetNotSupportedException()
+            => new($"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation ('{GetType()}') does not support '{nameof(CreateObject)}'.");
 
         throw GetNotSupportedException();
     }

--- a/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeNativeExposedTypeAttribute.cs
+++ b/src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeNativeExposedTypeAttribute.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace WindowsRuntime.InteropServices;
+
+/// <summary>
+/// Indicates a projected Windows Runtime class type for which CCW (COM Callable Wrapper) marshalling code
+/// should be generated, so that its instances can be marshalled to native code through a CCW.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CCW marshalling code is normally generated automatically for all managed types that implement one or more
+/// Windows Runtime interfaces. Projected Windows Runtime types are an exception, as they are backed by native
+/// objects and are marshalled by unwrapping the underlying native object directly, which means they normally
+/// never require a CCW. This attribute allows explicitly opting a projected class type into CCW marshalling
+/// code generation, for the niche scenarios where such support is required.
+/// </para>
+/// <para>
+/// One such scenario involves using a projected collection type as an items source for a XAML control.
+/// Consider using a <c>DependencyObjectCollection</c> as the items source for an <c>ItemsControl</c>. The
+/// control will query the object assigned to its items source (which is marshalled as an <c>IInspectable</c>
+/// value) for the <c>IBindableIterable</c> and <c>IIterable&lt;IInspectable&gt;</c> interfaces. This normally
+/// succeeds when assigning most collection types. However, <c>DependencyObjectCollection</c> implements neither
+/// of those interfaces. It implements <c>IIterable&lt;DependencyObject&gt;</c>, and Windows Runtime generic
+/// interfaces are not covariant on the native side, meaning each generic instantiation of a given generic
+/// Windows Runtime interface has a completely different IID.
+/// </para>
+/// <para>
+/// To handle this, XAML controls perform the following steps:
+/// <list type="number">
+///   <item>They query the source object for <c>IBindableIterable</c> and <c>IIterable&lt;IInspectable&gt;</c>.</item>
+///   <item>If that fails, they obtain a CCW from the source object and query that CCW instead.</item>
+/// </list>
+/// </para>
+/// <para>
+/// This might seem surprising, given that a projected type is backed by a native object, and so it would just
+/// be unwrapped when marshalled, with no CCW involved. The .NET runtime has dedicated logic for this case,
+/// where it will perform the following steps:
+/// <list type="number">
+///   <item>It creates an RCW (Runtime Callable Wrapper) for the native object.</item>
+///   <item>It uses <c>ComWrappers</c> to obtain a CCW for that RCW, to be used as a proxy.</item>
+/// </list>
+/// That is, in this scenario the reference from the control to the object is transformed from a direct
+/// reference into a reference to a CCW that wraps an RCW over the original native object.
+/// </para>
+/// <para>
+/// Because the RCW implements <c>IEnumerable&lt;DependencyObject&gt;</c>, and that interface is covariant in
+/// C#, marshalling it to native makes the query for <c>IIterable&lt;IInspectable&gt;</c> succeed, by going
+/// through this reference cycle with the proxy object. This works because CsWinRT computes all variant versions
+/// of each implemented interface on managed objects, and generates vtables for all of them. As a consequence,
+/// such native objects can only be used as items sources from .NET applications, and not from C++ applications.
+/// </para>
+/// <para>
+/// Applying this attribute to a projected class type explicitly requests that a CCW vtable be generated for it,
+/// which would not normally be present, since the type is just a projection.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+public sealed class WindowsRuntimeNativeExposedTypeAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new <see cref="WindowsRuntimeNativeExposedTypeAttribute"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="type">The projected Windows Runtime class type to generate CCW marshalling code for.</param>
+    public WindowsRuntimeNativeExposedTypeAttribute(Type type)
+    {
+        Type = type;
+    }
+
+    /// <summary>
+    /// Gets the projected Windows Runtime class type to generate CCW marshalling code for.
+    /// </summary>
+    public Type Type { get; }
+}

--- a/src/WinRT.Runtime2/InteropServices/TypeMapInfo/WindowsRuntimeMarshallingInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/TypeMapInfo/WindowsRuntimeMarshallingInfo.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable IDE0008, IDE0046
+#pragma warning disable IDE0008
 
 namespace WindowsRuntime.InteropServices;
 

--- a/src/WinRT.Runtime2/InteropServices/TypeMapInfo/WindowsRuntimeMarshallingInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/TypeMapInfo/WindowsRuntimeMarshallingInfo.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable IDE0008
+#pragma warning disable IDE0008, IDE0046
 
 namespace WindowsRuntime.InteropServices;
 
@@ -594,6 +594,28 @@ internal sealed class WindowsRuntimeMarshallingInfo
 
             // Delegate to the vtable provider to produce the first vtable entries
             ComWrappers.ComInterfaceEntry* vtableEntries = comWrappersMarshaller.ComputeVtables(out int count);
+
+            // When the attribute instance did not override 'ComputeVtables', it will just return 'null',
+            // which we can detect here. The reason for this is that we want to include the type of the
+            // object we failed to marshal in the exception message, but that wouldn't be available from
+            // the 'ComputeVtables' method itself. Returning 'null' is just an efficient way to signal the
+            // failure, rather than having that method throw and then catch and re-throw from here.
+            if (vtableEntries is null)
+            {
+                // Throws an exception with a message that includes the type of the object we failed to marshal
+                [DoesNotReturn]
+                [StackTraceHidden]
+                void ThrowNotSupportedException(WindowsRuntimeComWrappersMarshallerAttribute comWrappersMarshaller)
+                {
+                    throw new NotSupportedException(
+                        $"The current '{nameof(WindowsRuntimeComWrappersMarshallerAttribute)}' implementation ('{comWrappersMarshaller.GetType()}') associated with the " +
+                        $"metadata provider type '{_metadataProviderType}' does not support '{nameof(WindowsRuntimeComWrappersMarshallerAttribute.ComputeVtables)}'. " +
+                        $"If marshalling instances of this type is required, consider using '{nameof(WindowsRuntimeNativeExposedTypeAttribute)}' to explicitly enable generating " +
+                        $"marshalling code for this scenario. Additionally, please file an issue at https://github.com/microsoft/CsWinRT.");
+                }
+
+                ThrowNotSupportedException(comWrappersMarshaller);
+            }
 
             return _vtableInfo ??= new(vtableEntries, count);
         }

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -67,7 +67,7 @@ if "%cswinrt_assembly_version%"=="" set cswinrt_assembly_version=0.0.0.0
 if "%cswinrt_baseline_breaking_compat_errors%"=="" set cswinrt_baseline_breaking_compat_errors=false
 if "%cswinrt_baseline_assembly_version_compat_errors%"=="" set cswinrt_baseline_assembly_version_compat_errors=false
 
-set cswinrt_functional_tests=JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW
+set cswinrt_functional_tests=JsonValueFunctionCalls, ClassActivation, Structs, Events, DynamicInterfaceCasting, Collections, Async, DerivedClassActivation, DerivedClassAsBaseClass, CCW, NativeExposedType
 
 if "%cswinrt_platform%" EQU "x86" set run_functional_tests=true
 if "%cswinrt_platform%" EQU "x64" set run_functional_tests=true

--- a/src/cswinrt.dev.slnf
+++ b/src/cswinrt.dev.slnf
@@ -47,6 +47,7 @@
       "Tests\\FunctionalTests\\DynamicInterfaceCasting\\DynamicInterfaceCasting.csproj",
       "Tests\\FunctionalTests\\Events\\Events.csproj",
       "Tests\\FunctionalTests\\JsonValueFunctionCalls\\JsonValueFunctionCalls.csproj",
+      "Tests\\FunctionalTests\\NativeExposedType\\NativeExposedType.csproj",
       "Tests\\FunctionalTests\\NonWinRT\\NonWinRT.csproj",
       "Tests\\FunctionalTests\\OptInMode\\OptInMode.csproj",
       "Tests\\FunctionalTests\\Structs\\Structs.csproj",

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -347,6 +347,14 @@
       <Platform Solution="*|x86" Project="x86" />
       <Build Solution="*|ARM64" Project="false" />
     </Project>
+    <Project Path="Tests/FunctionalTests/NativeExposedType/NativeExposedType.csproj">
+      <Platform Solution="*|ARM" Project="ARM" />
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x86" />
+      <Build Solution="*|ARM" Project="false" />
+      <Build Solution="*|ARM64" Project="false" />
+    </Project>
     <Project Path="Tests/FunctionalTests/NonWinRT/NonWinRT.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -348,11 +348,9 @@
       <Build Solution="*|ARM64" Project="false" />
     </Project>
     <Project Path="Tests/FunctionalTests/NativeExposedType/NativeExposedType.csproj">
-      <Platform Solution="*|ARM" Project="ARM" />
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
       <Platform Solution="*|x86" Project="x86" />
-      <Build Solution="*|ARM" Project="false" />
       <Build Solution="*|ARM64" Project="false" />
     </Project>
     <Project Path="Tests/FunctionalTests/NonWinRT/NonWinRT.csproj">


### PR DESCRIPTION
## Summary

Introduce a new `WindowsRuntimeNativeExposedTypeAttribute` that lets a projected Windows Runtime class be explicitly opted into CCW (COM Callable Wrapper) marshalling code generation, which the interop generator normally skips for projected types. The PR adds interop generator support, three analyzer diagnostics, unit and functional (JIT and Native AOT) test coverage, and improved marshalling failure diagnostics.

## Motivation

The interop generator automatically generates CCW marshalling code for all managed types that implement one or more Windows Runtime interfaces. Projected Windows Runtime types are deliberately skipped, because they are backed by native objects and are marshalled by unwrapping the underlying native object directly, so they never normally require a CCW. There are, however, niche scenarios where a CCW is required for a projected type, and there was previously no way to request one.

The motivating scenario is using a projected collection type as the items source for a XAML control. Consider a `DependencyObjectCollection` assigned as the items source of an `ItemsControl`. The control queries the assigned object (marshalled as an `IInspectable`) for `IBindableIterable` and `IIterable<IInspectable>`. This succeeds for most collection types, but `DependencyObjectCollection` implements neither of those interfaces: it implements `IIterable<DependencyObject>`, and Windows Runtime generic interfaces are not covariant on the native side (each generic instantiation has a completely different IID). To handle this, XAML controls fall back to obtaining a CCW from the source object and querying that instead. The .NET runtime creates an RCW for the native object and uses `ComWrappers` to obtain a CCW proxy over it; because the RCW implements `IEnumerable<DependencyObject>`, which is covariant in C#, the query for `IIterable<IInspectable>` then succeeds through the proxy. This requires a CCW vtable to exist for the projected type, which the interop generator would not normally generate. The new attribute makes it possible to request exactly that.

## Changes

- **`src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeNativeExposedTypeAttribute.cs`**: new public, assembly-level attribute (`AllowMultiple`) that opts a projected Windows Runtime class into CCW marshalling code generation, with detailed documentation of the motivating scenario.
- **`src/WinRT.Interop.Generator/`** (`Discovery/InteropTypeDiscovery.cs`, `Generation/InteropGenerator.Discover.cs`, `References/InteropReferences.cs`, `Errors/WellKnownInteropExceptions.cs`): discover `[assembly: WindowsRuntimeNativeExposedType(typeof(X))]` applications and route the referenced projected types through the user-defined-type CCW pipeline, bypassing the check that normally skips projected types while keeping all other discovery filters.
- **`src/WinRT.Interop.Generator/References/WellKnownInterfaceIIDs.cs`**: add the missing `IStringable` case to `get_IID`. Every projected class implements the manually-projected `IStringable`, so resolving its interface entry is required when CCW code is generated for a projected type; this path was previously unreachable and threw `CSWINRTINTEROPGEN0052`.
- **`src/Authoring/WinRT.SourceGenerator2/Diagnostics/`** (`Analyzers/WindowsRuntimeNativeExposedTypeAnalyzer.cs`, `DiagnosticDescriptors.cs`, `AnalyzerReleases.Shipped.md`): new analyzer emitting `CSWINRT2018` (target type cannot be instantiated), `CSWINRT2019` (target type is not a projected class, so CCW code is already generated automatically), and `CSWINRT2020` (the same type is targeted by more than one application in the assembly). Applications in generated code are excluded, so a duplicate spanning user code and generated code only warns on the user application.
- **Tests** (`src/Tests/SourceGenerator2Test/Test_WindowsRuntimeNativeExposedTypeAnalyzer.cs`, `src/Tests/SourceGenerator2Test/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs`, `src/Tests/UnitTest/NativeExposedTypeTests.cs`, `src/Tests/FunctionalTests/NativeExposedType/`, `src/cswinrt.slnx`, `src/build.cmd`): analyzer unit tests (including a test-harness helper for injecting generated code to validate the generated-code exclusion), plus a self-contained `NativeExposedType` functional test that runs in both JIT and Native AOT and a unit test. Both verify that the interop generator registers a proxy type map association for an opted-in projected type and not for a projected type that was not opted in.
- **`src/WinRT.Runtime2/InteropServices/Attributes/WindowsRuntimeComWrappersMarshallerAttribute.cs`** and **`src/WinRT.Runtime2/InteropServices/TypeMapInfo/WindowsRuntimeMarshallingInfo.cs`**: improve marshalling failure diagnostics. The `NotSupportedException` messages now include the concrete marshaller type, and `ComputeVtables` returns `null` when not overridden so `WindowsRuntimeMarshallingInfo` can throw a detailed exception that names the marshaller and metadata provider types and points to `WindowsRuntimeNativeExposedTypeAttribute` as the remediation.
