### PR TITLE
Only carry over metadata attributes into reference projections

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Test-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Test-Steps.yml
@@ -52,6 +52,19 @@ steps:
         --no-build
       testRunTitle: WinMD Generator Tests
 
+# Run Projection Writer Tests. Gated to x64 only: these drive the projection writer through the
+# 'cswinrtprojectionrefgen' tool as a separate process, so the target platform adds no coverage.
+  - task: DotNetCoreCLI@2
+    displayName: Run Projection Writer Tests
+    condition: and(succeeded(), eq(variables['BuildPlatform'], 'x64'))
+    inputs:
+      command: test
+      projects: 'src/Tests/ProjectionWriterTest/ProjectionWriterTest.csproj'
+      arguments: >
+        /p:platform=$(BuildPlatform);configuration=$(BuildConfiguration)
+        --no-build
+      testRunTitle: Projection Writer Tests
+
 # Run Host Tests
   - task: CmdLine@2
     displayName: Run Host Tests

--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ProjectionWriterTest.Helpers;
+
+/// <summary>
+/// Runs the projection writer end-to-end (through <c>cswinrtprojectionrefgen</c>) and exposes the
+/// generated C# sources to tests.
+/// </summary>
+/// <remarks>
+/// The tool is invoked as a separate process with a response file, exactly as the
+/// <c>CsWinRTGenerateProjection</c> MSBuild target does, so the tests cover the real code path. Both
+/// projection modes are generated once per test run and cached, since generating them is the
+/// expensive part and every test only inspects the resulting text.
+/// </remarks>
+internal static class ProjectionWriterRunner
+{
+    /// <summary>
+    /// The namespace the projections are restricted to.
+    /// </summary>
+    /// <remarks>
+    /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
+    /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
+    /// still covering every projected type kind and every carried-over attribute of interest.
+    /// </remarks>
+    private const string IncludeNamespace = "Windows.Foundation";
+
+    /// <summary>
+    /// The lazily generated reference projection sources.
+    /// </summary>
+    private static readonly Lazy<string> ReferenceProjectionSources = new(static () => Generate(referenceProjection: true));
+
+    /// <summary>
+    /// The lazily generated implementation projection sources.
+    /// </summary>
+    private static readonly Lazy<string> ImplementationProjectionSources = new(static () => Generate(referenceProjection: false));
+
+    /// <summary>
+    /// Gets all generated C# sources for the requested projection mode, concatenated.
+    /// </summary>
+    /// <param name="referenceProjection">Whether to get the reference projection (rather than the implementation projection).</param>
+    /// <returns>The concatenated contents of every generated <c>.cs</c> file.</returns>
+    public static string GetSources(bool referenceProjection)
+    {
+        return referenceProjection
+            ? ReferenceProjectionSources.Value
+            : ImplementationProjectionSources.Value;
+    }
+
+    /// <summary>
+    /// Counts the applications of a given attribute in the generated sources.
+    /// </summary>
+    /// <remarks>
+    /// Attributes are matched on the emitted text (<c>[global::&lt;name&gt;</c>), which is how the writer
+    /// emits every carried-over attribute. Matching the fully qualified name avoids false positives from
+    /// same-named attributes in other namespaces.
+    /// </remarks>
+    /// <param name="referenceProjection">Whether to inspect the reference projection (rather than the implementation projection).</param>
+    /// <param name="attributeName">The fully qualified attribute name (without the <c>Attribute</c> suffix), e.g. <c>Windows.Foundation.Metadata.Overload</c>.</param>
+    /// <returns>The number of applications found.</returns>
+    public static int CountGlobalAttribute(bool referenceProjection, string attributeName)
+    {
+        return CountOccurrences(GetSources(referenceProjection), $"[global::{attributeName}");
+    }
+
+    /// <summary>
+    /// Counts the applications of a given attribute emitted without a <c>global::</c> prefix.
+    /// </summary>
+    /// <remarks>
+    /// The CsWinRT markers the implementation projection needs at runtime (e.g.
+    /// <c>[WindowsRuntimeType]</c>) are emitted unqualified, relying on the file's <c>using</c> directives.
+    /// </remarks>
+    /// <param name="referenceProjection">Whether to inspect the reference projection (rather than the implementation projection).</param>
+    /// <param name="attributeText">The emitted attribute text, e.g. <c>[WindowsRuntimeType]</c>.</param>
+    /// <returns>The number of applications found.</returns>
+    public static int CountAttributeText(bool referenceProjection, string attributeText)
+    {
+        return CountOccurrences(GetSources(referenceProjection), attributeText);
+    }
+
+    /// <summary>
+    /// Generates a projection for the requested mode and returns all generated sources, concatenated.
+    /// </summary>
+    /// <param name="referenceProjection">Whether to generate a reference projection.</param>
+    /// <returns>The concatenated contents of every generated <c>.cs</c> file.</returns>
+    private static string Generate(bool referenceProjection)
+    {
+        string toolPath = GetGeneratorPath();
+        string workingDirectory = Path.Combine(Path.GetTempPath(), $"ProjectionWriterTest_{Guid.NewGuid():N}");
+        string outputDirectory = Path.Combine(workingDirectory, "Generated");
+
+        _ = Directory.CreateDirectory(outputDirectory);
+
+        try
+        {
+            string responseFile = Path.Combine(workingDirectory, "projection.rsp");
+
+            // Each line holds a single '--argument value' pair, matching the MSBuild task's format. The 'sdk'
+            // input token makes the tool resolve the Windows SDK metadata installed on the machine.
+            File.WriteAllLines(responseFile,
+            [
+                "--input-paths sdk",
+                $"--output-directory {outputDirectory}",
+                "--target-framework net10.0",
+                $"--include-namespaces {IncludeNamespace}",
+                $"--reference-projection {(referenceProjection ? "true" : "false")}"
+            ]);
+
+            (int exitCode, string output) = Run(toolPath, $"@{responseFile}");
+
+            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespace}':{Environment.NewLine}{output}");
+
+            string[] sourceFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
+
+            Assert.AreNotEqual(0, sourceFiles.Length, "The projection writer produced no sources.");
+
+            return string.Join(Environment.NewLine, sourceFiles.Select(File.ReadAllText));
+        }
+        finally
+        {
+            TryDeleteDirectory(workingDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Runs the projection generator tool with a single argument.
+    /// </summary>
+    /// <param name="toolPath">The path of the tool assembly to run.</param>
+    /// <param name="argument">The single command line argument to pass.</param>
+    /// <returns>The process exit code and its combined standard output and error.</returns>
+    private static (int ExitCode, string Output) Run(string toolPath, string argument)
+    {
+        ProcessStartInfo startInfo = new("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add(toolPath);
+        startInfo.ArgumentList.Add(argument);
+
+        using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the projection generator process.");
+
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+
+        process.WaitForExit();
+
+        return (process.ExitCode, standardOutput + standardError);
+    }
+
+    /// <summary>
+    /// Resolves the path to the built <c>cswinrtprojectionrefgen</c> tool from assembly metadata.
+    /// </summary>
+    /// <returns>The full path of the tool assembly.</returns>
+    private static string GetGeneratorPath()
+    {
+        string? path = typeof(ProjectionWriterRunner).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(static attribute => attribute.Key == "ProjectionRefGeneratorAssemblyPath")?.Value;
+
+        Assert.IsFalse(string.IsNullOrEmpty(path), "The 'ProjectionRefGeneratorAssemblyPath' assembly metadata was not found.");
+
+        string fullPath = Path.GetFullPath(path!);
+
+        Assert.IsTrue(File.Exists(fullPath), $"The projection generator was not found at '{fullPath}'.");
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Counts the non-overlapping occurrences of a literal value in some text.
+    /// </summary>
+    /// <param name="text">The text to search.</param>
+    /// <param name="value">The literal value to count.</param>
+    /// <returns>The number of occurrences.</returns>
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Deletes a directory recursively, ignoring failures (best effort cleanup).
+    /// </summary>
+    /// <param name="directory">The directory to delete.</param>
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup; a leftover temp directory must not fail the test
+        }
+    }
+}

--- a/src/Tests/ProjectionWriterTest/ProjectionWriterTest.csproj
+++ b/src/Tests/ProjectionWriterTest/ProjectionWriterTest.csproj
@@ -1,0 +1,66 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Platforms>x64;x86</Platforms>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- This project runs the projection writer end-to-end; it needs no CsWinRT processing itself -->
+    <CsWinRTEnabled>false</CsWinRTEnabled>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'x86'">
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'x64'">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Core MSTest attributes/assertions -->
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest.Analyzers" />
+
+    <!-- MTP build integration + optional reporting -->
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+
+    <!-- MSTest runner and generators -->
+    <PackageReference Include="MSTest.Engine" />
+    <PackageReference Include="MSTest.SourceGeneration" />
+  </ItemGroup>
+
+  <!--
+    Build the reference projection generator tool, but do not reference its assembly: the tests invoke
+    it as a separate process (end-to-end), driving the projection writer exactly as a real build does.
+    'UndefineProperties' drops the build-tool publishing properties ('BuildToolArch' and
+    'PublishBuildTool', plus 'RuntimeIdentifier' / 'SelfContained') from this reference so the
+    generator is always built framework-dependent for the build host (output under 'net10.0\',
+    with no 'win-<arch>' RID subfolder). Without this, the generator's 'PublishAot' build is
+    self-contained and cannot be referenced by this non self-contained test project (NETSDK1151).
+    'Platform' is dropped as well: this project builds as x64/x86, but the generator declares no
+    platforms, so letting it through would place its output under 'bin\<platform>\' and no longer
+    match the path published as assembly metadata below.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\WinRT.Projection.Ref.Generator\WinRT.Projection.Ref.Generator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="_CsWinRTToolReference"
+                      UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained;Platform"
+                      Private="false" />
+  </ItemGroup>
+
+  <!-- Pass the built tool's path to the tests via assembly metadata -->
+  <ItemGroup>
+    <AssemblyMetadata Include="ProjectionRefGeneratorAssemblyPath"
+                      Value="$(MSBuildThisFileDirectory)..\..\WinRT.Projection.Ref.Generator\bin\$(Configuration)\net10.0\cswinrtprojectionrefgen.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+</Project>

--- a/src/Tests/ProjectionWriterTest/Test_CarriedOverAttributes.cs
+++ b/src/Tests/ProjectionWriterTest/Test_CarriedOverAttributes.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ProjectionWriterTest.Helpers;
+
+namespace ProjectionWriterTest;
+
+/// <summary>
+/// Tests for which Windows Runtime metadata attributes the projection writer carries over into each
+/// projection mode.
+/// </summary>
+/// <remarks>
+/// Implementation projections are only ever loaded at runtime; user code, compilers, analyzers and
+/// metadata tooling all see the reference projection instead. Attribute blobs cannot be trimmed by
+/// ILLink or ILC, so any metadata attribute carried into an implementation projection is permanent,
+/// unremovable metadata in the shipped application. These tests lock that down in both directions:
+/// the metadata attributes must be absent from implementation projections, and still present in
+/// reference projections (which also keeps the former assertions from silently becoming vacuous).
+/// </remarks>
+[TestClass]
+public class Test_CarriedOverAttributes
+{
+    /// <summary>
+    /// The Windows Runtime metadata attributes that are carried over into reference projections only.
+    /// </summary>
+    /// <remarks>
+    /// <c>[Overload]</c> comes from both the type-level carry-over in <c>CustomAttributeFactory</c> and
+    /// the interface member level one in <c>InterfaceFactory</c>, so it also covers the latter path.
+    /// Only attributes that actually occur in the projected namespace are listed here; the remaining
+    /// ones are covered by <see cref="ImplementationProjection_CarriesOverNoWindowsRuntimeMetadataAttribute"/>.
+    /// </remarks>
+    [TestMethod]
+    [DataRow("Windows.Foundation.Metadata.Overload")]
+    [DataRow("Windows.Foundation.Metadata.ContractVersion")]
+    public void MetadataAttribute_IsReferenceProjectionOnly(string attributeName)
+    {
+        int referenceCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: true, attributeName);
+        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, attributeName);
+
+        Assert.AreNotEqual(0, referenceCount, $"'[{attributeName}]' should be carried over into the reference projection.");
+        Assert.AreEqual(0, implementationCount, $"'[{attributeName}]' should not be carried over into the implementation projection.");
+    }
+
+    /// <summary>
+    /// The synthesized <c>[SupportedOSPlatform]</c> (derived from <c>[ContractVersion]</c>) is also
+    /// reference-projection-only.
+    /// </summary>
+    [TestMethod]
+    public void SupportedOSPlatform_IsReferenceProjectionOnly()
+    {
+        int referenceCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: true, "System.Runtime.Versioning.SupportedOSPlatform");
+        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, "System.Runtime.Versioning.SupportedOSPlatform");
+
+        Assert.AreNotEqual(0, referenceCount, "'[SupportedOSPlatform]' should be synthesized for the reference projection.");
+        Assert.AreEqual(0, implementationCount, "'[SupportedOSPlatform]' should not be synthesized for the implementation projection.");
+    }
+
+    /// <summary>
+    /// No attribute is carried over into an implementation projection from a namespace whose only
+    /// consumers are compilers, analyzers or metadata tooling.
+    /// </summary>
+    /// <remarks>
+    /// This is the general guard: rather than listing individual attributes, it asserts that
+    /// <em>nothing</em> from <c>Windows.Foundation.Metadata</c> survives. Any future metadata attribute
+    /// that starts leaking into implementation projections fails here.
+    /// </remarks>
+    [TestMethod]
+    public void ImplementationProjection_CarriesOverNoWindowsRuntimeMetadataAttribute()
+    {
+        int referenceCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: true, "Windows.Foundation.Metadata.");
+        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, "Windows.Foundation.Metadata.");
+
+        Assert.AreNotEqual(0, referenceCount, "'Windows.Foundation.Metadata' attributes should be carried over into the reference projection.");
+        Assert.AreEqual(0, implementationCount, "No 'Windows.Foundation.Metadata' attribute should be carried over into the implementation projection.");
+    }
+
+    /// <summary>
+    /// <c>[AttributeUsage]</c> is kept in both projection modes.
+    /// </summary>
+    /// <remarks>
+    /// It is not carried-over Windows Runtime metadata, but the .NET modeling of a projected attribute
+    /// type's own usage contract: its <c>AllowMultiple</c> and <c>Inherited</c> arguments drive
+    /// <c>Attribute.GetCustomAttributes(inherit: true)</c> semantics at runtime.
+    /// </remarks>
+    [TestMethod]
+    public void AttributeUsage_IsKeptInBothProjections()
+    {
+        int referenceCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: true, "System.AttributeUsage");
+        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, "System.AttributeUsage");
+
+        Assert.AreNotEqual(0, referenceCount, "'[AttributeUsage]' should be emitted for the reference projection.");
+        Assert.AreEqual(referenceCount, implementationCount, "'[AttributeUsage]' should be emitted identically for both projection modes.");
+    }
+
+    /// <summary>
+    /// The Windows Runtime <c>[allowmultiple]</c> metadata attribute is folded into the
+    /// <c>AllowMultiple</c> argument of the projected <c>[AttributeUsage]</c> in both projection modes.
+    /// </summary>
+    /// <remarks>
+    /// <c>[AllowMultiple]</c> is never carried over as an attribute of its own, so it has to be observed
+    /// before the carry-over filter runs. This guards that observation in the implementation projection,
+    /// where every other metadata attribute is dropped.
+    /// </remarks>
+    [TestMethod]
+    [DataRow("AllowMultiple = true")]
+    [DataRow("AllowMultiple = false")]
+    public void AllowMultiple_IsFoldedIntoAttributeUsageInBothProjections(string argumentText)
+    {
+        int referenceCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: true, argumentText);
+        int implementationCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: false, argumentText);
+
+        Assert.AreNotEqual(0, referenceCount, $"'{argumentText}' should be emitted for the reference projection.");
+        Assert.AreEqual(referenceCount, implementationCount, $"'{argumentText}' should be emitted identically for both projection modes.");
+    }
+
+    /// <summary>
+    /// The attributes the implementation projection actually needs at runtime (or to compile) are kept.
+    /// </summary>
+    /// <remarks>
+    /// <c>[WindowsRuntimeType]</c> and the other CsWinRT markers drive marshalling, <c>[Guid]</c> is the
+    /// runtime IID lookup for delegates, <c>[Flags]</c> backs <c>Enum.ToString</c>, and
+    /// <c>[IndexerName]</c> is required for the generated mapped interface stubs to compile.
+    /// </remarks>
+    [TestMethod]
+    [DataRow("[WindowsRuntimeType]")]
+    [DataRow("[WindowsRuntimeClassName(")]
+    [DataRow("[Guid(")]
+    [DataRow("[Flags]")]
+    [DataRow("[global::System.Runtime.CompilerServices.IndexerName(")]
+    public void RuntimeRelevantAttribute_IsKeptInImplementationProjection(string attributeText)
+    {
+        int implementationCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: false, attributeText);
+
+        Assert.AreNotEqual(0, implementationCount, $"'{attributeText}' should be emitted for the implementation projection.");
+    }
+}

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -5091,39 +5091,53 @@ namespace UnitTest
             }
         }
 
