### PR TITLE
Project the Windows Runtime [Experimental] attribute as the .NET one

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -739,6 +739,7 @@ All five .NET build tools (`cswinrtprojectionrefgen`, `cswinrtprojectiongen`, `c
 | Interop Generator | `CSWINRTINTEROPGENxxxx` | `0001`–`0100`, `9999` |
 | WinMD Generator | `CSWINRTWINMDGENxxxx` | `0001`–`0014`, `9999` |
 | Runtime (obsolete markers) | `CSWINRT3xxx` | `CSWINRT3001` (deriving from `WindowsRuntimeObject`), `CSWINRT3002` (type map group types), `CSWINRT3003` (component authoring attributes), `CSWINRT3004` (`WindowsRuntimeReferenceAssemblyAttribute`) |
+| Projections (user-facing markers) | `CSWINRT3xxx` | `CSWINRT3005` (using an experimental Windows Runtime API; emitted by the projection writer as `[Experimental]`, see `docs/attribute-projections.md`) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Generated C# source can be compiled into interop assemblies, similar to how [C++
 - [C#/WinRT version history](docs/version-history.md)
 - [Repository structure](docs/structure.md)
 - [COM Interop guide](docs/interop.md)
+- [Attribute projections](docs/attribute-projections.md)
 - [Object lifetime and reference tracking](docs/memory-management.md)
 - Related projects
     - [xlang](https://github.com/microsoft/xlang)

--- a/docs/attribute-projections.md
+++ b/docs/attribute-projections.md
@@ -1,0 +1,61 @@
+# Attribute projections
+
+## Overview
+
+Most Windows Runtime attributes are projected like any other Windows Runtime type: the attribute type itself is projected into C#, and every application of it is carried over onto the projected member. A handful are **custom-projected** instead: CsWinRT replaces them with a .NET attribute that models the same concept, or consumes them without ever emitting them.
+
+There are two reasons to do that:
+
+- **A .NET counterpart already exists.** `[Windows.Foundation.Metadata.Deprecated]` and `[Obsolete]`, or `[Windows.Foundation.Metadata.Experimental]` and `[Experimental]`, mean the same thing. Projecting the Windows Runtime one as-is would leave the .NET tooling (compilers, analyzers, IDEs) unable to act on it.
+- **The attribute is metadata for CsWinRT itself.** `[Guid]` becomes the interface IID, `[AllowMultiple]` becomes part of the projected `[AttributeUsage]`, and `[Default]`, `[ExclusiveTo]`, `[Activatable]` and friends shape the generated code. Carrying them over would add permanent metadata that nothing reads.
+
+This document is the reference for those cases, in both directions: `.winmd` → C# (**projection**, what a consumer sees) and C# → `.winmd` (**authoring**, what a component author writes). Everything not listed explicitly is covered by the catch-all row at the end of each table.
+
+## Projection (`.winmd` → C#)
+
+What CsWinRT emits for a Windows Runtime attribute application when projecting Windows Runtime metadata into C#.
+
+The **Modes** column says which projection assemblies the result lands in. Reference projections are what user code, compilers, analyzers and metadata tooling compile against; implementation projections are only ever loaded at runtime. Attribute blobs cannot be trimmed by ILLink or ILC, so anything emitted into an implementation projection is permanent, unremovable metadata in the shipped application. Anything whose only consumer is a compiler or analyzer is therefore reference-projection-only.
+
+| Windows Runtime metadata | Projected as | Modes |
+| --- | --- | --- |
+| `[Windows.Foundation.Metadata.Deprecated(message, DeprecationType.Deprecate, ...)]` | `[System.Obsolete(message)]` | both |
+| `[Windows.Foundation.Metadata.Deprecated(message, DeprecationType.Remove, ...)]` | *nothing* — a removed member is omitted from the projection, and its ABI vtable slot is preserved but stubbed to return `E_NOTIMPL`; a removed type is omitted from the projection and the ABI alike | both |
+| `[Windows.Foundation.Metadata.Experimental]` | `[System.Diagnostics.CodeAnalysis.Experimental("CSWINRT3005", UrlFormat = ..., Message = ...)]`, see [CSWINRT3005](diagnostics/cswinrt3005.md) | reference only |
+| `[Windows.Foundation.Metadata.AttributeUsage(targets)]` | `[System.AttributeUsage(targets)]`, with `Windows.Foundation.Metadata.AttributeTargets` mapped to `System.AttributeTargets` | both |
+| `[Windows.Foundation.Metadata.AllowMultiple]` | *nothing on its own* — it is folded into the `AllowMultiple` argument of the projected `[AttributeUsage]` (which is synthesized if the metadata declares none) | both |
+| `[Windows.Foundation.Metadata.Guid(...)]` | `[System.Runtime.InteropServices.Guid("...")]`, as the IID of the projected interface or delegate | both |
+| `[Windows.Foundation.Metadata.ContractVersion(contract, version)]` | itself, plus a synthesized `[System.Runtime.Versioning.SupportedOSPlatform("WindowsX.Y.Z.0")]` for the first contract that maps to a Windows release | reference only |
+| `[Windows.Foundation.Metadata.GCPressure]`, `[Windows.Foundation.Metadata.Version]`, and every other `Windows.Foundation.Metadata` attribute not listed above | *nothing* — they are either consumed to shape the generated code (`[Default]`, `[ExclusiveTo]`, `[Activatable]`, `[Static]`, `[Composable]`, `[Overridable]`, `[FastAbi]`, ...) or have no meaning in a .NET projection | — |
+| `[Windows.Foundation.Metadata.Overload(name)]`, `[Windows.Foundation.Metadata.DefaultOverload]`, and attributes from any other namespace (e.g. `[Microsoft.UI.Xaml.TemplatePart]`) | themselves — those attribute types are projected too, so their applications are carried over unchanged | reference only |
+
+Two consequences of the custom-mapped rows are worth calling out, because they are the ones that show up as "missing" types:
+
+- `Windows.Foundation.Metadata.ExperimentalAttribute`, `AttributeUsageAttribute` and `AttributeTargets` are **not** projected as types, since their .NET counterparts take their place. `ApiContractAttribute` and `ContractVersionAttribute` are not projected either: they are shipped by `WinRT.Runtime.dll` instead, so that projections can apply them without redefining them.
+- `DeprecatedAttribute`, `DeprecationType`, `OverloadAttribute`, `DefaultOverloadAttribute`, `VersionAttribute` and the rest of `Windows.Foundation.Metadata` **are** projected as ordinary types, so component authors can apply them (see the next section).
+
+Generated projection code suppresses `CS0612`/`CS0618` and `CSWINRT3005`: a projection has to name a deprecated or experimental type in order to project it at all, so those markers are guidance for the consumers of a projection, not for the projection itself. The suppressions are per file, so user code calling such an API still gets the diagnostic.
+
+## Authoring (C# → `.winmd`)
+
+What the WinMD generator emits into an authored component's `.winmd` for an attribute applied in C#.
+
+| C# attribute | Emitted into the `.winmd` as | Notes |
+| --- | --- | --- |
+| `[System.Diagnostics.CodeAnalysis.Experimental(id, ...)]` | `[Windows.Foundation.Metadata.Experimental]` | The diagnostic id, `UrlFormat` and `Message` are dropped: Windows Runtime metadata has nowhere to carry them, and CsWinRT synthesizes its own when the component is projected back. On a property or event the attribute is emitted on the accessor method, matching MIDL. |
+| `[Windows.Foundation.Metadata.Deprecated(...)]` | itself | On a property or event it is emitted on the accessor method, matching MIDL. |
+| `[System.Runtime.InteropServices.Guid("...")]` | `[Windows.Foundation.Metadata.Guid(...)]` | Without one, the IID is derived from the type name (UUID v5, as MIDL does). |
+| `[System.AttributeUsage(targets)]` | `[Windows.Foundation.Metadata.AttributeUsage(targets)]`, with `System.AttributeTargets` mapped to `Windows.Foundation.Metadata.AttributeTargets` | |
+| `[System.Flags]` | itself | Windows Runtime metadata uses the same `System.FlagsAttribute` for flag enums. |
+| `[Windows.Foundation.Metadata.Version(v)]` | itself | Emitted from the value the author specified, or the component's assembly major version when absent. |
+| `[Windows.Foundation.Metadata.Overload(name)]` | itself | Emitted with the author-specified name, or a generated one for overloads that need disambiguating. |
+| `[WindowsRuntime.Xaml.GeneratedCustomPropertyProvider]`, `[System.Reflection.DefaultMember]`, and anything under `System.Runtime.CompilerServices` | *nothing* | Either handled by CsWinRT itself or meaningless in Windows Runtime metadata. |
+| Any other public attribute type | itself | Non-public attribute types, and attributes whose signature cannot be read, are skipped. |
+
+> **Note**: `[System.Obsolete]` is **not** translated into `[Windows.Foundation.Metadata.Deprecated]`. It is copied as-is, so it is invisible to every other language projection. Use `[Windows.Foundation.Metadata.Deprecated]` to deprecate an API of an authored component. `[Experimental]` is the exception to that rule only because the Windows Runtime attribute has no projected form to apply.
+
+## Related documentation
+
+- [CSWINRT3005](diagnostics/cswinrt3005.md): using an experimental Windows Runtime API
+- [Authoring C#/WinRT components](authoring.md)
+- [CsWinRT 3.0 overview](cswinrt3.0-spec.md)

--- a/docs/attribute-projections.md
+++ b/docs/attribute-projections.md
@@ -42,7 +42,7 @@ What the WinMD generator emits into an authored component's `.winmd` for an attr
 
 | C# attribute | Emitted into the `.winmd` as | Notes |
 | --- | --- | --- |
-| `[System.Diagnostics.CodeAnalysis.Experimental(id, ...)]` | `[Windows.Foundation.Metadata.Experimental]` | The diagnostic id, `UrlFormat` and `Message` are dropped: Windows Runtime metadata has nowhere to carry them, and CsWinRT synthesizes its own when the component is projected back. On a property or event the attribute is emitted on the accessor method, matching MIDL. |
+| `[System.Diagnostics.CodeAnalysis.Experimental(id, ...)]` | `[Windows.Foundation.Metadata.Experimental]` | The diagnostic id, `UrlFormat` and `Message` are dropped: Windows Runtime metadata has nowhere to carry them, and CsWinRT synthesizes its own when the component is projected back. On a property or event the attribute is emitted on the accessor method, matching MIDL. On an assembly, a module or a constructor it is dropped, and reported as [CSWINRT2021](#cswinrt2021-unsupported-experimental-targets). |
 | `[Windows.Foundation.Metadata.Deprecated(...)]` | itself | On a property or event it is emitted on the accessor method, matching MIDL. |
 | `[System.Runtime.InteropServices.Guid("...")]` | `[Windows.Foundation.Metadata.Guid(...)]` | Without one, the IID is derived from the type name (UUID v5, as MIDL does). |
 | `[System.AttributeUsage(targets)]` | `[Windows.Foundation.Metadata.AttributeUsage(targets)]`, with `System.AttributeTargets` mapped to `Windows.Foundation.Metadata.AttributeTargets` | |
@@ -53,6 +53,15 @@ What the WinMD generator emits into an authored component's `.winmd` for an attr
 | Any other public attribute type | itself | Non-public attribute types, and attributes whose signature cannot be read, are skipped. |
 
 > **Note**: `[System.Obsolete]` is **not** translated into `[Windows.Foundation.Metadata.Deprecated]`. It is copied as-is, so it is invisible to every other language projection. Use `[Windows.Foundation.Metadata.Deprecated]` to deprecate an API of an authored component. `[Experimental]` is the exception to that rule only because the Windows Runtime attribute has no projected form to apply.
+
+### CSWINRT2021: unsupported `[Experimental]` targets
+
+The .NET `[Experimental]` attribute supports more targets than the Windows Runtime one it is translated into. Types (runtime classes, interfaces, structs, enums and delegates), methods, properties, events and fields (individual enum members and struct fields) all translate; **assemblies**, **modules** and **constructors** have no Windows Runtime metadata target that can carry the marker:
+
+- An assembly or a module has no counterpart at all: the generator produces a fresh `.winmd` containing only the authored types.
+- A constructor is exposed through an activation factory method (`IFooFactory.CreateFoo`), and the `.ctor` row on the runtime class is not where markers live. MIDL never emits one there, and no `.ctor` row in the Windows SDK carries a `[Deprecated]` or `[Experimental]` attribute.
+
+Rather than emit the marker where nothing would read it, which would silently make the API look stable to every other language projection, those applications are dropped and `CSWINRT2021` reports them at the source. Mark the whole runtime class as experimental to cover its constructors.
 
 ## Related documentation
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -256,6 +256,8 @@ C#/WinRT supports authoring out-of-process components that can be consumed by Wi
 
 Here are some resources that demonstrate authoring C#/WinRT components and the details discussed in this document.
 
+See also [attribute projections](attribute-projections.md), which covers the attributes CsWinRT translates between C# and Windows Runtime metadata (for instance, how to mark an authored API as deprecated or experimental).
+
 1. [Simple C#/WinRT component sample](https://github.com/microsoft/CsWinRT/tree/master/src/Samples/AuthoringDemo) and associated [walkthrough on creating a C#/WinRT component and consuming it from C++/WinRT](https://docs.microsoft.com/windows/uwp/csharp-winrt/create-windows-runtime-component-cswinrt) 
 
 2. [Background Task component sample](https://github.com/microsoft/CsWinRT/tree/master/src/Samples/BgTaskComponent) demonstrating consuming an out-of-process C#/WinRT component from a packaged .NET WPF app

--- a/docs/diagnostics/cswinrt3005.md
+++ b/docs/diagnostics/cswinrt3005.md
@@ -1,0 +1,45 @@
+# CsWinRT error CSWINRT3005
+
+Windows Runtime APIs can be marked as experimental in their Windows Runtime metadata, with the `[Windows.Foundation.Metadata.Experimental]` attribute (`[experimental]` in MIDL). Such an API is published for evaluation purposes only: it can change shape or be removed entirely in any future Windows SDK, with no compatibility guarantee. CsWinRT projects that marker as `[System.Diagnostics.CodeAnalysis.Experimental]` with the `CSWINRT3005` diagnostic id, so the compiler reports every use site.
+
+For instance, the following sample generates CSWINRT3005:
+
+```csharp
+using Windows.Graphics.Capture;
+
+// CSWINRT3005: 'IDisplayGraphicsCaptureSession' is marked as experimental
+void Capture(IDisplayGraphicsCaptureSession session)
+{
+}
+```
+
+## Additional resources
+
+`CSWINRT3005` is reported when user code references a Windows Runtime API that CsWinRT projected with `[Experimental]`. Windows Runtime metadata has no per-API diagnostic id (the metadata attribute takes no arguments), so all experimental Windows Runtime APIs share this one id.
+
+Following the [experimental attribute](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) design, this is reported as an **error** rather than a warning, so that depending on an experimental API is always a deliberate choice. It can be suppressed exactly like a warning, which is how the opt-in is expressed.
+
+Generated projection code suppresses this diagnostic: a projection has to name an experimental type in order to project it at all, so the marker is guidance for the consumers of a projection rather than for the projection itself.
+
+> **Note**: previous versions of CsWinRT relied on the C# compiler recognizing `Windows.Foundation.Metadata.ExperimentalAttribute` by name and reporting `CS8305`. That warning was not actionable per API: it could not be suppressed for one API without suppressing it for all of them, and it carried no link to any documentation. Suppressions of `CS8305` should be replaced with `CSWINRT3005`.
+
+## Recommended action
+
+- Prefer a stable API when one exists, and treat the experimental one as temporary.
+- If you do want to depend on an experimental API, opt in explicitly and as narrowly as possible:
+
+```csharp
+#pragma warning disable CSWINRT3005
+IDisplayGraphicsCaptureSession session = CreateSession();
+#pragma warning restore CSWINRT3005
+```
+
+  Or, to opt in for a whole project, add the id to `NoWarn`:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);CSWINRT3005</NoWarn>
+</PropertyGroup>
+```
+
+- Be ready for the API to change: because it is experimental, an update to the Windows SDK your project targets can change its signature or remove it, and no servicing guarantee applies.

--- a/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
+++ b/src/Authoring/WinRT.SourceGenerator2/AnalyzerReleases.Shipped.md
@@ -27,3 +27,4 @@ CSWINRT2017 | WindowsRuntime.SourceGenerator | Warning | Public authored type mi
 CSWINRT2018 | WindowsRuntime.SourceGenerator | Warning | '[WindowsRuntimeNativeExposedType]' target type cannot be instantiated
 CSWINRT2019 | WindowsRuntime.SourceGenerator | Warning | '[WindowsRuntimeNativeExposedType]' target type is not a projected class
 CSWINRT2020 | WindowsRuntime.SourceGenerator | Warning | Duplicate '[WindowsRuntimeNativeExposedType]' target type
+CSWINRT2021 | WindowsRuntime.SourceGenerator | Warning | Unsupported '[Experimental]' target for Windows Runtime metadata

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ExperimentalAttributeTargetAnalyzer.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/Analyzers/ExperimentalAttributeTargetAnalyzer.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace WindowsRuntime.SourceGenerator.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that reports applications of the .NET <c>[Experimental]</c> attribute on targets that
+/// Windows Runtime metadata cannot represent, in a Windows Runtime component.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Windows Runtime <c>[Experimental]</c> attribute is custom-mapped to the .NET one, so authored components
+/// apply the .NET attribute and the WinMD generator translates it back (see <c>docs/attribute-projections.md</c>).
+/// The .NET attribute supports more targets than the Windows Runtime one, though: it can also be applied to
+/// assemblies, modules and constructors, none of which have a Windows Runtime metadata target that can carry it
+/// (a constructor is exposed through an activation factory method, and no <c>.ctor</c> row in the Windows SDK
+/// carries such a marker).
+/// </para>
+/// <para>
+/// Those applications are dropped by the WinMD generator, which would silently make the API look stable to every
+/// other language projection, so they are reported here instead.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExperimentalAttributeTargetAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [DiagnosticDescriptors.ExperimentalAttributeUnsupportedTarget];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer only applies to Windows Runtime component authoring scenarios
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetCsWinRTComponent())
+            {
+                return;
+            }
+
+            // Get the '[Experimental]' symbol
+            if (context.Compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.ExperimentalAttribute") is not { } experimentalAttributeType)
+            {
+                return;
+            }
+
+            context.RegisterSyntaxNodeAction(context =>
+            {
+                AttributeSyntax attributeSyntax = (AttributeSyntax)context.Node;
+
+                // Cheap syntactic filter before any semantic work: the attribute has to be named 'Experimental'
+                // or 'ExperimentalAttribute' (possibly qualified) for it to possibly be the one being looked for
+                if (GetUnqualifiedName(attributeSyntax.Name) is not ("Experimental" or "ExperimentalAttribute"))
+                {
+                    return;
+                }
+
+                if (attributeSyntax.Parent is not AttributeListSyntax attributeList)
+                {
+                    return;
+                }
+
+                // Classify the target syntactically, so the semantic lookup below only runs for the targets
+                // that would actually be reported (the vast majority of applications are on valid targets)
+                if (!TryGetUnsupportedTarget(attributeList, context.SemanticModel, context.CancellationToken, out object? target, out string? targets))
+                {
+                    return;
+                }
+
+                // Make sure the attribute really is the .NET '[Experimental]' one, and not just a same-named
+                // attribute type declared elsewhere (the Windows Runtime one has no projected form to apply)
+                if (context.SemanticModel.GetSymbolInfo(attributeSyntax, context.CancellationToken).Symbol is not IMethodSymbol { ContainingType: { } attributeType } ||
+                    !SymbolEqualityComparer.Default.Equals(attributeType, experimentalAttributeType))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ExperimentalAttributeUnsupportedTarget,
+                    attributeSyntax.GetLocation(),
+                    target,
+                    targets));
+            }, SyntaxKind.Attribute);
+        });
+    }
+
+    /// <summary>
+    /// Tries to classify the target of an attribute list as one that Windows Runtime metadata cannot represent.
+    /// </summary>
+    /// <param name="attributeList">The attribute list to classify.</param>
+    /// <param name="semanticModel">The semantic model for the syntax tree being analyzed.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <param name="target">The resulting message argument identifying the target, if it is unsupported.</param>
+    /// <param name="targets">The resulting message argument naming the target kind in plural form, if it is unsupported.</param>
+    /// <returns>Whether the target of <paramref name="attributeList"/> is one that Windows Runtime metadata cannot represent.</returns>
+    private static bool TryGetUnsupportedTarget(
+        AttributeListSyntax attributeList,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out object? target,
+        out string? targets)
+    {
+        // Assembly and module level applications have no Windows Runtime metadata target at all: the generator
+        // produces a fresh '.winmd' with only the authored types in it, so they are not carried over anywhere.
+        if (attributeList.Target?.Identifier.Kind() is SyntaxKind.AssemblyKeyword)
+        {
+            target = semanticModel.Compilation.Assembly.Name;
+            targets = "assemblies";
+
+            return true;
+        }
+
+        if (attributeList.Target?.Identifier.Kind() is SyntaxKind.ModuleKeyword)
+        {
+            target = semanticModel.Compilation.SourceModule.Name;
+            targets = "modules";
+
+            return true;
+        }
+
+        // A constructor is exposed to Windows Runtime through an activation factory method, and the '.ctor' row
+        // on the runtime class carries no marker. Only the constructors that are actually part of the component
+        // surface are reported: the rest are never emitted into the '.winmd' to begin with.
+        if (attributeList.Parent is ConstructorDeclarationSyntax constructorDeclaration &&
+            semanticModel.GetDeclaredSymbol(constructorDeclaration, cancellationToken) is
+            {
+                MethodKind: MethodKind.Constructor,
+                DeclaredAccessibility: Accessibility.Public
+            } constructorSymbol &&
+            IsExternallyVisible(constructorSymbol.ContainingType))
+        {
+            target = constructorSymbol;
+            targets = "constructors";
+
+            return true;
+        }
+
+        target = null;
+        targets = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the unqualified name of a name syntax node (e.g. <c>Experimental</c> for <c>System.Diagnostics.CodeAnalysis.Experimental</c>).
+    /// </summary>
+    /// <param name="name">The name syntax node to get the unqualified name of.</param>
+    /// <returns>The unqualified name of <paramref name="name"/>.</returns>
+    private static string GetUnqualifiedName(NameSyntax name)
+    {
+        return name switch
+        {
+            SimpleNameSyntax simpleName => simpleName.Identifier.ValueText,
+            QualifiedNameSyntax qualifiedName => qualifiedName.Right.Identifier.ValueText,
+            AliasQualifiedNameSyntax aliasQualifiedName => aliasQualifiedName.Name.Identifier.ValueText,
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    /// Checks whether a given type is visible outside of the assembly declaring it.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>Whether <paramref name="type"/> is visible outside of the assembly declaring it.</returns>
+    private static bool IsExternallyVisible(INamedTypeSymbol type)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.ContainingType)
+        {
+            if (current.DeclaredAccessibility is not Accessibility.Public)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Diagnostics/DiagnosticDescriptors.cs
@@ -286,4 +286,17 @@ internal static partial class DiagnosticDescriptors
         description: "A given type should only be used as the target of a single '[WindowsRuntimeNativeExposedType]' attribute in an assembly. CCW marshalling code is only generated once per type, so additional applications of the attribute for the same type have no effect.",
         helpLinkUri: "https://github.com/microsoft/CsWinRT",
         customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an <c>[Experimental]</c> attribute applied to a target that Windows Runtime metadata cannot represent.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ExperimentalAttributeUnsupportedTarget = new(
+        id: "CSWINRT2021",
+        title: "Unsupported '[Experimental]' target for Windows Runtime metadata",
+        messageFormat: """The '[Experimental]' attribute applied to '{0}' will not be propagated to the generated '.winmd' file, as the Windows Runtime '[Experimental]' attribute cannot be applied to {1}. It can only be applied to types (runtime classes, interfaces, structs, enums and delegates), methods, properties, events and fields.""",
+        category: "WindowsRuntime.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The .NET '[Experimental]' attribute supports more targets than the Windows Runtime one it is translated into, so applications on targets that Windows Runtime metadata cannot represent are dropped, making the API appear stable to every other language projection.",
+        helpLinkUri: "https://github.com/microsoft/CsWinRT");
 }

--- a/src/Projections/Directory.Build.props
+++ b/src/Projections/Directory.Build.props
@@ -16,9 +16,6 @@
     -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0108;CS0109;CS0114;CS1591;CS0219;CS0628;CS0660;CA2257</WarningsNotAsErrors>
 
-    <!-- Generated projections surface evaluation-only ('[Experimental]') Windows Runtime APIs, so 'CS8305' is expected -->
-    <NoWarn>$(NoWarn);CS8305</NoWarn>
-
     <!-- Projection settings -->
     <CsWinRTGenerateReferenceProjection>true</CsWinRTGenerateReferenceProjection>
     <SimulateCsWinRTNugetReference>true</SimulateCsWinRTNugetReference>

--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -23,14 +23,16 @@ namespace ProjectionWriterTest.Helpers;
 internal static class ProjectionWriterRunner
 {
     /// <summary>
-    /// The namespace the projections are restricted to.
+    /// The namespaces the projections are restricted to.
     /// </summary>
     /// <remarks>
     /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
     /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
-    /// still covering every projected type kind and every carried-over attribute of interest.
+    /// still covering every projected type kind and almost every carried-over attribute of interest.
+    /// <c>Windows.Graphics.Capture</c> is added for the one it does not have: it is the smallest
+    /// Windows SDK namespace that declares <c>[Experimental]</c> APIs.
     /// </remarks>
-    private const string IncludeNamespace = "Windows.Foundation";
+    private const string IncludeNamespaces = "Windows.Foundation,Windows.Graphics.Capture";
 
     /// <summary>
     /// The lazily generated reference projection sources.
@@ -109,13 +111,13 @@ internal static class ProjectionWriterRunner
                 "--input-paths sdk",
                 $"--output-directory {outputDirectory}",
                 "--target-framework net10.0",
-                $"--include-namespaces {IncludeNamespace}",
+                $"--include-namespaces {IncludeNamespaces}",
                 $"--reference-projection {(referenceProjection ? "true" : "false")}"
             ]);
 
             (int exitCode, string output) = Run(toolPath, $"@{responseFile}");
 
-            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespace}':{Environment.NewLine}{output}");
+            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespaces}':{Environment.NewLine}{output}");
 
             string[] sourceFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
 

