### PR TITLE
Simplify .editorconfig to only non-default settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,231 +20,38 @@ insert_final_newline = false
 trim_trailing_whitespace = true
 
 # Misc settings
-max_line_length=160
+max_line_length = 160
 file_header_template = Copyright (c) Microsoft Corporation.\r\nLicensed under the MIT License.
 
 # C# files
 [*.cs]
-csharp_keep_user_linebreaks = true
-wrap_before_comma = false
-wrap_parameters_style = chop_if_long
-max_formal_parameters_on_line = 4
-wrap_after_dot_in_method_calls = false 
-csharp_preserve_single_line_blocks = false
-csharp_new_line_between_query_expression_clauses = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_open_brace = all
-
-#### Core EditorConfig Options ####
-
-# Indentation and spacing
-indent_size = 4
-indent_style = space
-tab_width = 4
-
-# New line preferences
-end_of_line = crlf
-insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
-# Organize usings
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = true
-
-# this. and Me. preferences
-dotnet_style_qualification_for_event = false
-dotnet_style_qualification_for_field = false
-dotnet_style_qualification_for_method = false
-dotnet_style_qualification_for_property = false
-
-# These two diagnostics are just 'Info' by default
+# 'this.' and 'Me.' preferences.
+# Note: IDE0003 and IDE0009 are 'silent' by default.
 dotnet_diagnostic.IDE0003.severity = warning
 dotnet_diagnostic.IDE0009.severity = warning
 
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true
-dotnet_style_predefined_type_for_member_access = true
-
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
-
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members
-
-# Expression-level preferences
-dotnet_style_coalesce_expression = true
-dotnet_style_collection_initializer = true
-dotnet_style_explicit_tuple_names = true
-dotnet_style_null_propagation = true
-dotnet_style_object_initializer = true
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_auto_properties = true
-dotnet_style_prefer_compound_assignment = true
-dotnet_style_prefer_conditional_expression_over_assignment = true
-dotnet_style_prefer_conditional_expression_over_return = true
-dotnet_style_prefer_inferred_anonymous_type_member_names = true
-dotnet_style_prefer_inferred_tuple_names = true
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true
-dotnet_style_prefer_simplified_boolean_expressions = true
-dotnet_style_prefer_simplified_interpolation = true
-
-# Field preferences
-dotnet_style_readonly_field = true
-
-# Namespace preferences
+# Namespace preferences.
+# Note: 'dotnet_style_namespace_match_folder' defaults to 'true'.
 dotnet_style_namespace_match_folder = false
-
-# Primary constructor preference
-csharp_style_prefer_primary_constructors = false;
-
-# Parameter preferences
-dotnet_code_quality_unused_parameters = all
-
-# Suppression preferences
-dotnet_remove_unnecessary_suppression_exclusions = none
 
 #### C# Coding Conventions ####
 
-# var preferences
-csharp_style_var_elsewhere = false
-csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = false
+# Primary constructor preference.
+# Note: 'csharp_style_prefer_primary_constructors' defaults to 'true'.
+csharp_style_prefer_primary_constructors = false
 
-# Expression-bodied members
+# Expression-bodied members.
+# Note: these default to 'true' (accessors, indexers, lambdas, properties) or 'false' (local functions, operators).
 csharp_style_expression_bodied_accessors = when_on_single_line
-csharp_style_expression_bodied_constructors = false
 csharp_style_expression_bodied_indexers = when_on_single_line
 csharp_style_expression_bodied_lambdas = when_on_single_line
 csharp_style_expression_bodied_local_functions = when_on_single_line
-csharp_style_expression_bodied_methods = false
 csharp_style_expression_bodied_operators = when_on_single_line
 csharp_style_expression_bodied_properties = when_on_single_line
 
-# Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_not_pattern = true
-csharp_style_prefer_pattern_matching = true
-csharp_style_prefer_switch_expression = true
-
-# Null-checking preferences
-csharp_style_conditional_delegate_call = true
-
-# Modifier preferences
-csharp_prefer_static_local_function = true
-csharp_preferred_modifier_order = public, private, protected, internal, file, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, required, volatile, async
-
-# Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
-
-# Expression-level preferences
-csharp_prefer_simple_default_expression = true
-csharp_style_deconstructed_variable_declaration = true
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-csharp_style_inlined_variable_declaration = true
-csharp_style_pattern_local_over_anonymous_function = true
-csharp_style_prefer_index_operator = true
-csharp_style_prefer_range_operator = true
-csharp_style_throw_expression = true
-csharp_style_unused_value_assignment_preference = discard_variable
-csharp_style_unused_value_expression_statement_preference = discard_variable
-
-# 'using' directive preferences
-csharp_using_directive_placement = outside_namespace
-
-#### C# Formatting Rules ####
-
-# New line preferences
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_open_brace = all
-csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-# Space preferences
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-
-# Wrapping preferences
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-# Namespace declaration preferences
+# Namespace declaration preferences.
+# Note: 'csharp_style_namespace_declarations' defaults to 'block_scoped' with a 'silent' severity.
 csharp_style_namespace_declarations = file_scoped:warning
-
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case


### PR DESCRIPTION
## Summary

Simplify `.editorconfig` by removing every setting whose value already matched the documented default, going from 250 lines down to 57. Each entry was checked one by one against the `Default option value` row on its official [.NET code style rule](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/) documentation page, so only settings that genuinely deviate from the default remain.

## Motivation

