### PR TITLE
Project Windows Runtime struct fields as C# fields

### DIFF
--- a/docs/cswinrt3.0-spec.md
+++ b/docs/cswinrt3.0-spec.md
@@ -94,9 +94,15 @@ CsWinRT 3.0 will update the projection of `T[]` parameters to use first-class sp
 
 This means you no longer need to allocate and copy stuff into arrays all over the place (because you also need the size to be exactly right, so you can't even use the array pool). Instead, you'll be able to just use spans normally. Which also means you can now even make it 0-alloc and pass stack-allocated params entirely. This is source compatible thanks to the [first class span](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/first-class-span-types) types feature of C# 14.
 
-### Fixing `Point`/`Rect`/`Size` properties
+### Fixing `Point`/`Rect`/`Size` fields
 
-These foundational types have historically been projecting their fields as `double`, instead of `float`. This is not ideal for several reasons: it introduces implicit casts when assigning to or reading from them, it doesn't match the WinRT ABI (the backing data is still just floats), and it unnecessary impacts performance when doing lots of heavy calculations with them. In CsWinRT 3.0, we want to try fixing this design aspect and correctly projecting these members as `float`, and monitor what the real impact is on popular projects using WinRT from C#.
+These foundational types have historically been projecting their fields as `double` properties, instead of `float` fields. This is not ideal for several reasons: it introduces implicit casts when assigning to or reading from them, it doesn't match the WinRT ABI (the backing data is still just floats), and it unnecessary impacts performance when doing lots of heavy calculations with them. In CsWinRT 3.0, we want to try fixing this design aspect and correctly projecting these members as `float` fields, and monitor what the real impact is on popular projects using WinRT from C#.
+
+### Projecting struct fields as fields
+
+Windows Runtime structs are plain data: all their members are fields in metadata. CsWinRT 3.0 projects them as C# fields, matching both the metadata and what C++/WinRT does. This keeps the projected shape honest (there is no accessor to run any logic behind), it allows callers to take a reference to a member (e.g. to pass it as a `ref` argument), and it makes authoring work symmetrically: `cswinrtwinmdgen.exe` maps public instance fields of an authored `struct` back to Windows Runtime struct fields, so the shape you consume is exactly the shape you author.
+
+This also applies to the manually projected and custom-mapped struct types, such as `Windows.Foundation.Point` and `Microsoft.UI.Xaml.CornerRadius`. Any additional member those types expose that does not correspond to a Windows Runtime struct field (e.g. `Rect.Left` or `GridLength.IsAuto`) remains a managed-only property.
 
 ### Unifying foundational event handers with .NET
 

--- a/docs/event-infrastructure.md
+++ b/docs/event-infrastructure.md
@@ -57,7 +57,7 @@ A simple value type wrapping a 64-bit integer. This is the Windows Runtime's con
 ```csharp
 public struct EventRegistrationToken : IEquatable<EventRegistrationToken>
 {
-    public long Value { get; set; }
+    public long Value;
 }
 ```
 

--- a/src/Tests/ProjectionWriterTest/Test_ProjectedStructs.cs
+++ b/src/Tests/ProjectionWriterTest/Test_ProjectedStructs.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ProjectionWriterTest.Helpers;
+
+namespace ProjectionWriterTest;
+
+/// <summary>
+/// Tests for how the projection writer projects the members of Windows Runtime struct types.
+/// </summary>
+/// <remarks>
+/// Windows Runtime structs are plain data: their members are fields in metadata, and they must be
+/// projected as C# fields. Projecting them as properties breaks authoring (the WinMD generator only
+/// maps public instance fields back to Windows Runtime struct fields, so an authored struct using
+/// properties would produce an empty struct in metadata), and it prevents callers from taking a
+/// reference to a member.
+/// </remarks>
+[TestClass]
+public class Test_ProjectedStructs
+{
+    /// <summary>
+    /// Every field of a projected struct is emitted as a public C# field.
+    /// </summary>
+    /// <remarks>
+    /// <c>Windows.Foundation.Numerics.Rational</c> is the only non-mapped struct in the projected
+    /// namespace, so it is the anchor for both assertions.
+    /// </remarks>
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void StructFields_AreProjectedAsFields(bool referenceProjection)
+    {
+        string sources = ProjectionWriterRunner.GetSources(referenceProjection);
+
+        StringAssert.Contains(sources, "public uint Numerator;", "'Rational.Numerator' should be projected as a field.");
+        StringAssert.Contains(sources, "public uint Denominator;", "'Rational.Denominator' should be projected as a field.");
+    }
+
+    /// <summary>
+    /// No projected struct member is emitted as an auto-property.
+    /// </summary>
+    /// <remarks>
+    /// Guards against a regression to the <c>{ readonly get; set; }</c> form that projected struct
+    /// members used to be emitted with.
+    /// </remarks>
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void StructFields_AreNotProjectedAsProperties(bool referenceProjection)
+    {
+        string sources = ProjectionWriterRunner.GetSources(referenceProjection);
+
+        Assert.IsFalse(sources.Contains("readonly get; set;"), "Struct members should be projected as fields, not as auto-properties.");
+    }
+}

--- a/src/WinRT.Projection.Writer/Builders/ProjectionFileBuilder.cs
+++ b/src/WinRT.Projection.Writer/Builders/ProjectionFileBuilder.cs
@@ -201,6 +201,16 @@ internal static class ProjectionFileBuilder
 
         using (writer.WriteBlock())
         {
+            // Windows Runtime struct fields are projected as C# fields, matching the ABI
+            // layout exactly. They are emitted first, so that the declaration order (which
+            // determines the sequential layout of the struct) mirrors the metadata order.
+            foreach ((string typeStr, string name, string _, bool _) in fields)
+            {
+                writer.WriteLine($"public {typeStr} {name};");
+            }
+
+            writer.WriteLineIf(fields.Count > 0);
+
             // Emit the constructor declaration
             writer.Write($"public {projectionName}(");
             for (int i = 0; i < fields.Count; i++)
@@ -231,17 +241,6 @@ internal static class ProjectionFileBuilder
                 }
 
                 writer.WriteLine();
-            }
-
-            // Properties (all getters are readonly)
-            foreach ((string typeStr, string name, string _, bool _) in fields)
-            {
-                writer.WriteLine($$"""
-                    public {{typeStr}} {{name}}
-                    {
-                        readonly get; set;
-                    }
-                    """);
             }
 
             // Overridden '==' operator

