### PR TITLE
Carry over all applications of repeated Windows Runtime attributes

### DIFF
--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -713,6 +713,29 @@ And this is another one"
         void f();
     }
 
+    // Repeated applications of an '[allowmultiple]' attribute must all be carried over to the
+    // projection. See https://github.com/microsoft/CsWinRT/issues/2491.
+    [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
+    [attributename("attr_repeatable")]
+    [allowmultiple]
+    attribute MyRepeatableAttribute
+    {
+        String Name;
+        String GroupName;
+    }
+
+    [attr_repeatable("Normal", "CommonStates")]
+    [attr_repeatable("PointerOver", "CommonStates")]
+    [attr_string("some other attribute in between")]
+    [attr_repeatable("Horizontal", "OrientationStates")]
+    // MIDL allows an '[allowmultiple]' attribute to be applied twice with the same arguments, and
+    // reflection reports both, so the projection has to carry both over as well.
+    [attr_repeatable("Horizontal", "OrientationStates")]
+    runtimeclass RepeatedAttributeTest
+    {
+        void f();
+    }
+
     static runtimeclass StaticDelegateClassTest
     {
         static void Run(EventHandler0 e);

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -5090,5 +5090,51 @@ namespace UnitTest
                 _ = Marshal.Release((nint)ccw);
             }
         }
+
+        // Every application of an '[allowmultiple]' Windows Runtime attribute has to be carried over to
+        // the projection, not just the last one. See https://github.com/microsoft/CsWinRT/issues/2491.
+        [TestMethod]
+        public void TestRepeatedAttributesAreProjected()
+        {
+            // The '.winmd' does not preserve the declaration order from the '.idl', so the applications
+            // are sorted by name to make the comparison deterministic. The two identical entries are
+            // intentional: MIDL allows them, and both have to survive the projection.
+            (string Name, string GroupName)[] applications = typeof(RepeatedAttributeTest)
+                .GetCustomAttributes<MyRepeatableAttribute>()
+                .Select(static attribute => (attribute.Name, attribute.GroupName))
+                .OrderBy(static application => application.Name, StringComparer.Ordinal)
+                .ToArray();
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    ("Horizontal", "OrientationStates"),
+                    ("Horizontal", "OrientationStates"),
+                    ("Normal", "CommonStates"),
+                    ("PointerOver", "CommonStates")
+                },
+                applications);
+
+            // An attribute that is not repeatable is still projected exactly once
+            MyStringAttribute[] singleApplication = typeof(RepeatedAttributeTest).GetCustomAttributes<MyStringAttribute>().ToArray();
+
+            Assert.AreEqual(1, singleApplication.Length);
+            Assert.AreEqual("some other attribute in between", singleApplication[0].Content);
+        }
+
+        // The Windows Runtime '[allowmultiple]' attribute has no .NET counterpart: it maps to the
+        // 'AllowMultiple' named argument of '[AttributeUsage]' on the projected attribute type.
+        [TestMethod]
+        public void TestAllowMultipleIsProjectedOnAttributeUsage()
+        {
+            AttributeUsageAttribute repeatableUsage = typeof(MyRepeatableAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+            AttributeUsageAttribute singleUsage = typeof(MyStringAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+            Assert.IsNotNull(repeatableUsage);
+            Assert.IsNotNull(singleUsage);
+
+            Assert.IsTrue(repeatableUsage.AllowMultiple);
+            Assert.IsFalse(singleUsage.AllowMultiple);
+        }
     }
 }

--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -369,8 +369,8 @@ internal static class CustomAttributeFactory
     /// <param name="enablePlatformAttrib">Whether to also emit a <c>[SupportedOSPlatform]</c> attribute synthesized from any <c>[ContractVersion]</c>.</param>
     public static void WriteCustomAttributes(IndentedTextWriter writer, ProjectionEmitContext context, IHasCustomAttribute member, bool enablePlatformAttrib)
     {
-        const string attributeUsageName = "System.AttributeUsage";
-        const string supportedOSPlatformName = "System.Runtime.Versioning.SupportedOSPlatform";
+        const string AttributeUsageName = "System.AttributeUsage";
+        const string SupportedOSPlatformName = "System.Runtime.Versioning.SupportedOSPlatform";
 
         // Applications are collected in metadata order, with one entry per application. A Windows Runtime
         // attribute marked '[allowmultiple]' (e.g. '[TemplateVisualState]') can legitimately be applied
@@ -405,7 +405,7 @@ internal static class CustomAttributeFactory
             }
 
             string fullAttrName = strippedName == "AttributeUsage"
-                ? attributeUsageName
+                ? AttributeUsageName
                 : ns + "." + strippedName;
 
             List<string> args = WriteCustomAttributeArgs(attr);
@@ -419,7 +419,7 @@ internal static class CustomAttributeFactory
 
                 if (!string.IsNullOrEmpty(platform))
                 {
-                    attributes.Add((supportedOSPlatformName, [platform]));
+                    attributes.Add((SupportedOSPlatformName, [platform]));
 
                     hasPlatform = true;
                 }