The `.editorconfig` had grown into a near-verbatim copy of the Visual Studio generated template, where the overwhelming majority of entries just restated the defaults. That made it very hard to tell at a glance which style choices are actually intentional for this repository, and it buried the handful of settings that do matter under ~200 lines of noise. It also hid several latent bugs (see below), which is exactly the kind of thing that goes unnoticed when a config file is mostly redundant boilerplate.

Trimming the file down to only the deliberate deviations makes the repository's actual style policy self-documenting, and means future changes to it are meaningful rather than cosmetic.

## Changes

- **`.editorconfig`**: removed roughly 135 settings that were identical to their documented defaults, and added a short comment next to each remaining setting recording what the default is, so the intent behind each deviation stays obvious.

### What was kept (and how it differs from the default)

| Setting | Default | This repo |
| --- | --- | --- |
| `dotnet_diagnostic.IDE0003.severity` | `silent` | `warning` |
| `dotnet_diagnostic.IDE0009.severity` | `silent` | `warning` |
| `dotnet_style_namespace_match_folder` | `true` | `false` |
| `csharp_style_prefer_primary_constructors` | `true` | `false` |
| `csharp_style_expression_bodied_accessors` | `true` | `when_on_single_line` |
| `csharp_style_expression_bodied_indexers` | `true` | `when_on_single_line` |
| `csharp_style_expression_bodied_lambdas` | `true` | `when_on_single_line` |
| `csharp_style_expression_bodied_properties` | `true` | `when_on_single_line` |
| `csharp_style_expression_bodied_local_functions` | `false` | `when_on_single_line` |
| `csharp_style_expression_bodied_operators` | `false` | `when_on_single_line` |
| `csharp_style_namespace_declarations` | `block_scoped` (silent) | `file_scoped:warning` |

The core EditorConfig options in the `[*]` section (`charset`, `indent_style`, `indent_size`, `tab_width`, `end_of_line`, `insert_final_newline`, `trim_trailing_whitespace`, `max_line_length`) are also kept, since those are not Roslyn style rules and have no compiler-side default, along with `file_header_template` (whose documented default is `unset`).

### What was removed

- The **entire C# formatting section** (37 settings covering new lines, indentation, spacing and wrapping) matched the documented defaults exactly, including less obvious ones such as `csharp_indent_labels = one_less_than_current`, `csharp_space_between_parentheses = false` and `csharp_new_line_before_open_brace = all`.

- The **entire naming styles section** (26 lines) turned out to be a byte-for-byte reproduction of Roslyn's built-in `NamingStylePreferences.DefaultNamingPreferencesString`: the same three rules (types to Pascal case, non-field members to Pascal case, interfaces prefixed with `I`), the same symbol kinds and accessibilities, and the same `Info` enforcement level that `severity = suggestion` maps to. The documentation confirms these defaults apply automatically when no custom naming rules are specified.

- All four `dotnet_style_qualification_for_*`, all four `dotnet_style_parentheses_*`, both `dotnet_style_predefined_type_*`, all three `csharp_style_var_*`, all five pattern matching preferences, and both `using` directive sorting options.

- All fifteen `dotnet_style_*` expression-level preferences, plus `dotnet_style_readonly_field`, `dotnet_code_quality_unused_parameters`, `dotnet_remove_unnecessary_suppression_exclusions`, `dotnet_style_require_accessibility_modifiers` and `dotnet_style_operator_placement_when_wrapping`.

- Ten C# expression-level preferences, plus `csharp_prefer_braces`, `csharp_prefer_simple_using_statement`, `csharp_prefer_static_local_function`, `csharp_using_directive_placement`, and `csharp_preferred_modifier_order` (which matched the documented modifier order exactly).

- Five core options (`indent_size`, `indent_style`, `tab_width`, `end_of_line`, `insert_final_newline`) that were duplicated in `[*.cs]` despite already being inherited from `[*]`.

### Bugs fixed along the way

- **`csharp_style_prefer_primary_constructors = false;`** had a stray trailing semicolon, which made the value invalid. Roslyn silently ignored the line and fell back to the default of `true`, meaning primary constructors were never actually disabled. This is the one real behaviour change in this PR: the setting now takes effect as originally intended.

- **`csharp_style_pattern_local_over_anonymous_function`** is not a real option name. Roslyn calls it `csharp_style_prefer_local_over_anonymous_function`, so the line was a no-op (and `true` is the default in any case).

- **`csharp_preserve_single_line_blocks`** was declared twice in the same section with conflicting values (`false`, then `true`). The later one won and matched the default, so the first was dead configuration.

- Five ReSharper-style wrapping keys (`csharp_keep_user_linebreaks`, `wrap_before_comma`, `wrap_parameters_style`, `max_formal_parameters_on_line`, `wrap_after_dot_in_method_calls`) are not .NET options and are ignored by Roslyn and Visual Studio. There is no `.DotSettings` file anywhere in the repository, so nothing was consuming them. They can be re-added with the appropriate `resharper_` or `csharp_` prefix if anyone wants them for Rider.

## Validation

`WinRT.Runtime.csproj` was rebuilt in `Release` (where `TreatWarningsAsErrors`, `EnforceCodeStyleInBuild` and `AnalysisLevelStyle=latest-all` are all active) and produced 0 warnings and 0 errors.

To confirm the trimmed file is genuinely live and behaviour preserving, a temporary file with deliberate violations was compiled: `IDE0161` fired, proving a kept setting is still enforced, and `IDE0044` fired, proving that a removed setting (`dotnet_style_readonly_field = true`) still behaves identically through its default. The temporary file was then deleted.

The file's CRLF line endings and its no-trailing-newline convention are both preserved.