-        // Every application of an '[allowmultiple]' Windows Runtime attribute has to be carried over to
-        // the projection, not just the last one. See https://github.com/microsoft/CsWinRT/issues/2491.
+        // Windows Runtime metadata attributes are deliberately not carried over into implementation
+        // projections: nothing consumes them there (user code, compilers, analyzers and metadata tooling
+        // all see the reference projection instead), and attribute blobs cannot be trimmed by ILLink or
+        // ILC, so they would be permanent metadata in every shipped app. At runtime the projected types
+        // resolve through the forwarder assembly into the implementation projection, so that is what
+        // reflection observes here. The reference projection still carries every application over (see
+        // https://github.com/microsoft/CsWinRT/issues/2491); that side is covered by 'ProjectionWriterTest',
+        // which can assert on both projection modes.
         [TestMethod]
-        public void TestRepeatedAttributesAreProjected()
+        public void TestWindowsRuntimeAttributesAreNotProjectedInImplementationProjection()
         {
-            // The '.winmd' does not preserve the declaration order from the '.idl', so the applications
-            // are sorted by name to make the comparison deterministic. The two identical entries are
-            // intentional: MIDL allows them, and both have to survive the projection.
-            (string Name, string GroupName)[] applications = typeof(RepeatedAttributeTest)
-                .GetCustomAttributes<MyRepeatableAttribute>()
-                .Select(static attribute => (attribute.Name, attribute.GroupName))
-                .OrderBy(static application => application.Name, StringComparer.Ordinal)
-                .ToArray();
+            // 'RepeatedAttributeTest' is decorated in the '.idl' with four '[attr_repeatable]' applications
+            // and one '[attr_string]' application. None of them survive into the implementation projection.
+            Assert.AreEqual(0, typeof(RepeatedAttributeTest).GetCustomAttributes<MyRepeatableAttribute>().Count());
+            Assert.AreEqual(0, typeof(RepeatedAttributeTest).GetCustomAttributes<MyStringAttribute>().Count());
 
-            CollectionAssert.AreEqual(
-                new[]
+            // Matching on the namespace rather than on those two types also acts as a blanket guard, so any
+            // future metadata attribute that starts leaking in fails here too. The marshalling attributes
+            // CsWinRT needs at runtime live in the 'ABI.*' namespaces, so they are deliberately not matched.
+            List<string> projectedAttributes = [];
+            bool hasWindowsRuntimeType = false;
+
+            foreach (CustomAttributeData data in typeof(RepeatedAttributeTest).GetCustomAttributesData())
+            {
+                string attributeName = data.AttributeType.FullName ?? string.Empty;
+
+                if (attributeName.StartsWith("TestComponentCSharp.", StringComparison.Ordinal))
                 {
-                    ("Horizontal", "OrientationStates"),
-                    ("Horizontal", "OrientationStates"),
-                    ("Normal", "CommonStates"),
-                    ("PointerOver", "CommonStates")
-                },
-                applications);
+                    projectedAttributes.Add(attributeName);
+                }
+                else if (attributeName == "WindowsRuntime.WindowsRuntimeTypeAttribute")
+                {
+                    hasWindowsRuntimeType = true;
+                }
+            }
 
