### PR TITLE
Make debug repro packing resilient to repeated input paths

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Test-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Test-Steps.yml
@@ -38,6 +38,20 @@ steps:
         --no-build
       testRunTitle: Source Generator 2 Tests
 
+# Run WinMD Generator Tests. Gated to x64 only for the same reason as the source generator tests: these
+# run the 'cswinrtwinmdgen' tool end-to-end as a separate process (which is always built for the build
+# host), so the target platform makes no difference to what they cover.
+  - task: DotNetCoreCLI@2
+    displayName: Run WinMD Generator Tests
+    condition: and(succeeded(), eq(variables['BuildPlatform'], 'x64'))
+    inputs:
+      command: test
+      projects: 'src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj'
+      arguments: >
+        /p:platform=$(BuildPlatform);configuration=$(BuildConfiguration)
+        --no-build
+      testRunTitle: WinMD Generator Tests
+
 # Run Host Tests
   - task: CmdLine@2
     displayName: Run Host Tests

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -75,6 +75,47 @@ internal static class WinMDGeneratorRunner
     }
 
     /// <summary>
+    /// Asserts that the generator saves a debug repro for a caller-provided response file, and that
+    /// replaying that debug repro also succeeds.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="responseFileFactory"/> receives a fresh temporary working directory and the
+    /// directory to point <c>--debug-repro-directory</c> at, and returns the full response file content.
+    /// </remarks>
+    /// <param name="responseFileFactory">Builds the full response file content for the given directories.</param>
+    public static void AssertDebugReproRoundTrips(Func<string, string, string> responseFileFactory)
+    {
+        string toolPath = GetGeneratorPath();
+        string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
+
+        try
+        {
+            string debugReproDirectory = Directory.CreateDirectory(Path.Combine(temporaryDirectory, "repro")).FullName;
+            string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
+
+            File.WriteAllText(responseFilePath, responseFileFactory(temporaryDirectory, debugReproDirectory));
+
+            (int exitCode, string output) = RunTool(toolPath, responseFilePath);
+
+            Assert.AreEqual(0, exitCode, output);
+
+            string debugReproPath = Path.Combine(debugReproDirectory, "winmd-debug-repro.zip");
+
+            Assert.IsTrue(File.Exists(debugReproPath), $"The debug repro was not saved to '{debugReproPath}'.");
+
+            // Replaying the saved archive validates that the packed inputs and the path maps inside
+            // it are consistent, and not just that saving the archive happened to not throw
+            (exitCode, output) = RunTool(toolPath, debugReproPath);
+
+            Assert.AreEqual(0, exitCode, output);
+        }
+        finally
+        {
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    /// <summary>
     /// Compiles the given C# <paramref name="source"/> into <c>TestInput.dll</c> in <paramref name="directory"/>.
     /// </summary>
     /// <remarks>
@@ -218,7 +259,7 @@ internal static class WinMDGeneratorRunner
         {
             Directory.Delete(directory, recursive: true);
         }
-        catch (IOException)
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
             // Best effort cleanup; a leftover temp directory must not fail the test
         }

--- a/src/Tests/WinMDGeneratorTest/Test_DebugRepro.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_DebugRepro.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+using WinMDGeneratorTest.Helpers;
+
+namespace WinMDGeneratorTest;
+
+/// <summary>
+/// End-to-end tests for the WinMD generator's debug repro support.
+/// </summary>
+/// <remarks>
+/// These tests run the actual <c>cswinrtwinmdgen</c> tool with <c>--debug-repro-directory</c>, and then
+/// replay the resulting archive. They cover the shared packing logic in <c>WinRT.Generator.Core</c>, which
+/// every CsWinRT build tool uses, so a regression here would break debug repros for all of them.
+/// </remarks>
+[TestClass]
+public class Test_DebugRepro
+{
+    [TestMethod]
+    public void DebugRepro_IsSavedAndCanBeReplayed()
+    {
+        WinMDGeneratorRunner.AssertDebugReproRoundTrips(static (temporaryDirectory, debugReproDirectory) =>
+        {
+            string inputAssemblyPath = WinMDGeneratorRunner.CompileComponent("""
+                public interface IComponent
+                {
+                    int Method(int value);
+                }
+                """, temporaryDirectory);
+
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                --debug-repro-directory {debugReproDirectory}
+                """;
+        });
+    }
+
+    [TestMethod]
+    public void DebugRepro_WithRepeatedInputPaths_IsSavedAndCanBeReplayed()
+    {
+        // MSBuild item lists are not deduplicated, and several targets contribute to the same reference
+        // sets (e.g. '@(ReferencePathWithRefAssemblies)'), so the same path can reach the generators more
+        // than once. Packing a debug repro must tolerate that instead of failing the whole build.
+        WinMDGeneratorRunner.AssertDebugReproRoundTrips(static (temporaryDirectory, debugReproDirectory) =>
+        {
+            string inputAssemblyPath = WinMDGeneratorRunner.CompileComponent("""
+                public interface IComponent
+                {
+                    int Method(int value);
+                }
+                """, temporaryDirectory);
+
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath},{inputAssemblyPath}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                --debug-repro-directory {debugReproDirectory}
+                """;
+        });
+    }
+
+    [TestMethod]
+    public void DebugRepro_WithRepeatedReadOnlyInputPaths_IsSavedAndCanBeReplayed()
+    {
+        // Input files can be read-only (e.g. in enlistment-style builds), and 'File.Copy' propagates that
+        // attribute to the staged copies. Staging the same file twice would then fail on the read-only
+        // destination, and leaving the copies read-only would make the staging directory undeletable.
+        WinMDGeneratorRunner.AssertDebugReproRoundTrips(static (temporaryDirectory, debugReproDirectory) =>
+        {
+            string inputAssemblyPath = WinMDGeneratorRunner.CompileComponent("""
+                public interface IComponent
+                {
+                    int Method(int value);
+                }
+                """, temporaryDirectory);
+
+            File.SetAttributes(inputAssemblyPath, File.GetAttributes(inputAssemblyPath) | FileAttributes.ReadOnly);
+
+            return $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath},{inputAssemblyPath}
+                --output-winmd-path {Path.Combine(temporaryDirectory, "TestInput.winmd")}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections False
+                --debug-repro-directory {debugReproDirectory}
+                """;
+        });
+    }
+}

--- a/src/WinRT.Generator.Core/DebugRepro/DebugReproPacker.cs
+++ b/src/WinRT.Generator.Core/DebugRepro/DebugReproPacker.cs
@@ -42,6 +42,12 @@ internal static class DebugReproPacker
     /// <summary>
     /// Copies all specified files to a target folder using hashed file names, and returns the list of updated names.
     /// </summary>
+    /// <remarks>
+    /// The same path can legitimately appear more than once in <paramref name="filePaths"/>, as MSBuild item lists
+    /// are not deduplicated and several targets can contribute to the same reference set. Repeated entries are
+    /// still reported in the returned list (so the rebuilt response file matches the original invocation), but
+    /// they are only staged and recorded once.
+    /// </remarks>
     /// <param name="filePaths">The input file paths.</param>
     /// <param name="destinationDirectory">The target directory to copy the files to.</param>
     /// <param name="originalPaths">A dictionary to store the original paths of the copied files (keyed by hashed file name).</param>
@@ -59,13 +65,7 @@ internal static class DebugReproPacker
         {
             token.ThrowIfCancellationRequested();
 
-            string hashedName = GetHashedFileName(filePath);
-            string destinationPath = Path.Combine(destinationDirectory, hashedName);
-
-            File.Copy(filePath, destinationPath, overwrite: true);
-
-            updatedFileNames.Add(hashedName);
-            originalPaths.Add(hashedName, filePath);
+            updatedFileNames.Add(CopyHashedFile(filePath, destinationDirectory, originalPaths));
         }
 
         return updatedFileNames;
@@ -76,8 +76,8 @@ internal static class DebugReproPacker
     /// </summary>
     /// <remarks>
     /// This is the simple variant used by the impl, projection, projection-ref, and WinMD generators.
-    /// The interop generator keeps its own variant locally (which adds reserved-DLL dedupe and throws
-    /// on path mismatches against the shared reference set).
+    /// The interop generator keeps its own variant locally (which additionally validates that a reserved
+    /// .dll was passed with the same path in the shared reference set).
     /// </remarks>
     /// <param name="filePath">The input file path, or <see langword="null"/> to skip.</param>
     /// <param name="destinationDirectory">The target directory to copy the file to.</param>
@@ -96,14 +96,41 @@ internal static class DebugReproPacker
             return null;
         }
 
+        token.ThrowIfCancellationRequested();
+
+        return CopyHashedFile(filePath, destinationDirectory, originalPaths);
+    }
+
+    /// <summary>
+    /// Stages a single input file into a target folder using its hashed file name, and records its original path.
+    /// </summary>
+    /// <param name="filePath">The input file path.</param>
+    /// <param name="destinationDirectory">The target directory to copy the file to.</param>
+    /// <param name="originalPaths">A dictionary to store the original path of the copied file (keyed by hashed file name).</param>
+    /// <returns>The hashed filename of the staged file.</returns>
+    private static string CopyHashedFile(
+        string filePath,
+        string destinationDirectory,
+        Dictionary<string, string> originalPaths)
+    {
         string hashedName = GetHashedFileName(filePath);
         string destinationPath = Path.Combine(destinationDirectory, hashedName);
 
-        File.Copy(filePath, destinationPath, overwrite: true);
+        // Hashed names are derived from the full original path, so a file already staged at this exact
+        // destination was necessarily copied from this exact source, and staging it again is a no-op.
+        // The check is per destination folder, as the same file can legitimately also be staged under
+        // another folder of the same repro (e.g. as both the input assembly and a reference assembly).
+        if (!File.Exists(destinationPath))
+        {
+            File.Copy(filePath, destinationPath);
 
-        token.ThrowIfCancellationRequested();
+            // Clear the read-only attribute, which 'File.Copy' propagates from the source file. Inputs can
+            // be read-only (e.g. in enlistment-style builds), and leaving the staged copies read-only would
+            // make it impossible to delete the staging directory once the archive has been created.
+            File.SetAttributes(destinationPath, File.GetAttributes(destinationPath) & ~FileAttributes.ReadOnly);
+        }
 
-        originalPaths.Add(hashedName, filePath);
+        _ = originalPaths.TryAdd(hashedName, filePath);
 
         return hashedName;
     }

--- a/src/WinRT.Impl.Generator/Generation/ImplGenerator.DebugRepro.cs
+++ b/src/WinRT.Impl.Generator/Generation/ImplGenerator.DebugRepro.cs
@@ -91,15 +91,17 @@ internal static partial class ImplGenerator
             // Extract the .dll to the new destination path
             dllEntry.ExtractToFile(destinationPath, overwrite: true);
 
-            // Track all extracted reference paths, as well as the output assembly path.
+            // Track all extracted reference paths, as well as the output assembly path. The output
+            // assembly is the only entry at the top level, so entries in the 'reference' subfolder
+            // are always references, even when the same file was also passed as the output assembly.
             // Note that the debug repro only uses filenames, not full paths, for .dll-s.
-            if (dllEntry.Name == args.OutputAssemblyPath)
-            {
-                outputAssemblyPath = destinationPath;
-            }
-            else if (isReferenceDll)
+            if (isReferenceDll)
             {
                 referencePaths.Add(destinationPath);
+            }
+            else if (dllEntry.Name == args.OutputAssemblyPath)
+            {
+                outputAssemblyPath = destinationPath;
             }
             else
             {

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.DebugRepro.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.DebugRepro.cs
@@ -299,13 +299,18 @@ internal partial class InteropGenerator
         Dictionary<string, string> originalPaths,
         CancellationToken token)
     {
+        if (filePath is null)
+        {
+            return null;
+        }
+
+        string hashedName = DebugReproPacker.GetHashedFileName(filePath);
+
         // A private implementation detail assembly (e.g. 'WinRT.Projection.dll') is expected to already be in
         // the original paths at this point, as it is also passed via the reference set. A hashed name that maps
         // to a different original path would instead mean it was passed with two different paths, which should
         // never happen (it's invalid), so validate that before staging the file.
-        if (filePath is not null &&
-            originalPaths.TryGetValue(DebugReproPacker.GetHashedFileName(filePath), out string? originalPath) &&
-            originalPath != filePath)
+        if (originalPaths.TryGetValue(hashedName, out string? originalPath) && originalPath != filePath)
         {
             string fileName = Path.GetFileName(Path.Normalize(filePath));
 

--- a/src/WinRT.Interop.Generator/Generation/InteropGenerator.DebugRepro.cs
+++ b/src/WinRT.Interop.Generator/Generation/InteropGenerator.DebugRepro.cs
@@ -116,20 +116,22 @@ internal partial class InteropGenerator
             // Extract the .dll to the new destination path
             dllEntry.ExtractToFile(destinationPath, overwrite: true);
 
-            // Track all extracted reference paths, as well as the output assembly path.
+            // Track all extracted reference paths, as well as the output assembly path. The output
+            // assembly is the only entry at the top level, so entries in a category subfolder always
+            // belong to that category, even when the same file was also passed as the output assembly.
             // Note that the debug repro only uses filenames, not full paths, for .dll-s.
             // We also split reference paths and implementation paths in different folders.
-            if (dllEntry.Name == args.OutputAssemblyPath)
-            {
-                outputAssemblyPath = destinationPath;
-            }
-            else if (isReferenceDll)
+            if (isReferenceDll)
             {
                 referencePaths.Add(destinationPath);
             }
             else if (isImplementationDll)
             {
                 implementationPaths.Add(destinationPath);
+            }
+            else if (dllEntry.Name == args.OutputAssemblyPath)
+            {
+                outputAssemblyPath = destinationPath;
             }
             else
             {
@@ -274,15 +276,15 @@ internal partial class InteropGenerator
     }
 
     /// <summary>
-    /// Copies a single specified file to a target folder, with reserved-DLL dedupe.
+    /// Copies a single specified file to a target folder, validating reserved .dll-s.
     /// </summary>
     /// <remarks>
-    /// The interop generator keeps a local variant (instead of using the shared
+    /// The interop generator keeps a local variant (wrapping the shared
     /// <see cref="DebugReproPacker.CopyHashedFileToDirectory(string?, string, Dictionary{string, string}, CancellationToken)"/>)
     /// to handle the private implementation-detail assemblies (<c>WinRT.Sdk.Projection.dll</c>, <c>WinRT.Sdk.Xaml.Projection.dll</c>,
     /// <c>WinRT.Projection.dll</c>, <c>WinRT.Component.dll</c>) that are passed both via the reference set and
-    /// explicitly via dedicated properties. When the same path is already in the map (under the same hashed name),
-    /// the copy is skipped; if the hashed name collides but the original paths differ, that's a real bug and we
+    /// explicitly via dedicated properties. Staging those just once is handled by the shared helper; if the hashed
+    /// name collides but the original paths differ, that's a real bug and we
     /// throw <see cref="WellKnownInteropExceptions.ReservedDllOriginalPathMismatchFromDebugRepro(string)"/>.
     /// </remarks>
     /// <param name="filePath">The input file path, or <see langword="null"/> to skip.</param>
@@ -297,41 +299,19 @@ internal partial class InteropGenerator
         Dictionary<string, string> originalPaths,
         CancellationToken token)
     {
-        if (filePath is null)
-        {
-            return null;
-        }
-
-        string hashedName = DebugReproPacker.GetHashedFileName(filePath);
-
-        // Special case for private implementation detail assemblies (e.g. 'WinRT.Projection.dll') that are
-        // both passed via the reference set, but also explicitly as separate properties. In that case, we
-        // expect that those should already be in the original paths at this point. So we validate that
-        // the path actually matches, and simply do nothing if that's the case, as this is intended.
-        if (originalPaths.TryGetValue(hashedName, out string? originalPath) && originalPath == filePath)
-        {
-            return hashedName;
-        }
-
-        // If we get to this point, it means that either a private implementation assembly was passed with a
-        // different path than the one provided to the reference set, which should never happen (it's invalid).
-        if (originalPaths.ContainsKey(hashedName))
+        // A private implementation detail assembly (e.g. 'WinRT.Projection.dll') is expected to already be in
+        // the original paths at this point, as it is also passed via the reference set. A hashed name that maps
+        // to a different original path would instead mean it was passed with two different paths, which should
+        // never happen (it's invalid), so validate that before staging the file.
+        if (filePath is not null &&
+            originalPaths.TryGetValue(DebugReproPacker.GetHashedFileName(filePath), out string? originalPath) &&
+            originalPath != filePath)
         {
             string fileName = Path.GetFileName(Path.Normalize(filePath));
 
             throw WellKnownInteropExceptions.ReservedDllOriginalPathMismatchFromDebugRepro(fileName);
         }
 
-        string destinationPath = Path.Combine(destinationDirectory, hashedName);
-
-        // After validating that the file is unique and should be copied, we can safely do that. We move
-        // this operation to ensure we don't accidentally end up with duplicated .dll-s in the debug repro.
-        File.Copy(filePath, destinationPath, overwrite: true);
-
-        token.ThrowIfCancellationRequested();
-
-        originalPaths.Add(hashedName, filePath);
-
-        return hashedName;
+        return DebugReproPacker.CopyHashedFileToDirectory(filePath, destinationDirectory, originalPaths, token);
     }
 }

--- a/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.DebugRepro.cs
+++ b/src/WinRT.WinMD.Generator/Generation/WinMDGenerator.DebugRepro.cs
@@ -152,12 +152,10 @@ internal static partial class WinMDGenerator
             // Extract the file to the new destination path
             assemblyEntry.ExtractToFile(destinationPath, overwrite: true);
 
-            // Track the extracted paths per category
-            if (assemblyEntry.Name == args.InputAssemblyPath)
-            {
-                inputAssemblyPath = destinationPath;
-            }
-            else if (isReferenceAssembly)
+            // Track the extracted paths per category. The input assembly is the only entry at the top
+            // level, so entries in a category subfolder always belong to that category, even when the
+            // same file was also passed as the input assembly.
+            if (isReferenceAssembly)
             {
                 referencePaths.Add(destinationPath);
             }
@@ -167,8 +165,13 @@ internal static partial class WinMDGenerator
             }
             else if (!isWindowsMetadataAssembly)
             {
-                // We should never hit this case, so throw to validate that the debug repro is valid.
-                throw WellKnownWinMDExceptions.DebugReproUnrecognizedFileEntry(assemblyEntry.FullName);
+                // Any other top-level entry means the debug repro is not valid, so throw to validate it
+                if (assemblyEntry.Name != args.InputAssemblyPath)
+                {
+                    throw WellKnownWinMDExceptions.DebugReproUnrecognizedFileEntry(assemblyEntry.FullName);
+                }
+
+                inputAssemblyPath = destinationPath;
             }
         }
 


### PR DESCRIPTION
## Problem

All five CsWinRT build tools support a **debug repro**: with `--debug-repro-directory` set they package every input file plus a faithful `.rsp` into a self-contained `.zip` that can be replayed by passing the `.zip` back to the tool. Files are staged under a name derived from a SHA-256 of their **full original path**, and that name is then used as the key of the original-path map.

MSBuild item lists are not deduplicated, and several targets contribute to the same reference sets, so the same path routinely reaches a generator more than once. `@(ReferencePathWithRefAssemblies)` really does end up with e.g. `Microsoft.CSharp.dll` listed twice. `originalPaths.Add(...)` then threw, and the whole build failed:

```
error CSWINRTPROJECTIONGEN9999: The CsWinRT projection generator failed with an unhandled exception
('ArgumentException': 'Argument_AddingDuplicateWithKey, Microsoft.CSharp_5FB6655A486AE16885AE02CEFF80DE94.dll')
during the 'save-debug-repro' phase.
```

This is reproducible on `staging/3.0` today by building any project with `-p:CsWinRTGeneratorDebugReproDirectory=<dir>`. It is how I found it: I could not capture an `interop-debug-repro.zip` to attach to an upstream issue, because asking for one broke the build.

## Fix

Staging is now deduplicated **per destination folder**. The hashed name is path-derived, so a file already staged at a given destination necessarily came from the exact same source and staging it again is a no-op. The check is deliberately per-folder rather than "already in the map", because the same file can legitimately be staged under two folders of the same repro (e.g. as both the input assembly and a reference assembly), and both copies are load-bearing. The returned name list still mirrors the original argument list, so the packed `.rsp` stays faithful.

Two related issues surfaced while writing the tests and are fixed here too:

- **Read-only inputs.** `File.Copy` propagates the read-only attribute, so a read-only input (normal in enlistment-style builds) left a read-only staged copy behind. Staging it twice failed with `UnauthorizedAccessException`, and `Directory.Delete(recursive: true)` on the staging directory failed as well. The attribute is now cleared on each staged copy.
- **Unpack mis-attribution.** The single top-level file (the input/output assembly) was matched by entry name *before* the category subfolder was checked. Since entry names are the path-derived hashed names, a file staged both at the top level and inside a subfolder had its subfolder entry mis-claimed as the top-level file and dropped from its category — producing an archive that saved fine but failed to replay with `CSWINRTWINMDGEN0003: Failed to parse argument 'ReferenceAssemblyPaths'`. Category subfolders now win; the top-level entry is still validated by name.

As a side effect the interop generator's local `CopyHashedFileToDirectory` shrinks to just the reserved-`.dll` path validation and defers staging to the shared helper, which also removes the same latent skip bug from it.

## Tests

Three new tests in `src/Tests/WinMDGeneratorTest/Test_DebugRepro.cs`, driving the real `cswinrtwinmdgen` end-to-end. Each saves an archive **and replays it**, so a repro that saves but cannot be replayed still fails. Each one fails on `staging/3.0` with a distinct symptom:

| Test | Symptom without the fix |
|---|---|
| `DebugRepro_IsSavedAndCanBeReplayed` | `ArgumentException: Argument_AddingDuplicateWithKey` |
| `DebugRepro_WithRepeatedInputPaths_IsSavedAndCanBeReplayed` | `ArgumentException: Argument_AddingDuplicateWithKey` |
| `DebugRepro_WithRepeatedReadOnlyInputPaths_IsSavedAndCanBeReplayed` | `UnauthorizedAccessException` on the staged copy |

Reverting only the unpack-ordering change instead makes the first two fail with `CSWINRTWINMDGEN0003` on replay, so that half is load-bearing too.

`WinMDGeneratorTest` has never been run in CI (it was added in #2443 and only ever built), so it is also wired into `CsWinRT-Test-Steps.yml`, x64-only, mirroring the source generator tests.

## Validation

- `WinMDGeneratorTest`: 17/17 pass with the fix, 14/17 without it (the 3 new ones fail).
- Real end-to-end: building `ObjectLifetimeTests.Lifted` with `-p:CsWinRTGeneratorDebugReproDirectory=<dir>` fails on `staging/3.0` and succeeds here, producing both `interop-debug-repro.zip` (21 MB) and `projection-debug-repro.zip` (16 MB).
- Both of those archives were then replayed successfully through `cswinrtinteropgen.exe` / `cswinrtprojectiongen.exe`, each emitting its output assembly.