--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -23,16 +23,22 @@ namespace ProjectionWriterTest.Helpers;
 internal static class ProjectionWriterRunner
 {
     /// <summary>
-    /// The namespaces the projections are restricted to.
+    /// The namespace the projections are restricted to.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
     /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
-    /// still covering every projected type kind and almost every carried-over attribute of interest.
-    /// <c>Windows.Graphics.Capture</c> is added for the one it does not have: it is the smallest
-    /// Windows SDK namespace that declares <c>[Experimental]</c> APIs.
+    /// still covering every projected type kind and every carried-over attribute of interest.
+    /// </para>
+    /// <para>
+    /// Tests must only assert on things this namespace is guaranteed to contain in every Windows SDK:
+    /// the input metadata is whichever SDK is installed on the machine, so an assertion that some API
+    /// carries a given attribute is really an assertion about that SDK, and breaks when an agent has a
+    /// different one (an experimental API becoming stable, or not existing yet, is enough).
+    /// </para>
     /// </remarks>
-    private const string IncludeNamespaces = "Windows.Foundation,Windows.Graphics.Capture";
+    private const string IncludeNamespace = "Windows.Foundation";
 
     /// <summary>
     /// The lazily generated reference projection sources.
@@ -111,13 +117,13 @@ internal static class ProjectionWriterRunner
                 "--input-paths sdk",
                 $"--output-directory {outputDirectory}",
                 "--target-framework net10.0",
-                $"--include-namespaces {IncludeNamespaces}",
+                $"--include-namespaces {IncludeNamespace}",
                 $"--reference-projection {(referenceProjection ? "true" : "false")}"
             ]);
 
             (int exitCode, string output) = Run(toolPath, $"@{responseFile}");
 
