### PR TITLE
Hide WinRT.Host runtime assets in Solution Explorer

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.Authoring.targets
@@ -63,24 +63,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
     For Project Reference consumers, copy the necessary WinRT DLLs to output directory.
     Only include these if we are not generating native exports for NativeAOT.
+    These are build/runtime assets, so they're marked as not visible to avoid
+    showing them as project items in Solution Explorer.
   --> 
   <ItemGroup Condition="'$(CsWinRTAotExportsEnabled)' != 'true'"> 
 
     <None Condition="Exists('$(CsWinRTPath)lib\net8.0\WinRT.Host.Shim.dll')" Include="$(CsWinRTPath)lib\net8.0\WinRT.Host.Shim.dll">
       <TargetPath>WinRT.Host.Shim.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
     </None>
 
     <None Condition="Exists('$(CsWinRTPath)hosting\$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll')" 
           Include="$(CsWinRTPath)hosting\$(CsWinRTAuthoring_Platform)\native\WinRT.Host.dll">
       <TargetPath>WinRT.Host.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
     </None>
 
     <None Condition="Exists('$(CsWinRTPath)hosting\$(CsWinRTAuthoring_Platform)\native\en-US\WinRT.Host.dll.mui')"
           Include="$(CsWinRTPath)hosting\$(CsWinRTAuthoring_Platform)\native\en-US\WinRT.Host.dll.mui">
       <TargetPath>WinRT.Host.dll.mui</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
     </None>
 
  </ItemGroup>


### PR DESCRIPTION
## Summary

Mark the `WinRT.Host.dll`, `WinRT.Host.dll.mui` and `WinRT.Host.Shim.dll` items added by the authoring targets with `Visible=false`, so they no longer show up as project items in Solution Explorer. This is the CsWinRT 2.x counterpart of #2500, which makes the same change for 3.0. Both address #2499.

## Motivation

When a project authors a Windows Runtime component, `Microsoft.Windows.CsWinRT.Authoring.targets` adds three `None` items in an evaluation-time `ItemGroup` so the hosting assets get copied to the output directory. Because these items are created at evaluation time (as opposed to the `Content` items in the packaging target, which are only created while the target runs), Visual Studio surfaces them as regular project items in Solution Explorer.

These are purely build/runtime assets that come out of the CsWinRT NuGet package. Users are never meant to interact with them from Solution Explorer, and having them listed there is just noise (they also look out of place, since they're the only items in the project that live outside the project directory).

## Changes

- **`nuget/Microsoft.Windows.CsWinRT.Authoring.targets`**: add `<Visible>false</Visible>` metadata to the three hosting asset `None` items, and update the surrounding comment to explain why.

Note that `Visible` only affects how the items are displayed by the IDE, so the assets are still copied to the output directory exactly as before. This was verified by evaluating the targets file (all three items are still produced, with `CopyToOutputDirectory=PreserveNewest` intact) and by building a small project with equivalent items, which still copies both files to the output directory.
