### PR TITLE
Fix over-release of caller-owned interface pointer in CreateObject

### DIFF
--- a/src/Tests/UnitTest/ComWrappersTests.cs
+++ b/src/Tests/UnitTest/ComWrappersTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WindowsRuntime.InteropServices;
+using WindowsRuntime.InteropServices.Marshalling;
+
+namespace UnitTest;
+
+/// <summary>
+/// Tests for the <c>ComWrappers</c> infrastructure backing RCW creation.
+/// </summary>
+[TestClass]
+public unsafe class ComWrappersTests
+{
+    // Marshalling a native object to managed goes through 'WindowsRuntimeComWrappers.CreateObject', which is
+    // handed an interface pointer that the caller owns. Some marshallers additionally marshal nested objects
+    // while they run, which re-enters the marshalling infrastructure on the same thread.
+    //
+    // 'NotifyCollectionChangedEventArgs' is the shipping example: 'CreateObject' resolves its runtime class
+    // name to its marshaller, whose 'ConvertToManaged' marshals the 'NewItems'/'OldItems' collections through
+    // 'IListMarshaller.ConvertToManaged'. That nested operation used to reset the thread-static state that the
+    // outer 'CreateObject' read in its 'finally' block to decide whether it had acquired the interface pointer
+    // itself. It wrongly concluded that it had, and released a pointer owned by the caller.
+    //
+    // That type needs the WinUI runtime to activate, which is not available in this test host, so this test
+    // reproduces the same re-entrancy with a minimal native object whose 'GetRuntimeClassName' marshals a
+    // second native object (that callback runs inside the outer 'CreateObject', exactly like the nested
+    // marshalling above). Rather than hard-coding how many references the marshalling infrastructure takes
+    // internally, the test compares a re-entrant marshalling operation against a non-re-entrant one: both must
+    // have the same net effect on the reference count of the pointer owned by the caller.
+    [TestMethod]
+    public void TestReentrantMarshallingDoesNotReleaseCallerOwnedInterfacePointer()
+    {
+        int deltaWithoutReentrancy = MarshalAndGetReferenceCountDelta(reentrant: false);
+        int deltaWithReentrancy = MarshalAndGetReferenceCountDelta(reentrant: true);
+
+        // Sanity check that the marshalling actually took a reference on the object we passed in
+        Assert.IsTrue(deltaWithoutReentrancy > 0, "Marshalling a native object should take a reference on it.");
+
+        Assert.AreEqual(
+            deltaWithoutReentrancy,
+            deltaWithReentrancy,
+            "Marshalling a native object that re-enters the marshalling infrastructure should have the same effect " +
+            "on the reference count of the caller-owned interface pointer as one that does not. A smaller delta means " +
+            "the caller-owned pointer was released by 'CreateObject', which does not own it.");
+
+        static int MarshalAndGetReferenceCountDelta(bool reentrant)
+        {
+            void* nested = reentrant ? FakeInspectable.Create(nested: null) : null;
+            void* target = FakeInspectable.Create(nested);
+
+            try
+            {
+                int referenceCountBefore = FakeInspectable.GetReferenceCount(target);
+
+                object wrapper = WindowsRuntimeMarshal.ConvertToManaged(target);
+
+                int referenceCountAfter = FakeInspectable.GetReferenceCount(target);
+
+                Assert.IsNotNull(wrapper, "Marshalling a native object should always produce a managed wrapper.");
+
+                // The wrapper owns a reference to 'target', so it has to stay alive until after the measurement
+                GC.KeepAlive(wrapper);
+
+                return referenceCountAfter - referenceCountBefore;
+            }
+            finally
+            {
+                FakeInspectable.Release(target);
+
+                if (nested is not null)
+                {
+                    FakeInspectable.Release(nested);
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// A minimal native <c>IInspectable</c> object with a hand-written vtable, used to observe reference counts
+/// and to control what happens while <c>ComWrappers</c> is creating a wrapper for it.
+/// </summary>
+file static unsafe class FakeInspectable
+{
+    /// <summary>The runtime class name reported by these objects (it intentionally matches no projected type).</summary>
+    private const string RuntimeClassName = "UnitTest.FakeInspectable";
+
+    private static readonly Guid IID_IUnknown = new("00000000-0000-0000-C000-000000000046");
+    private static readonly Guid IID_IInspectable = new("AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90");
+    private static readonly Guid IID_IAgileObject = new("94EA2B94-E9CC-49E0-C0FF-EE64CA8F5B90");
+
+    /// <summary>The shared vtable for all instances (allocated once, never freed).</summary>
+    private static readonly void** Vftbl = CreateVftbl();
+
+    /// <summary>The instance state, laid out so that the vtable pointer comes first (as COM requires).</summary>
+    private struct Instance
+    {
+        public void** Vftbl;
+        public int ReferenceCount;
+
+        /// <summary>An object to marshal from <c>GetRuntimeClassName</c>, to force a re-entrant marshalling operation.</summary>
+        public nint Nested;
+    }
+
+    /// <summary>Creates a new instance with a reference count of 1.</summary>
+    public static void* Create(void* nested)
+    {
+        Instance* instance = (Instance*)NativeMemory.AllocZeroed((nuint)sizeof(Instance));
+
+        instance->Vftbl = Vftbl;
+        instance->ReferenceCount = 1;
+        instance->Nested = (nint)nested;
+
+        return instance;
+    }
+
+    /// <summary>Gets the current reference count of a given instance.</summary>
+    public static int GetReferenceCount(void* thisPtr)
+    {
+        return Volatile.Read(ref ((Instance*)thisPtr)->ReferenceCount);
+    }
+
+    /// <summary>Releases a reference, freeing the instance when the count reaches 0.</summary>
+    public static void Release(void* thisPtr)
+    {
+        _ = ReleaseCore((Instance*)thisPtr);
+    }
+
+    private static void** CreateVftbl()
+    {
+        void** vftbl = (void**)NativeMemory.Alloc(6, (nuint)sizeof(void*));
+
+        vftbl[0] = (delegate* unmanaged[MemberFunction]<void*, Guid*, void**, int>)&QueryInterface;
+        vftbl[1] = (delegate* unmanaged[MemberFunction]<void*, uint>)&AddRef;
+        vftbl[2] = (delegate* unmanaged[MemberFunction]<void*, uint>)&ReleaseUnmanaged;
+        vftbl[3] = (delegate* unmanaged[MemberFunction]<void*, uint*, Guid**, int>)&GetIids;
+        vftbl[4] = (delegate* unmanaged[MemberFunction]<void*, void**, int>)&GetRuntimeClassName;
+        vftbl[5] = (delegate* unmanaged[MemberFunction]<void*, int*, int>)&GetTrustLevel;
+
+        return vftbl;
+    }
+
+    private static uint AddRefCore(Instance* instance)
+    {
+        return (uint)Interlocked.Increment(ref instance->ReferenceCount);
+    }
+
+    private static uint ReleaseCore(Instance* instance)
+    {
+        int referenceCount = Interlocked.Decrement(ref instance->ReferenceCount);
+
+        if (referenceCount == 0)
+        {
+            NativeMemory.Free(instance);
+        }
+
+        return (uint)referenceCount;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int QueryInterface(void* thisPtr, Guid* iid, void** ppvObject)
+    {
+        // Respond to 'IAgileObject' as well, so that the object is treated as free-threaded. This keeps the
+        // marshalling path deterministic, and independent of the COM apartment the test happens to run on.
+        if (*iid == IID_IUnknown || *iid == IID_IInspectable || *iid == IID_IAgileObject)
+        {
+            _ = AddRefCore((Instance*)thisPtr);
+
+            *ppvObject = thisPtr;
+
+            return 0; // S_OK
+        }
+
+        *ppvObject = null;
+
+        return unchecked((int)0x80004002); // E_NOINTERFACE
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static uint AddRef(void* thisPtr)
+    {
+        return AddRefCore((Instance*)thisPtr);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static uint ReleaseUnmanaged(void* thisPtr)
+    {
+        return ReleaseCore((Instance*)thisPtr);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int GetIids(void* thisPtr, uint* iidCount, Guid** iids)
+    {
+        *iidCount = 0;
+        *iids = null;
+
+        return 0; // S_OK
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int GetRuntimeClassName(void* thisPtr, void** className)
+    {
+        Instance* instance = (Instance*)thisPtr;
+
+        // This runs inside the outer 'CreateObject' call, so marshalling another native object here re-enters
+        // the marshalling infrastructure exactly like a marshaller that also marshals nested objects would.
+        // Only do it once, so that the nested marshalling operation does not recurse indefinitely.
+        void* nested = (void*)Interlocked.Exchange(ref instance->Nested, 0);
+
+        if (nested is not null)
+        {
+            _ = WindowsRuntimeMarshal.ConvertToManaged(nested);
+        }
+
+        *className = HStringMarshaller.ConvertToUnmanaged(RuntimeClassName.AsSpan());
+
+        return 0; // S_OK
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int GetTrustLevel(void* thisPtr, int* trustLevel)
+    {
+        *trustLevel = 0; // BaseTrust
+
+        return 0; // S_OK
+    }
+}

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
@@ -343,6 +343,14 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
         // We always need this, and all callers are expected to be providing one.
         void* interfacePointer = CreateObjectTargetInterfacePointer;
 
+        // Whether we acquired 'interfacePointer' ourselves, and are therefore responsible for releasing it below.
+        // This must be tracked in a local: it cannot be inferred in the 'finally' block by checking whether
+        // 'CreateObjectTargetInterfacePointer' is 'null', because re-entrant marshalling on the same thread (ie.
+        // a marshaller which also marshals nested objects, such as the one for 'NotifyCollectionChangedEventArgs'
+        // marshalling its 'NewItems'/'OldItems' collections) resets that field before we get to observe it. Doing
+        // so would make us release an interface pointer that was supplied by the caller, and that we do not own.
+        bool isInterfacePointerOwned = false;
+
         // There is a rare case where we might not have an input interface pointer, and that is if this
         // call was directly to 'ComWrappers' through the rehydration path in 'WeakReference<T>'. That
         // is, if we had a 'WeakReference<T>' instance pointing to an RCW object which got collected,
@@ -361,6 +369,8 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
 
             // Manually 'QueryInterface' to retrieve the 'IInspectable' object we need
             IUnknownVftbl.QueryInterfaceUnsafe((void*)externalComObject, in WellKnownWindowsInterfaceIIDs.IID_IInspectable, out interfacePointer).Assert();
+
+            isInterfacePointerOwned = true;
         }
 
         try
@@ -454,7 +464,7 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
         {
             // If we hit the special case mentioned above where we had to manually 'QueryInterface' for 'IInspectable', as the caller
             // hadn't provided a valid interface pointer, we need to also make sure to release that acquired interface pointer here.
-            if (CreateObjectTargetInterfacePointer is null)
+            if (isInterfacePointerOwned)
             {
                 _ = IUnknownVftbl.ReleaseUnsafe(interfacePointer);
             }

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs
@@ -277,6 +277,16 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
         WindowsRuntimeObjectComWrappersCallback? objectComWrappersCallback,
         WindowsRuntimeUnsealedObjectComWrappersCallback? unsealedObjectComWrappersCallback)
     {
+        // Save the current state before overwriting it, so that it can be restored below. For a top-level
+        // marshalling operation this is all 'null', but it will not be when re-entering this method from a
+        // marshalling operation that is already in flight on this thread. That happens whenever a marshaller
+        // also needs to marshal nested objects (eg. the one for 'NotifyCollectionChangedEventArgs', which
+        // marshals its 'NewItems'/'OldItems' collections). Restoring, rather than unconditionally clearing,
+        // keeps the state of the outer marshalling operation intact for when control returns to it.
+        WindowsRuntimeObjectComWrappersCallback? previousObjectComWrappersCallback = ObjectComWrappersCallback;
+        WindowsRuntimeUnsealedObjectComWrappersCallback? previousUnsealedObjectComWrappersCallback = UnsealedObjectComWrappersCallback;
+        void* previousCreateObjectTargetInterfacePointer = CreateObjectTargetInterfacePointer;
+
         ObjectComWrappersCallback = objectComWrappersCallback;
         UnsealedObjectComWrappersCallback = unsealedObjectComWrappersCallback;
         CreateObjectTargetInterfacePointer = (void*)externalComObject;
@@ -290,14 +300,15 @@ internal sealed unsafe class WindowsRuntimeComWrappers : ComWrappers
         }
         finally
         {
-            // Always reset the shared state after the call, regardless of whether the call succeeded. We want to
-            // make sure that those fields are always 'null' before any following calls. This is necessary because
-            // we cannot guarantee callers will always go through this overload to set them correctly. In particular,
-            // the 'WeakReference<T>' callback might use this 'ComWrappers' instance externally, and if any of these
-            // fields were set it would cause issues. See additional notes below for this in 'CreateObject'.
-            ObjectComWrappersCallback = null;
-            UnsealedObjectComWrappersCallback = null;
-            CreateObjectTargetInterfacePointer = null;
+            // Always restore the shared state after the call, regardless of whether the call succeeded. For a
+            // top-level marshalling operation the saved values are all 'null', so this preserves the invariant
+            // that these fields are 'null' before any following calls. That invariant is necessary because we
+            // cannot guarantee callers will always go through this overload to set them correctly. In particular,
+            // the 'WeakReference<T>' callback might use this 'ComWrappers' instance externally, and if any of
+            // these fields were set it would cause issues. See additional notes below for this in 'CreateObject'.
+            ObjectComWrappersCallback = previousObjectComWrappersCallback;
+            UnsealedObjectComWrappersCallback = previousUnsealedObjectComWrappersCallback;
+            CreateObjectTargetInterfacePointer = previousCreateObjectTargetInterfacePointer;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a reference count over-release in `WindowsRuntimeComWrappers.CreateObject`, which released an interface pointer owned by the caller whenever a marshalling operation re-entered the marshalling infrastructure on the same thread.

## Motivation

`CreateObject` receives the `IInspectable` interface pointer through the `CreateObjectTargetInterfacePointer` thread-static. That pointer is normally supplied (and owned) by the caller, but in the `WeakReference<T>` rehydration path there is no caller context, so `CreateObject` has to `QueryInterface` for it itself and release it afterwards.

To tell those two cases apart, the `finally` block re-read `CreateObjectTargetInterfacePointer` and treated `null` as "I acquired this myself". That inference is only valid as long as nothing resets the field while `CreateObject` is running, and `GetOrCreateObjectForComInstanceUnsafe` resets it to `null` on exit. Any nested marshalling operation therefore left the field `null`, so the outer `finally` released a pointer it did not own, dropping the reference count one time too many.

This is reachable today. Marshalling a `NotifyCollectionChangedEventArgs` resolves through the most-derived-type lookup to its ComWrappers marshaller, whose `CreateObject` calls `NotifyCollectionChangedEventArgsMarshaller.ConvertToManaged`. That in turn marshals the `NewItems`/`OldItems` collections through `IListMarshaller.ConvertToManaged`, which re-enters `GetOrCreateObjectForComInstanceUnsafe`.

While fixing that, the same shared state turned out to have a second, independent problem: because `GetOrCreateObjectForComInstanceUnsafe` unconditionally cleared the callbacks rather than restoring them, a nested marshalling operation also destroyed the outer operation's static type information. Once control returned to the outer `CreateObject`, the fallback that would have produced a wrapper specialized to the statically known type saw a `null` callback and silently degraded to an opaque `IInspectable` wrapper.

## Changes

- **`src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs`**: track whether `CreateObject` acquired the interface pointer itself in a local, instead of inferring it in the `finally` block from shared thread-static state. This is the actual fix for the over-release.

- **`src/WinRT.Runtime2/InteropServices/WindowsRuntimeComWrappers.cs`**: save and restore the three marshalling thread-statics in `GetOrCreateObjectForComInstanceUnsafe` instead of always writing `null`, so a nested marshalling operation no longer destroys the outer operation's state. For a top-level call the saved values are `null`, so the existing invariant that these fields are `null` outside a marshalling operation is preserved, and the `WeakReference<T>` rehydration path keeps behaving as before.

- **`src/Tests/UnitTest/ComWrappersTests.cs`**: new regression test covering re-entrant marshalling. The shipping trigger (`NotifyCollectionChangedEventArgs`) needs the WinUI runtime to activate, which is not available in the unit test host, so the test instead uses a minimal native `IInspectable` with a hand-written vtable whose `GetRuntimeClassName` marshals a second native object. That callback runs inside the outer `CreateObject`, reproducing the same re-entrancy without any activation dependency. Rather than hard-coding how many references the marshalling infrastructure takes internally, the test marshals twice (once re-entrant, once not) and asserts that both have the same net effect on the reference count of the caller-owned pointer, which keeps it robust to unrelated internal changes.

## Validation

The new test was verified against each state of the fix:

| Runtime state | Result |
|-|-|
| Before the fix | Fails with `Expected:<1>. Actual:<0>` |
| First commit only | Passes |
| Both commits | Passes |

`Actual:<0>` is exactly the expected symptom: the spurious `Release` cancels out the reference that the created wrapper takes.

Running the full `UnitTest` suite before and after the change goes from `432 failed / 81 passed` to `431 failed / 82 passed`, so exactly one test flips and there are no regressions. The remaining failures are pre-existing and environmental: the C++ test component is not registered in the local test host, so those tests fail with `REGDB_E_CLASSNOTREG` while constructing the test class.