-            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespaces}':{Environment.NewLine}{output}");
+            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespace}':{Environment.NewLine}{output}");
 
             string[] sourceFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
 

--- a/src/Tests/ProjectionWriterTest/Test_MappedAttributes.cs
+++ b/src/Tests/ProjectionWriterTest/Test_MappedAttributes.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ProjectionWriterTest.Helpers;
+
+namespace ProjectionWriterTest;
+
+/// <summary>
+/// Tests for the Windows Runtime metadata attributes the projection writer replaces with a .NET
+/// counterpart, rather than carrying over as-is.
+/// </summary>
+/// <remarks>
+/// See <c>docs/attribute-projections.md</c> for the full mapping table. These tests pin down the
+/// <c>[Experimental]</c> mapping, which is the one the Windows SDK exercises.
+/// </remarks>
+[TestClass]
+public class Test_MappedAttributes
+{
+    /// <summary>
+    /// The <c>[Experimental]</c> attribute the projection writer emits, in full.
+    /// </summary>
+    /// <remarks>
+    /// The Windows Runtime attribute carries no arguments, so all of these are synthesized. Asserting
+    /// the exact text keeps the diagnostic id, url and message in sync with <c>docs/diagnostics/cswinrt3005.md</c>:
+    /// user code suppresses the id, so changing it silently would be a breaking change.
+    /// </remarks>
+    private const string ExperimentalAttributeText =
+        """[global::System.Diagnostics.CodeAnalysis.Experimental("CSWINRT3005", UrlFormat = "https://aka.ms/cswinrt/errors/{0}", Message = "This Windows Runtime API is marked as experimental in its Windows Runtime metadata")]""";
+
+    /// <summary>
+    /// The Windows Runtime <c>[Experimental]</c> attribute is projected as the .NET one.
+    /// </summary>
+    [TestMethod]
+    public void Experimental_IsProjectedAsTheDotNetAttribute()
+    {
+        int referenceCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: true, ExperimentalAttributeText);
+
+        Assert.AreNotEqual(0, referenceCount, "The Windows Runtime '[Experimental]' attribute should be projected as the .NET one.");
+    }
+
+    /// <summary>
+    /// The projected <c>[Experimental]</c> attribute is reference-projection-only, like every other
+    /// carried-over metadata attribute.
+    /// </summary>
+    /// <remarks>
+    /// It is only consumed by compilers and analyzers, which always see the reference projection, and
+    /// attribute blobs cannot be trimmed by ILLink or ILC (see <see cref="Test_CarriedOverAttributes"/>).
+    /// </remarks>
+    [TestMethod]
+    public void Experimental_IsReferenceProjectionOnly()
+    {
+        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, "System.Diagnostics.CodeAnalysis.Experimental");
+
+        Assert.AreEqual(0, implementationCount, "'[Experimental]' should not be emitted into the implementation projection.");
+    }
+
+    /// <summary>
+    /// The Windows Runtime <c>[Experimental]</c> attribute type is custom-mapped, so it is not projected
+    /// itself, and no application of it survives under its Windows Runtime name.
+    /// </summary>
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void WindowsRuntimeExperimentalAttribute_IsNotProjected(bool referenceProjection)
+    {
+        int typeCount = ProjectionWriterRunner.CountAttributeText(referenceProjection, "class ExperimentalAttribute");
+        int applicationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection, "Windows.Foundation.Metadata.Experimental");
+
+        Assert.AreEqual(0, typeCount, "The Windows Runtime 'ExperimentalAttribute' type should not be projected.");
+        Assert.AreEqual(0, applicationCount, "No application of the Windows Runtime '[Experimental]' attribute should survive.");
+    }
+}

--- a/src/Tests/ProjectionWriterTest/Test_MappedAttributes.cs
+++ b/src/Tests/ProjectionWriterTest/Test_MappedAttributes.cs
@@ -10,53 +10,26 @@ namespace ProjectionWriterTest;
 /// counterpart, rather than carrying over as-is.
 /// </summary>
 /// <remarks>
+/// <para>
 /// See <c>docs/attribute-projections.md</c> for the full mapping table. These tests pin down the
-/// <c>[Experimental]</c> mapping, which is the one the Windows SDK exercises.
+/// <c>[Experimental]</c> mapping, which is the only one that removes a metadata attribute type from
+/// the projection outright.
+/// </para>
+/// <para>
+/// They assert the shape of the projection, never the contents of the Windows SDK: the input metadata
+/// is whichever SDK is installed on the machine, so which APIs happen to be experimental is not stable
+/// across agents. The emitted <c>[Experimental]</c> attribute itself is covered where it is
+/// deterministic instead — <c>TestComponentCSharp</c> declares an <c>[experimental]</c> runtime class,
+/// and the <c>#pragma warning disable CSWINRT3005</c> around its use in <c>UnitTest</c> only compiles
+/// while the writer emits exactly that diagnostic id.
+/// </para>
 /// </remarks>
 [TestClass]
 public class Test_MappedAttributes
 {
     /// <summary>
-    /// The <c>[Experimental]</c> attribute the projection writer emits, in full.
-    /// </summary>
-    /// <remarks>
-    /// The Windows Runtime attribute carries no arguments, so all of these are synthesized. Asserting
-    /// the exact text keeps the diagnostic id, url and message in sync with <c>docs/diagnostics/cswinrt3005.md</c>:
-    /// user code suppresses the id, so changing it silently would be a breaking change.
-    /// </remarks>
-    private const string ExperimentalAttributeText =
-        """[global::System.Diagnostics.CodeAnalysis.Experimental("CSWINRT3005", UrlFormat = "https://aka.ms/cswinrt/errors/{0}", Message = "This Windows Runtime API is marked as experimental in its Windows Runtime metadata")]""";
-
-    /// <summary>
-    /// The Windows Runtime <c>[Experimental]</c> attribute is projected as the .NET one.
-    /// </summary>
-    [TestMethod]
-    public void Experimental_IsProjectedAsTheDotNetAttribute()
-    {
-        int referenceCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: true, ExperimentalAttributeText);
-
-        Assert.AreNotEqual(0, referenceCount, "The Windows Runtime '[Experimental]' attribute should be projected as the .NET one.");
-    }
-
-    /// <summary>
-    /// The projected <c>[Experimental]</c> attribute is reference-projection-only, like every other
-    /// carried-over metadata attribute.
-    /// </summary>
-    /// <remarks>
-    /// It is only consumed by compilers and analyzers, which always see the reference projection, and
-    /// attribute blobs cannot be trimmed by ILLink or ILC (see <see cref="Test_CarriedOverAttributes"/>).
-    /// </remarks>
-    [TestMethod]
-    public void Experimental_IsReferenceProjectionOnly()
-    {
-        int implementationCount = ProjectionWriterRunner.CountGlobalAttribute(referenceProjection: false, "System.Diagnostics.CodeAnalysis.Experimental");
-
-        Assert.AreEqual(0, implementationCount, "'[Experimental]' should not be emitted into the implementation projection.");
-    }
-
-    /// <summary>
-    /// The Windows Runtime <c>[Experimental]</c> attribute type is custom-mapped, so it is not projected
-    /// itself, and no application of it survives under its Windows Runtime name.
+    /// The Windows Runtime <c>[Experimental]</c> attribute type is custom-mapped to the .NET one, so it
+    /// is not projected itself, and no application of it survives under its Windows Runtime name.
     /// </summary>
     [TestMethod]
     [DataRow(true)]