-            // An attribute that is not repeatable is still projected exactly once
-            MyStringAttribute[] singleApplication = typeof(RepeatedAttributeTest).GetCustomAttributes<MyStringAttribute>().ToArray();
+            Assert.AreEqual(0, projectedAttributes.Count, $"Unexpected projected attributes: {string.Join(", ", projectedAttributes)}");
 
-            Assert.AreEqual(1, singleApplication.Length);
-            Assert.AreEqual("some other attribute in between", singleApplication[0].Content);
+            // The CsWinRT marker driving marshalling must still be applied (guards against over-stripping)
+            Assert.IsTrue(hasWindowsRuntimeType, "'[WindowsRuntimeType]' should still be applied in the implementation projection.");
         }
 
         // The Windows Runtime '[allowmultiple]' attribute has no .NET counterpart: it maps to the
-        // 'AllowMultiple' named argument of '[AttributeUsage]' on the projected attribute type.
+        // 'AllowMultiple' named argument of '[AttributeUsage]' on the projected attribute type. Unlike the
+        // carried-over metadata attributes above, '[AttributeUsage]' is kept in both projection modes: it
+        // models the projected attribute type's own usage contract, which drives
+        // 'Attribute.GetCustomAttributes(inherit: true)' semantics at runtime.
         [TestMethod]
         public void TestAllowMultipleIsProjectedOnAttributeUsage()
         {

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -5005,13 +5005,13 @@ namespace UnitTest
         [TestMethod]
         public void TestGenericsOverWindowsRuntimeAttributeTypes()
         {
-            // 'GetCustomAttributes<T>' over a projected Windows Runtime attribute type creates
-            // 'IEnumerable<MyStringAttribute>' and 'IEnumerator<MyStringAttribute>' instantiations
-            MyStringAttribute[] attributes = typeof(MultiLineStringAttributeTest).GetCustomAttributes<MyStringAttribute>().ToArray();
+            // 'GetCustomAttributes<T>' over a projected Windows Runtime attribute type creates the
+            // 'IEnumerable<MyStringAttribute>' and 'IEnumerator<MyStringAttribute>' instantiations this test
+            // is about, so the call stays. Its result is not used though: implementation projections don't
+            // carry metadata attribute applications over (see the test below), so it finds nothing at runtime.
+            _ = typeof(MultiLineStringAttributeTest).GetCustomAttributes<MyStringAttribute>().ToArray();
 
-            Assert.AreEqual(1, attributes.Length);
-
-            List<MyStringAttribute> list = [attributes[0]];
+            List<MyStringAttribute> list = [new MyStringAttribute { Content = "Hello world" }];
 
             // Assigning to an 'IIterable<Object>' property actually marshals the collection across the ABI,
             // which queries the CCW for 'IIterable<IInspectable>'. That interface is in the vtables because
@@ -5040,7 +5040,7 @@ namespace UnitTest
             // The IID of 'IIterable<IInspectable>', which the covariance expansion adds for the list
             Guid iidIIterableInspectable = new("092B849B-60B1-52BE-A44A-6FE8E933CBE4");
 
-            List<MyStringAttribute> list = [typeof(MultiLineStringAttributeTest).GetCustomAttributes<MyStringAttribute>().First()];
+            List<MyStringAttribute> list = [new MyStringAttribute { Content = "Hello world" }];
 
             void* ccw = WindowsRuntimeMarshal.ConvertToUnmanaged(list);
 

--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -353,15 +353,20 @@ internal static class CustomAttributeFactory
     }
 
     /// <summary>
-    /// Writes any custom attributes (e.g. <c>[Obsolete]</c>, <c>[Deprecated]</c>,
-    /// <c>[SupportedOSPlatform]</c>) carried over from <paramref name="member"/> to the projection.
+    /// Writes the Windows Runtime metadata custom attributes carried over from <paramref name="member"/>
+    /// to the projection (e.g. <c>[AttributeUsage]</c>, and — in reference projections only —
+    /// <c>[Overload]</c>, <c>[Experimental]</c>, <c>[ContractVersion]</c>, plus the synthesized
+    /// <c>[SupportedOSPlatform]</c>).
     /// </summary>
     /// <remarks>
     /// Attributes are emitted in metadata order, one line per application. Windows Runtime attributes
     /// marked <c>[allowmultiple]</c> can be applied several times to the same member, so every
     /// application is carried over. The <c>[AllowMultiple]</c> metadata attribute itself is not
     /// projected: it is folded into the <c>AllowMultiple</c> named argument of the projected
-    /// <c>[AttributeUsage]</c>, matching how .NET models repeatability.
+    /// <c>[AttributeUsage]</c>, matching how .NET models repeatability. Which applications survive is
+    /// decided by <see cref="ShouldCarryOverAttribute"/>: implementation projections keep only
+    /// <c>[AttributeUsage]</c>, since every other metadata attribute is dead, untrimmable weight in an
+    /// assembly that is only ever loaded at runtime (see that method for the full rationale).
     /// </remarks>
     /// <param name="writer">The writer to emit to.</param>
     /// <param name="context">The active emit context.</param>
@@ -404,11 +409,12 @@ internal static class CustomAttributeFactory
                 continue;
             }
 