--- a/src/WinRT.Projection.Writer/Factories/AbiStructFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiStructFactory.cs
@@ -25,9 +25,10 @@ internal static class AbiStructFactory
     public static void WriteAbiStruct(IndentedTextWriter writer, ProjectionEmitContext context, TypeDefinition type)
     {
         // Emit the underlying ABI struct only when not blittable AND not a mapped struct
-        // (mapped structs like Duration/KeyTime/RepeatBehavior have addition files that
-        // replace the public struct's field layout, so a per-field ABI struct can't be
-        // built directly from the projected type).
+        // (mapped structs like Duration/KeyTime/RepeatBehavior are defined in full by an
+        // addition file rather than generated from metadata, so the writer can't build a
+        // per-field ABI struct from the projected type; those types instead guarantee a
+        // layout-compatible shape themselves and are passed through by value).
         bool blittable = AbiTypeHelpers.IsTypeBlittable(context.Cache, type);
         (string typeNs, string typeNm) = type.Names();
         bool isMappedStruct = MappedTypes.Get(typeNs, typeNm) is not null;

--- a/src/WinRT.Projection.Writer/Factories/StructEnumMarshallerFactory.cs
+++ b/src/WinRT.Projection.Writer/Factories/StructEnumMarshallerFactory.cs
@@ -75,9 +75,9 @@ internal static class StructEnumMarshallerFactory
 
         // For structs that are mapped (e.g. Duration, KeyTime, RepeatBehavior — they have
         // EmitAbi=true and an addition file that completely replaces the public struct), skip
-        // the per-field ConvertToUnmanaged/ConvertToManaged because the projected struct's
-        // public fields don't match the WinMD field layout. The truth marshaller for these
-        // contains only BoxToUnmanaged/UnboxToManaged.
+        // the per-field ConvertToUnmanaged/ConvertToManaged: no ABI struct is emitted for them
+        // (see AbiStructFactory), as they are passed through by value. The truth marshaller for
+        // these contains only BoxToUnmanaged/UnboxToManaged.
         (string typeNs, string typeNm) = type.Names();
         bool isMappedStruct = isNonBlittableStruct && MappedTypes.Get(typeNs, typeNm) is not null;
 

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.KeyTime.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.KeyTime.cs
@@ -8,8 +8,10 @@ namespace Microsoft.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Media.Animation.KeyTime>")]
     [ABI.Microsoft.UI.Xaml.Media.Animation.KeyTimeComWrappersMarshaller]
 #endif
-    public readonly struct KeyTime : IEquatable<KeyTime>
+    public struct KeyTime : IEquatable<KeyTime>
     {
+        public TimeSpan TimeSpan;
+
         public static KeyTime FromTimeSpan(TimeSpan timeSpan)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(timeSpan, TimeSpan.Zero, nameof(timeSpan));
@@ -55,11 +57,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
         public static implicit operator KeyTime(TimeSpan timeSpan)
         {
             return KeyTime.FromTimeSpan(timeSpan);
-        }
-
-        public TimeSpan TimeSpan
-        {
-            readonly get; private init;
         }
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Animation/Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs
@@ -10,6 +10,10 @@ namespace Microsoft.UI.Xaml.Media.Animation
 #endif
     public struct RepeatBehavior : IFormattable, IEquatable<RepeatBehavior>
     {
+        public double Count;
+        public TimeSpan Duration;
+        public RepeatBehaviorType Type;
+
         internal static bool IsFinite(double value)
         {
             return !(double.IsNaN(value) || double.IsInfinity(value));
@@ -61,21 +65,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
             {
                 return Type == RepeatBehaviorType.Duration;
             }
-        }
-
-        public double Count
-        {
-            readonly get; set;
-        }
-
-        public TimeSpan Duration
-        {
-            readonly get; set;
-        }
-
-        public RepeatBehaviorType Type
-        {
-            readonly get; set;
         }
 
         public readonly override string ToString()

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Media3D/Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml.Media.Media3D/Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs
@@ -10,14 +10,31 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 #endif
     public struct Matrix3D : IFormattable, IEquatable<Matrix3D>
     {
+        public double M11;
+        public double M12;
+        public double M13;
+        public double M14;
+        public double M21;
+        public double M22;
+        public double M23;
+        public double M24;
+        public double M31;
+        public double M32;
+        public double M33;
+        public double M34;
+        public double OffsetX;
+        public double OffsetY;
+        public double OffsetZ;
+        public double M44;
+
         // Assuming this matrix has fourth column of 0,0,0,1 and isn't identity this function:
         // Returns false if HasInverse is false, otherwise inverts the matrix.
         private bool NormalizedAffineInvert()
         {
-            double z20 = _m12 * _m23 - _m22 * _m13;
-            double z10 = _m32 * _m13 - _m12 * _m33;
-            double z00 = _m22 * _m33 - _m32 * _m23;
-            double det = _m31 * z20 + _m21 * z10 + _m11 * z00;
+            double z20 = M12 * M23 - M22 * M13;
+            double z10 = M32 * M13 - M12 * M33;
+            double z00 = M22 * M33 - M32 * M23;
+            double det = M31 * z20 + M21 * z10 + M11 * z00;
 
             if (IsZero(det))
             {
@@ -25,23 +42,23 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             }
 
             // Compute 3x3 non-zero cofactors for the 2nd column
-            double z21 = _m21 * _m13 - _m11 * _m23;
-            double z11 = _m11 * _m33 - _m31 * _m13;
-            double z01 = _m31 * _m23 - _m21 * _m33;
+            double z21 = M21 * M13 - M11 * M23;
+            double z11 = M11 * M33 - M31 * M13;
+            double z01 = M31 * M23 - M21 * M33;
 
             // Compute all six 2x2 determinants of 1st two columns
-            double y01 = _m11 * _m22 - _m21 * _m12;
-            double y02 = _m11 * _m32 - _m31 * _m12;
-            double y03 = _m11 * _offsetY - _offsetX * _m12;
-            double y12 = _m21 * _m32 - _m31 * _m22;
-            double y13 = _m21 * _offsetY - _offsetX * _m22;
-            double y23 = _m31 * _offsetY - _offsetX * _m32;
+            double y01 = M11 * M22 - M21 * M12;
+            double y02 = M11 * M32 - M31 * M12;
+            double y03 = M11 * OffsetY - OffsetX * M12;
+            double y12 = M21 * M32 - M31 * M22;
+            double y13 = M21 * OffsetY - OffsetX * M22;
+            double y23 = M31 * OffsetY - OffsetX * M32;
 
             // Compute all non-zero and non-one 3x3 cofactors for 2nd
             // two columns
-            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
-            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
-            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
+            double z23 = M23 * y03 - OffsetZ * y01 - M13 * y13;
+            double z13 = M13 * y23 - M33 * y03 + OffsetZ * y02;
+            double z03 = M33 * y13 - OffsetZ * y12 - M23 * y23;
             double z22 = y01;
             double z12 = -y02;
             double z02 = y12;
@@ -49,21 +66,21 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             double rcp = 1.0 / det;
 
             // Multiply all 3x3 cofactors by reciprocal & transpose
-            _m11 = (z00 * rcp);
-            _m12 = (z10 * rcp);
-            _m13 = (z20 * rcp);
+            M11 = (z00 * rcp);
+            M12 = (z10 * rcp);
+            M13 = (z20 * rcp);
 
-            _m21 = (z01 * rcp);
-            _m22 = (z11 * rcp);
-            _m23 = (z21 * rcp);
+            M21 = (z01 * rcp);
+            M22 = (z11 * rcp);
+            M23 = (z21 * rcp);
 
-            _m31 = (z02 * rcp);
-            _m32 = (z12 * rcp);
-            _m33 = (z22 * rcp);
+            M31 = (z02 * rcp);
+            M32 = (z12 * rcp);
+            M33 = (z22 * rcp);
 
-            _offsetX = (z03 * rcp);
-            _offsetY = (z13 * rcp);
-            _offsetZ = (z23 * rcp);
+            OffsetX = (z03 * rcp);
+            OffsetY = (z13 * rcp);
+            OffsetZ = (z23 * rcp);
 
             return true;
         }
@@ -77,21 +94,21 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             }
 
             // compute all six 2x2 determinants of 2nd two columns
-            double y01 = _m13 * _m24 - _m23 * _m14;
-            double y02 = _m13 * _m34 - _m33 * _m14;
-            double y03 = _m13 * _m44 - _offsetZ * _m14;
-            double y12 = _m23 * _m34 - _m33 * _m24;
-            double y13 = _m23 * _m44 - _offsetZ * _m24;
-            double y23 = _m33 * _m44 - _offsetZ * _m34;
+            double y01 = M13 * M24 - M23 * M14;
+            double y02 = M13 * M34 - M33 * M14;
+            double y03 = M13 * M44 - OffsetZ * M14;
+            double y12 = M23 * M34 - M33 * M24;
+            double y13 = M23 * M44 - OffsetZ * M24;
+            double y23 = M33 * M44 - OffsetZ * M34;
 
             // Compute 3x3 cofactors for 1st the column
-            double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
-            double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
-            double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
-            double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+            double z30 = M22 * y02 - M32 * y01 - M12 * y12;
+            double z20 = M12 * y13 - M22 * y03 + OffsetY * y01;
+            double z10 = M32 * y03 - OffsetY * y02 - M12 * y23;
+            double z00 = M22 * y23 - M32 * y13 + OffsetY * y12;
 
             // Compute 4x4 determinant
-            double det = _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+            double det = OffsetX * z30 + M31 * z20 + M21 * z10 + M11 * z00;
 
             if (IsZero(det))
             {
@@ -99,51 +116,51 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             }
 
             // Compute 3x3 cofactors for the 2nd column
-            double z31 = _m11 * y12 - _m21 * y02 + _m31 * y01;
-            double z21 = _m21 * y03 - _offsetX * y01 - _m11 * y13;
-            double z11 = _m11 * y23 - _m31 * y03 + _offsetX * y02;
-            double z01 = _m31 * y13 - _offsetX * y12 - _m21 * y23;
+            double z31 = M11 * y12 - M21 * y02 + M31 * y01;
+            double z21 = M21 * y03 - OffsetX * y01 - M11 * y13;
+            double z11 = M11 * y23 - M31 * y03 + OffsetX * y02;
+            double z01 = M31 * y13 - OffsetX * y12 - M21 * y23;
 
             // Compute all six 2x2 determinants of 1st two columns
-            y01 = _m11 * _m22 - _m21 * _m12;
-            y02 = _m11 * _m32 - _m31 * _m12;
-            y03 = _m11 * _offsetY - _offsetX * _m12;
-            y12 = _m21 * _m32 - _m31 * _m22;
-            y13 = _m21 * _offsetY - _offsetX * _m22;
-            y23 = _m31 * _offsetY - _offsetX * _m32;
+            y01 = M11 * M22 - M21 * M12;
+            y02 = M11 * M32 - M31 * M12;
+            y03 = M11 * OffsetY - OffsetX * M12;
+            y12 = M21 * M32 - M31 * M22;
+            y13 = M21 * OffsetY - OffsetX * M22;
+            y23 = M31 * OffsetY - OffsetX * M32;
 
             // Compute all 3x3 cofactors for 2nd two columns
-            double z33 = _m13 * y12 - _m23 * y02 + _m33 * y01;
-            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
-            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
-            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
-            double z32 = _m24 * y02 - _m34 * y01 - _m14 * y12;
-            double z22 = _m14 * y13 - _m24 * y03 + _m44 * y01;
-            double z12 = _m34 * y03 - _m44 * y02 - _m14 * y23;
-            double z02 = _m24 * y23 - _m34 * y13 + _m44 * y12;
+            double z33 = M13 * y12 - M23 * y02 + M33 * y01;
+            double z23 = M23 * y03 - OffsetZ * y01 - M13 * y13;
+            double z13 = M13 * y23 - M33 * y03 + OffsetZ * y02;
+            double z03 = M33 * y13 - OffsetZ * y12 - M23 * y23;
+            double z32 = M24 * y02 - M34 * y01 - M14 * y12;
+            double z22 = M14 * y13 - M24 * y03 + M44 * y01;
+            double z12 = M34 * y03 - M44 * y02 - M14 * y23;
+            double z02 = M24 * y23 - M34 * y13 + M44 * y12;
 
             double rcp = 1.0 / det;
 
             // Multiply all 3x3 cofactors by reciprocal & transpose
-            _m11 = (z00 * rcp);
-            _m12 = (z10 * rcp);
-            _m13 = (z20 * rcp);
-            _m14 = (z30 * rcp);
+            M11 = (z00 * rcp);
+            M12 = (z10 * rcp);
+            M13 = (z20 * rcp);
+            M14 = (z30 * rcp);
 
-            _m21 = (z01 * rcp);
-            _m22 = (z11 * rcp);
-            _m23 = (z21 * rcp);
-            _m24 = (z31 * rcp);
+            M21 = (z01 * rcp);
+            M22 = (z11 * rcp);
+            M23 = (z21 * rcp);
+            M24 = (z31 * rcp);
 
-            _m31 = (z02 * rcp);
-            _m32 = (z12 * rcp);
-            _m33 = (z22 * rcp);
-            _m34 = (z32 * rcp);
+            M31 = (z02 * rcp);
+            M32 = (z12 * rcp);
+            M33 = (z22 * rcp);
+            M34 = (z32 * rcp);
 
-            _offsetX = (z03 * rcp);
-            _offsetY = (z13 * rcp);
-            _offsetZ = (z23 * rcp);
-            _m44 = (z33 * rcp);
+            OffsetX = (z03 * rcp);
+            OffsetY = (z13 * rcp);
+            OffsetZ = (z23 * rcp);
+            M44 = (z33 * rcp);
 
             return true;
         }
@@ -153,219 +170,27 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                         double m31, double m32, double m33, double m34,
                         double offsetX, double offsetY, double offsetZ, double m44)
         {
-            _m11 = m11;
-            _m12 = m12;
-            _m13 = m13;
-            _m14 = m14;
-            _m21 = m21;
-            _m22 = m22;
-            _m23 = m23;
-            _m24 = m24;
-            _m31 = m31;
-            _m32 = m32;
-            _m33 = m33;
-            _m34 = m34;
-            _offsetX = offsetX;
-            _offsetY = offsetY;
-            _offsetZ = offsetZ;
-            _m44 = m44;
+            M11 = m11;
+            M12 = m12;
+            M13 = m13;
+            M14 = m14;
+            M21 = m21;
+            M22 = m22;
+            M23 = m23;
+            M24 = m24;
+            M31 = m31;
+            M32 = m32;
+            M33 = m33;
+            M34 = m34;
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+            OffsetZ = offsetZ;
+            M44 = m44;
         }
 
         // the transform is identity by default
         // Actually fill in the fields - some (internal) code uses the fields directly for perf.
         private static Matrix3D s_identity = CreateIdentity();
-
-        public double M11
-        {
-            readonly get
-            {
-                return _m11;
-            }
-            set
-            {
-                _m11 = value;
-            }
-        }
-
-        public double M12
-        {
-            readonly get
-            {
-                return _m12;
-            }
-            set
-            {
-                _m12 = value;
-            }
-        }
-
-        public double M13
-        {
-            readonly get
-            {
-                return _m13;
-            }
-            set
-            {
-                _m13 = value;
-            }
-        }
-
-        public double M14
-        {
-            readonly get
-            {
-                return _m14;
-            }
-            set
-            {
-                _m14 = value;
-            }
-        }
-
-        public double M21
-        {
-            readonly get
-            {
-                return _m21;
-            }
-            set
-            {
-                _m21 = value;
-            }
-        }
-
-        public double M22
-        {
-            readonly get
-            {
-                return _m22;
-            }
-            set
-            {
-                _m22 = value;
-            }
-        }
-
-        public double M23
-        {
-            readonly get
-            {
-                return _m23;
-            }
-            set
-            {
-                _m23 = value;
-            }
-        }
-
-        public double M24
-        {
-            readonly get
-            {
-                return _m24;
-            }
-            set
-            {
-                _m24 = value;
-            }
-        }
-
-        public double M31
-        {
-            readonly get
-            {
-                return _m31;
-            }
-            set
-            {
-                _m31 = value;
-            }
-        }
-
-        public double M32
-        {
-            readonly get
-            {
-                return _m32;
-            }
-            set
-            {
-                _m32 = value;
-            }
-        }
-
-        public double M33
-        {
-            readonly get
-            {
-                return _m33;
-            }
-            set
-            {
-                _m33 = value;
-            }
-        }
-
-        public double M34
-        {
-            readonly get
-            {
-                return _m34;
-            }
-            set
-            {
-                _m34 = value;
-            }
-        }
-
-        public double OffsetX
-        {
-            readonly get
-            {
-                return _offsetX;
-            }
-            set
-            {
-                _offsetX = value;
-            }
-        }
-
-        public double OffsetY
-        {
-            readonly get
-            {
-                return _offsetY;
-            }
-            set
-            {
-                _offsetY = value;
-            }
-        }
-
-        public double OffsetZ
-        {
-            readonly get
-            {
-                return _offsetZ;
-            }
-            set
-            {
-                _offsetZ = value;
-            }
-        }
-
-        public double M44
-        {
-            readonly get
-            {
-                return _m44;
-            }
-            set
-            {
-                _m44 = value;
-            }
-        }
 
         public static Matrix3D Identity
         {
@@ -379,10 +204,10 @@ namespace Microsoft.UI.Xaml.Media.Media3D
         {
             get
             {
-                return _m11 == 1 && _m12 == 0 && _m13 == 0 && _m14 == 0 &&
-                         _m21 == 0 && _m22 == 1 && _m23 == 0 && _m24 == 0 &&
-                         _m31 == 0 && _m32 == 0 && _m33 == 1 && _m34 == 0 &&
-                         _offsetX == 0 && _offsetY == 0 && _offsetZ == 0 && _m44 == 1;
+                return M11 == 1 && M12 == 0 && M13 == 0 && M14 == 0 &&
+                         M21 == 0 && M22 == 1 && M23 == 0 && M24 == 0 &&
+                         M31 == 0 && M32 == 0 && M33 == 1 && M34 == 0 &&
+                         OffsetX == 0 && OffsetY == 0 && OffsetZ == 0 && M44 == 1;
             }
         }
 
@@ -417,37 +242,37 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             // Helper to get the numeric list separator for a given culture.
             char separator = global::WindowsRuntime.InteropServices.TokenizerHelper.GetNumericListSeparator(provider);
             DefaultInterpolatedStringHandler handler = new(0, 31, provider, stackalloc char[256]);
-            handler.AppendFormatted(_m11, format);
+            handler.AppendFormatted(M11, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m12, format);
+            handler.AppendFormatted(M12, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m13, format);
+            handler.AppendFormatted(M13, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m14, format);
+            handler.AppendFormatted(M14, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m21, format);
+            handler.AppendFormatted(M21, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m22, format);
+            handler.AppendFormatted(M22, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m23, format);
+            handler.AppendFormatted(M23, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m24, format);
+            handler.AppendFormatted(M24, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m31, format);
+            handler.AppendFormatted(M31, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m32, format);
+            handler.AppendFormatted(M32, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m33, format);
+            handler.AppendFormatted(M33, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m34, format);
+            handler.AppendFormatted(M34, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetX, format);
+            handler.AppendFormatted(OffsetX, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetY, format);
+            handler.AppendFormatted(OffsetY, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetZ, format);
+            handler.AppendFormatted(OffsetZ, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m44, format);
+            handler.AppendFormatted(M44, format);
             return handler.ToStringAndClear();
 #endif
         }
@@ -613,22 +438,22 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                                double m31, double m32, double m33, double m34,
                                double offsetX, double offsetY, double offsetZ, double m44)
         {
-            _m11 = m11;
-            _m12 = m12;
-            _m13 = m13;
-            _m14 = m14;
-            _m21 = m21;
-            _m22 = m22;
-            _m23 = m23;
-            _m24 = m24;
-            _m31 = m31;
-            _m32 = m32;
-            _m33 = m33;
-            _m34 = m34;
-            _offsetX = offsetX;
-            _offsetY = offsetY;
-            _offsetZ = offsetZ;
-            _m44 = m44;
+            M11 = m11;
+            M12 = m12;
+            M13 = m13;
+            M14 = m14;
+            M21 = m21;
+            M22 = m22;
+            M23 = m23;
+            M24 = m24;
+            M31 = m31;
+            M32 = m32;
+            M33 = m33;
+            M34 = m34;
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+            OffsetZ = offsetZ;
+            M44 = m44;
         }
 
         private static bool Equals(Matrix3D matrix1, Matrix3D matrix2)
