### PR TITLE
Put IReferenceArray<object> on vtable for arrays of reference types

### DIFF
--- a/src/Tests/FunctionalTests/CCW/Program.cs
+++ b/src/Tests/FunctionalTests/CCW/Program.cs
@@ -402,6 +402,19 @@ if (!CheckRuntimeClassName(ccw, "Windows.Foundation.IReferenceArray`1<Object>"))
     return 147;
 }
 
+// Round-trip a boxed array of projected objects through native and back, verifying each element marshals.
+var roundTripElement0 = new Class() { IntProperty = 42 };
+var roundTripElement1 = new Class() { IntProperty = 123 };
+object[] roundTripped = Class.UnboxObjectArray(new object[] { roundTripElement0, roundTripElement1 });
+if (roundTripped.Length != 2 ||
+    !ReferenceEquals(roundTripped[0], roundTripElement0) ||
+    !ReferenceEquals(roundTripped[1], roundTripElement1) ||
+    ((Class)roundTripped[0]).IntProperty != 42 ||
+    ((Class)roundTripped[1]).IntProperty != 123)
+{
+    return 148;
+}
+
 return 100;
 
 

--- a/src/Tests/FunctionalTests/CCW/Program.cs
+++ b/src/Tests/FunctionalTests/CCW/Program.cs
@@ -366,6 +366,42 @@ if (!CheckRuntimeClassName(ccw, "Windows.Foundation.Collections.IVector`1<Single
     return 142;
 }
 
+// Boxing an array of reference types (object, projected class, interface, or non-projected type)
+// produces an 'IReferenceArray<Object>' with both 'IReferenceArray' and 'IPropertyValue' on the vtable.
+Guid IID_IReferenceArrayOfObject = new("9CD7A84F-0C80-59C5-B44E-977841BB43D9");
+Guid IID_IPropertyValue = new("4BD682DD-7554-40E9-9A9B-82654EDE7E62");
+
+ccw = MarshalInspectable<object>.CreateMarshaler(new object[] { new Class(), new Class() });
+if (!CheckRuntimeClassName(ccw, "Windows.Foundation.IReferenceArray`1<Object>"))
+{
+    return 143;
+}
+
+ccw.TryAs<IUnknownVftbl>(IID_IReferenceArrayOfObject, out var referenceArrayCCW);
+if (referenceArrayCCW == null)
+{
+    return 144;
+}
+
+ccw.TryAs<IUnknownVftbl>(IID_IPropertyValue, out var referenceArrayPropertyValueCCW);
+if (referenceArrayPropertyValueCCW == null)
+{
+    return 145;
+}
+
+// Arrays of projected classes and non-projected types box the same way.
+ccw = MarshalInspectable<object>.CreateMarshaler(new Class[] { new Class() });
+if (!CheckRuntimeClassName(ccw, "Windows.Foundation.IReferenceArray`1<Object>"))
+{
+    return 146;
+}
+
+ccw = MarshalInspectable<object>.CreateMarshaler(new ManagedProperties[] { new ManagedProperties(1) });
+if (!CheckRuntimeClassName(ccw, "Windows.Foundation.IReferenceArray`1<Object>"))
+{
+    return 147;
+}
+
 return 100;
 
 

--- a/src/Tests/TestComponentCSharp/Class.cpp
+++ b/src/Tests/TestComponentCSharp/Class.cpp
@@ -1745,6 +1745,11 @@ namespace winrt::TestComponentCSharp::implementation
         return obj.as<IReferenceArray<hstring>>().Value();
     }
 