@@ -68,5 +41,26 @@ public class Test_MappedAttributes
 
         Assert.AreEqual(0, typeCount, "The Windows Runtime 'ExperimentalAttribute' type should not be projected.");
         Assert.AreEqual(0, applicationCount, "No application of the Windows Runtime '[Experimental]' attribute should survive.");
+    }
+
+    /// <summary>
+    /// The metadata attribute types that are <em>not</em> custom-mapped are still projected.
+    /// </summary>
+    /// <remarks>
+    /// This is what keeps <see cref="WindowsRuntimeExperimentalAttribute_IsNotProjected"/> honest: both
+    /// types live in <c>Windows.Foundation.Metadata</c> and are emitted by the same code path, so if
+    /// that namespace ever stopped being projected at all, the assertion there would pass for the wrong
+    /// reason. <c>[Deprecated]</c> in particular has to stay projected, as component authors apply it
+    /// directly (see <c>docs/attribute-projections.md</c>).
+    /// </remarks>
+    [TestMethod]
+    [DataRow("class DeprecatedAttribute")]
+    [DataRow("class OverloadAttribute")]
+    [DataRow("class VersionAttribute")]
+    public void UnmappedMetadataAttribute_IsStillProjected(string typeDeclaration)
+    {
+        int typeCount = ProjectionWriterRunner.CountAttributeText(referenceProjection: true, typeDeclaration);
+
+        Assert.AreNotEqual(0, typeCount, $"'{typeDeclaration}' should still be projected.");
     }
 }

--- a/src/Tests/SourceGenerator2Test/Test_ExperimentalAttributeTargetAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_ExperimentalAttributeTargetAnalyzer.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using WindowsRuntime.SourceGenerator.Diagnostics;
+using WindowsRuntime.SourceGenerator.Tests.Helpers;
+
+namespace WindowsRuntime.SourceGenerator.Tests;
+
+using VerifyCS = CSharpAnalyzerTest<ExperimentalAttributeTargetAnalyzer>;
+
+/// <summary>
+/// Tests for <see cref="ExperimentalAttributeTargetAnalyzer"/>.
+/// </summary>
+[TestClass]
+public sealed class Test_ExperimentalAttributeTargetAnalyzer
+{
+    [TestMethod]
+    [DataRow("public sealed class MyClass;")]
+    [DataRow("public interface IMyInterface;")]
+    [DataRow("public struct MyStruct;")]
+    [DataRow("public enum MyEnum { A }")]
+    [DataRow("public delegate void MyDelegate();")]
+    public async Task ExperimentalOnType_DoesNotWarn(string declaration)
+    {
+        string source = $$"""
+            using System.Diagnostics.CodeAnalysis;
+
+            [Experimental("TEST0001")]
+            {{declaration}}
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnMembers_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [Experimental("TEST0001")]
+                public int MyMethod() => 42;
+
+                [Experimental("TEST0002")]
+                public int MyProperty { get; set; }
+
+                [Experimental("TEST0003")]
+                public event EventHandler<int> MyEvent;
+            }
+
+            public struct MyStruct
+            {
+                [Experimental("TEST0004")]
+                public int MyField;
+            }
+
+            public enum MyEnum
+            {
+                [Experimental("TEST0005")]
+                A
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    [DataRow("private")]
+    [DataRow("internal")]
+    [DataRow("protected")]
+    public async Task ExperimentalOnNonPublicConstructor_DoesNotWarn(string accessibility)
+    {
+        string source = $$"""
+            using System.Diagnostics.CodeAnalysis;
+
+            public class MyClass
+            {
+                [Experimental("TEST0001")]
+                {{accessibility}} MyClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnStaticConstructor_DoesNotWarn()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [Experimental("TEST0001")]
+                static MyClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnConstructorOfNonVisibleType_DoesNotWarn()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            internal sealed class MyInternalClass
+            {
+                [Experimental("TEST0001")]
+                public MyInternalClass()
+                {
+                }
+            }
+
+            internal class MyOuterClass
+            {
+                public sealed class MyNestedClass
+                {
+                    [Experimental("TEST0002")]
+                    public MyNestedClass()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnConstructor_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [Experimental("TEST0001")]
+                public MyClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task AssemblyLevelExperimental_NotComponent_DoesNotWarn()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            [assembly: Experimental("TEST0001")]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    /// <summary>
+    /// A same-named attribute type that is not the .NET <c>[Experimental]</c> one is never translated
+    /// by the WinMD generator to begin with, so it is copied like any other user attribute.
+    /// </summary>
+    [TestMethod]
+    public async Task UnrelatedExperimentalAttribute_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+
+            public sealed class ExperimentalAttribute : Attribute
+            {
+                public ExperimentalAttribute(string diagnosticId)
+                {
+                }
+            }
+
+            public sealed class MyClass
+            {
+                [Experimental("TEST0001")]
+                public MyClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnPublicConstructor_Warns()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [{|CSWINRT2021:Experimental("TEST0001")|}]
+                public MyClass()
+                {
+                }
+
+                [{|CSWINRT2021:Experimental("TEST0002", UrlFormat = "https://example.com/{0}", Message = "Not final")|}]
+                public MyClass(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ExperimentalOnPublicConstructorOfNestedPublicType_Warns()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            public class MyOuterClass
+            {
+                public sealed class MyNestedClass
+                {
+                    [{|CSWINRT2021:Experimental("TEST0001")|}]
+                    public MyNestedClass()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    [DataRow("""Experimental("TEST0001")""")]
+    [DataRow("""ExperimentalAttribute("TEST0001")""")]
+    [DataRow("""System.Diagnostics.CodeAnalysis.Experimental("TEST0001")""")]
+    [DataRow("""global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute("TEST0001")""")]
+    public async Task ExperimentalOnPublicConstructor_AnySyntacticForm_Warns(string attribute)
+    {
+        string source = $$"""
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [{|CSWINRT2021:{{attribute}}|}]
+                public MyClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task AssemblyLevelExperimental_Warns()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            [assembly: {|CSWINRT2021:Experimental("TEST0001")|}]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+
+    [TestMethod]
+    public async Task ModuleLevelExperimental_Warns()
+    {
+        const string source = """
+            using System.Diagnostics.CodeAnalysis;
+
+            [module: {|CSWINRT2021:Experimental("TEST0001")|}]
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, isCsWinRTComponent: true);
+    }
+}

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -4744,15 +4744,30 @@ namespace UnitTest
             Assert.IsFalse(seventh.Equals(eighth));
         }
 
-        // Manually verify warning for experimental.
+        // Windows Runtime APIs marked '[experimental]' in metadata are projected with the .NET
+        // '[Experimental]' attribute, which reports 'CSWINRT3005' at every use site (see
+        // 'docs/diagnostics/cswinrt3005.md'). This method is what verifies that at compile time: it only
+        // builds because the diagnostic is explicitly suppressed here, exactly as user code would have to.
         private void TestExperimentAttribute()
         {
-            // This method intentionally uses an '[Experimental]' API to manually verify the warning, so suppress
-            // 'CS8305' here to keep the intentional usage from breaking the build (warnings are treated as errors).
-#pragma warning disable CS8305
+#pragma warning disable CSWINRT3005
             CustomExperimentClass custom = new CustomExperimentClass();
             custom.f();
-#pragma warning restore CS8305
+#pragma warning restore CSWINRT3005
+        }
+
+        // Like the carried-over metadata attributes it replaces, the projected '[Experimental]' attribute
+        // is reference-projection-only: it is only ever consumed by compilers and analyzers, which see the
+        // reference projection, so it must not survive into the implementation projection loaded at runtime.
+        [TestMethod]
+        public void TestExperimentalIsNotProjectedInImplementationProjection()
+        {
+            // Naming the type at all is a use site, so the diagnostic has to be suppressed here too
+#pragma warning disable CSWINRT3005
+            Type experimentalType = typeof(CustomExperimentClass);
+#pragma warning restore CSWINRT3005
+
+            Assert.IsNull(experimentalType.GetCustomAttribute<ExperimentalAttribute>());
         }
 
         void OnDeviceAdded(DeviceWatcher sender, DeviceInformation args)

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -151,6 +154,149 @@ internal static class WinMDGeneratorRunner
         Assert.IsTrue(result.Success, $"Input compilation failed:\n{string.Join("\n", result.Diagnostics)}");
 
         return outputPath;
+    }
+
+    /// <summary>
+    /// Runs the generator for the given component source and returns the custom attributes applied in
+    /// the produced <c>.winmd</c>, keyed by the metadata row they are applied to.
+    /// </summary>
+    /// <remarks>
+    /// Keys are formatted as <c>Namespace.Type</c> for types and <c>Namespace.Type.Member</c> for methods,
+    /// properties and events. That distinction matters: Windows Runtime metadata places some member
+    /// attributes on the accessor method (e.g. <c>get_Value</c>) rather than on the property or event row.
+    /// </remarks>
+    /// <param name="source">The C# source defining the authored component types.</param>
+    /// <returns>A lookup from metadata row to the fully qualified names of the attributes applied to it.</returns>
+    public static ILookup<string, string> GetGeneratedAttributes(string source)
+    {
+        string toolPath = GetGeneratorPath();
+        string temporaryDirectory = Directory.CreateTempSubdirectory("WinMDGeneratorTest_").FullName;
+
+        try
+        {
+            string inputAssemblyPath = CompileComponent(source, temporaryDirectory);
+            string outputWinMDPath = Path.Combine(temporaryDirectory, "TestInput.winmd");
+            string responseFilePath = Path.Combine(temporaryDirectory, "args.rsp");
+
+            File.WriteAllText(responseFilePath, $"""
+                --input-assembly-path {inputAssemblyPath}
+                --reference-assembly-paths {inputAssemblyPath}
+                --output-winmd-path {outputWinMDPath}
+                --assembly-version 1.0.0.0
+                --use-windows-ui-xaml-projections false
+                """);
+
+            (int exitCode, string output) = RunTool(toolPath, responseFilePath);
+
+            Assert.AreEqual(0, exitCode, output);
+
+            return ReadAttributes(outputWinMDPath);
+        }
+        finally
+        {
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Reads every custom attribute application in a <c>.winmd</c>, keyed by the metadata row it is applied to.
+    /// </summary>
+    /// <param name="winmdPath">The path of the <c>.winmd</c> to read.</param>
+    /// <returns>A lookup from metadata row to the fully qualified names of the attributes applied to it.</returns>
+    private static ILookup<string, string> ReadAttributes(string winmdPath)
+    {
+        using FileStream stream = File.OpenRead(winmdPath);
+        using PEReader peReader = new(stream);
+
+        // Windows Runtime projections are deliberately not applied: the tests assert the raw Windows
+        // Runtime metadata the generator emits, not the CLR view of it that the reader can synthesize
+        MetadataReader reader = peReader.GetMetadataReader(MetadataReaderOptions.None);
+
+        List<KeyValuePair<string, string>> attributes = [];
+
+        void AddAttributes(string owner, CustomAttributeHandleCollection handles)
+        {
+            foreach (CustomAttributeHandle handle in handles)
+            {
+                attributes.Add(new KeyValuePair<string, string>(owner, GetAttributeTypeName(reader, reader.GetCustomAttribute(handle))));
+            }
+        }
+
+        foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions)
+        {
+            TypeDefinition type = reader.GetTypeDefinition(typeHandle);
+            string owner = Format(reader.GetString(type.Namespace), reader.GetString(type.Name));
+
+            AddAttributes(owner, type.GetCustomAttributes());
+
+            foreach (MethodDefinitionHandle methodHandle in type.GetMethods())
+            {
+                MethodDefinition method = reader.GetMethodDefinition(methodHandle);
+
+                AddAttributes($"{owner}.{reader.GetString(method.Name)}", method.GetCustomAttributes());
+            }
+
+            foreach (PropertyDefinitionHandle propertyHandle in type.GetProperties())
+            {
+                PropertyDefinition property = reader.GetPropertyDefinition(propertyHandle);
+
+                AddAttributes($"{owner}.{reader.GetString(property.Name)}", property.GetCustomAttributes());
+            }
+
+            foreach (EventDefinitionHandle eventHandle in type.GetEvents())
+            {
+                EventDefinition @event = reader.GetEventDefinition(eventHandle);
+
+                AddAttributes($"{owner}.{reader.GetString(@event.Name)}", @event.GetCustomAttributes());
+            }
+        }
+
+        return attributes.ToLookup(static pair => pair.Key, static pair => pair.Value);
+    }
+
+    /// <summary>
+    /// Resolves the fully qualified type name of the attribute a custom attribute application refers to.
+    /// </summary>
+    /// <param name="reader">The metadata reader for the <c>.winmd</c>.</param>
+    /// <param name="attribute">The custom attribute application to resolve.</param>
+    /// <returns>The fully qualified name of the attribute type.</returns>
+    private static string GetAttributeTypeName(MetadataReader reader, CustomAttribute attribute)
+    {
+        // The constructor is a 'MemberReference' for attributes defined outside the '.winmd' (which is
+        // every attribute the generator emits) and a 'MethodDefinition' for any defined inside it
+        EntityHandle declaringType = attribute.Constructor.Kind switch
+        {
+            HandleKind.MemberReference => reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor).Parent,
+            HandleKind.MethodDefinition => reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor).GetDeclaringType(),
+            _ => default
+        };
+
+        if (declaringType.Kind == HandleKind.TypeReference)
+        {
+            TypeReference typeReference = reader.GetTypeReference((TypeReferenceHandle)declaringType);
+
+            return Format(reader.GetString(typeReference.Namespace), reader.GetString(typeReference.Name));
+        }
+
+        if (declaringType.Kind == HandleKind.TypeDefinition)
+        {
+            TypeDefinition typeDefinition = reader.GetTypeDefinition((TypeDefinitionHandle)declaringType);
+
+            return Format(reader.GetString(typeDefinition.Namespace), reader.GetString(typeDefinition.Name));
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Formats a namespace and type name as a fully qualified type name.
+    /// </summary>
+    /// <param name="typeNamespace">The namespace of the type (possibly empty).</param>
+    /// <param name="typeName">The name of the type.</param>
+    /// <returns>The fully qualified type name.</returns>
+    private static string Format(string typeNamespace, string typeName)
+    {
+        return typeNamespace.Length == 0 ? typeName : $"{typeNamespace}.{typeName}";
     }
 
     /// <summary>

--- a/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
+++ b/src/Tests/WinMDGeneratorTest/Helpers/WinMDGeneratorRunner.cs
@@ -162,7 +162,7 @@ internal static class WinMDGeneratorRunner
     /// </summary>
     /// <remarks>
     /// Keys are formatted as <c>Namespace.Type</c> for types and <c>Namespace.Type.Member</c> for methods,
-    /// properties and events. That distinction matters: Windows Runtime metadata places some member
+    /// properties, events and fields. That distinction matters: Windows Runtime metadata places some member
     /// attributes on the accessor method (e.g. <c>get_Value</c>) rather than on the property or event row.
     /// </remarks>
     /// <param name="source">The C# source defining the authored component types.</param>
@@ -248,6 +248,13 @@ internal static class WinMDGeneratorRunner
                 EventDefinition @event = reader.GetEventDefinition(eventHandle);
 
                 AddAttributes($"{owner}.{reader.GetString(@event.Name)}", @event.GetCustomAttributes());
+            }
+
+            foreach (FieldDefinitionHandle fieldHandle in type.GetFields())
+            {
+                FieldDefinition field = reader.GetFieldDefinition(fieldHandle);
+
+                AddAttributes($"{owner}.{reader.GetString(field.Name)}", field.GetCustomAttributes());
             }
         }
 

--- a/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 using WinMDGeneratorTest.Helpers;
 
@@ -18,6 +19,11 @@ namespace WinMDGeneratorTest;
 /// <para>
 /// The .NET attribute's diagnostic id, url format and message have no Windows Runtime counterpart and
 /// are dropped, so the tests only assert the presence and placement of the translated attribute.
+/// </para>
+/// <para>
+/// The .NET attribute also supports targets the Windows Runtime one does not (assemblies, modules and
+/// constructors). Those applications are not translated, and are reported by the <c>CSWINRT2021</c>
+/// analyzer instead.
 /// </para>
 /// </remarks>
 [TestClass]
@@ -129,6 +135,45 @@ public class Test_ExperimentalAttribute
     }
 
     /// <summary>
+    /// Windows Runtime exposes constructors through activation factory methods, and the <c>.ctor</c>
+    /// row on a runtime class carries no marker (no Windows SDK <c>.ctor</c> row has one). The
+    /// application is reported by the <c>CSWINRT2021</c> analyzer instead.
+    /// </summary>
+    [TestMethod]
+    public void ExperimentalOnConstructors_IsNotTranslated()
+    {
+        ILookup<string, string> attributes = WinMDGeneratorRunner.GetGeneratedAttributes("""
+            using System.Diagnostics.CodeAnalysis;
+
+            public sealed class MyClass
+            {
+                [Experimental("TEST0001")]
+                public MyClass()
+                {
+                }
+
+                [Experimental("TEST0002")]
+                public MyClass(int value)
+                {
+                }
+
+                [Experimental("TEST0003")]
+                public int ExperimentalMethod() => 42;
+            }
+            """);
+
+        AssertIsNotExperimental(attributes, "MyClass..ctor");
+        AssertIsNotExperimental(attributes, "IMyClassFactory.CreateMyClass");
+
+        // The marker is still translated for every other member of the same type
+        AssertIsExperimental(attributes, "MyClass.ExperimentalMethod");
+
+        // Assert the complete set of rows, so no other row (e.g. the synthesized default or factory
+        // interface a constructor is projected into) silently carries the marker either
+        AssertExperimentalRows(attributes, "IMyClassClass.ExperimentalMethod", "MyClass.ExperimentalMethod");
+    }
+
+    /// <summary>
     /// Asserts that exactly one Windows Runtime <c>[Experimental]</c> attribute is applied to a row.
     /// </summary>
     /// <param name="attributes">The attributes read back from the generated <c>.winmd</c>.</param>
@@ -150,5 +195,22 @@ public class Test_ExperimentalAttribute
         bool isExperimental = attributes[row].Contains(WindowsRuntimeExperimentalAttribute);
 
         Assert.IsFalse(isExperimental, $"'{row}' should have no '[{WindowsRuntimeExperimentalAttribute}]' applied.");
+    }
+
+    /// <summary>
+    /// Asserts the complete set of metadata rows carrying a Windows Runtime <c>[Experimental]</c> attribute.
+    /// </summary>
+    /// <param name="attributes">The attributes read back from the generated <c>.winmd</c>.</param>
+    /// <param name="rows">The metadata rows expected to carry the attribute (see <c>WinMDGeneratorRunner.GetGeneratedAttributes</c>).</param>
+    private static void AssertExperimentalRows(ILookup<string, string> attributes, params string[] rows)
+    {
+        string actualRows = string.Join(", ", attributes
+            .Where(static group => group.Contains(WindowsRuntimeExperimentalAttribute))
+            .Select(static group => group.Key)
+            .Order(StringComparer.Ordinal));
+
+        string expectedRows = string.Join(", ", rows.Order(StringComparer.Ordinal));
+
+        Assert.AreEqual(expectedRows, actualRows, $"Unexpected set of rows carrying '[{WindowsRuntimeExperimentalAttribute}]'.");
     }
 }

--- a/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
@@ -96,6 +96,39 @@ public class Test_ExperimentalAttribute
     }
 
     /// <summary>