@@ -653,18 +478,18 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
         private readonly double GetNormalizedAffineDeterminant()
         {
-            double z20 = _m12 * _m23 - _m22 * _m13;
-            double z10 = _m32 * _m13 - _m12 * _m33;
-            double z00 = _m22 * _m33 - _m32 * _m23;
+            double z20 = M12 * M23 - M22 * M13;
+            double z10 = M32 * M13 - M12 * M33;
+            double z00 = M22 * M33 - M32 * M23;
 
-            return _m31 * z20 + _m21 * z10 + _m11 * z00;
+            return M31 * z20 + M21 * z10 + M11 * z00;
         }
 
         private readonly bool IsAffine
         {
             get
             {
-                return _m14 == 0.0 && _m24 == 0.0 && _m34 == 0.0 && _m44 == 1.0;
+                return M14 == 0.0 && M24 == 0.0 && M34 == 0.0 && M44 == 1.0;
             }
         }
 
@@ -678,20 +503,20 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 }
 
                 // compute all six 2x2 determinants of 2nd two columns
-                double y01 = _m13 * _m24 - _m23 * _m14;
-                double y02 = _m13 * _m34 - _m33 * _m14;
-                double y03 = _m13 * _m44 - _offsetZ * _m14;
-                double y12 = _m23 * _m34 - _m33 * _m24;
-                double y13 = _m23 * _m44 - _offsetZ * _m24;
-                double y23 = _m33 * _m44 - _offsetZ * _m34;
+                double y01 = M13 * M24 - M23 * M14;
+                double y02 = M13 * M34 - M33 * M14;
+                double y03 = M13 * M44 - OffsetZ * M14;
+                double y12 = M23 * M34 - M33 * M24;
+                double y13 = M23 * M44 - OffsetZ * M24;
+                double y23 = M33 * M44 - OffsetZ * M34;
 
                 // Compute 3x3 cofactors for 1st the column
-                double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
-                double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
-                double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
-                double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+                double z30 = M22 * y02 - M32 * y01 - M12 * y12;
+                double z20 = M12 * y13 - M22 * y03 + OffsetY * y01;
+                double z10 = M32 * y03 - OffsetY * y02 - M12 * y23;
+                double z00 = M22 * y23 - M32 * y13 + OffsetY * y12;
 
-                return _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+                return OffsetX * z30 + M31 * z20 + M21 * z10 + M11 * z00;
             }
         }
 
@@ -701,22 +526,5 @@ namespace Microsoft.UI.Xaml.Media.Media3D
         }
 
         private const double DBL_EPSILON_RELATIVE_1 = 1.1102230246251567e-016; /* smallest such that 1.0+DBL_EPSILON != 1.0 */
-
-        private double _m11;
-        private double _m12;
-        private double _m13;
-        private double _m14;
-        private double _m21;
-        private double _m22;
-        private double _m23;
-        private double _m24;
-        private double _m31;
-        private double _m32;
-        private double _m33;
-        private double _m34;
-        private double _offsetX;
-        private double _offsetY;
-        private double _offsetZ;
-        private double _m44;
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.CornerRadius.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.CornerRadius.cs
@@ -10,25 +10,25 @@ namespace Microsoft.UI.Xaml
 #endif
     public struct CornerRadius : IEquatable<CornerRadius>
     {
-        private double _TopLeft;
-        private double _TopRight;
-        private double _BottomRight;
-        private double _BottomLeft;
+        public double TopLeft;
+        public double TopRight;
+        public double BottomRight;
+        public double BottomLeft;
 
         public CornerRadius(double uniformRadius)
         {
             Validate(uniformRadius, uniformRadius, uniformRadius, uniformRadius);
-            _TopLeft = _TopRight = _BottomRight = _BottomLeft = uniformRadius;
+            TopLeft = TopRight = BottomRight = BottomLeft = uniformRadius;
         }
 
         public CornerRadius(double topLeft, double topRight, double bottomRight, double bottomLeft)
         {
             Validate(topLeft, topRight, bottomRight, bottomLeft);
 
-            _TopLeft = topLeft;
-            _TopRight = topRight;
-            _BottomRight = bottomRight;
-            _BottomLeft = bottomLeft;
+            TopLeft = topLeft;
+            TopRight = topRight;
+            BottomRight = bottomRight;
+            BottomLeft = bottomLeft;
         }
 
         private static void Validate(double topLeft, double topRight, double bottomRight, double bottomLeft)
@@ -62,13 +62,13 @@ namespace Microsoft.UI.Xaml
             // 48 = 4x double (twelve digits is generous for the range of values likely)
             //  3 = 3x separator characters
             DefaultInterpolatedStringHandler handler = new(0, 7, cultureInfo, stackalloc char[64]);
-            InternalAddToHandler(_TopLeft, ref handler);
+            InternalAddToHandler(TopLeft, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_TopRight, ref handler);
+            InternalAddToHandler(TopRight, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_BottomRight, ref handler);
+            InternalAddToHandler(BottomRight, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_BottomLeft, ref handler);
+            InternalAddToHandler(BottomLeft, ref handler);
             return handler.ToStringAndClear();
 #endif
         }
