### PR TITLE
Fix SupportedOSPlatform attributes for Desktop extension SDK

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Variables.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Variables.yml
@@ -4,9 +4,9 @@ variables:
 - name: MinorVersion
   value: 3
 - name: PatchVersion
-  value: 0
+  value: 1
 - name: WinRT.Runtime.AssemblyVersion
-  value: '2.3.0.0'
+  value: '2.3.1.0'
 - name: Net5.SDK.Feed
   value: 'https://dotnetcli.blob.core.windows.net/dotnet'
 - name: Net8.SDK.Version

--- a/src/cswinrt/PreviousPlatforms.linq
+++ b/src/cswinrt/PreviousPlatforms.linq
@@ -3,18 +3,23 @@
 // This script can be run periodically from within LINQPad (https://www.linqpad.net) 
 // to generate aggregate data for get_contract_platform in helpers.h
 
-var doc = XDocument.Load(@"C:\Program Files (x86)\Windows Kits\10\Platforms\UAP\10.0.26100.0\PreviousPlatforms.xml");
+var docs = new[]
+{
+	XDocument.Load(@"C:\Program Files (x86)\Windows Kits\10\Platforms\UAP\10.0.26100.0\PreviousPlatforms.xml"),
+	XDocument.Load(@"C:\Program Files (x86)\Windows Kits\10\Extension SDKs\WindowsDesktop\10.0.26100.0\PreviousPlatforms.xml"),
+};
 
 XNamespace pp = "http://microsoft.com/schemas/Windows/SDK/PreviousPlatforms";
 
 var contracts =
+	from doc in docs
 	from platform in doc.Elements().Elements()
 	let PlatformName = platform.Attribute("friendlyName").Value
 	let PlatformVersion = platform.Attribute("version").Value
 	from contract in platform.Elements(pp + "ContainedApiContracts").Elements()
 	let ContractName = contract.Attribute("name").Value
 	let ContractVersion = contract.Attribute("version").Value
-	let ContractNumber = int.Parse(ContractVersion.Replace(".0.0.0",""))
+	let ContractNumber = int.Parse(ContractVersion.Split('.')[0])
 	orderby ContractName, ContractNumber, PlatformVersion
 	group new{ContractNumber, PlatformVersion} by ContractName;
 

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -1229,6 +1229,11 @@ namespace cswinrt
                     { 1, "10.0.10586.0" },
                 }
             },