+    /// Windows Runtime metadata supports member markers on individual enum members and struct fields,
+    /// which is how the Windows SDK marks a single new enum member of an existing enum experimental.
+    /// </summary>
+    [TestMethod]
+    public void ExperimentalOnFields_IsTranslated()
+    {
+        ILookup<string, string> attributes = WinMDGeneratorRunner.GetGeneratedAttributes("""
+            using System.Diagnostics.CodeAnalysis;
+
+            public enum MyEnum
+            {
+                Stable,
+                [Experimental("TEST0001")]
+                Experimental
+            }
+
+            public struct MyStruct
+            {
+                public int StableField;
+
+                [Experimental("TEST0002")]
+                public int ExperimentalField;
+            }
+            """);
+
+        AssertIsExperimental(attributes, "MyEnum.Experimental");
+        AssertIsExperimental(attributes, "MyStruct.ExperimentalField");
+
+        AssertIsNotExperimental(attributes, "MyEnum.Stable");
+        AssertIsNotExperimental(attributes, "MyStruct.StableField");
+    }
+
+    /// <summary>
     /// Asserts that exactly one Windows Runtime <c>[Experimental]</c> attribute is applied to a row.
     /// </summary>
     /// <param name="attributes">The attributes read back from the generated <c>.winmd</c>.</param>