@@ -449,7 +449,7 @@ internal static class CustomAttributeFactory
 
             attributes.Add((fullAttrName, args));
 
-            if (fullAttrName == attributeUsageName)
+            if (fullAttrName == AttributeUsageName)
             {
                 attributeUsageArgs = args;
             }
@@ -465,7 +465,7 @@ internal static class CustomAttributeFactory
         }
         else if (allowMultiple)
         {
-            attributes.Add((attributeUsageName, ["global::System.AttributeTargets.All", "AllowMultiple = true"]));
+            attributes.Add((AttributeUsageName, ["global::System.AttributeTargets.All", "AllowMultiple = true"]));
         }
 
         foreach ((string attributeName, List<string> attributeArgs) in attributes)

--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -356,14 +356,32 @@ internal static class CustomAttributeFactory
     /// Writes any custom attributes (e.g. <c>[Obsolete]</c>, <c>[Deprecated]</c>,
     /// <c>[SupportedOSPlatform]</c>) carried over from <paramref name="member"/> to the projection.
     /// </summary>
+    /// <remarks>
+    /// Attributes are emitted in metadata order, one line per application. Windows Runtime attributes
+    /// marked <c>[allowmultiple]</c> can be applied several times to the same member, so every
+    /// application is carried over. The <c>[AllowMultiple]</c> metadata attribute itself is not
+    /// projected: it is folded into the <c>AllowMultiple</c> named argument of the projected
+    /// <c>[AttributeUsage]</c>, matching how .NET models repeatability.
+    /// </remarks>
     /// <param name="writer">The writer to emit to.</param>
     /// <param name="context">The active emit context.</param>
     /// <param name="member">The metadata member whose custom attributes to emit.</param>
     /// <param name="enablePlatformAttrib">Whether to also emit a <c>[SupportedOSPlatform]</c> attribute synthesized from any <c>[ContractVersion]</c>.</param>
     public static void WriteCustomAttributes(IndentedTextWriter writer, ProjectionEmitContext context, IHasCustomAttribute member, bool enablePlatformAttrib)
     {
-        Dictionary<string, List<string>> attributes = [];
+        const string attributeUsageName = "System.AttributeUsage";
+        const string supportedOSPlatformName = "System.Runtime.Versioning.SupportedOSPlatform";
+
+        // Applications are collected in metadata order, with one entry per application. A Windows Runtime
+        // attribute marked '[allowmultiple]' (e.g. '[TemplateVisualState]') can legitimately be applied
+        // several times to the same member, and every application has to be carried over.
+        List<(string Name, List<string> Args)> attributes = [];
+
+        // The arguments of the recorded '[AttributeUsage]' application, if any, so that a separate
+        // '[AllowMultiple]' application can be folded into it once all attributes have been seen
+        List<string>? attributeUsageArgs = null;
         bool allowMultiple = false;
+        bool hasPlatform = false;
 
         for (int i = 0; i < member.CustomAttributes.Count; i++)
         {
@@ -387,24 +405,23 @@ internal static class CustomAttributeFactory
             }
 
             string fullAttrName = strippedName == "AttributeUsage"
-                ? "System.AttributeUsage"
+                ? attributeUsageName
                 : ns + "." + strippedName;
 
             List<string> args = WriteCustomAttributeArgs(attr);
 
-            if (context.Settings.ReferenceProjection && enablePlatformAttrib && strippedName == "ContractVersion" && attr.Signature?.FixedArguments.Count == 2)
+            // '[SupportedOSPlatform]' takes a single platform, so only the first resolved one is emitted
+            // (matching the member-level behavior in 'WritePlatformAttributeBody'). A member can carry
+            // several '[ContractVersion]' attributes, but only one of them can define the minimum platform.
+            if (!hasPlatform && context.Settings.ReferenceProjection && enablePlatformAttrib && strippedName == "ContractVersion" && attr.Signature?.FixedArguments.Count == 2)
             {
                 string platform = GetPlatform(context, attr);
 
                 if (!string.IsNullOrEmpty(platform))
                 {
-                    if (!attributes.TryGetValue("System.Runtime.Versioning.SupportedOSPlatform", out List<string>? list))
-                    {
-                        list = [];
-                        attributes["System.Runtime.Versioning.SupportedOSPlatform"] = list;
-                    }
+                    attributes.Add((supportedOSPlatformName, [platform]));
 
-                    list.Add(platform);
+                    hasPlatform = true;
                 }
             }
 
@@ -430,27 +447,39 @@ internal static class CustomAttributeFactory
                 }
             }
 
-            attributes[fullAttrName] = args;
+            attributes.Add((fullAttrName, args));
+
+            if (fullAttrName == attributeUsageName)
+            {
+                attributeUsageArgs = args;
+            }
         }
 