+    com_array<WF::IInspectable> Class::UnboxObjectArray(WF::IInspectable const& obj)
+    {
+        return obj.as<IReferenceArray<WF::IInspectable>>().Value();
+    }
+
     int32_t Class::UnboxInt32UsingPropertyValue(IInspectable const& obj)
     {
         if (auto ipv = obj.try_as<IPropertyValue>())
@@ -1802,6 +1807,17 @@ namespace winrt::TestComponentCSharp::implementation
         if (auto ipv = obj.try_as<IPropertyValue>())
         {
             ipv.GetPointArray(arr);
+        }
+
+        return arr;
+    }
+
+    com_array<WF::IInspectable> Class::UnboxObjectArrayUsingPropertyValue(IInspectable const& obj)
+    {
+        com_array<WF::IInspectable> arr;
+        if (auto ipv = obj.try_as<IPropertyValue>())
+        {
+            ipv.GetInspectableArray(arr);
         }
 
         return arr;

--- a/src/Tests/TestComponentCSharp/Class.h
+++ b/src/Tests/TestComponentCSharp/Class.h
@@ -411,6 +411,7 @@ namespace winrt::TestComponentCSharp::implementation
         static com_array<int32_t> UnboxInt32Array(IInspectable const& obj);
         static com_array<bool> UnboxBooleanArray(IInspectable const& obj);
         static com_array<hstring> UnboxStringArray(IInspectable const& obj);
+        static com_array<Windows::Foundation::IInspectable> UnboxObjectArray(IInspectable const& obj);
 
         static int32_t UnboxInt32UsingPropertyValue(IInspectable const& obj);
         static hstring UnboxStringUsingPropertyValue(IInspectable const& obj);
@@ -418,6 +419,7 @@ namespace winrt::TestComponentCSharp::implementation
         static com_array<int32_t> UnboxInt32ArrayUsingPropertyValue(IInspectable const& obj);
         static com_array<bool> UnboxBooleanArrayUsingPropertyValue(IInspectable const& obj);
         static com_array<Windows::Foundation::Point> UnboxPointArrayUsingPropertyValue(IInspectable const& obj);
+        static com_array<Windows::Foundation::IInspectable> UnboxObjectArrayUsingPropertyValue(IInspectable const& obj);
  
         static void UnboxAndCallProgressHandler(IInspectable const& httpProgressHandler);
         double Calculate(winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::IReference<double>> const& values);

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -441,6 +441,7 @@ namespace TestComponentCSharp
         static Int32[] UnboxInt32Array(Object obj);
         static Boolean[] UnboxBooleanArray(Object obj);
         static String[] UnboxStringArray(Object obj);
+        static Object[] UnboxObjectArray(Object obj);
         static Object BoxedDelegate{ get; };
         static Object BoxedEnum{ get; };
         static Object BoxedEventHandler{ get; };
@@ -456,6 +457,7 @@ namespace TestComponentCSharp
         static Int32[] UnboxInt32ArrayUsingPropertyValue(Object obj);
         static Boolean[] UnboxBooleanArrayUsingPropertyValue(Object obj);
         static Windows.Foundation.Point[] UnboxPointArrayUsingPropertyValue(Object obj);
+        static Object[] UnboxObjectArrayUsingPropertyValue(Object obj);
 
         static Int32 GetPropertyType(Object obj);
         static String GetName(Object obj);

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2747,6 +2747,27 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestReferenceArrayValueRoundTrip()
+        {
+            // Marshal a boxed array of projected objects to native and back, verifying each element round-trips.
+            var element0 = new Class() { IntProperty = 42 };
+            var element1 = new Class() { IntProperty = 123 };
+            object[] objectArray = new object[] { element0, element1 };
+
+            object[] unboxed = Class.UnboxObjectArray(objectArray);
+            Assert.Equal(2, unboxed.Length);
+            Assert.Same(element0, unboxed[0]);
+            Assert.Same(element1, unboxed[1]);
+            Assert.Equal(42, ((Class)unboxed[0]).IntProperty);
+            Assert.Equal(123, ((Class)unboxed[1]).IntProperty);
+
+            object[] unboxedViaPropertyValue = Class.UnboxObjectArrayUsingPropertyValue(objectArray);
+            Assert.Equal(2, unboxedViaPropertyValue.Length);
+            Assert.Same(element0, unboxedViaPropertyValue[0]);
+            Assert.Same(element1, unboxedViaPropertyValue[1]);
+        }
+
+        [Fact]
         public void TestValueBoxing()
         {
             int i = 42;

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2718,6 +2718,35 @@ namespace UnitTest
         }
 
         [Fact]
+        public void TestReferenceArrayBoxing()
+        {
+            // Arrays of reference types (object, projected class, interface, non-projected) are boxed
+            // as IReferenceArray<Object> (an inspectable array), carrying IReferenceArray and IPropertyValue.
+            object[] objectArray = new object[] { new Class(), new Class() };
+            Class[] classArray = new Class[] { new Class(), new Class() };
+            IProperties1[] interfaceArray = new IProperties1[] { new Class(), new Class() };
+            ManagedType[] nonProjectedArray = new ManagedType[] { new ManagedType(), new ManagedType() };
+
+            Assert.Equal((int)PropertyType.InspectableArray, Class.GetPropertyType(objectArray));
+            Assert.Equal((int)PropertyType.InspectableArray, Class.GetPropertyType(classArray));
+            Assert.Equal((int)PropertyType.InspectableArray, Class.GetPropertyType(interfaceArray));
+            Assert.Equal((int)PropertyType.InspectableArray, Class.GetPropertyType(nonProjectedArray));
+
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Object>", Class.GetName(objectArray));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Object>", Class.GetName(classArray));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Object>", Class.GetName(interfaceArray));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Object>", Class.GetName(nonProjectedArray));
+
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<Object>",
+                new IInspectable(ComWrappersSupport.CreateCCWForObject(objectArray)).GetRuntimeClassName());
+
+            // Arrays of well-known element types keep their dedicated IReferenceArray<T>.
+            string[] stringArray = new string[] { "a", "b" };
+            Assert.Equal((int)PropertyType.StringArray, Class.GetPropertyType(stringArray));
+            Assert.Equal("Windows.Foundation.IReferenceArray`1<String>", Class.GetName(stringArray));
+        }
+
+        [Fact]
         public void TestValueBoxing()
         {
             int i = 42;

--- a/src/WinRT.Runtime/ComWrappersSupport.cs
+++ b/src/WinRT.Runtime/ComWrappersSupport.cs
@@ -379,6 +379,12 @@ namespace WinRT
                     entries.Add(IPropertyValueEntry);
                     entries.Add(ProvideIReferenceArray(type));
                 }