@@ -101,57 +101,17 @@ namespace Microsoft.UI.Xaml
 
         public readonly override int GetHashCode()
         {
-            return _TopLeft.GetHashCode() ^ _TopRight.GetHashCode() ^ _BottomLeft.GetHashCode() ^ _BottomRight.GetHashCode();
+            return TopLeft.GetHashCode() ^ TopRight.GetHashCode() ^ BottomLeft.GetHashCode() ^ BottomRight.GetHashCode();
         }
 
         public static bool operator ==(CornerRadius cr1, CornerRadius cr2)
         {
-            return cr1._TopLeft == cr2._TopLeft && cr1._TopRight == cr2._TopRight && cr1._BottomRight == cr2._BottomRight && cr1._BottomLeft == cr2._BottomLeft;
+            return cr1.TopLeft == cr2.TopLeft && cr1.TopRight == cr2.TopRight && cr1.BottomRight == cr2.BottomRight && cr1.BottomLeft == cr2.BottomLeft;
         }
 
         public static bool operator !=(CornerRadius cr1, CornerRadius cr2)
         {
             return !(cr1 == cr2);
-        }
-
-        public double TopLeft
-        {
-            readonly get { return _TopLeft; }
-            set
-            {
-                Validate(value, 0, 0, 0);
-                _TopLeft = value;
-            }
-        }
-
-        public double TopRight
-        {
-            readonly get { return _TopRight; }
-            set
-            {
-                Validate(0, value, 0, 0);
-                _TopRight = value;
-            }
-        }
-
-        public double BottomRight
-        {
-            readonly get { return _BottomRight; }
-            set
-            {
-                Validate(0, 0, value, 0);
-                _BottomRight = value;
-            }
-        }
-
-        public double BottomLeft
-        {
-            readonly get { return _BottomLeft; }
-            set
-            {
-                Validate(0, 0, 0, value);
-                _BottomLeft = value;
-            }
         }
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.Duration.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.Duration.cs
@@ -8,20 +8,20 @@ namespace Microsoft.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.Duration>")]
     [ABI.Microsoft.UI.Xaml.DurationComWrappersMarshaller]
 #endif
-    public readonly struct Duration : IEquatable<Duration>
+    public struct Duration : IEquatable<Duration>
     {
-        private readonly TimeSpan _timeSpan;
-        private readonly DurationType _durationType;
+        public TimeSpan TimeSpan;
+        public DurationType Type;
 
         public Duration(TimeSpan timeSpan)
         {
-            _durationType = DurationType.TimeSpan;
-            _timeSpan = timeSpan;
+            Type = DurationType.TimeSpan;
+            TimeSpan = timeSpan;
         }
 
         private Duration(DurationType durationType)
         {
-            _durationType = durationType;
+            Type = durationType;
         }
 
         public static implicit operator Duration(TimeSpan timeSpan)
@@ -33,9 +33,9 @@ namespace Microsoft.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return new Duration(t1._timeSpan + t2._timeSpan);
+                return new Duration(t1.TimeSpan + t2.TimeSpan);
             }
-            else if (t1._durationType != DurationType.Automatic && t2._durationType != DurationType.Automatic)
+            else if (t1.Type != DurationType.Automatic && t2.Type != DurationType.Automatic)
             {
                 return Duration.Forever;
             }
@@ -50,9 +50,9 @@ namespace Microsoft.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return new Duration(t1._timeSpan - t2._timeSpan);
+                return new Duration(t1.TimeSpan - t2.TimeSpan);
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return Duration.Forever;
             }
@@ -76,13 +76,13 @@ namespace Microsoft.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return t1._timeSpan > t2._timeSpan;
+                return t1.TimeSpan > t2.TimeSpan;
             }
-            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            else if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
             {
                 return false;
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return true;
             }
@@ -94,11 +94,11 @@ namespace Microsoft.UI.Xaml
 
         public static bool operator >=(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            else if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
             {
                 return false;
             }
@@ -112,13 +112,13 @@ namespace Microsoft.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return t1._timeSpan < t2._timeSpan;
+                return t1.TimeSpan < t2.TimeSpan;
             }
-            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            else if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return false;
             }
@@ -130,11 +130,11 @@ namespace Microsoft.UI.Xaml
 
         public static bool operator <=(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            else if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
             {
                 return false;
             }
@@ -146,9 +146,9 @@ namespace Microsoft.UI.Xaml
 
         public static int Compare(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic)
             {
-                if (t2._durationType == DurationType.Automatic)
+                if (t2.Type == DurationType.Automatic)
                 {
                     return 0;
                 }
@@ -157,7 +157,7 @@ namespace Microsoft.UI.Xaml
                     return -1;
                 }
             }
-            else if (t2._durationType == DurationType.Automatic)
+            else if (t2.Type == DurationType.Automatic)
             {
                 return 1;
             }
@@ -187,7 +187,7 @@ namespace Microsoft.UI.Xaml
         {
             get
             {
-                return _durationType == DurationType.TimeSpan;
+                return Type == DurationType.TimeSpan;
             }
         }
 
@@ -207,21 +207,6 @@ namespace Microsoft.UI.Xaml
             }
         }
 
-        public readonly TimeSpan TimeSpan
-        {
-            get
-            {
-                if (HasTimeSpan)
-                {
-                    return _timeSpan;
-                }
-                else
-                {
-                    throw new InvalidOperationException();
-                }
-            }
-        }
-
         public readonly Duration Add(Duration duration)
         {
             return this + duration;
@@ -238,7 +223,7 @@ namespace Microsoft.UI.Xaml
             {
                 if (duration.HasTimeSpan)
                 {
-                    return _timeSpan == duration._timeSpan;
+                    return TimeSpan == duration.TimeSpan;
                 }
                 else
                 {
@@ -247,7 +232,7 @@ namespace Microsoft.UI.Xaml
             }
             else
             {
-                return _durationType == duration._durationType;
+                return Type == duration.Type;
             }
         }
 
@@ -260,11 +245,11 @@ namespace Microsoft.UI.Xaml
         {
             if (HasTimeSpan)
             {
-                return _timeSpan.GetHashCode();
+                return TimeSpan.GetHashCode();
             }
             else
             {
-                return _durationType.GetHashCode() + 17;
+                return Type.GetHashCode() + 17;
             }
         }
 
@@ -277,9 +262,9 @@ namespace Microsoft.UI.Xaml
         {
             if (HasTimeSpan)
             {
-                return _timeSpan.ToString(); // "00"; //TypeDescriptor.GetConverter(_timeSpan).ConvertToString(_timeSpan);
+                return TimeSpan.ToString();
             }
-            else if (_durationType == DurationType.Forever)
+            else if (Type == DurationType.Forever)
             {
                 return "Forever";
             }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
@@ -8,10 +8,10 @@ namespace Microsoft.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Microsoft.UI.Xaml.GridLength>")]
     [ABI.Microsoft.UI.Xaml.GridLengthComWrappersMarshaller]
 #endif
-    public readonly struct GridLength : IEquatable<GridLength>
+    public struct GridLength : IEquatable<GridLength>
     {
-        private readonly double _unitValue;
-        private readonly GridUnitType _unitType;
+        public double Value;
+        public GridUnitType GridUnitType;
 
         private const double Default = 1.0;
         private static readonly GridLength s_auto = new(Default, GridUnitType.Auto);
@@ -38,18 +38,13 @@ namespace Microsoft.UI.Xaml
                 throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(type));
             }
 
-            _unitValue = (type == GridUnitType.Auto) ? Default : value;
-            _unitType = type;
+            Value = (type == GridUnitType.Auto) ? Default : value;
+            GridUnitType = type;
         }
 