--- a/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
+++ b/src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using WinMDGeneratorTest.Helpers;
+
+namespace WinMDGeneratorTest;
+
+/// <summary>
+/// End-to-end tests for how the WinMD generator translates the .NET <c>[Experimental]</c> attribute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Windows Runtime <c>[Experimental]</c> attribute is custom-mapped to the .NET one, so it has no
+/// projected form an author could apply. Authored components use the .NET attribute instead, and the
+/// generator translates it back into Windows Runtime metadata (see <c>docs/attribute-projections.md</c>).
+/// </para>
+/// <para>
+/// The .NET attribute's diagnostic id, url format and message have no Windows Runtime counterpart and
+/// are dropped, so the tests only assert the presence and placement of the translated attribute.
+/// </para>
+/// </remarks>
+[TestClass]
+public class Test_ExperimentalAttribute
+{
+    /// <summary>
+    /// The name of the Windows Runtime attribute the .NET one is translated into.
+    /// </summary>
+    private const string WindowsRuntimeExperimentalAttribute = "Windows.Foundation.Metadata.ExperimentalAttribute";
+
+    /// <summary>
+    /// The name of the .NET attribute, which must never reach the <c>.winmd</c> (its type does not exist
+    /// in Windows Runtime metadata, so a copied application would not even be resolvable).
+    /// </summary>
+    private const string DotNetExperimentalAttribute = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
+
+    [TestMethod]
+    public void ExperimentalOnTypesAndMethods_IsTranslated()
+    {
+        ILookup<string, string> attributes = WinMDGeneratorRunner.GetGeneratedAttributes("""
+            using System.Diagnostics.CodeAnalysis;
+
+            [Experimental("TEST0001")]
+            public interface IExperimentalComponent
+            {
+                int Method(int value);
+            }
+
+            public interface IComponent
+            {
+                [Experimental("TEST0002", UrlFormat = "https://example.com/{0}", Message = "Not final")]
+                int ExperimentalMethod(int value);
+
+                int StableMethod(int value);
+            }
+            """);
+
+        AssertIsExperimental(attributes, "IExperimentalComponent");
+        AssertIsExperimental(attributes, "IComponent.ExperimentalMethod");
+
+        AssertIsNotExperimental(attributes, "IComponent");
+        AssertIsNotExperimental(attributes, "IComponent.StableMethod");
+
+        // The .NET attribute type has no Windows Runtime counterpart, so no row may reference it
+        Assert.IsFalse(
+            attributes.SelectMany(static group => group).Contains(DotNetExperimentalAttribute),
+            $"'{DotNetExperimentalAttribute}' should never be copied into the '.winmd'.");
+    }
+
+    /// <summary>
+    /// Windows Runtime metadata places member-level markers on the accessor method rather than on the
+    /// property or event row, which is the placement MIDL produces.
+    /// </summary>
+    [TestMethod]
+    public void ExperimentalOnPropertiesAndEvents_IsTranslatedOntoTheAccessor()
+    {
+        ILookup<string, string> attributes = WinMDGeneratorRunner.GetGeneratedAttributes("""
+            using System;
+            using System.Diagnostics.CodeAnalysis;
+
+            public interface IComponent
+            {
+                [Experimental("TEST0001")]
+                int ExperimentalProperty { get; set; }
+
+                [Experimental("TEST0002")]
+                event EventHandler<int> ExperimentalEvent;
+            }
+            """);
+
+        AssertIsExperimental(attributes, "IComponent.get_ExperimentalProperty");
+        AssertIsExperimental(attributes, "IComponent.add_ExperimentalEvent");
+
+        AssertIsNotExperimental(attributes, "IComponent.ExperimentalProperty");
+        AssertIsNotExperimental(attributes, "IComponent.ExperimentalEvent");
+    }
+
+    /// <summary>
+    /// Asserts that exactly one Windows Runtime <c>[Experimental]</c> attribute is applied to a row.
+    /// </summary>
+    /// <param name="attributes">The attributes read back from the generated <c>.winmd</c>.</param>
+    /// <param name="row">The metadata row to check (see <c>WinMDGeneratorRunner.GetGeneratedAttributes</c>).</param>
+    private static void AssertIsExperimental(ILookup<string, string> attributes, string row)
+    {
+        int count = attributes[row].Count(static name => name == WindowsRuntimeExperimentalAttribute);
+
+        Assert.AreEqual(1, count, $"'{row}' should have exactly one '[{WindowsRuntimeExperimentalAttribute}]' applied.");
+    }
+
+    /// <summary>
+    /// Asserts that no Windows Runtime <c>[Experimental]</c> attribute is applied to a row.
+    /// </summary>
+    /// <param name="attributes">The attributes read back from the generated <c>.winmd</c>.</param>
+    /// <param name="row">The metadata row to check (see <c>WinMDGeneratorRunner.GetGeneratedAttributes</c>).</param>
+    private static void AssertIsNotExperimental(ILookup<string, string> attributes, string row)
+    {
+        bool isExperimental = attributes[row].Contains(WindowsRuntimeExperimentalAttribute);
+
+        Assert.IsFalse(isExperimental, $"'{row}' should have no '[{WindowsRuntimeExperimentalAttribute}]' applied.");
+    }
+}

--- a/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
+++ b/src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj
@@ -46,12 +46,15 @@
     generator is always built framework-dependent for the build host (output under 'net10.0\',
     with no 'win-<arch>' RID subfolder). Without this, the generator's 'PublishAot' build is
     self-contained and cannot be referenced by this non self-contained test project (NETSDK1151).
+    'Platform' is dropped as well: this project builds as x64/x86, but the generator declares no
+    platforms, so letting it through would place its output under 'bin\<platform>\' and no longer
+    match the path published as assembly metadata below (leaving the tests running a stale tool).
   -->
   <ItemGroup>
     <ProjectReference Include="..\..\WinRT.WinMD.Generator\WinRT.WinMD.Generator.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="_CsWinRTToolReference"
-                      UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained"
+                      UndefineProperties="BuildToolArch;PublishBuildTool;RuntimeIdentifier;SelfContained;Platform"
                       Private="false" />
   </ItemGroup>
 

--- a/src/WinRT.Projection.Writer/Extensions/ProjectionWriterExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/ProjectionWriterExtensions.cs
@@ -54,6 +54,7 @@ internal static class ProjectionWriterExtensions
                 #pragma warning disable CSWINRT3002 // "Type '...' is a private implementation detail"
                 #pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
                 #pragma warning disable CS0612, CS0618 // "'...' is obsolete" (deprecated Windows Runtime APIs are projected as '[Obsolete]', but generated code still has to reference them)