+                else if (elementType.ShouldProvideIReferenceArrayOfObject())
+                {
+                    // Arrays of reference types are boxed as 'IReferenceArray<Object>'.
+                    entries.Add(IPropertyValueEntry);
+                    entries.Add(ProvideIReferenceArrayOfObject());
+                }
             }
             else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.KeyValuePair<,>) && Projections.IsTypeWindowsRuntimeType(type))
             {
@@ -1231,6 +1237,20 @@ namespace WinRT
                 Vtable = (IntPtr)typeof(BoxedArrayIReferenceArrayImpl<>).MakeGenericType(type).GetAbiToProjectionVftblPtr()
             };
 #pragma warning restore IL3050
+        }
+
+        private static ComInterfaceEntry ProvideIReferenceArrayOfObject()
+        {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                throw new NotSupportedException("Support for 'IReferenceArray<T>' is not enabled.");
+            }
+
+            return new ComInterfaceEntry
+            {
+                IID = IID.IID_IReferenceArrayOfObject,
+                Vtable = BoxedArrayIReferenceArrayImpl<object>.AbiToProjectionVftablePtr
+            };
         }
 
         internal sealed class InspectableInfo

--- a/src/WinRT.Runtime/TypeExtensions.cs
+++ b/src/WinRT.Runtime/TypeExtensions.cs
@@ -294,6 +294,20 @@ namespace WinRT
                 ((type.IsValueType || type.IsDelegate()) && Projections.IsTypeWindowsRuntimeType(type));
         }
 
+        // Whether an array with this element type should be boxed as 'IReferenceArray<Object>'.
+        // Reference type elements have no dedicated 'IReferenceArray<T>' and marshal individually
+        // as 'IInspectable', so they box as 'IReferenceArray<Object>' (an inspectable array).
+        // Only valid when the element type isn't already handled by 'ShouldProvideIReference'.
+        internal static bool ShouldProvideIReferenceArrayOfObject(this Type type)
+        {
+            if (!FeatureSwitches.EnableIReferenceSupport)
+            {
+                return false;
+            }
+
+            return !type.IsValueType;
+        }
+
         internal static bool IsTypeOfType(this Type type)
         {
             return typeof(Type).IsAssignableFrom(type);

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -598,6 +598,16 @@ namespace WinRT
                     }
                     return false;
                 }
+                else if (elementType.ShouldProvideIReferenceArrayOfObject())
+                {
+                    builder.Append("Windows.Foundation.IReferenceArray`1<");
+                    if (TryAppendTypeName(typeof(object), builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
+                    {
+                        builder.Append('>');
+                        return true;
+                    }
+                    return false;
+                }
                 else
                 {
                     return false;

--- a/src/WinRT.Runtime/TypeNameSupport.cs
+++ b/src/WinRT.Runtime/TypeNameSupport.cs
@@ -600,13 +600,8 @@ namespace WinRT
                 }
                 else if (elementType.ShouldProvideIReferenceArrayOfObject())
                 {
-                    builder.Append("Windows.Foundation.IReferenceArray`1<");
-                    if (TryAppendTypeName(typeof(object), builder, flags & ~TypeNameGenerationFlags.GenerateBoxedName))
-                    {
-                        builder.Append('>');
-                        return true;
-                    }
-                    return false;
+                    builder.Append("Windows.Foundation.IReferenceArray`1<Object>");
+                    return true;
                 }
                 else
                 {


### PR DESCRIPTION
We previously didn't put `IReferenceArray<object>` on the vtable for boxed C# arrays of class types.  We only did it for value types and delegates.  But `IInspectableArray` is a thing that `PropertyValue` recognizes and even has `CreateIInspectableArray`.  So, we are fixing our logic to also project `IReferenceArray<object>` and `IPropertyValue` for C# arrays of class types.  Also double checked with cppwinrt's implementation that they also have `IReferenceArray<object>`.