-        // Add AllowMultiple to AttributeUsage if needed
-        if (attributes.TryGetValue("System.AttributeUsage", out List<string>? usage))
+        // Windows Runtime models attribute repeatability with a separate '[AllowMultiple]' metadata
+        // attribute, whereas .NET models it as a named argument on '[AttributeUsage]'. Fold the former
+        // into the latter, synthesizing an '[AttributeUsage]' if the metadata doesn't declare one (in
+        // which case the .NET default of 'AllowMultiple = false' would make the projection unusable).
+        if (attributeUsageArgs is not null)
         {
-            usage.Add("AllowMultiple = " + (allowMultiple ? "true" : "false"));
+            attributeUsageArgs.Add("AllowMultiple = " + (allowMultiple ? "true" : "false"));
+        }
+        else if (allowMultiple)
+        {
+            attributes.Add((attributeUsageName, ["global::System.AttributeTargets.All", "AllowMultiple = true"]));
         }
 
-        foreach (KeyValuePair<string, List<string>> kv in attributes)
+        foreach ((string attributeName, List<string> attributeArgs) in attributes)
         {
-            writer.Write($"[global::{kv.Key}");
+            writer.Write($"[global::{attributeName}");
 
-            if (kv.Value.Count > 0)
+            if (attributeArgs.Count > 0)
             {
                 writer.Write("(");
-                for (int i = 0; i < kv.Value.Count; i++)
+                for (int i = 0; i < attributeArgs.Count; i++)
                 {
                     writer.WriteIf(i > 0, ", ");
 
-                    writer.Write(kv.Value[i]);
+                    writer.Write(attributeArgs[i]);
                 }
                 writer.Write(")");
             }


### PR DESCRIPTION
## Summary

Fixes #2491: when a Windows Runtime type carries the same `[allowmultiple]` attribute more than once, the projection only kept one of the applications. All applications are now carried over.

## Motivation

`CustomAttributeFactory.WriteCustomAttributes` accumulated the attributes to carry over into a `Dictionary<string, List<string>>` keyed by the projected attribute's full name, and assigned with `attributes[fullAttrName] = args`. Windows Runtime attributes marked `[allowmultiple]` (for instance `[TemplateVisualState]`) can legitimately be applied several times to the same type, so every application after the first silently overwrote the previous one and was lost from the generated projection.

The issue report shows this with a control declaring eight `[TemplateVisualState]` attributes in its `.idl`: the `.winmd` contains all eight, but the generated C# only carries a single one.

Two adjacent problems in the same method are fixed at the same time:

- Several `[ContractVersion]` attributes merged their computed platform strings into the argument list of a *single* `[SupportedOSPlatform]`, which is not a valid constructor shape. Only the first resolved platform is emitted now, which matches the pre-existing member-level behavior in `WritePlatformAttributeBody`.

- The Windows Runtime `[AllowMultiple]` metadata attribute has no .NET counterpart: it maps to the `AllowMultiple` named argument of `[AttributeUsage]` on the projected attribute type. That mapping only happened when the metadata also carried an `[AttributeUsage]`. When it didn't, the projected attribute type silently fell back to the .NET default of `AllowMultiple = false` and could not be applied more than once. An `[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]` is now synthesized in that case.

## Changes

- **`src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs`**: collect the carried-over attributes into an ordered list with one entry per application instead of a dictionary keyed by attribute name, so repeated applications are all emitted; emit at most one `[SupportedOSPlatform]`; synthesize an `[AttributeUsage]` when the metadata only carries `[AllowMultiple]`.

- **`src/Tests/TestComponentCSharp/TestComponentCSharp.idl`**: add an `[allowmultiple]` attribute (`MyRepeatableAttribute`, `attr_repeatable`) and a `RepeatedAttributeTest` runtime class carrying several of its applications, interleaved with a non-repeatable attribute, plus one exact-duplicate application (MIDL accepts those for repeatable attributes, and reflection reports both).

- **`src/Tests/UnitTest/TestComponentCSharp_Tests.cs`**: add `TestRepeatedAttributesAreProjected`, verifying every application survives the projection with the right arguments and that a non-repeatable attribute is still projected exactly once, and `TestAllowMultipleIsProjectedOnAttributeUsage`, verifying the `[AllowMultiple]` to `AttributeUsage(AllowMultiple = ...)` mapping in both directions.

## Validation

- Ran `cswinrtprojectionrefgen` over the entire Windows SDK (reference projection and merged projection modes) and over the full WinUI surface, before and after the change: the generated sources are byte-identical, so no existing projection is affected.

- Built `TestComponentCSharp.winmd` with MIDL from the new `.idl` and projected it before and after: the only difference is the newly preserved attribute applications.

- Verified against MIDL that duplicated applications of a non-repeatable attribute are rejected (`MIDL2096`) while duplicated applications of an `[allowmultiple]` attribute are accepted and preserved in the `.winmd`, so the emission is intentionally faithful rather than de-duplicating.