-            string fullAttrName = strippedName == "AttributeUsage"
-                ? AttributeUsageName
-                : ns + "." + strippedName;
-
-            List<string> args = WriteCustomAttributeArgs(attr);
+            // '[AllowMultiple]' is never carried over itself: it is observed here (in both projection
+            // modes) and folded into the projected '[AttributeUsage]' after all attributes are seen.
+            if (ns == WindowsFoundationMetadata && strippedName == "AllowMultiple")
+            {
+                allowMultiple = true;
+            }
 
             // '[SupportedOSPlatform]' takes a single platform, so only the first resolved one is emitted
             // (matching the member-level behavior in 'WritePlatformAttributeBody'). A member can carry
@@ -425,31 +431,21 @@ internal static class CustomAttributeFactory
                 }
             }
 
-            // Skip metadata attributes without a projection
-            if (ns == WindowsFoundationMetadata)
-            {
-                if (strippedName == "AllowMultiple")
-                {
-                    allowMultiple = true;
-                }
+            bool isAttributeUsage = strippedName == "AttributeUsage";
 
-                // ContractVersion and ApiContract are only emitted for reference assemblies
-                if (strippedName is "ContractVersion" or "ApiContract")
-                {
-                    if (!context.Settings.ReferenceProjection)
-                    {
-                        continue;
-                    }
-                }
-                else if (strippedName is not ("DefaultOverload" or "Overload" or "AttributeUsage" or "Experimental"))
-                {
-                    continue;
-                }
+            if (!ShouldCarryOverAttribute(context, ns, strippedName, isAttributeUsage))
+            {
+                continue;
             }
+
+            // Only format the arguments of attributes that are actually carried over. Implementation
+            // projections drop almost everything, and they are the hot publish-time path.
+            List<string> args = WriteCustomAttributeArgs(attr);
+            string fullAttrName = isAttributeUsage ? AttributeUsageName : ns + "." + strippedName;
 
             attributes.Add((fullAttrName, args));
 
-            if (fullAttrName == AttributeUsageName)
+            if (isAttributeUsage)
             {
                 attributeUsageArgs = args;
             }
@@ -486,6 +482,53 @@ internal static class CustomAttributeFactory
 
             writer.WriteLine("]");
         }