-
-        public readonly double Value { get { return (_unitType == GridUnitType.Auto) ? s_auto._unitValue : _unitValue; } }
-        public readonly GridUnitType GridUnitType { get { return _unitType; } }
-
-
-        public readonly bool IsAbsolute { get { return _unitType == GridUnitType.Pixel; } }
-        public readonly bool IsAuto { get { return _unitType == GridUnitType.Auto; } }
-        public readonly bool IsStar { get { return _unitType == GridUnitType.Star; } }
+        public readonly bool IsAbsolute { get { return GridUnitType == GridUnitType.Pixel; } }
+        public readonly bool IsAuto { get { return GridUnitType == GridUnitType.Auto; } }
+        public readonly bool IsStar { get { return GridUnitType == GridUnitType.Star; } }
 
         public static GridLength Auto
         {
@@ -85,19 +80,19 @@ namespace Microsoft.UI.Xaml
 
         public readonly override int GetHashCode()
         {
-            return (int)_unitValue + (int)_unitType;
+            return (int)Value + (int)GridUnitType;
         }
 
         public readonly override string ToString()
         {
-            if (_unitType == GridUnitType.Auto)
+            if (GridUnitType == GridUnitType.Auto)
             {
                 return "Auto";
             }
 
-            bool isStar = (_unitType == GridUnitType.Star);
+            bool isStar = (GridUnitType == GridUnitType.Star);
             DefaultInterpolatedStringHandler handler = new(isStar ? 1 : 0, 1, global::System.Globalization.CultureInfo.InvariantCulture, stackalloc char[32]);
-            handler.AppendFormatted(_unitValue);
+            handler.AppendFormatted(Value);
             if (isStar)
             {
                 handler.AppendLiteral("*");

--- a/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Microsoft.UI.Xaml/Microsoft.UI.Xaml.GridLength.cs
@@ -21,18 +21,8 @@ namespace Microsoft.UI.Xaml
         {
         }
 
-        internal static bool IsFinite(double value)
-        {
-            return !(double.IsNaN(value) || double.IsInfinity(value));
-        }
-
         public GridLength(double value, GridUnitType type)
         {
-            if (!IsFinite(value) || value < 0.0)
-            {
-                throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(value));
-            }
-
             if (type is not (GridUnitType.Auto or GridUnitType.Pixel or GridUnitType.Star))
             {
                 throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(type));

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.KeyTime.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.KeyTime.cs
@@ -8,8 +8,10 @@ namespace Windows.UI.Xaml.Media.Animation
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Media.Animation.KeyTime>")]
     [ABI.Windows.UI.Xaml.Media.Animation.KeyTimeComWrappersMarshaller]
 #endif
-    public readonly struct KeyTime : IEquatable<KeyTime>
+    public struct KeyTime : IEquatable<KeyTime>
     {
+        public TimeSpan TimeSpan;
+
         public static KeyTime FromTimeSpan(TimeSpan timeSpan)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(timeSpan, TimeSpan.Zero, nameof(timeSpan));
@@ -55,11 +57,6 @@ namespace Windows.UI.Xaml.Media.Animation
         public static implicit operator KeyTime(TimeSpan timeSpan)
         {
             return KeyTime.FromTimeSpan(timeSpan);
-        }
-
-        public TimeSpan TimeSpan
-        {
-            readonly get; private init;
         }
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Animation/Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs
@@ -10,6 +10,10 @@ namespace Windows.UI.Xaml.Media.Animation
 #endif
     public struct RepeatBehavior : IFormattable, IEquatable<RepeatBehavior>
     {
+        public double Count;
+        public TimeSpan Duration;
+        public RepeatBehaviorType Type;
+
         internal static bool IsFinite(double value)
         {
             return !(double.IsNaN(value) || double.IsInfinity(value));
@@ -61,21 +65,6 @@ namespace Windows.UI.Xaml.Media.Animation
             {
                 return Type == RepeatBehaviorType.Duration;
             }
-        }
-
-        public double Count
-        {
-            readonly get; set;
-        }
-
-        public TimeSpan Duration
-        {
-            readonly get; set;
-        }
-
-        public RepeatBehaviorType Type
-        {
-            readonly get; set;
         }
 
         public readonly override string ToString()

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.Matrix3D.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml.Media.Media3D/Windows.UI.Xaml.Media.Media3D.Matrix3D.cs
@@ -10,14 +10,31 @@ namespace Windows.UI.Xaml.Media.Media3D
 #endif
     public struct Matrix3D : IFormattable, IEquatable<Matrix3D>
     {
+        public double M11;
+        public double M12;
+        public double M13;
+        public double M14;
+        public double M21;
+        public double M22;
+        public double M23;
+        public double M24;
+        public double M31;
+        public double M32;
+        public double M33;
+        public double M34;
+        public double OffsetX;
+        public double OffsetY;
+        public double OffsetZ;
+        public double M44;
+
         // Assuming this matrix has fourth column of 0,0,0,1 and isn't identity this function:
         // Returns false if HasInverse is false, otherwise inverts the matrix.
         private bool NormalizedAffineInvert()
         {
-            double z20 = _m12 * _m23 - _m22 * _m13;
-            double z10 = _m32 * _m13 - _m12 * _m33;
-            double z00 = _m22 * _m33 - _m32 * _m23;
-            double det = _m31 * z20 + _m21 * z10 + _m11 * z00;
+            double z20 = M12 * M23 - M22 * M13;
+            double z10 = M32 * M13 - M12 * M33;
+            double z00 = M22 * M33 - M32 * M23;
+            double det = M31 * z20 + M21 * z10 + M11 * z00;
 
             if (IsZero(det))
             {
@@ -25,23 +42,23 @@ namespace Windows.UI.Xaml.Media.Media3D
             }
 
             // Compute 3x3 non-zero cofactors for the 2nd column
-            double z21 = _m21 * _m13 - _m11 * _m23;
-            double z11 = _m11 * _m33 - _m31 * _m13;
-            double z01 = _m31 * _m23 - _m21 * _m33;
+            double z21 = M21 * M13 - M11 * M23;
+            double z11 = M11 * M33 - M31 * M13;
+            double z01 = M31 * M23 - M21 * M33;
 
             // Compute all six 2x2 determinants of 1st two columns
-            double y01 = _m11 * _m22 - _m21 * _m12;
-            double y02 = _m11 * _m32 - _m31 * _m12;
-            double y03 = _m11 * _offsetY - _offsetX * _m12;
-            double y12 = _m21 * _m32 - _m31 * _m22;
-            double y13 = _m21 * _offsetY - _offsetX * _m22;
-            double y23 = _m31 * _offsetY - _offsetX * _m32;
+            double y01 = M11 * M22 - M21 * M12;
+            double y02 = M11 * M32 - M31 * M12;
+            double y03 = M11 * OffsetY - OffsetX * M12;
+            double y12 = M21 * M32 - M31 * M22;
+            double y13 = M21 * OffsetY - OffsetX * M22;
+            double y23 = M31 * OffsetY - OffsetX * M32;
 
             // Compute all non-zero and non-one 3x3 cofactors for 2nd
             // two columns
-            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
-            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
-            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
+            double z23 = M23 * y03 - OffsetZ * y01 - M13 * y13;
+            double z13 = M13 * y23 - M33 * y03 + OffsetZ * y02;
+            double z03 = M33 * y13 - OffsetZ * y12 - M23 * y23;
             double z22 = y01;
             double z12 = -y02;
             double z02 = y12;
@@ -49,21 +66,21 @@ namespace Windows.UI.Xaml.Media.Media3D
             double rcp = 1.0 / det;
 
             // Multiply all 3x3 cofactors by reciprocal & transpose
-            _m11 = (z00 * rcp);
-            _m12 = (z10 * rcp);
-            _m13 = (z20 * rcp);
+            M11 = (z00 * rcp);
+            M12 = (z10 * rcp);
+            M13 = (z20 * rcp);
 
-            _m21 = (z01 * rcp);
-            _m22 = (z11 * rcp);
-            _m23 = (z21 * rcp);
+            M21 = (z01 * rcp);
+            M22 = (z11 * rcp);
+            M23 = (z21 * rcp);
 
-            _m31 = (z02 * rcp);
-            _m32 = (z12 * rcp);
-            _m33 = (z22 * rcp);
+            M31 = (z02 * rcp);
+            M32 = (z12 * rcp);
+            M33 = (z22 * rcp);
 
-            _offsetX = (z03 * rcp);
-            _offsetY = (z13 * rcp);
-            _offsetZ = (z23 * rcp);
+            OffsetX = (z03 * rcp);
+            OffsetY = (z13 * rcp);
+            OffsetZ = (z23 * rcp);
 
             return true;
         }
@@ -77,21 +94,21 @@ namespace Windows.UI.Xaml.Media.Media3D
             }
 
             // compute all six 2x2 determinants of 2nd two columns
-            double y01 = _m13 * _m24 - _m23 * _m14;
-            double y02 = _m13 * _m34 - _m33 * _m14;
-            double y03 = _m13 * _m44 - _offsetZ * _m14;
-            double y12 = _m23 * _m34 - _m33 * _m24;
-            double y13 = _m23 * _m44 - _offsetZ * _m24;
-            double y23 = _m33 * _m44 - _offsetZ * _m34;
+            double y01 = M13 * M24 - M23 * M14;
+            double y02 = M13 * M34 - M33 * M14;
+            double y03 = M13 * M44 - OffsetZ * M14;
+            double y12 = M23 * M34 - M33 * M24;
+            double y13 = M23 * M44 - OffsetZ * M24;
+            double y23 = M33 * M44 - OffsetZ * M34;
 
             // Compute 3x3 cofactors for 1st the column
-            double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
-            double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
-            double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
-            double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+            double z30 = M22 * y02 - M32 * y01 - M12 * y12;
+            double z20 = M12 * y13 - M22 * y03 + OffsetY * y01;
+            double z10 = M32 * y03 - OffsetY * y02 - M12 * y23;
+            double z00 = M22 * y23 - M32 * y13 + OffsetY * y12;
 
             // Compute 4x4 determinant
-            double det = _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+            double det = OffsetX * z30 + M31 * z20 + M21 * z10 + M11 * z00;
 
             if (IsZero(det))
             {
@@ -99,51 +116,51 @@ namespace Windows.UI.Xaml.Media.Media3D
             }
 
             // Compute 3x3 cofactors for the 2nd column
-            double z31 = _m11 * y12 - _m21 * y02 + _m31 * y01;
-            double z21 = _m21 * y03 - _offsetX * y01 - _m11 * y13;
-            double z11 = _m11 * y23 - _m31 * y03 + _offsetX * y02;
-            double z01 = _m31 * y13 - _offsetX * y12 - _m21 * y23;
+            double z31 = M11 * y12 - M21 * y02 + M31 * y01;
+            double z21 = M21 * y03 - OffsetX * y01 - M11 * y13;
+            double z11 = M11 * y23 - M31 * y03 + OffsetX * y02;
+            double z01 = M31 * y13 - OffsetX * y12 - M21 * y23;
 
             // Compute all six 2x2 determinants of 1st two columns
-            y01 = _m11 * _m22 - _m21 * _m12;
-            y02 = _m11 * _m32 - _m31 * _m12;
-            y03 = _m11 * _offsetY - _offsetX * _m12;
-            y12 = _m21 * _m32 - _m31 * _m22;
-            y13 = _m21 * _offsetY - _offsetX * _m22;
-            y23 = _m31 * _offsetY - _offsetX * _m32;
+            y01 = M11 * M22 - M21 * M12;
+            y02 = M11 * M32 - M31 * M12;
+            y03 = M11 * OffsetY - OffsetX * M12;
+            y12 = M21 * M32 - M31 * M22;
+            y13 = M21 * OffsetY - OffsetX * M22;
+            y23 = M31 * OffsetY - OffsetX * M32;
 
             // Compute all 3x3 cofactors for 2nd two columns
-            double z33 = _m13 * y12 - _m23 * y02 + _m33 * y01;
-            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
-            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
-            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
-            double z32 = _m24 * y02 - _m34 * y01 - _m14 * y12;
-            double z22 = _m14 * y13 - _m24 * y03 + _m44 * y01;
-            double z12 = _m34 * y03 - _m44 * y02 - _m14 * y23;
-            double z02 = _m24 * y23 - _m34 * y13 + _m44 * y12;
+            double z33 = M13 * y12 - M23 * y02 + M33 * y01;
+            double z23 = M23 * y03 - OffsetZ * y01 - M13 * y13;
+            double z13 = M13 * y23 - M33 * y03 + OffsetZ * y02;
+            double z03 = M33 * y13 - OffsetZ * y12 - M23 * y23;
+            double z32 = M24 * y02 - M34 * y01 - M14 * y12;
+            double z22 = M14 * y13 - M24 * y03 + M44 * y01;
+            double z12 = M34 * y03 - M44 * y02 - M14 * y23;
+            double z02 = M24 * y23 - M34 * y13 + M44 * y12;
 
             double rcp = 1.0 / det;
 
             // Multiply all 3x3 cofactors by reciprocal & transpose
-            _m11 = (z00 * rcp);
-            _m12 = (z10 * rcp);
-            _m13 = (z20 * rcp);
-            _m14 = (z30 * rcp);
+            M11 = (z00 * rcp);
+            M12 = (z10 * rcp);
+            M13 = (z20 * rcp);
+            M14 = (z30 * rcp);
 
-            _m21 = (z01 * rcp);
-            _m22 = (z11 * rcp);
-            _m23 = (z21 * rcp);
-            _m24 = (z31 * rcp);
+            M21 = (z01 * rcp);
+            M22 = (z11 * rcp);
+            M23 = (z21 * rcp);
+            M24 = (z31 * rcp);
 
-            _m31 = (z02 * rcp);
-            _m32 = (z12 * rcp);
-            _m33 = (z22 * rcp);
-            _m34 = (z32 * rcp);
+            M31 = (z02 * rcp);
+            M32 = (z12 * rcp);
+            M33 = (z22 * rcp);
+            M34 = (z32 * rcp);
 
-            _offsetX = (z03 * rcp);
-            _offsetY = (z13 * rcp);
-            _offsetZ = (z23 * rcp);
-            _m44 = (z33 * rcp);
+            OffsetX = (z03 * rcp);
+            OffsetY = (z13 * rcp);
+            OffsetZ = (z23 * rcp);
+            M44 = (z33 * rcp);
 
             return true;
         }
@@ -153,219 +170,27 @@ namespace Windows.UI.Xaml.Media.Media3D
                         double m31, double m32, double m33, double m34,
                         double offsetX, double offsetY, double offsetZ, double m44)
         {
-            _m11 = m11;
-            _m12 = m12;
-            _m13 = m13;
-            _m14 = m14;
-            _m21 = m21;
-            _m22 = m22;
-            _m23 = m23;
-            _m24 = m24;
-            _m31 = m31;
-            _m32 = m32;
-            _m33 = m33;
-            _m34 = m34;
-            _offsetX = offsetX;
-            _offsetY = offsetY;
-            _offsetZ = offsetZ;
-            _m44 = m44;
+            M11 = m11;
+            M12 = m12;
+            M13 = m13;
+            M14 = m14;
+            M21 = m21;
+            M22 = m22;
+            M23 = m23;
+            M24 = m24;
+            M31 = m31;
+            M32 = m32;
+            M33 = m33;
+            M34 = m34;
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+            OffsetZ = offsetZ;
+            M44 = m44;
         }
 
         // the transform is identity by default
         // Actually fill in the fields - some (internal) code uses the fields directly for perf.
         private static Matrix3D s_identity = CreateIdentity();
-
-        public double M11
-        {
-            readonly get
-            {
-                return _m11;
-            }
-            set
-            {
-                _m11 = value;
-            }
-        }
-
-        public double M12
-        {
-            readonly get
-            {
-                return _m12;
-            }
-            set
-            {
-                _m12 = value;
-            }
-        }
-
-        public double M13
-        {
-            readonly get
-            {
-                return _m13;
-            }
-            set
-            {
-                _m13 = value;
-            }
-        }
-
-        public double M14
-        {
-            readonly get
-            {
-                return _m14;
-            }
-            set
-            {
-                _m14 = value;
-            }
-        }
-
-        public double M21
-        {
-            readonly get
-            {
-                return _m21;
-            }
-            set
-            {
-                _m21 = value;
-            }
-        }
-
-        public double M22
-        {
-            readonly get
-            {
-                return _m22;
-            }
-            set
-            {
-                _m22 = value;
-            }
-        }
-
-        public double M23
-        {
-            readonly get
-            {
-                return _m23;
-            }
-            set
-            {
-                _m23 = value;
-            }
-        }
-
-        public double M24
-        {
-            readonly get
-            {
-                return _m24;
-            }
-            set
-            {
-                _m24 = value;
-            }
-        }
-
-        public double M31
-        {
-            readonly get
-            {
-                return _m31;
-            }
-            set
-            {
-                _m31 = value;
-            }
-        }
-
-        public double M32
-        {
-            readonly get
-            {
-                return _m32;
-            }
-            set
-            {
-                _m32 = value;
-            }
-        }
-
-        public double M33
-        {
-            readonly get
-            {
-                return _m33;
-            }
-            set
-            {
-                _m33 = value;
-            }
-        }
-
-        public double M34
-        {
-            readonly get
-            {
-                return _m34;
-            }
-            set
-            {
-                _m34 = value;
-            }
-        }
-
-        public double OffsetX
-        {
-            readonly get
-            {
-                return _offsetX;
-            }
-            set
-            {
-                _offsetX = value;
-            }
-        }
-
-        public double OffsetY
-        {
-            readonly get
-            {
-                return _offsetY;
-            }
-            set
-            {
-                _offsetY = value;
-            }
-        }
-
-        public double OffsetZ
-        {
-            readonly get
-            {
-                return _offsetZ;
-            }
-            set
-            {
-                _offsetZ = value;
-            }
-        }
-
-        public double M44
-        {
-            readonly get
-            {
-                return _m44;
-            }
-            set
-            {
-                _m44 = value;
-            }
-        }
 
         public static Matrix3D Identity
         {
@@ -379,10 +204,10 @@ namespace Windows.UI.Xaml.Media.Media3D
         {
             get
             {
-                return _m11 == 1 && _m12 == 0 && _m13 == 0 && _m14 == 0 &&
-                         _m21 == 0 && _m22 == 1 && _m23 == 0 && _m24 == 0 &&
-                         _m31 == 0 && _m32 == 0 && _m33 == 1 && _m34 == 0 &&
-                         _offsetX == 0 && _offsetY == 0 && _offsetZ == 0 && _m44 == 1;
+                return M11 == 1 && M12 == 0 && M13 == 0 && M14 == 0 &&
+                         M21 == 0 && M22 == 1 && M23 == 0 && M24 == 0 &&
+                         M31 == 0 && M32 == 0 && M33 == 1 && M34 == 0 &&
+                         OffsetX == 0 && OffsetY == 0 && OffsetZ == 0 && M44 == 1;
             }
         }
 
@@ -417,37 +242,37 @@ namespace Windows.UI.Xaml.Media.Media3D
             // Helper to get the numeric list separator for a given culture.
             char separator = global::WindowsRuntime.InteropServices.TokenizerHelper.GetNumericListSeparator(provider);
             DefaultInterpolatedStringHandler handler = new(0, 31, provider, stackalloc char[256]);
-            handler.AppendFormatted(_m11, format);
+            handler.AppendFormatted(M11, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m12, format);
+            handler.AppendFormatted(M12, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m13, format);
+            handler.AppendFormatted(M13, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m14, format);
+            handler.AppendFormatted(M14, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m21, format);
+            handler.AppendFormatted(M21, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m22, format);
+            handler.AppendFormatted(M22, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m23, format);
+            handler.AppendFormatted(M23, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m24, format);
+            handler.AppendFormatted(M24, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m31, format);
+            handler.AppendFormatted(M31, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m32, format);
+            handler.AppendFormatted(M32, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m33, format);
+            handler.AppendFormatted(M33, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m34, format);
+            handler.AppendFormatted(M34, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetX, format);
+            handler.AppendFormatted(OffsetX, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetY, format);
+            handler.AppendFormatted(OffsetY, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_offsetZ, format);
+            handler.AppendFormatted(OffsetZ, format);
             handler.AppendFormatted(separator);
-            handler.AppendFormatted(_m44, format);
+            handler.AppendFormatted(M44, format);
             return handler.ToStringAndClear();
 #endif
         }
@@ -613,22 +438,22 @@ namespace Windows.UI.Xaml.Media.Media3D
                                double m31, double m32, double m33, double m34,
                                double offsetX, double offsetY, double offsetZ, double m44)
         {
-            _m11 = m11;
-            _m12 = m12;
-            _m13 = m13;
-            _m14 = m14;
-            _m21 = m21;
-            _m22 = m22;
-            _m23 = m23;
-            _m24 = m24;
-            _m31 = m31;
-            _m32 = m32;
-            _m33 = m33;
-            _m34 = m34;
-            _offsetX = offsetX;
-            _offsetY = offsetY;
-            _offsetZ = offsetZ;
-            _m44 = m44;
+            M11 = m11;
+            M12 = m12;
+            M13 = m13;
+            M14 = m14;
+            M21 = m21;
+            M22 = m22;
+            M23 = m23;
+            M24 = m24;
+            M31 = m31;
+            M32 = m32;
+            M33 = m33;
+            M34 = m34;
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+            OffsetZ = offsetZ;
+            M44 = m44;
         }
 
         private static bool Equals(Matrix3D matrix1, Matrix3D matrix2)
@@ -653,18 +478,18 @@ namespace Windows.UI.Xaml.Media.Media3D
 
         private readonly double GetNormalizedAffineDeterminant()
         {
-            double z20 = _m12 * _m23 - _m22 * _m13;
-            double z10 = _m32 * _m13 - _m12 * _m33;
-            double z00 = _m22 * _m33 - _m32 * _m23;
+            double z20 = M12 * M23 - M22 * M13;
+            double z10 = M32 * M13 - M12 * M33;
+            double z00 = M22 * M33 - M32 * M23;
 
-            return _m31 * z20 + _m21 * z10 + _m11 * z00;
+            return M31 * z20 + M21 * z10 + M11 * z00;
         }
 
         private readonly bool IsAffine
         {
             get
             {
-                return _m14 == 0.0 && _m24 == 0.0 && _m34 == 0.0 && _m44 == 1.0;
+                return M14 == 0.0 && M24 == 0.0 && M34 == 0.0 && M44 == 1.0;
             }
         }
 
@@ -678,20 +503,20 @@ namespace Windows.UI.Xaml.Media.Media3D
                 }
 
                 // compute all six 2x2 determinants of 2nd two columns
-                double y01 = _m13 * _m24 - _m23 * _m14;
-                double y02 = _m13 * _m34 - _m33 * _m14;
-                double y03 = _m13 * _m44 - _offsetZ * _m14;
-                double y12 = _m23 * _m34 - _m33 * _m24;
-                double y13 = _m23 * _m44 - _offsetZ * _m24;
-                double y23 = _m33 * _m44 - _offsetZ * _m34;
+                double y01 = M13 * M24 - M23 * M14;
+                double y02 = M13 * M34 - M33 * M14;
+                double y03 = M13 * M44 - OffsetZ * M14;
+                double y12 = M23 * M34 - M33 * M24;
+                double y13 = M23 * M44 - OffsetZ * M24;
+                double y23 = M33 * M44 - OffsetZ * M34;
 
                 // Compute 3x3 cofactors for 1st the column
-                double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
-                double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
-                double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
-                double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+                double z30 = M22 * y02 - M32 * y01 - M12 * y12;
+                double z20 = M12 * y13 - M22 * y03 + OffsetY * y01;
+                double z10 = M32 * y03 - OffsetY * y02 - M12 * y23;
+                double z00 = M22 * y23 - M32 * y13 + OffsetY * y12;
 
-                return _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+                return OffsetX * z30 + M31 * z20 + M21 * z10 + M11 * z00;
             }
         }
 
