### PR TITLE
Do not treat Windows Runtime attribute types as Windows Runtime types

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -4987,5 +4987,108 @@ namespace UnitTest
             // Non projected class changes the behavior of the Value property to double it.
             Assert.AreEqual(6, customEquals.Value);
         }
+
+        // Windows Runtime attribute types are metadata-only: they are never activated, never cross the ABI
+        // boundary, and have no Windows Runtime type signature, so the projection deliberately emits no
+        // marshalling infrastructure for them at all. They are therefore not Windows Runtime types as far as
+        // marshalling is concerned, and behave like plain managed types: a 'List<SomeAttribute>' is handled
+        // exactly like a 'List<SomeManagedClass>', and the attribute instances themselves marshal as opaque
+        // 'IInspectable' objects.
+        //
+        // Treating them as Windows Runtime types instead failed twice over: the interop generator tried to
+        // generate marshalling code for 'IIterable<SomeAttribute>' and failed the build with
+        // 'CSWINRTINTEROPGEN0055' (there is no type signature to compute), and the runtime resolved the
+        // attribute type as its own metadata provider and then threw from 'GetComWrappersMarshaller'.
+        //
+        // This test building at all covers the first failure, as the interop generator runs over this
+        // assembly and sees the instantiations created below. The assertions cover the second one.
+        [TestMethod]
+        public void TestGenericsOverWindowsRuntimeAttributeTypes()
+        {
+            // 'GetCustomAttributes<T>' over a projected Windows Runtime attribute type creates
+            // 'IEnumerable<MyStringAttribute>' and 'IEnumerator<MyStringAttribute>' instantiations
+            MyStringAttribute[] attributes = typeof(MultiLineStringAttributeTest).GetCustomAttributes<MyStringAttribute>().ToArray();
+
+            Assert.AreEqual(1, attributes.Length);
+
+            List<MyStringAttribute> list = [attributes[0]];
+
+            // Assigning to an 'IIterable<Object>' property actually marshals the collection across the ABI,
+            // which queries the CCW for 'IIterable<IInspectable>'. That interface is in the vtables because
+            // the covariance expansion adds it for 'List<T>'; there is deliberately no
+            // 'IIterable<MyStringAttribute>' entry, as no marshalling code can exist for it. Enumerating the
+            // collection then marshals the attribute instances themselves, as opaque objects. Round-tripping
+            // the property back (unlike a plain 'object' property, which just hands the same CCW back
+            // regardless of its vtables) is what makes this an actual test of the marshalling code.
+            TestObject.ObjectIterableProperty = list;
+
+            Assert.IsTrue(TestObject.ObjectIterableProperty.SequenceEqual(list));
+        }
+
+        // A 'List<SomeAttribute>' must end up with exactly one 'IIterable<IInspectable>' interface entry. Its
+        // own 'IEnumerable<SomeAttribute>' contributes none, as attribute types are not Windows Runtime types,
+        // so the single entry comes from the 'IEnumerable<object>' produced by the covariance expansion. Were
+        // the attribute type to be treated as a Windows Runtime type again, the generated interface entries
+        // would carry the same IID (and vtable) twice, for no reason other than wasted binary size.
+        //
+        // 'IInspectable::GetIids' reports exactly the generated 'ComInterfaceEntries' for the object, so it
+        // can be used to count them. Note that a duplicate entry would be invisible to 'QueryInterface'
+        // (which just returns the first match), so this is the only way to actually observe it.
+        [TestMethod]
+        public unsafe void TestWindowsRuntimeAttributeTypeInterfaceEntriesAreNotDuplicated()
+        {
+            // The IID of 'IIterable<IInspectable>', which the covariance expansion adds for the list
+            Guid iidIIterableInspectable = new("092B849B-60B1-52BE-A44A-6FE8E933CBE4");
+
+            List<MyStringAttribute> list = [typeof(MultiLineStringAttributeTest).GetCustomAttributes<MyStringAttribute>().First()];
+
+            void* ccw = WindowsRuntimeMarshal.ConvertToUnmanaged(list);
+
+            try
+            {
+                // 'ConvertToUnmanaged' hands back an 'IUnknown' pointer, so it has to be queried for
+                // 'IInspectable' first: 'GetIids' is not in the 'IUnknown' vtable
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface((nint)ccw, in WellKnownInterfaceIIDs.IID_IInspectable, out nint inspectable));
+
+                try
+                {
+                    uint iidCount = 0;
+                    Guid* iids = null;
+
+                    // 'IInspectable::GetIids' is the fourth vtable entry, right after the 'IUnknown' methods
+                    Marshal.ThrowExceptionForHR(((delegate* unmanaged[MemberFunction]<void*, uint*, Guid**, int>)(*(void***)inspectable)[3])(
+                        (void*)inspectable,
+                        &iidCount,
+                        &iids));
+
+                    try
+                    {
+                        int matches = 0;
+
+                        for (uint i = 0; i < iidCount; i++)
+                        {
+                            if (iids[i] == iidIIterableInspectable)
+                            {
+                                matches++;
+                            }
+                        }
+
+                        Assert.AreEqual(1, matches, "'IIterable<IInspectable>' should have exactly one entry in the CCW interface entries.");
+                    }
+                    finally
+                    {
+                        Marshal.FreeCoTaskMem((nint)iids);
+                    }
+                }
+                finally
+                {
+                    _ = Marshal.Release(inspectable);
+                }
+            }
+            finally
+            {
+                _ = Marshal.Release((nint)ccw);
+            }
+        }
     }
 }