+            { "Windows.Management.Update.Cluster.ClusterNativeUpdatingContract",
+                {
+                    { 1, "10.0.28000.0" },
+                }
+            },
             { "Windows.Management.Update.WindowsUpdateContract",
                 {
                     { 1, "10.0.22621.0" },

--- a/src/cswinrt/helpers.h
+++ b/src/cswinrt/helpers.h
@@ -950,6 +950,16 @@ namespace cswinrt
         } contract_mappings[] =
         {
             // Use PreviousPlatforms.linq LinqPad query to generate mapping data
+            { "Windows.AI.Actions.ActionsContract",
+                {
+                    { 8, "10.0.26100.0" },
+                }
+            },
+            { "Windows.AI.Agents.AgentsContract",
+                {
+                    { 2, "10.0.26100.0" },
+                }
+            },
             { "Windows.AI.MachineLearning.MachineLearningContract",
                 {
                     { 1, "10.0.17763.0" },
@@ -965,9 +975,34 @@ namespace cswinrt
                     { 2, "10.0.17763.0" },
                 }
             },
+            { "Windows.ApplicationModel.Activation.ActivatedEventsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Activation.ActivationCameraSettingsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Activation.ContactActivatedEventsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Activation.WebUISearchActivatedEventsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Background.BackgroundAlarmApplicationContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
             { "Windows.ApplicationModel.Calls.Background.CallsBackgroundContract",
                 {
-                    { 1, "10.0.17763.0" },
+                    { 1, "10.0.10586.0" },
                     { 2, "10.0.18362.0" },
                     { 3, "10.0.20348.0" },
                     { 4, "10.0.22621.0" },
@@ -990,9 +1025,51 @@ namespace cswinrt
                     { 5, "10.0.26100.0" },
                 }
             },
+            { "Windows.ApplicationModel.Calls.LockScreenCallContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
             { "Windows.ApplicationModel.CommunicationBlocking.CommunicationBlockingContract",
                 {
                     { 2, "10.0.17763.0" },
+                }
+            },
+            { "Windows.ApplicationModel.FullTrustAppContract",
+                {
+                    { 1, "10.0.15063.0" },
+                    { 2, "10.0.22000.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Preview.InkWorkspace.PreviewInkWorkspaceContract",
+                {
+                    { 1, "10.0.15063.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Preview.Notes.PreviewNotesContract",
+                {
+                    { 2, "10.0.15063.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Preview.StartupAppsPreviewContract",
+                {
+                    { 1, "10.0.26100.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Resources.Management.ResourceIndexerContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.17763.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Search.Core.SearchCoreContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.ApplicationModel.Search.SearchContract",
+                {
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.ApplicationModel.SocialInfo.SocialInfoContract",
@@ -1003,13 +1080,20 @@ namespace cswinrt
             },
             { "Windows.ApplicationModel.StartupTaskContract",
                 {
+                    { 1, "10.0.15063.0" },
                     { 2, "10.0.16299.0" },
                     { 3, "10.0.17134.0" },
                 }
             },
+            { "Windows.ApplicationModel.Wallet.WalletContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.22621.0" },
+                }
+            },
             { "Windows.Devices.Custom.CustomDeviceContract",
                 {
-                    { 1, "10.0.16299.0" },
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.Devices.DevicesLowLevelContract",
@@ -1018,9 +1102,30 @@ namespace cswinrt
                     { 3, "10.0.15063.0" },
                 }
             },
+            { "Windows.Devices.Portable.PortableDeviceContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Devices.Power.PowerGridApiContract",
+                {
+                    { 1, "10.0.26100.0" },
+                }
+            },
+            { "Windows.Devices.Printers.Extensions.ExtensionsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.10586.0" },
+                }
+            },
             { "Windows.Devices.Printers.PrintersContract",
                 {
-                    { 1, "10.0.10586.0" },
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Devices.Scanners.ScannerDeviceContract",
+                {
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.Devices.SmartCards.SmartCardBackgroundTriggerContract",
@@ -1032,6 +1137,11 @@ namespace cswinrt
                 {
                     { 5, "10.0.16299.0" },
                     { 6, "10.0.17763.0" },
+                }
+            },
+            { "Windows.Devices.Sms.LegacySmsApiContract",
+                {
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.Foundation.FoundationContract",
@@ -1064,16 +1174,129 @@ namespace cswinrt
                     { 1, "10.0.17134.0" },
                 }
             },
+            { "Windows.Gaming.Input.GamingInputPreviewContract",
+                {
+                    { 1, "10.0.15063.0" },
+                    { 2, "10.0.22621.0" },
+                }
+            },
+            { "Windows.Gaming.Preview.GamesEnumerationContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Gaming.UI.GameChatOverlayContract",
+                {
+                    { 1, "10.0.15063.0" },
+                }
+            },
+            { "Windows.Gaming.UI.GamingUIProviderContract",
+                {
+                    { 1, "10.0.16299.0" },
+                }
+            },
             { "Windows.Gaming.XboxLive.StorageApiContract",
                 {
                     { 1, "10.0.16299.0" },
                 }
             },
+            { "Windows.Globalization.GlobalizationJapanesePhoneticAnalyzerContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
             { "Windows.Graphics.Printing3D.Printing3DContract",
                 {
+                    { 1, "10.0.10240.0" },
                     { 2, "10.0.10586.0" },
                     { 3, "10.0.14393.0" },
                     { 4, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Management.Deployment.Preview.DeploymentPreviewContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Management.Deployment.SharedPackageContainerContract",
+                {
+                    { 1, "10.0.22000.0" },
+                }
+            },
+            { "Windows.Management.Orchestration.OrchestrationContract",
+                {
+                    { 1, "10.0.10586.0" },
+                }
+            },
+            { "Windows.Management.Update.WindowsUpdateContract",
+                {
+                    { 1, "10.0.22621.0" },
+                    { 2, "10.0.26100.0" },
+                }
+            },
+            { "Windows.Management.Workplace.WorkplaceSettingsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Media.AppBroadcasting.AppBroadcastingContract",
+                {
+                    { 1, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Media.AppRecording.AppRecordingContract",
+                {
+                    { 1, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Media.Capture.AppBroadcastContract",
+                {
+                    { 1, "10.0.15063.0" },
+                    { 2, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Media.Capture.AppCaptureContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.10586.0" },
+                    { 3, "10.0.14393.0" },
+                    { 4, "10.0.15063.0" },
+                }
+            },
+            { "Windows.Media.Capture.AppCaptureMetadataContract",
+                {
+                    { 1, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Media.Capture.CameraCaptureUIContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Media.Capture.GameBarContract",
+                {
+                    { 1, "10.0.15063.0" },
+                }
+            },
+            { "Windows.Media.Devices.CallControlContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Media.MediaControlContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Media.Playlists.PlaylistsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.Media.Protection.ProtectionRenewalContract",
+                {
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.Networking.Connectivity.WwanContract",
@@ -1083,9 +1306,40 @@ namespace cswinrt
                     { 3, "10.0.26100.0" },
                 }
             },
+            { "Windows.Networking.NetworkOperators.LegacyNetworkOperatorsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
             { "Windows.Networking.Sockets.ControlChannelTriggerContract",
                 {
-                    { 3, "10.0.17763.0" },
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.15063.0" },
+                    { 3, "10.0.17134.0" },
+                }
+            },
+            { "Windows.Networking.XboxLive.XboxLiveSecureSocketsContract",
+                {
+                    { 1, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Perception.Automation.Core.PerceptionAutomationCoreContract",
+                {
+                    { 1, "10.0.15063.0" },
+                }
+            },
+            { "Windows.Security.EnterpriseData.EnterpriseDataContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.10586.0" },
+                    { 3, "10.0.14393.0" },
+                    { 4, "10.0.15063.0" },
+                    { 5, "10.0.16299.0" },
+                }
+            },
+            { "Windows.Security.ExchangeActiveSyncProvisioning.EasContract",
+                {
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.Security.Isolation.IsolatedWindowsEnvironmentContract",
@@ -1098,12 +1352,17 @@ namespace cswinrt
             },
             { "Windows.Services.Maps.GuidanceContract",
                 {
-                    { 3, "10.0.17763.0" },
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.10586.0" },
+                    { 3, "10.0.16299.0" },
                 }
             },
             { "Windows.Services.Maps.LocalSearchContract",
                 {
-                    { 4, "10.0.17763.0" },
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.10586.0" },
+                    { 3, "10.0.15063.0" },
+                    { 4, "10.0.16299.0" },
                 }
             },
             { "Windows.Services.Store.StoreContract",
@@ -1121,19 +1380,32 @@ namespace cswinrt
             },
             { "Windows.Storage.Provider.CloudFilesContract",
                 {
+                    { 1, "10.0.16299.0" },
+                    { 2, "10.0.17134.0" },
+                    { 3, "10.0.17763.0" },
                     { 4, "10.0.19041.0" },
                     { 6, "10.0.20348.0" },
                     { 7, "10.0.22621.0" },
                 }
             },
+            { "Windows.System.Power.Thermal.PowerThermalApiContract",
+                {
+                    { 1, "10.0.26100.0" },
+                }
+            },
+            { "Windows.System.Profile.PlatformAutomaticAppSignInContract",
+                {
+                    { 1, "10.0.19041.0" },
+                }
+            },
             { "Windows.System.Profile.ProfileHardwareTokenContract",
                 {
-                    { 1, "10.0.14393.0" },
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.System.Profile.ProfileRetailInfoContract",
                 {
-                    { 1, "10.0.20348.0" },
+                    { 1, "10.0.10240.0" },
                 }
             },
             { "Windows.System.Profile.ProfileSharedModeContract",
@@ -1144,6 +1416,8 @@ namespace cswinrt
             },
             { "Windows.System.Profile.SystemManufacturers.SystemManufacturersContract",
                 {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.16299.0" },
                     { 3, "10.0.17763.0" },
                 }
             },
@@ -1151,6 +1425,57 @@ namespace cswinrt
                 {
                     { 6, "10.0.17763.0" },
                     { 7, "10.0.19041.0" },
+                }
+            },
+            { "Windows.System.UserProfile.UserProfileContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.16299.0" },
+                }
+            },
+            { "Windows.System.UserProfile.UserProfileLockScreenContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.UI.ApplicationSettings.ApplicationsSettingsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.UI.Core.AnimationMetrics.AnimationMetricsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.UI.Core.CoreWindowDialogsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                }
+            },
+            { "Windows.UI.Input.Preview.Text.PreviewTextContract",
+                {
+                    { 1, "10.0.26100.0" },
+                }
+            },
+            { "Windows.UI.Shell.CompanionWindows.CompanionWindowsContract",
+                {
+                    { 1, "10.0.26100.0" },
+                }
+            },
+            { "Windows.UI.Shell.SecurityAppManagerContract",
+                {
+                    { 1, "10.0.17763.0" },
+                }
+            },
+            { "Windows.UI.Shell.Tasks.AppTaskContract",
+                {
+                    { 2, "10.0.26100.0" },
+                }
+            },
+            { "Windows.UI.Shell.WindowTabManagerContract",
+                {
+                    { 1, "10.0.22621.0" },
                 }
             },
             { "Windows.UI.UIAutomation.UIAutomationContract",
@@ -1170,6 +1495,21 @@ namespace cswinrt
                     { 2, "10.0.18362.0" },
                     { 3, "10.0.20348.0" },
                     { 5, "10.0.22000.0" },
+                }
+            },
+            { "Windows.UI.Xaml.Hosting.HostingContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.16299.0" },
+                    { 3, "10.0.17763.0" },
+                    { 4, "10.0.18362.0" },
+                    { 5, "10.0.22000.0" },
+                }
+            },
+            { "Windows.Web.Http.Diagnostics.HttpDiagnosticsContract",
+                {
+                    { 1, "10.0.10240.0" },
+                    { 2, "10.0.15063.0" },
                 }
             },
         };


### PR DESCRIPTION
We project types from the Desktop extension SDK, but our lookup for generating SupportedOSPlatform didn't have those in the entries.  In addition, when we did the previous fix related to SupportedOSPlatform to not have an exact matching, it changed some of the attributes in the cases where they were moved from the desktop extension SDK to the main UAP windows SDK.  So this should address those scenarios too.  Given we had already spun a 2.3 build, incrementing version.