+                #pragma warning disable CSWINRT3005 // "'...' is for evaluation purposes only" (experimental Windows Runtime APIs are projected as '[Experimental]', but generated code still has to reference them)
                 
                 """);
         }

--- a/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs
@@ -10,6 +10,7 @@ using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using WindowsRuntime.ProjectionWriter.Generation;
 using WindowsRuntime.ProjectionWriter.Helpers;
+using WindowsRuntime.ProjectionWriter.References;
 using WindowsRuntime.ProjectionWriter.Writers;
 using static WindowsRuntime.ProjectionWriter.References.WellKnownNamespaces;
 
@@ -20,6 +21,30 @@ namespace WindowsRuntime.ProjectionWriter.Factories;
 /// </summary>
 internal static class CustomAttributeFactory
 {
+    /// <summary>
+    /// The projected name of the Windows Runtime <c>[Experimental]</c> attribute.
+    /// </summary>
+    /// <remarks>
+    /// The two attributes model the same concept, but the .NET one is richer: it requires a diagnostic
+    /// id, which lets user code opt into an experimental API by suppressing that specific id (the
+    /// Windows Runtime attribute carries no arguments at all). See <see cref="ProjectedExperimentalArgs"/>.
+    /// </remarks>
+    private const string ProjectedExperimentalName = "System.Diagnostics.CodeAnalysis.Experimental";
+
+    /// <summary>
+    /// The pre-formatted arguments emitted for <see cref="ProjectedExperimentalName"/>.
+    /// </summary>
+    /// <remarks>
+    /// They are the same for every experimental Windows Runtime API: the Windows Runtime attribute has
+    /// no arguments to derive a per-API id or message from, so all of them share one CsWinRT id.
+    /// </remarks>
+    private static readonly string[] ProjectedExperimentalArgs =
+    [
+        $"\"{WellKnownDiagnostics.ExperimentalWindowsRuntimeApiId}\"",
+        $"UrlFormat = \"{WellKnownDiagnostics.UrlFormat}\"",
+        $"Message = \"{WellKnownDiagnostics.ExperimentalWindowsRuntimeApiMessage}\""
+    ];
+
     /// <summary>
     /// Returns the formatted argument list for emitting <paramref name="attribute"/> as a C# attribute.
     /// </summary>
@@ -380,7 +405,7 @@ internal static class CustomAttributeFactory
         // Applications are collected in metadata order, with one entry per application. A Windows Runtime
         // attribute marked '[allowmultiple]' (e.g. '[TemplateVisualState]') can legitimately be applied
         // several times to the same member, and every application has to be carried over.
-        List<(string Name, List<string> Args)> attributes = [];
+        List<(string Name, IReadOnlyList<string> Args)> attributes = [];
 
         // The arguments of the recorded '[AttributeUsage]' application, if any, so that a separate
         // '[AllowMultiple]' application can be folded into it once all attributes have been seen
@@ -438,6 +463,16 @@ internal static class CustomAttributeFactory
                 continue;
             }
 
+            // '[Experimental]' is custom-mapped to the .NET attribute of the same name, which requires a
+            // diagnostic id that Windows Runtime metadata has no counterpart for, so a CsWinRT-owned one
+            // is synthesized (see 'ProjectedExperimentalArgs')
+            if (ns == WindowsFoundationMetadata && strippedName == "Experimental")
+            {
+                attributes.Add((ProjectedExperimentalName, ProjectedExperimentalArgs));
+
+                continue;
+            }
+
             // Only format the arguments of attributes that are actually carried over. Implementation
             // projections drop almost everything, and they are the hot publish-time path.
             List<string> args = WriteCustomAttributeArgs(attr);
@@ -464,24 +499,44 @@ internal static class CustomAttributeFactory
             attributes.Add((AttributeUsageName, ["global::System.AttributeTargets.All", "AllowMultiple = true"]));
         }
 
-        foreach ((string attributeName, List<string> attributeArgs) in attributes)
+        foreach ((string attributeName, IReadOnlyList<string> attributeArgs) in attributes)
         {
-            writer.Write($"[global::{attributeName}");
-
-            if (attributeArgs.Count > 0)
-            {
-                writer.Write("(");
-                for (int i = 0; i < attributeArgs.Count; i++)
-                {
-                    writer.WriteIf(i > 0, ", ");
-
-                    writer.Write(attributeArgs[i]);
-                }
-                writer.Write(")");
-            }
-
-            writer.WriteLine("]");
+            WriteAttribute(writer, attributeName, attributeArgs);
         }
+    }
+
+    /// <summary>
+    /// Writes the projected form of the Windows Runtime <c>[Experimental]</c> attribute, on its own line.
+    /// </summary>
+    /// <param name="writer">The writer to emit to.</param>
+    public static void WriteExperimentalAttribute(IndentedTextWriter writer)
+    {
+        WriteAttribute(writer, ProjectedExperimentalName, ProjectedExperimentalArgs);
+    }
+
+    /// <summary>
+    /// Writes a single attribute application, on its own line.
+    /// </summary>
+    /// <param name="writer">The writer to emit to.</param>
+    /// <param name="attributeName">The fully-qualified attribute name (without the <c>global::</c> prefix).</param>
+    /// <param name="attributeArgs">The pre-formatted positional + named argument strings (in order).</param>
+    private static void WriteAttribute(IndentedTextWriter writer, string attributeName, IReadOnlyList<string> attributeArgs)
+    {
+        writer.Write($"[global::{attributeName}");
+
+        if (attributeArgs.Count > 0)
+        {
+            writer.Write("(");
+            for (int i = 0; i < attributeArgs.Count; i++)
+            {
+                writer.WriteIf(i > 0, ", ");
+
+                writer.Write(attributeArgs[i]);
+            }
+            writer.Write(")");
+        }
+
+        writer.WriteLine("]");
     }
 
     /// <summary>
@@ -545,7 +600,8 @@ internal static class CustomAttributeFactory
             return false;
         }
 
-        // Metadata attributes without a projected form are always dropped
+        // Metadata attributes without a projected form are always dropped. '[Experimental]' is listed
+        // here as it is custom-mapped rather than carried over (see 'WriteCustomAttributes').
         if (ns == WindowsFoundationMetadata)
         {
             return strippedName is "ContractVersion" or "ApiContract" or "DefaultOverload" or "Overload" or "Experimental";

--- a/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs
@@ -388,7 +388,16 @@ internal static class InterfaceFactory
 
             string baseName = nm.EndsWith("Attribute", StringComparison.Ordinal) ? nm[..^"Attribute".Length] : nm;
 
-            if (baseName is not ("Overload" or "DefaultOverload" or "Experimental"))
+            // '[Experimental]' is custom-mapped to the .NET attribute of the same name, which needs a
+            // synthesized diagnostic id, so it goes through the shared writer rather than being copied
+            if (baseName == "Experimental")
+            {
+                CustomAttributeFactory.WriteExperimentalAttribute(writer);
+
+                continue;
+            }
+
+            if (baseName is not ("Overload" or "DefaultOverload"))
             {
                 continue;
             }

--- a/src/WinRT.Projection.Writer/Helpers/MappedTypes.cs
+++ b/src/WinRT.Projection.Writer/Helpers/MappedTypes.cs
@@ -164,6 +164,7 @@ internal static class MappedTypes
             ["AttributeTargets"] = new("AttributeTargets", "System", "AttributeTargets"),
             ["AttributeUsageAttribute"] = new("AttributeUsageAttribute", "System", "AttributeUsageAttribute"),
             [ContractVersionAttribute] = new(ContractVersionAttribute, WindowsFoundationMetadata, ContractVersionAttribute),
+            [ExperimentalAttribute] = new(ExperimentalAttribute, SystemDiagnosticsCodeAnalysis, ExperimentalAttribute),
         }.ToFrozenDictionary(),
         ["Windows.Foundation.Numerics"] = new Dictionary<string, MappedType>
         {

--- a/src/WinRT.Projection.Writer/References/WellKnownAttributeNames.cs
+++ b/src/WinRT.Projection.Writer/References/WellKnownAttributeNames.cs
@@ -55,6 +55,11 @@ internal static class WellKnownAttributeNames
     public const string ContractVersionAttribute = "ContractVersionAttribute";
 
     /// <summary>
+    /// The <c>[ExperimentalAttribute]</c> attribute type name (marks an API as evaluation-only).
+    /// </summary>
+    public const string ExperimentalAttribute = "ExperimentalAttribute";
+
+    /// <summary>
     /// The <c>[VersionAttribute]</c> attribute type name.
     /// </summary>
     public const string VersionAttribute = "VersionAttribute";

--- a/src/WinRT.Projection.Writer/References/WellKnownDiagnostics.cs
+++ b/src/WinRT.Projection.Writer/References/WellKnownDiagnostics.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WindowsRuntime.ProjectionWriter.References;
+
+/// <summary>
+/// Well-known CsWinRT diagnostics that generated projections report in user code, through the
+/// attributes the projection writer emits.
+/// </summary>
+/// <remarks>
+/// Each id has a documentation page under <c>docs/diagnostics</c>, reachable through
+/// <see cref="UrlFormat"/>. The ids are part of the public contract of a projection: user code
+/// suppresses them by id, so they must never be renamed or reused for a different meaning.
+/// </remarks>
+internal static class WellKnownDiagnostics
+{
+    /// <summary>
+    /// The diagnostic id reported when user code uses a Windows Runtime API marked with the
+    /// <c>[Windows.Foundation.Metadata.Experimental]</c> attribute in its Windows Runtime metadata.
+    /// </summary>
+    /// <remarks>
+    /// Windows Runtime metadata has no per-API diagnostic id (the attribute carries no arguments),
+    /// so every experimental Windows Runtime API shares this single id.
+    /// </remarks>
+    public const string ExperimentalWindowsRuntimeApiId = "CSWINRT3005";
+
+    /// <summary>
+    /// The message reported alongside <see cref="ExperimentalWindowsRuntimeApiId"/>.
+    /// </summary>
+    /// <remarks>
+    /// The compiler already explains that the API is for evaluation purposes only, so this only adds
+    /// the piece of context it cannot know: that the marker comes from Windows Runtime metadata.
+    /// </remarks>
+    public const string ExperimentalWindowsRuntimeApiMessage = "This Windows Runtime API is marked as experimental in its Windows Runtime metadata";
+
+    /// <summary>
+    /// The URL format for all CsWinRT diagnostics.
+    /// </summary>
+    /// <remarks>
+    /// This URL format assumes it will receive the diagnostic id as a parameter.
+    /// </remarks>
+    public const string UrlFormat = "https://aka.ms/cswinrt/errors/{0}";
+}

--- a/src/WinRT.Projection.Writer/References/WellKnownNamespaces.cs
+++ b/src/WinRT.Projection.Writer/References/WellKnownNamespaces.cs
@@ -29,6 +29,11 @@ internal static class WellKnownNamespaces
     public const string System = "System";
 
     /// <summary>
+    /// The <c>System.Diagnostics.CodeAnalysis</c> namespace (where the .NET <c>[Experimental]</c> attribute lives).
+    /// </summary>
+    public const string SystemDiagnosticsCodeAnalysis = "System.Diagnostics.CodeAnalysis";
+
+    /// <summary>
     /// The <c>WindowsRuntime.Internal</c> namespace (internal interop interfaces).
     /// </summary>
     public const string WindowsRuntimeInternal = "WindowsRuntime.Internal";

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
@@ -315,6 +315,33 @@ internal sealed partial class WinMDWriter
     }
 
     /// <summary>
+    /// Adds a <c>[Windows.Foundation.Metadata.Experimental]</c> attribute to a metadata element.
+    /// </summary>
+    /// <remarks>
+    /// This is the reverse of the projection-time mapping: the .NET <c>[Experimental]</c> attribute is
+    /// how an authored component marks an API as evaluation-only, since the Windows Runtime attribute
+    /// type is custom-mapped and so has no projected form to apply. The Windows Runtime attribute is
+    /// parameterless, so the diagnostic id, url format and message are dropped: Windows Runtime metadata
+    /// has nowhere to carry them, and CsWinRT synthesizes its own when projecting the component back
+    /// (see <c>docs/attribute-projections.md</c>).
+    /// </remarks>
+    /// <param name="target">The output metadata element to add the attribute to.</param>
+    private void AddExperimentalAttribute(IHasCustomAttribute target)
+    {
+        TypeReference experimentalAttrType = GetOrCreateTypeReference(
+            @namespace: "Windows.Foundation.Metadata",
+            name: "ExperimentalAttribute",
+            assemblyName: "Windows.Foundation.FoundationContract");
+
+        MemberReference ctor = new(
+            parent: experimentalAttrType,
+            name: ".ctor"u8,
+            signature: MethodSignature.CreateInstance(_outputModule.CorLibTypeFactory.Void));
+
+        target.CustomAttributes.Add(new CustomAttribute(ctor, new CustomAttributeSignature()));
+    }
+
+    /// <summary>
     /// Gets the version number for a type from its <c>[Version]</c> attribute, or falls back
     /// to the assembly major version.
     /// </summary>
@@ -331,18 +358,18 @@ internal sealed partial class WinMDWriter
     /// </summary>
     /// <param name="source">The source element to copy attributes from.</param>
     /// <param name="target">The target element to copy attributes to.</param>
-    /// <param name="skipDeprecated">
-    /// Whether to skip the <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute. This is set when
-    /// copying to a property or event row, because the deprecation attribute is emitted on the accessor
-    /// method instead (see <see cref="CopyDeprecatedAttributeToAccessor"/>).
+    /// <param name="skipAccessorAttributes">
+    /// Whether to skip the attributes that belong on an accessor. This is set when copying to a property
+    /// or event row, because those are emitted on the accessor method instead (see
+    /// <see cref="CopyAccessorAttributes"/>).
     /// </param>
-    private void CopyCustomAttributes(IHasCustomAttribute source, IHasCustomAttribute target, bool skipDeprecated = false)
+    private void CopyCustomAttributes(IHasCustomAttribute source, IHasCustomAttribute target, bool skipAccessorAttributes = false)
     {
         foreach (CustomAttribute attribute in source.CustomAttributes)
         {
-            // The '[Deprecated]' attribute on properties and events is emitted on the accessor method
-            // (matching MIDL), so it is skipped here when copying attributes to the property or event row
-            if (skipDeprecated && IsDeprecatedAttribute(attribute))
+            // The accessor attributes on properties and events are emitted on the accessor method
+            // (matching MIDL), so they are skipped here when copying to the property or event row
+            if (skipAccessorAttributes && IsAccessorAttribute(attribute))
             {
                 continue;
             }
@@ -359,6 +386,15 @@ internal sealed partial class WinMDWriter
     /// <param name="target">The target element to copy the attribute to.</param>
     private void CopyCustomAttribute(CustomAttribute attribute, IHasCustomAttribute target)
     {
+        // The .NET '[Experimental]' attribute is translated back to the Windows Runtime one rather than
+        // copied: it is the projected form of it, and its own type has no Windows Runtime counterpart
+        if (IsDotNetExperimentalAttribute(attribute))
+        {
+            AddExperimentalAttribute(target);
+
+            return;
+        }
+
         if (!ShouldCopyAttribute(attribute, _runtimeContext))
         {
             return;
@@ -375,26 +411,37 @@ internal sealed partial class WinMDWriter
     }
 
     /// <summary>
-    /// Copies the <c>[Windows.Foundation.Metadata.Deprecated]</c> attribute (if any) from a property or
-    /// event onto its accessor method (the getter for properties, the <c>add</c> accessor for events).
+    /// Copies the accessor attributes (if any) from a property or event onto its accessor method (the
+    /// getter for properties, the <c>add</c> accessor for events).
     /// </summary>
     /// <remarks>
-    /// Windows Runtime metadata places the deprecation attribute on the accessor method rather than the
-    /// property or event row (this is the placement MIDL produces). Emitting it on the accessor keeps
-    /// authored components consistent with the Windows SDK, so that both CsWinRT and other consumers
-    /// (e.g. <c>windows-rs</c>) resolve member deprecation the same way.
+    /// Windows Runtime metadata places these attributes on the accessor method rather than the property
+    /// or event row (this is the placement MIDL produces). Emitting them on the accessor keeps authored
+    /// components consistent with the Windows SDK, so that both CsWinRT and other consumers
+    /// (e.g. <c>windows-rs</c>) resolve member deprecation and experimental markers the same way.
     /// </remarks>
-    /// <param name="source">The source property or event to read the attribute from.</param>
-    /// <param name="accessor">The accessor method (or fallback element) to copy the attribute to.</param>
-    private void CopyDeprecatedAttributeToAccessor(IHasCustomAttribute source, IHasCustomAttribute accessor)
+    /// <param name="source">The source property or event to read the attributes from.</param>
+    /// <param name="accessor">The accessor method (or fallback element) to copy the attributes to.</param>
+    private void CopyAccessorAttributes(IHasCustomAttribute source, IHasCustomAttribute accessor)
     {
         foreach (CustomAttribute attribute in source.CustomAttributes)
         {
-            if (IsDeprecatedAttribute(attribute))
+            if (IsAccessorAttribute(attribute))
             {
                 CopyCustomAttribute(attribute, accessor);
             }
         }
+    }
+
+    /// <summary>
+    /// Returns whether the given custom attribute belongs on a property or event accessor in Windows
+    /// Runtime metadata, rather than on the property or event row itself.
+    /// </summary>
+    /// <param name="attribute">The custom attribute to evaluate.</param>
+    /// <returns><see langword="true"/> if the attribute belongs on the accessor; otherwise, <see langword="false"/>.</returns>
+    private static bool IsAccessorAttribute(CustomAttribute attribute)
+    {
+        return IsDeprecatedAttribute(attribute) || IsDotNetExperimentalAttribute(attribute);
     }
 
     /// <summary>
@@ -405,6 +452,16 @@ internal sealed partial class WinMDWriter
     private static bool IsDeprecatedAttribute(CustomAttribute attribute)
     {
         return attribute.Constructor?.DeclaringType?.FullName == "Windows.Foundation.Metadata.DeprecatedAttribute";
+    }
+
+    /// <summary>
+    /// Returns whether the given custom attribute is a <c>[System.Diagnostics.CodeAnalysis.Experimental]</c> attribute.
+    /// </summary>
+    /// <param name="attribute">The custom attribute to evaluate.</param>
+    /// <returns><see langword="true"/> if the attribute is the .NET experimental attribute; otherwise, <see langword="false"/>.</returns>
+    private static bool IsDotNetExperimentalAttribute(CustomAttribute attribute)
+    {
+        return attribute.Constructor?.DeclaringType?.FullName == "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs
@@ -363,13 +363,31 @@ internal sealed partial class WinMDWriter
     /// or event row, because those are emitted on the accessor method instead (see
     /// <see cref="CopyAccessorAttributes"/>).
     /// </param>
-    private void CopyCustomAttributes(IHasCustomAttribute source, IHasCustomAttribute target, bool skipAccessorAttributes = false)
+    /// <param name="skipExperimentalAttribute">
+    /// Whether to skip the .NET <c>[Experimental]</c> attribute. This is set when copying to a constructor,
+    /// which has no Windows Runtime target that can carry it (see <see cref="AddExperimentalAttribute"/>).
+    /// </param>
+    private void CopyCustomAttributes(
+        IHasCustomAttribute source,
+        IHasCustomAttribute target,
+        bool skipAccessorAttributes = false,
+        bool skipExperimentalAttribute = false)
     {
         foreach (CustomAttribute attribute in source.CustomAttributes)
         {
             // The accessor attributes on properties and events are emitted on the accessor method
             // (matching MIDL), so they are skipped here when copying to the property or event row
             if (skipAccessorAttributes && IsAccessorAttribute(attribute))
+            {
+                continue;
+            }
+
+            // Windows Runtime has no constructor target for '[Experimental]': constructors are exposed
+            // through activation factory methods, and the '.ctor' row on a runtime class carries no such
+            // marker (MIDL never emits one there, and no Windows SDK '.ctor' row has one). The application
+            // is reported by the 'CSWINRT2021' analyzer instead of being silently emitted where nothing
+            // would ever read it.
+            if (skipExperimentalAttribute && IsDotNetExperimentalAttribute(attribute))
             {
                 continue;
             }

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -123,8 +123,9 @@ internal sealed partial class WinMDWriter
 
         outputType.Methods.Add(outputMethod);
 
-        // Copy custom attributes from the input method
-        CopyCustomAttributes(inputMethod, outputMethod);
+        // Copy custom attributes from the input method. Constructors are exposed to Windows Runtime
+        // through activation factory methods, so their '.ctor' row carries no '[Experimental]' marker.
+        CopyCustomAttributes(inputMethod, outputMethod, skipExperimentalAttribute: isConstructor);
     }
 
     /// <summary>

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs
@@ -343,11 +343,11 @@ internal sealed partial class WinMDWriter
 
         outputType.Properties.Add(outputProperty);
 
-        // Copy custom attributes from the input property. The '[Deprecated]' attribute is emitted on the
-        // accessor (the getter, or the setter for write-only properties) rather than the property row,
-        // matching the placement used by MIDL so that property deprecation resolves consistently
-        CopyCustomAttributes(inputProperty, outputProperty, skipDeprecated: true);
-        CopyDeprecatedAttributeToAccessor(inputProperty, getter ?? setter ?? (IHasCustomAttribute)outputProperty);
+        // Copy custom attributes from the input property. The accessor attributes (e.g. '[Deprecated]')
+        // are emitted on the accessor (the getter, or the setter for write-only properties) rather than
+        // the property row, matching the placement used by MIDL so that they resolve consistently
+        CopyCustomAttributes(inputProperty, outputProperty, skipAccessorAttributes: true);
+        CopyAccessorAttributes(inputProperty, getter ?? setter ?? (IHasCustomAttribute)outputProperty);
     }
 
     /// <summary>
@@ -375,10 +375,10 @@ internal sealed partial class WinMDWriter
 
         outputType.Properties.Add(outputProperty);
 
-        // Copy custom attributes from the input property. The '[Deprecated]' attribute is emitted on the
-        // setter accessor rather than the property row, matching the placement used by MIDL
-        CopyCustomAttributes(inputProperty, outputProperty, skipDeprecated: true);
-        CopyDeprecatedAttributeToAccessor(inputProperty, setter);
+        // Copy custom attributes from the input property. The accessor attributes (e.g. '[Deprecated]')
+        // are emitted on the setter accessor rather than the property row, matching the placement used by MIDL
+        CopyCustomAttributes(inputProperty, outputProperty, skipAccessorAttributes: true);
+        CopyAccessorAttributes(inputProperty, setter);
     }
 
     /// <summary>
@@ -483,9 +483,9 @@ internal sealed partial class WinMDWriter
 
         outputType.Events.Add(outputEvent);
 
-        // Copy custom attributes from the input event. The '[Deprecated]' attribute is emitted on the
-        // 'add' accessor rather than the event row, matching the placement used by MIDL
-        CopyCustomAttributes(inputEvent, outputEvent, skipDeprecated: true);
-        CopyDeprecatedAttributeToAccessor(inputEvent, adder);
+        // Copy custom attributes from the input event. The accessor attributes (e.g. '[Deprecated]') are
+        // emitted on the 'add' accessor rather than the event row, matching the placement used by MIDL
+        CopyCustomAttributes(inputEvent, outputEvent, skipAccessorAttributes: true);
+        CopyAccessorAttributes(inputEvent, adder);
     }
 }

--- a/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
+++ b/src/WinRT.WinMD.Generator/Writers/WinMDWriter.Types.cs
@@ -132,6 +132,10 @@ internal sealed partial class WinMDWriter
             }
 
             outputType.Fields.Add(outputField);
+
+            // Copy custom attributes from the input field: Windows Runtime metadata supports member
+            // markers (e.g. '[Deprecated]' and '[Experimental]') on individual enum members
+            CopyCustomAttributes(field, outputField);
         }
     }
 
@@ -360,6 +364,10 @@ internal sealed partial class WinMDWriter
                 signature: new FieldSignature(MapTypeSignatureToOutput(field.Signature!.FieldType)));
 
             outputType.Fields.Add(outputField);
+
+            // Copy custom attributes from the input field: Windows Runtime metadata supports member
+            // markers (e.g. '[Deprecated]' and '[Experimental]') on individual struct fields
+            CopyCustomAttributes(field, outputField);
         }
     }
 


### PR DESCRIPTION
## Summary

Custom-map `Windows.Foundation.Metadata.ExperimentalAttribute` to `System.Diagnostics.CodeAnalysis.ExperimentalAttribute`, with the `CSWINRT3005` diagnostic id, in both directions (projection and component authoring). Also adds `docs/attribute-projections.md`, documenting every attribute CsWinRT translates rather than projects verbatim.

> [!NOTE]
> Stacked on top of #2457, which is where the `[Deprecated]` support this builds on comes from. Only the last three commits belong to this PR.

## Motivation

`Windows.Foundation.Metadata.ExperimentalAttribute` was projected as an ordinary Windows Runtime attribute type, and the C# compiler happened to recognize it *by name* and report `CS8305` for its use sites. That is a hard-coded, single, non-actionable warning: it cannot be suppressed for one API without suppressing it for every experimental API in the SDK, it carries no link to any documentation, and it only works because the compiler special-cases that one type name.

C# 12 added [`[Experimental]`](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) as the first-class modeling of exactly this concept, and it is strictly richer: it carries a diagnostic id, a help link, and a message, so opting into an experimental API becomes a normal, per-id, greppable suppression. Projecting the Windows Runtime attribute as the .NET one is the same treatment `IClosable`, `IReference<T>` and every other Windows Runtime type with a .NET counterpart already gets.

The behavior around attributes is also currently only discoverable by reading the projection writer and the WinMD generator, which is why this adds a documentation page for it.

## Changes

### Projection (`.winmd` → C#)

- **`src/WinRT.Projection.Writer/Helpers/MappedTypes.cs`**: custom-maps `Windows.Foundation.Metadata.ExperimentalAttribute` to `System.Diagnostics.CodeAnalysis.ExperimentalAttribute`, so the Windows Runtime attribute type is no longer projected.

- **`src/WinRT.Projection.Writer/Factories/CustomAttributeFactory.cs`**: emits `[Experimental("CSWINRT3005", UrlFormat = ..., Message = ...)]` for every application. Windows Runtime metadata has no per-API diagnostic id (the attribute takes no arguments), so all experimental APIs share one CsWinRT-owned id. The emit loop is extracted into a `WriteAttribute` helper so this and the carried-over path share it.

- **`src/WinRT.Projection.Writer/Factories/InterfaceFactory.cs`**: the same for the interface member level carry-over path.

- **`src/WinRT.Projection.Writer/References/WellKnownDiagnostics.cs`**: new, holds the diagnostic id, message and url format.

- **`src/WinRT.Projection.Writer/Extensions/ProjectionWriterExtensions.cs`**: generated projection files suppress `CSWINRT3005` in their prelude, alongside the `CS0612`/`CS0618` they already suppress. A projection has to name an experimental type in order to project it at all, so the marker is guidance for the consumers of a projection, not for the projection itself. Unlike `CS8305`, this is reported as an error by default, so the suppression is what keeps the Windows SDK projection building.

- **`src/Projections/Directory.Build.props`**: drops the now-redundant `CS8305` `NoWarn` (verified by building the full Windows SDK reference projection without it).

Emission stays reference-projection-only, matching every other metadata attribute: implementation projections are only ever loaded at runtime, and attribute blobs cannot be trimmed by ILLink or ILC.

### Authoring (C# → `.winmd`)

Since the Windows Runtime attribute type is no longer projected, it has no projected form left for a component author to apply. Authored components use the .NET `[Experimental]` instead, and the generator translates it back, so the component looks the same to every other language projection as one authored in MIDL.

- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.Attributes.cs`**: translates `System.Diagnostics.CodeAnalysis.ExperimentalAttribute` into `Windows.Foundation.Metadata.ExperimentalAttribute`. The diagnostic id, `UrlFormat` and `Message` are dropped, as Windows Runtime metadata has nowhere to carry them.

- **`src/WinRT.WinMD.Generator/Writers/WinMDWriter.Members.cs`**: generalizes the accessor placement established for `[Deprecated]` in #2457, so both attributes land on the accessor method for properties and events (the placement MIDL produces), rather than duplicating it.

### Documentation

- **`docs/attribute-projections.md`**: new, one table per direction covering every attribute CsWinRT translates rather than projects verbatim, including which projection assemblies each result lands in. The two asymmetries easiest to get wrong are called out explicitly: the metadata attribute types that are not projected as types at all, and the fact that `[Obsolete]` on an authored component is *not* translated into `[Deprecated]`, so it is invisible to every other language projection.

- **`docs/diagnostics/cswinrt3005.md`**: new, the diagnostic page, including how to opt into an experimental API and why it is an error rather than a warning.

- **`README.md`**, **`docs/authoring.md`**, **`.github/copilot-instructions.md`**: link the new pages and record the new diagnostic id.

## Testing

- **`src/Tests/ProjectionWriterTest/Test_MappedAttributes.cs`**: new, asserts the exact attribute text the writer emits (so the id, url and message cannot drift from the docs page silently), that it is reference-projection-only, and that neither the Windows Runtime attribute type nor any application of it survives.

- **`src/Tests/WinMDGeneratorTest/Test_ExperimentalAttribute.cs`**: new, asserts the authoring translation for types, methods, properties and events. `WinMDGeneratorRunner` gains the ability to read attributes back out of the generated `.winmd` (via `System.Reflection.Metadata`, with Windows Runtime projections disabled so the raw metadata is asserted), which is what lets these tests assert *placement*, not just success.

- **`src/Tests/UnitTest/TestComponentCSharp_Tests.cs`**: updates the existing `CS8305` suppression to `CSWINRT3005`, and adds a test asserting the attribute does not survive into the implementation projection loaded at runtime.

- **`src/Tests/WinMDGeneratorTest/WinMDGeneratorTest.csproj`**: drops `Platform` from the generator `ProjectReference`'s `UndefineProperties`, matching `ProjectionWriterTest`. Without it, building with an explicit platform puts the tool under `bin\<platform>\` while the tests look for it under `bin\`, so they silently run against a stale tool.

Verified by building the full Windows SDK reference projection (0 warnings, 0 errors, 40 projected `[Experimental]` applications and no leftover Windows Runtime ones) and running both generator test suites.