--- a/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
+++ b/src/WinRT.Interop.Generator/Extensions/WindowsRuntimeExtensions.cs
@@ -825,6 +825,34 @@ internal static class WindowsRuntimeExtensions
                     ? interopDefinitions.WindowsRuntimeSdkXamlProjectionModule
                     : interopDefinitions.WindowsRuntimeProjectionModule;
         }
+
+        /// <summary>
+        /// Checks whether a <see cref="TypeDefinition"/> represents a Windows Runtime attribute type.
+        /// </summary>
+        /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
+        /// <returns>Whether the type represents a Windows Runtime attribute type.</returns>
+        /// <remarks>
+        /// <para>
+        /// Windows Runtime attribute types are metadata-only: they are never activated and never cross the ABI
+        /// boundary, so the projection deliberately emits no marshalling infrastructure for them (no default
+        /// interface, no IID, no <c>Impl</c> type, no marshaller). They are still projected as ordinary .NET
+        /// attribute types, and can appear as generic type arguments in managed code (e.g.
+        /// <c>type.GetCustomAttributes&lt;SomeAttribute&gt;()</c> creates an <c>IEnumerable&lt;SomeAttribute&gt;</c>
+        /// instantiation), so they have to be treated as plain managed types, exactly like any type that is
+        /// not projected at all.
+        /// </para>
+        /// <para>
+        /// Windows Runtime attribute types always derive <em>directly</em> from <see cref="Attribute"/>, as the
+        /// Windows Runtime type system does not allow an attribute to derive from another one. Checking the
+        /// immediate base type is therefore both sufficient and much cheaper than walking the base class chain.
+        /// </para>
+        /// </remarks>
+        public bool IsWindowsRuntimeAttributeType(InteropReferences interopReferences)
+        {
+            return
+                type.BaseType is { } baseType &&
+                SignatureComparer.IgnoreVersion.Equals(baseType, interopReferences.Attribute);
+        }
     }
 
     extension(TypeSignature signature)
@@ -1055,6 +1083,13 @@ internal static class WindowsRuntimeExtensions
 
             TypeDefinition type = signature.Resolve(interopReferences.RuntimeContext);
 
+            // Windows Runtime attribute types carry no marshalling code at all, so they behave exactly like
+            // types that are not projected (see the remarks on the check below for the full rationale).
+            if (type.IsWindowsRuntimeAttributeType(interopReferences))
+            {
+                return false;
+            }
+
             // For all other cases, just check that the type is projected. This will also include manually
             // projected types that are defined in 'WinRT.Runtime.dll' (same attributes). Public types from
             // authored component assemblies, and types from reference projection assemblies, are also
@@ -1123,6 +1158,12 @@ internal static class WindowsRuntimeExtensions
             }
 
             TypeDefinition type = signature.Resolve(interopReferences.RuntimeContext);
+
+            // Windows Runtime attribute types carry no marshalling code at all (same as above)
+            if (type.IsWindowsRuntimeAttributeType(interopReferences))
+            {
+                return false;
+            }
 
             // For all other cases, first check that the type is projected. Public types from authored
             // component assemblies, and types from reference projection assemblies, are also considered

--- a/src/WinRT.Projection.Writer/Factories/MetadataAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/MetadataAttributeFactory.cs
@@ -121,7 +121,20 @@ internal static class MetadataAttributeFactory
             return;
         }
 
-        writer.Write("[WindowsRuntimeType]");
+        // The marker states that a type participates in Windows Runtime marshalling, which is not the case for
+        // Windows Runtime attribute types: they are metadata-only, so no marshalling infrastructure is emitted
+        // for them at all (no default interface, no IID, no 'Impl' type, no marshaller). Applying it anyway
+        // would make both consumers treat them as marshallable and then fail to find any marshalling logic: the
+        // runtime resolves a metadata provider for them and then throws from 'GetComWrappersMarshaller', and the
+        // interop generator treats generic instantiations over them as Windows Runtime ones and then fails to
+        // compute a type signature. Without the marker they behave like any other managed type, which is exactly
+        // what they are: the attribute instances marshal as opaque 'IInspectable' objects, and instantiations
+        // such as 'IEnumerable<SomeAttribute>' are covered by the 'IEnumerable<object>' covariance expansion.
+        // The '.winmd' stem below is still recorded, as that is build-time only data for the other generators.
+        if (!type.IsAttributeType)
+        {
+            writer.Write("[WindowsRuntimeType]");
+        }
 
         // Record the type -> .winmd-stem mapping for the centralized lookup type. The metadata value is build-time
         // only (consumed by the interop generator), so keeping it off the type itself lets it be trimmed away.