+    }
+
+    /// <summary>
+    /// Returns whether a Windows Runtime metadata attribute application should be carried over to the projection.
+    /// </summary>
+    /// <param name="context">The active emit context.</param>
+    /// <param name="ns">The namespace of the attribute type.</param>
+    /// <param name="strippedName">The name of the attribute type, with any <c>Attribute</c> suffix removed.</param>
+    /// <param name="isAttributeUsage">Whether the application is an <c>[AttributeUsage]</c> attribute.</param>
+    /// <returns>Whether the attribute application should be emitted.</returns>
+    /// <remarks>
+    /// <para>
+    /// <c>[AttributeUsage]</c> is carried over in both projection modes. It is not Windows Runtime
+    /// metadata being preserved for tooling, but the .NET modeling of the attribute type's own usage
+    /// contract: its <c>AllowMultiple</c> and <c>Inherited</c> arguments drive
+    /// <c>Attribute.GetCustomAttributes(inherit: true)</c> semantics at runtime for user code applying a
+    /// projected attribute. It is also negligible in size (34 applications across the entire Windows SDK).
+    /// </para>
+    /// <para>
+    /// Every other metadata attribute is carried over into reference projections only. Implementation
+    /// projections are only ever loaded at runtime, never compiled against (user code compiles against
+    /// the reference projection instead), so attributes whose only consumers are compilers, analyzers
+    /// and metadata tooling are pure dead weight there. Attribute blobs cannot be trimmed by ILLink or
+    /// ILC either, so anything carried over is permanent, unremovable metadata in the shipped app.
+    /// </para>
+    /// </remarks>
+    private static bool ShouldCarryOverAttribute(ProjectionEmitContext context, string ns, string strippedName, bool isAttributeUsage)
+    {
+        if (isAttributeUsage)
+        {
+            return true;
+        }
+
+        if (!context.Settings.ReferenceProjection)
+        {
+            return false;
+        }
+
+        // Metadata attributes without a projected form are always dropped
+        if (ns == WindowsFoundationMetadata)
+        {
+            return strippedName is "ContractVersion" or "ApiContract" or "DefaultOverload" or "Overload" or "Experimental";
+        }
+
+        // Attributes from any other namespace (e.g. '[Microsoft.UI.Xaml.TemplatePart]') are themselves
+        // projected types, so their applications are carried over as-is
+        return true;
     }
 
     /// <summary>