@@ -701,22 +526,5 @@ namespace Windows.UI.Xaml.Media.Media3D
         }
 
         private const double DBL_EPSILON_RELATIVE_1 = 1.1102230246251567e-016; /* smallest such that 1.0+DBL_EPSILON != 1.0 */
-
-        private double _m11;
-        private double _m12;
-        private double _m13;
-        private double _m14;
-        private double _m21;
-        private double _m22;
-        private double _m23;
-        private double _m24;
-        private double _m31;
-        private double _m32;
-        private double _m33;
-        private double _m34;
-        private double _offsetX;
-        private double _offsetY;
-        private double _offsetZ;
-        private double _m44;
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.CornerRadius.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.CornerRadius.cs
@@ -10,25 +10,25 @@ namespace Windows.UI.Xaml
 #endif
     public struct CornerRadius : IEquatable<CornerRadius>
     {
-        private double _TopLeft;
-        private double _TopRight;
-        private double _BottomRight;
-        private double _BottomLeft;
+        public double TopLeft;
+        public double TopRight;
+        public double BottomRight;
+        public double BottomLeft;
 
         public CornerRadius(double uniformRadius)
         {
             Validate(uniformRadius, uniformRadius, uniformRadius, uniformRadius);
-            _TopLeft = _TopRight = _BottomRight = _BottomLeft = uniformRadius;
+            TopLeft = TopRight = BottomRight = BottomLeft = uniformRadius;
         }
 
         public CornerRadius(double topLeft, double topRight, double bottomRight, double bottomLeft)
         {
             Validate(topLeft, topRight, bottomRight, bottomLeft);
 
-            _TopLeft = topLeft;
-            _TopRight = topRight;
-            _BottomRight = bottomRight;
-            _BottomLeft = bottomLeft;
+            TopLeft = topLeft;
+            TopRight = topRight;
+            BottomRight = bottomRight;
+            BottomLeft = bottomLeft;
         }
 
         private static void Validate(double topLeft, double topRight, double bottomRight, double bottomLeft)
@@ -62,13 +62,13 @@ namespace Windows.UI.Xaml
             // 48 = 4x double (twelve digits is generous for the range of values likely)
             //  3 = 3x separator characters
             DefaultInterpolatedStringHandler handler = new(0, 7, cultureInfo, stackalloc char[64]);
-            InternalAddToHandler(_TopLeft, ref handler);
+            InternalAddToHandler(TopLeft, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_TopRight, ref handler);
+            InternalAddToHandler(TopRight, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_BottomRight, ref handler);
+            InternalAddToHandler(BottomRight, ref handler);
             handler.AppendFormatted(listSeparator);
-            InternalAddToHandler(_BottomLeft, ref handler);
+            InternalAddToHandler(BottomLeft, ref handler);
             return handler.ToStringAndClear();
 #endif
         }