### PR DESCRIPTION
## Problem

Using a projected Windows Runtime attribute type as a generic type argument failed the whole build:

```
error CSWINRTINTEROPGEN0055: Failed to generate the type signature for type 'TestComponentCSharp.MyStringAttribute'.
```

`type.GetCustomAttributes<SomeAttribute>()` is enough to trigger it — it creates `IEnumerable<SomeAttribute>` and `IEnumerator<SomeAttribute>` instantiations in the assembly.

## Root cause

Windows Runtime attributes are **metadata-only**: they are never activated and never cross the ABI boundary, so the projection deliberately emits no marshalling infrastructure for them — no default interface, no IID, no `Impl` type, no marshaller (everything in `ProjectionGenerator.Namespace.cs` is guarded on `!type.IsAttributeType`).

It did however still stamp them with `[WindowsRuntimeType]`, which is precisely the statement *"this type participates in Windows Runtime marshalling"*. Both consumers believed it and then failed to find any marshalling logic:

- **Interop generator.** `IsWindowsRuntimeType` classifies a generic instantiation as a Windows Runtime one only when **every type argument** is a Windows Runtime type. That is why `IEnumerable<SomeManagedClass>` is not one, is never tracked, and the CCW instead gets `IEnumerable<object>` from the covariance expansion. Attribute types wrongly passed that check, so `IEnumerable<SomeAttribute>` went down the Windows Runtime path and `SignatureGenerator.Class` found neither a default interface nor an IID → `CSWINRTINTEROPGEN0055`.
- **Runtime.** `WindowsRuntimeMarshallingInfo.GetMetadataProviderType` short-circuits on `[WindowsRuntimeType]` for non-generic types and returns the type as its own metadata provider. `GetOrCreateComInterfaceForObject` then calls `GetComWrappersMarshaller()`, which throws `NotSupportedException` instead of falling through to the opaque-`IInspectable` path that every other managed object takes.

One cause, two symptoms — the second only became reachable once the first was worked around.

## Fix

Stop reporting attribute types as Windows Runtime types.

- **Projection writer** — don't emit `[WindowsRuntimeType]` on attribute types. The `.winmd` stem is still recorded in the centralized `ABI.WindowsRuntimeMetadataTypes` lookup, since that is build-time only data for the other generators.
- **Interop generator** — exclude them in `IsWindowsRuntimeType` / `IsNotExclusiveToWindowsRuntimeType`. This is still needed on top of the above, because **reference projections carry no per-type marker at all**: `IsReferenceProjectionWindowsRuntimeType` is assembly-level, so every type in a NuGet-shipped reference projection would otherwise still qualify.

Attribute types now behave like any managed type: `List<SomeAttribute>` is handled exactly like `List<SomeManagedClass>` — it still gets its own proxy/type-map entry, its CCW gets `IIterable<IInspectable>` from the covariance expansion, and the attribute instances marshal as opaque `IInspectable` objects.

The detection is a direct base-type comparison against `System.Attribute`. Windows Runtime attributes always derive directly from it (the type system does not allow an attribute to derive from another one), so no base-class-chain walk is needed.

## Notes

An earlier revision of this PR type-erased the attribute type arguments to `object` in the interop generator instead. That treated the symptom rather than the cause: it needed a dedicated eraser, erasure call sites in three discovery entry points, careful ordering against the resolvability guards, and an extra parameter threaded through `TryAddExposedInterfaceType` for the dedup invariant — and it still left the runtime failure in place. All of that is gone; the existing managed/covariance path already does the right thing once the classification is correct.

It also removes the `IsAssignableFrom` call that was tripping the `NullReferenceException` reported in Washi1337/AsmResolver#770.

## Tests

Two tests in `src/Tests/UnitTest`:

- `TestGenericsOverWindowsRuntimeAttributeTypes` — the original repro (`GetCustomAttributes<T>`), then marshals a `List<SomeAttribute>` across the ABI through an `IIterable<Object>` property and round-trips it back. The test *building* covers the `CSWINRTINTEROPGEN0055` failure; the assertions cover the `GetComWrappersMarshaller` one, since the native side enumerates the collection and marshals the attribute instances.
- `TestWindowsRuntimeAttributeTypeInterfaceEntriesAreNotDuplicated` — reads the CCW's IIDs via `IInspectable::GetIids` and asserts `IIterable<IInspectable>` appears exactly once (a duplicate entry is invisible to `QueryInterface`, so this is the only way to observe it).

## Validation

- All five build tools build clean.
- Full CsWinRT pipeline (projection ref gen → SDK/merged projection gen → impl gen → interop gen) verified end-to-end on `ObjectLifetimeTests.Lifted`.
- Regenerated the `TestComponentCSharp` implementation projection and confirmed `MyStringAttribute` no longer carries `[WindowsRuntimeType]`, that real runtime classes such as `NonAgileClass` still carry it plus their marshaller, and that the `.winmd` stem entry is still emitted.