--- a/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
@@ -220,9 +220,9 @@ internal static class InterfaceFactory
         {
             MethodSignatureInfo sig = new(method);
 
-            // Only emit Windows.Foundation.Metadata attributes that have a projected form
-            // (Overload, DefaultOverload, AttributeUsage, Experimental).
-            WriteMethodCustomAttributes(writer, method);
+            // Carried-over metadata attributes ([Overload], [DefaultOverload], [Experimental]) are
+            // reference-projection-only.
+            WriteMethodCustomAttributes(writer, context, method);
             IndentedTextWriterCallback ret = MethodFactory.WriteProjectionReturnType(context, sig);
             IndentedTextWriterCallback parms = MethodFactory.WriteParameterList(context, sig);
             writer.WriteLine($"{ret} {method.GetRawName()}({parms});");
@@ -322,8 +322,18 @@ internal static class InterfaceFactory
     /// Emits the projected custom attributes for an interface method (filtered for the projected
     /// attributes: Overload, DefaultOverload, Experimental).
     /// </summary>
-    private static void WriteMethodCustomAttributes(IndentedTextWriter writer, MethodDefinition method)
+    /// <remarks>
+    /// These attributes are only consumed by compilers, analyzers and metadata tooling, all of which
+    /// see the reference projection. Implementation projections are only ever loaded at runtime, and
+    /// attribute blobs cannot be trimmed by ILLink or ILC, so nothing is emitted for them.
+    /// </remarks>
+    private static void WriteMethodCustomAttributes(IndentedTextWriter writer, ProjectionEmitContext context, MethodDefinition method)
     {
+        if (!context.Settings.ReferenceProjection)
+        {
+            return;
+        }
+
         foreach (CustomAttribute attr in method.CustomAttributes)
         {
             ITypeDefOrRef? attrType = attr.Constructor?.DeclaringType;

--- a/src/cswinrt.slnx
+++ b/src/cswinrt.slnx
@@ -258,6 +258,12 @@
       <Platform Solution="*|x86" Project="x86" />
       <Build Solution="*|ARM64" Project="false" />
     </Project>
+    <Project Path="Tests/ProjectionWriterTest/ProjectionWriterTest.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x86" />
+      <Build Solution="*|ARM64" Project="false" />
+    </Project>
     <Project Path="Tests/SourceGenerator2Test/SourceGenerator2Test.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />


### PR DESCRIPTION
## Summary

Implementation projections now carry over no Windows Runtime metadata attributes at all (except `[AttributeUsage]`). Reference projections are completely unchanged: their generated output is byte-identical before and after.

## Motivation

Implementation projections (`WinRT.Sdk.Projection.dll`, `WinRT.Sdk.Xaml.Projection.dll`, `WinRT.Projection.dll`, produced by `cswinrtprojectiongen` at publish time) are only ever *loaded* at runtime. User code, compilers, analyzers and metadata tooling all see the *reference* projection instead. Any Windows Runtime metadata attribute carried into an implementation projection therefore has no consumer.

Worse, attribute blobs cannot be trimmed by ILLink or ILC, so every one of those applications is permanent, unremovable metadata in the shipped application.

`[ContractVersion]`, `[ApiContract]` and the synthesized `[SupportedOSPlatform]` were already reference-projection-only. This generalizes that to every carried-over metadata attribute.

## Changes

- **`src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs`**: a new `ShouldCarryOverAttribute` predicate replaces the inline special cases in `WriteCustomAttributes`, so the "reference-only" rule lives in one documented place instead of being spread across the loop. It also drops the previously carried-over attributes from other namespaces (e.g. `Microsoft.UI.Xaml.TemplatePart`, the `MUX*` attributes). Argument formatting now happens *after* the filter, so no work is done for attributes that get dropped (implementation projections are the hot publish-time path). The `[AllowMultiple]` observation and the reference-only `[SupportedOSPlatform]` synthesis are unchanged.
- **`src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs`**: `WriteMethodCustomAttributes` now takes the emit context and returns early for implementation projections. This path was not gated on the projection mode at all, and was the single largest contributor.
- **`src/Tests/ProjectionWriterTest/`**: new test project that drives the projection writer end-to-end through `cswinrtprojectionrefgen` and asserts which attributes survive in each mode.
- **`src/Tests/UnitTest/TestComponentCSharp_Tests.cs`**: `TestRepeatedAttributesAreProjected` inverted (see below).
- **`src/cswinrt.slnx`**, **`build/AzurePipelineTemplates/CsWinRT-Test-Steps.yml`**: wire up the new test project.

`[AttributeUsage]` is deliberately kept in both modes. It is not carried-over Windows Runtime metadata but the .NET modeling of a projected attribute type's own usage contract, and its `AllowMultiple`/`Inherited` arguments drive `Attribute.GetCustomAttributes(inherit: true)` semantics at runtime. It is also negligible in size (36 applications across the entire Windows SDK projection).

## Results

Measured on the real `WinRT.Sdk.Projection.dll` (SDK 26100), at IL metadata level:

| | Before | After |
| --- | --- | --- |
| Assembly size | 23,913,472 bytes | **23,885,824 bytes** (-27,648, -0.116%) |
| Custom attribute applications | 99,279 | **98,543** (-736) |
| `[Overload]` | 720 | **0** |
| `[DefaultOverload]` | 16 | **0** |
| `[WindowsRuntimeType]` | 8,451 | 8,451 (unchanged) |
| `[AttributeUsage]` | 36 | 36 (unchanged) |

Generated sources, running the writer over both metadata sets in both modes:

| Projection | Attribute applications removed | Source bytes removed |
| --- | --- | --- |
| Windows SDK, implementation | **746** (707 `[Overload]`, 27 `[Experimental]`, 12 `[DefaultOverload]`) | 61,554 |
| WinUI, implementation | **411** (146 `[Overload]`, 180 `MUX*`, 73 `ContentProperty`, 6 `[DefaultOverload]`, 4 `InputProperty`, 1 `[Bindable]`, 1 `MUXHasCustomActivationFactory`) | 36,444 |
| Windows SDK, reference | 0 | **0 (byte-identical, 295/295 files)** |
| WinUI, reference | 0 | **0 (byte-identical, 65/65 files)** |

Across every changed implementation-projection file there are **zero added lines**; every removed line is an attribute application. The compiled reference assembly (`ref\Microsoft.Windows.SDK.NET.dll`) is byte-identical too.

## Test coverage

The new `ProjectionWriterTest` project runs `cswinrtprojectionrefgen` as a separate process (exactly as the MSBuild target does) over `Windows.Foundation` in both modes, caching the sources so the whole suite runs in about a second. Its central assertion is that **no** `Windows.Foundation.Metadata` attribute survives into an implementation projection, so any future leak fails the build instead of silently adding permanent metadata. The reference-projection counterparts are asserted too, which keeps the negative assertions from becoming vacuous, along with the `[AllowMultiple]` folding (identical in both modes) and the attributes implementation projections genuinely need. Verified that the suite fails without the writer change and passes with it.

`TestRepeatedAttributesAreProjected` (added in the base PR) asserted the opposite and had to be inverted. Projection assemblies ship a forwarder as their primary output, with the reference assembly under `ref\`, so at runtime those types resolve into the implementation projection generated for the app, which is exactly where these attributes are now dropped. It is replaced by `TestWindowsRuntimeAttributesAreNotProjectedInImplementationProjection`, which asserts the four `[attr_repeatable]` and one `[attr_string]` applications are gone, that no projected Windows Runtime attribute type survives at all, and that `[WindowsRuntimeType]` is still applied so over-stripping is caught too. `TestAllowMultipleIsProjectedOnAttributeUsage` is unchanged and still passes.

One caveat worth flagging: the base PR's assertion that *all four* applications of a repeated `[allowmultiple]` attribute are carried over no longer has runtime coverage, because the runtime only ever sees the implementation projection. There is no type anywhere in the Windows SDK or WinUI metadata with two or more applications of the same attribute, so that scenario is only reachable through `TestComponentCSharp.winmd`, which the new test project does not consume (it uses the `sdk` input token and has no C++/MIDL dependency). Happy to wire the test component's `.winmd` in if that is preferred.

## Out of scope

- The hand-written `[SupportedOSPlatform]` applications in `Resources/Base/ComInteropExtensions.cs` and `Resources/Additions/*` are literal resource text (15 of them survive into the Windows SDK implementation projection). Making those conditional is a separate change.
- `src/Tests/WinMDGeneratorTest` has the same latent `Platform` propagation issue the new test project works around with `UndefineProperties`; left alone as unrelated.