@@ -101,57 +101,17 @@ namespace Windows.UI.Xaml
 
         public readonly override int GetHashCode()
         {
-            return _TopLeft.GetHashCode() ^ _TopRight.GetHashCode() ^ _BottomLeft.GetHashCode() ^ _BottomRight.GetHashCode();
+            return TopLeft.GetHashCode() ^ TopRight.GetHashCode() ^ BottomLeft.GetHashCode() ^ BottomRight.GetHashCode();
         }
 
         public static bool operator ==(CornerRadius cr1, CornerRadius cr2)
         {
-            return cr1._TopLeft == cr2._TopLeft && cr1._TopRight == cr2._TopRight && cr1._BottomRight == cr2._BottomRight && cr1._BottomLeft == cr2._BottomLeft;
+            return cr1.TopLeft == cr2.TopLeft && cr1.TopRight == cr2.TopRight && cr1.BottomRight == cr2.BottomRight && cr1.BottomLeft == cr2.BottomLeft;
         }
 
         public static bool operator !=(CornerRadius cr1, CornerRadius cr2)
         {
             return !(cr1 == cr2);
-        }
-
-        public double TopLeft
-        {
-            readonly get { return _TopLeft; }
-            set
-            {
-                Validate(value, 0, 0, 0);
-                _TopLeft = value;
-            }
-        }
-
-        public double TopRight
-        {
-            readonly get { return _TopRight; }
-            set
-            {
-                Validate(0, value, 0, 0);
-                _TopRight = value;
-            }
-        }
-
-        public double BottomRight
-        {
-            readonly get { return _BottomRight; }
-            set
-            {
-                Validate(0, 0, value, 0);
-                _BottomRight = value;
-            }
-        }
-
-        public double BottomLeft
-        {
-            readonly get { return _BottomLeft; }
-            set
-            {
-                Validate(0, 0, 0, value);
-                _BottomLeft = value;
-            }
         }
     }
 }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.Duration.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.Duration.cs
@@ -8,20 +8,20 @@ namespace Windows.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.Duration>")]
     [ABI.Windows.UI.Xaml.DurationComWrappersMarshaller]
 #endif
-    public readonly struct Duration : IEquatable<Duration>
+    public struct Duration : IEquatable<Duration>
     {
-        private readonly TimeSpan _timeSpan;
-        private readonly DurationType _durationType;
+        public TimeSpan TimeSpan;
+        public DurationType Type;
 
         public Duration(TimeSpan timeSpan)
         {
-            _durationType = DurationType.TimeSpan;
-            _timeSpan = timeSpan;
+            Type = DurationType.TimeSpan;
+            TimeSpan = timeSpan;
         }
 
         private Duration(DurationType durationType)
         {
-            _durationType = durationType;
+            Type = durationType;
         }
 
         public static implicit operator Duration(TimeSpan timeSpan)
@@ -33,9 +33,9 @@ namespace Windows.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return new Duration(t1._timeSpan + t2._timeSpan);
+                return new Duration(t1.TimeSpan + t2.TimeSpan);
             }
-            else if (t1._durationType != DurationType.Automatic && t2._durationType != DurationType.Automatic)
+            else if (t1.Type != DurationType.Automatic && t2.Type != DurationType.Automatic)
             {
                 return Duration.Forever;
             }
@@ -50,9 +50,9 @@ namespace Windows.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return new Duration(t1._timeSpan - t2._timeSpan);
+                return new Duration(t1.TimeSpan - t2.TimeSpan);
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return Duration.Forever;
             }
@@ -76,13 +76,13 @@ namespace Windows.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return t1._timeSpan > t2._timeSpan;
+                return t1.TimeSpan > t2.TimeSpan;
             }
-            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            else if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
             {
                 return false;
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return true;
             }
