### PR TITLE
Fix SDK projection impl generation in CI

### DIFF
--- a/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
+++ b/build/AzurePipelineTemplates/CsWinRT-Build-Steps.yml
@@ -239,16 +239,16 @@ steps:
           WinRT.Runtime.pdb
         TargetFolder: $(StagingFolder)\net10.0
 
-    # Build the WinRT.Runtime reference assembly, with implementation-only types stripped out. Like the
-    # implementation assembly, it is built as AnyCPU (no platform), so its outputs land in the platform-less
-    # 'bin\<config>\net10.0' and 'obj\<config>\net10.0\ref' folders. It is staged after the implementation
-    # assembly (above), since the reference build overwrites the 'bin' outputs.
+    # Build WinRT.Runtime with implementation-only types stripped out. Put the reference build's normal binary
+    # outputs (including its XML documentation) in a temporary folder so its TargetPath does not overwrite the
+    # implementation assembly needed to build the Windows SDK implementation projections. The metadata-only
+    # reference assembly is still emitted under 'obj\<config>\net10.0\ref' and staged separately below.
     - task: VSBuild@1
       displayName: Build WinRT.Runtime reference assembly
       condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
       inputs:
         solution: $(Build.SourcesDirectory)\src\WinRT.Runtime2\WinRT.Runtime.csproj
-        msbuildArgs: /restore /p:VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),CsWinRTBuildReferenceAssembly=true,ContinuousIntegrationBuild=true
+        msbuildArgs: /restore /p:VersionNumber=$(VersionNumber),VersionString=$(Build.BuildNumber),AssemblyVersionNumber=$(WinRT.Runtime.AssemblyVersion),CsWinRTBuildReferenceAssembly=true,ContinuousIntegrationBuild=true /p:BaseOutputPath=$(Agent.TempDirectory)\WinRT.Runtime.Reference\
         configuration: $(BuildConfiguration)
 
     # Stage WinRT.Runtime reference assembly (metadata-only assembly produced under 'obj\...\ref')
@@ -260,12 +260,12 @@ steps:
         Contents: WinRT.Runtime.dll
         TargetFolder: $(StagingFolder)\net10.0\ref
 
-    # Stage WinRT.Runtime reference assembly XML documentation (stripped to the reference surface)
+    # Stage the matching XML documentation from the isolated reference-build output
     - task: CopyFiles@2
       displayName: Stage WinRT.Runtime reference assembly XML
       condition: and(succeeded(), eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildConfiguration'], 'release'))
       inputs:
-        SourceFolder: $(Build.SourcesDirectory)\src\WinRT.Runtime2\bin\$(BuildConfiguration)\net10.0
+        SourceFolder: $(Agent.TempDirectory)\WinRT.Runtime.Reference\$(BuildConfiguration)\net10.0
         Contents: WinRT.Runtime.xml
         TargetFolder: $(StagingFolder)\net10.0\ref
 


### PR DESCRIPTION
Keep the stripped WinRT.Runtime reference build from overwriting the implementation assembly required by SDK projection generation.