@@ -94,11 +94,11 @@ namespace Windows.UI.Xaml
 
         public static bool operator >=(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            else if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
             {
                 return false;
             }
@@ -112,13 +112,13 @@ namespace Windows.UI.Xaml
         {
             if (t1.HasTimeSpan && t2.HasTimeSpan)
             {
-                return t1._timeSpan < t2._timeSpan;
+                return t1.TimeSpan < t2.TimeSpan;
             }
-            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            else if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            else if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
             {
                 return false;
             }
@@ -130,11 +130,11 @@ namespace Windows.UI.Xaml
 
         public static bool operator <=(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
             {
                 return true;
             }
-            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            else if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
             {
                 return false;
             }
@@ -146,9 +146,9 @@ namespace Windows.UI.Xaml
 
         public static int Compare(Duration t1, Duration t2)
         {
-            if (t1._durationType == DurationType.Automatic)
+            if (t1.Type == DurationType.Automatic)
             {
-                if (t2._durationType == DurationType.Automatic)
+                if (t2.Type == DurationType.Automatic)
                 {
                     return 0;
                 }
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml
                     return -1;
                 }
             }
-            else if (t2._durationType == DurationType.Automatic)
+            else if (t2.Type == DurationType.Automatic)
             {
                 return 1;
             }
@@ -187,7 +187,7 @@ namespace Windows.UI.Xaml
         {
             get
             {
-                return _durationType == DurationType.TimeSpan;
+                return Type == DurationType.TimeSpan;
             }
         }
 
@@ -207,21 +207,6 @@ namespace Windows.UI.Xaml
             }
         }
 
-        public readonly TimeSpan TimeSpan
-        {
-            get
-            {
-                if (HasTimeSpan)
-                {
-                    return _timeSpan;
-                }
-                else
-                {
-                    throw new InvalidOperationException();
-                }
-            }
-        }
-
         public readonly Duration Add(Duration duration)
         {
             return this + duration;
@@ -238,7 +223,7 @@ namespace Windows.UI.Xaml
             {
                 if (duration.HasTimeSpan)
                 {
-                    return _timeSpan == duration._timeSpan;
+                    return TimeSpan == duration.TimeSpan;
                 }
                 else
                 {
@@ -247,7 +232,7 @@ namespace Windows.UI.Xaml
             }
             else
             {
-                return _durationType == duration._durationType;
+                return Type == duration.Type;
             }
         }
 
@@ -260,11 +245,11 @@ namespace Windows.UI.Xaml
         {
             if (HasTimeSpan)
             {
-                return _timeSpan.GetHashCode();
+                return TimeSpan.GetHashCode();
             }
             else
             {
-                return _durationType.GetHashCode() + 17;
+                return Type.GetHashCode() + 17;
             }
         }
 
@@ -277,9 +262,9 @@ namespace Windows.UI.Xaml
         {
             if (HasTimeSpan)
             {
-                return _timeSpan.ToString(); // "00"; //TypeDescriptor.GetConverter(_timeSpan).ConvertToString(_timeSpan);
+                return TimeSpan.ToString();
             }
-            else if (_durationType == DurationType.Forever)
+            else if (Type == DurationType.Forever)
             {
                 return "Forever";
             }

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
@@ -8,10 +8,10 @@ namespace Windows.UI.Xaml
     [WindowsRuntimeClassName("Windows.Foundation.IReference`1<Windows.UI.Xaml.GridLength>")]
     [ABI.Windows.UI.Xaml.GridLengthComWrappersMarshaller]
 #endif
-    public readonly struct GridLength : IEquatable<GridLength>
+    public struct GridLength : IEquatable<GridLength>
     {
-        private readonly double _unitValue;
-        private readonly GridUnitType _unitType;
+        public double Value;
+        public GridUnitType GridUnitType;
 
         private const double Default = 1.0;
         private static readonly GridLength s_auto = new(Default, GridUnitType.Auto);
@@ -38,18 +38,13 @@ namespace Windows.UI.Xaml
                 throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(type));
             }
 
-            _unitValue = (type == GridUnitType.Auto) ? Default : value;
-            _unitType = type;
+            Value = (type == GridUnitType.Auto) ? Default : value;
+            GridUnitType = type;
         }
 
-
-        public readonly double Value { get { return (_unitType == GridUnitType.Auto) ? s_auto._unitValue : _unitValue; } }
-        public readonly GridUnitType GridUnitType { get { return _unitType; } }
-
-
-        public readonly bool IsAbsolute { get { return _unitType == GridUnitType.Pixel; } }
-        public readonly bool IsAuto { get { return _unitType == GridUnitType.Auto; } }
-        public readonly bool IsStar { get { return _unitType == GridUnitType.Star; } }
+        public readonly bool IsAbsolute { get { return GridUnitType == GridUnitType.Pixel; } }
+        public readonly bool IsAuto { get { return GridUnitType == GridUnitType.Auto; } }
+        public readonly bool IsStar { get { return GridUnitType == GridUnitType.Star; } }
 
         public static GridLength Auto
         {
@@ -85,19 +80,19 @@ namespace Windows.UI.Xaml
 
         public readonly override int GetHashCode()
         {
-            return (int)_unitValue + (int)_unitType;
+            return (int)Value + (int)GridUnitType;
         }
 
         public readonly override string ToString()
         {
-            if (_unitType == GridUnitType.Auto)
+            if (GridUnitType == GridUnitType.Auto)
             {
                 return "Auto";
             }
 
-            bool isStar = (_unitType == GridUnitType.Star);
+            bool isStar = (GridUnitType == GridUnitType.Star);
             DefaultInterpolatedStringHandler handler = new(isStar ? 1 : 0, 1, global::System.Globalization.CultureInfo.InvariantCulture, stackalloc char[32]);
-            handler.AppendFormatted(_unitValue);
+            handler.AppendFormatted(Value);
             if (isStar)
             {
                 handler.AppendLiteral("*");

--- a/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
+++ b/src/WinRT.Projection.Writer/Resources/Additions/Windows.UI.Xaml/Windows.UI.Xaml.GridLength.cs
@@ -21,18 +21,8 @@ namespace Windows.UI.Xaml
         {
         }
 
-        internal static bool IsFinite(double value)
-        {
-            return !(double.IsNaN(value) || double.IsInfinity(value));
-        }
-
         public GridLength(double value, GridUnitType type)
         {
-            if (!IsFinite(value) || value < 0.0)
-            {
-                throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(value));
-            }
-
             if (type is not (GridUnitType.Auto or GridUnitType.Pixel or GridUnitType.Star))
             {
                 throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(type));

--- a/src/WinRT.Runtime2/InteropServices/Events/EventRegistrationToken.cs
+++ b/src/WinRT.Runtime2/InteropServices/Events/EventRegistrationToken.cs
@@ -20,6 +20,11 @@ namespace WindowsRuntime.InteropServices;
 public struct EventRegistrationToken : IEquatable<EventRegistrationToken>
 {
     /// <summary>
+    /// The reference to the delegate. A valid reference will not have a value of zero.
+    /// </summary>
+    public long Value;
+
+    /// <summary>
     /// Creates a new <see cref="EventRegistrationToken"/> value with the specified parameters.
     /// </summary>
     /// <param name="value">The reference to the delegate. A valid reference will not have a value of zero.</param>
@@ -27,11 +32,6 @@ public struct EventRegistrationToken : IEquatable<EventRegistrationToken>
     {
         Value = value;
     }
-
-    /// <summary>
-    /// Gets or sets the reference to the delegate. A valid reference will not have a value of zero.
-    /// </summary>
-    public long Value { readonly get; set; }
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/WinRT.Runtime2/Windows.Foundation/Point.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Point.cs
@@ -31,6 +31,16 @@ namespace Windows.Foundation;
 public struct Point : IEquatable<Point>, IFormattable
 {
     /// <summary>
+    /// The horizontal position of the point.
+    /// </summary>
+    public float X;
+
+    /// <summary>
+    /// The vertical position of the point.
+    /// </summary>
+    public float Y;
+
+    /// <summary>
     /// Creates a new <see cref="Point"/> value with the specified parameters.
     /// </summary>
     /// <param name="x">The horizontal position of the point.</param>
@@ -40,16 +50,6 @@ public struct Point : IEquatable<Point>, IFormattable
         X = x;
         Y = y;
     }
-
-    /// <summary>
-    /// Gets or sets the horizontal position of the point.
-    /// </summary>
-    public float X { readonly get; set; }
-
-    /// <summary>
-    /// Gets or sets the vertical position of the point.
-    /// </summary>
-    public float Y { readonly get; set; }
 
     /// <summary>
     /// Deconstructs the current <see cref="Point"/> value into its components.

--- a/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
@@ -33,6 +33,26 @@ namespace Windows.Foundation;
 public struct Rect : IEquatable<Rect>, IFormattable
 {
     /// <summary>
+    /// The x-coordinate of the upper-left corner of the rectangle.
+    /// </summary>
+    public float X;
+
+    /// <summary>
+    /// The y-coordinate of the upper-left corner of the rectangle.
+    /// </summary>
+    public float Y;
+
+    /// <summary>
+    /// The width of the rectangle, in pixels.
+    /// </summary>
+    public float Width;
+
+    /// <summary>
+    /// The height of the rectangle, in pixels.
+    /// </summary>
+    public float Height;
+
+    /// <summary>
     /// Creates a new <see cref="Rect"/> value with the specified parameters.
     /// </summary>
     /// <param name="point1">The first point that the new rectangle must contain.</param>
@@ -76,50 +96,13 @@ public struct Rect : IEquatable<Rect>, IFormattable
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="width"/> or <paramref name="height"/> are less than zero.</exception>
     public Rect(float x, float y, float width, float height)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(width);
+        ArgumentOutOfRangeException.ThrowIfNegative(height);
+
         X = x;
         Y = y;
         Width = width;
         Height = height;
-    }
-
-    /// <summary>
-    /// Gets or sets the x-coordinate of the upper-left corner of the rectangle.
-    /// </summary>
-    public float X { readonly get; set; }
-
-    /// <summary>
-    /// Gets or sets the y-coordinate of the upper-left corner of the rectangle.
-    /// </summary>
-    public float Y { readonly get; set; }
-
-    /// <summary>
-    /// Gets or sets the width of the rectangle, in pixels.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is less than zero.</exception>
-    public float Width
-    {
-        readonly get;
-        set
-        {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
-
-            field = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the height of the rectangle, in pixels.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is less than zero.</exception>
-    public float Height
-    {
-        readonly get;
-        set
-        {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
-
-            field = value;
-        }
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/Windows.Foundation/Size.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Size.cs
@@ -30,6 +30,16 @@ namespace Windows.Foundation;
 public struct Size : IEquatable<Size>, IFormattable
 {
     /// <summary>
+    /// The width.
+    /// </summary>
+    public float Width;
+
+    /// <summary>
+    /// The height.
+    /// </summary>
+    public float Height;
+
+    /// <summary>
     /// Creates a new <see cref="Size"/> value with the specified parameters.
     /// </summary>
     /// <param name="width">The width.</param>
@@ -37,38 +47,11 @@ public struct Size : IEquatable<Size>, IFormattable
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="width"/> or <paramref name="height"/> are less than zero.</exception>
     public Size(float width, float height)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(width);
+        ArgumentOutOfRangeException.ThrowIfNegative(height);
+
         Width = width;
         Height = height;
-    }
-
-    /// <summary>
-    /// Gets or sets the width.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is less than zero.</exception>
-    public float Width
-    {
-        readonly get;
-        set
-        {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
-
-            field = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the height.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is less than zero.</exception>
-    public float Height
-    {
-        readonly get;
-        set
-        {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
-
-            field = value;
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Projects the fields of Windows Runtime struct types as C# fields instead of `{ readonly get; set; }` properties, across the projection writer, the manually projected types in `WinRT.Runtime`, and the custom-mapped XAML types defined by addition files.

## Motivation

Projecting struct fields as properties turned out to be problematic, and confusing.

The biggest issue is authoring. `cswinrtwinmdgen.exe` maps the public instance **fields** of an authored `struct` to Windows Runtime struct fields, which is the only shape that can round-trip: an author writing a struct against the projected shape (properties) would silently produce an empty struct in the generated `.winmd`. Projecting fields as fields makes consumption and authoring symmetrical: the shape you consume is exactly the shape you author.

Beyond authoring, Windows Runtime structs are plain data — there is no accessor to run any logic behind, so a property only obscures that, and it prevents callers from taking a reference to a member (e.g. to pass it as a `ref` argument, or to mutate an element of an array of structs in place). This also matches what C++/WinRT does, and what CsWinRT 2.x did for generated struct projections.

## Changes

**Projection writer**

- **`src/WinRT.Projection.Writer/Builders/ProjectionFileBuilder.cs`**: `WriteStruct` now emits a public field per Windows Runtime struct field, declared before the constructor so declaration order (which drives the sequential layout of the struct) mirrors the metadata order.
- **`src/WinRT.Projection.Writer/Factories/AbiStructFactory.cs`**, **`src/WinRT.Projection.Writer/Factories/StructEnumMarshallerFactory.cs`**: refresh comments that justified the mapped-struct special cases by claiming their projected public fields don't match the WinMD field layout, which is no longer accurate.

**Manually projected types**

- **`src/WinRT.Runtime2/Windows.Foundation/Point.cs`**, **`Rect.cs`**, **`Size.cs`**, **`src/WinRT.Runtime2/InteropServices/Events/EventRegistrationToken.cs`**: `X`, `Y`, `Width`, `Height` and `Value` become public fields. The negative-value validation that lived in the `Rect`/`Size` setters moves into the constructors that document it (which is also what CsWinRT 2.x did). Managed-only members (`Left`, `Top`, `Right`, `Bottom`, `IsEmpty`, `Empty`, ...) are unchanged.

**Custom-mapped XAML types (addition files, both the `Microsoft.UI.Xaml` and `Windows.UI.Xaml` copies)**

- **`…/Microsoft.UI.Xaml.CornerRadius.cs`**: `TopLeft`, `TopRight`, `BottomRight`, `BottomLeft`
- **`…/Microsoft.UI.Xaml.GridLength.cs`**: `Value`, `GridUnitType`
- **`…/Microsoft.UI.Xaml.Duration.cs`**: `TimeSpan`, `Type`
- **`…/Microsoft.UI.Xaml.Media.Animation.KeyTime.cs`**: `TimeSpan`
- **`…/Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs`**: `Count`, `Duration`, `Type`
- **`…/Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs`**: `M11`-`M34`, `OffsetX`, `OffsetY`, `OffsetZ`, `M44`

These types are defined in full by their addition files, so they kept the property-over-private-backing-field shape inherited from the UWP/WPF managed projections. Leaving them alone would have made them inconsistent with their own siblings, since `Thickness`, `Matrix`, `GeneratorPosition` and `Color` are generated types in CsWinRT 3.0 and therefore now expose fields. Field declaration order (and therefore the sequential layout each of these blittable structs marshals with) is unchanged, and validation that lived in the removed setters is preserved where the constructors already performed it. `GridLength` and `KeyTime` are no longer `readonly struct`-s, since Windows Runtime structs are mutable data. Members that are not Windows Runtime struct fields are left untouched (`GridLength.IsAbsolute`/`IsAuto`/`IsStar`/`Auto`, `Duration.HasTimeSpan`/`Automatic`/`Forever`, `RepeatBehavior.HasCount`/`HasDuration`/`Forever`, `Matrix3D.Identity`/`IsIdentity`/`HasInverse`, and all operators, conversions and formatting helpers).

There is one deliberate behavior change on top of that: the `GridLength` constructors no longer reject negative (or non-finite) values. Negative `GridLength` values turn out to be a valid pattern that real apps rely on (e.g. the Microsoft Store uses them in several custom layout panels), and now that `Value` is a public mutable field the check was trivially bypassable anyway. The `GridUnitType` validation is unchanged, `GridUnitType.Auto` still normalizes the value to the default, and the `IsFinite` helper the removed check was the only user of goes away with it.

**Tests and docs**

- **`src/Tests/ProjectionWriterTest/Test_ProjectedStructs.cs`**: new tests asserting that projected struct fields are emitted as C# fields, and that no projected struct member is emitted as an auto-property, in both projection modes.
- **`docs/cswinrt3.0-spec.md`**: documents the projection rule, and renames the neighbouring `Point`/`Rect`/`Size` section (which was already about their fields rather than properties).
- **`docs/event-infrastructure.md`**: refreshes the `EventRegistrationToken` snippet.

## Validation

- `ProjectionWriterTest` (16), `WinMDGeneratorTest` (17) and `SourceGenerator2Test` (129) all pass.
- The `Windows`, `Windows.UI.Xaml` and `WinAppSDK` projections were regenerated end-to-end and compile cleanly, which covers the emitted structs, their marshallers, and all of the addition files.
- Both `GridLength` addition files were compiled standalone and exercised to confirm negative, `NaN` and infinite values now construct successfully, that `GridUnitType.Auto` still normalizes to the default, and that an out-of-range `GridUnitType` still throws.
