### PR TITLE
Fix the GetMany and IndexOf vtable signatures for IVector<T> and IVectorView<T>

### DIFF
--- a/src/WinRT.Generator.Core/Extensions/TypeSignatureExtensions.cs
+++ b/src/WinRT.Generator.Core/Extensions/TypeSignatureExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AsmResolver.DotNet.Signatures;
+
+namespace WindowsRuntime.Generator;
+
+/// <summary>
+/// Extensions for <see cref="TypeSignature"/>.
+/// </summary>
+internal static class TypeSignatureExtensions
+{
+    extension(TypeSignature signature)
+    {
+        /// <summary>
+        /// Strips trailing <see cref="ByReferenceTypeSignature"/> and <see cref="CustomModifierTypeSignature"/>
+        /// wrappers from the signature, returning the underlying signature.
+        /// </summary>
+        /// <returns>The underlying signature with byref + custom-modifier wrappers stripped.</returns>
+        public TypeSignature StripByRefAndCustomModifiers()
+        {
+            TypeSignature current = signature;
+
+            while (true)
+            {
+                if (current is ByReferenceTypeSignature byReferenceTypeSignature)
+                {
+                    current = byReferenceTypeSignature.BaseType;
+
+                    continue;
+                }
+
+                if (current is CustomModifierTypeSignature customModifierTypeSignature)
+                {
+                    current = customModifierTypeSignature.BaseType;
+
+                    continue;
+                }
+
+                return current;
+            }
+        }
+    }
+}

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs
@@ -483,9 +483,13 @@ internal static partial class InteropTypeDefinitionBuilder
         {
             implType.Methods.Add(method);
 
+            FieldDefinition vtableSlot = vftblType.Fields[vtableOffset++];
+
+            VtableSignatureValidator.ValidateSlot(vtableSlot, method);
+
             _ = cctor.CilMethodBody.Instructions.Add(Ldsflda, vftblField);
             _ = cctor.CilMethodBody.Instructions.Add(Ldftn, method);
-            _ = cctor.CilMethodBody.Instructions.Add(Stfld, vftblType.Fields[vtableOffset++]);
+            _ = cctor.CilMethodBody.Instructions.Add(Stfld, vtableSlot);
         }
 
         // Enforce that we did initialize all vtable entries

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -416,7 +416,7 @@ internal static partial class WellKnownTypeDefinitionFactory
         // public delegate* unmanaged[MemberFunction]<void*, uint, <ELEMENT_TYPE>*, HRESULT> GetAt;
         // public delegate* unmanaged[MemberFunction]<void*, uint*, HRESULT> get_Size;
         // public delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, HRESULT> IndexOf;
-        // public delegate* unmanaged[MemberFunction]<void*, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany;
+        // public delegate* unmanaged[MemberFunction]<void*, uint, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany;
         vftblType.Fields.Add(new FieldDefinition("QueryInterface"u8, FieldAttributes.Public, queryInterfaceType.MakeFunctionPointerType()));
         vftblType.Fields.Add(new FieldDefinition("AddRef"u8, FieldAttributes.Public, addRefType.MakeFunctionPointerType()));
         vftblType.Fields.Add(new FieldDefinition("Release"u8, FieldAttributes.Public, releaseType.MakeFunctionPointerType()));

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -415,7 +415,7 @@ internal static partial class WellKnownTypeDefinitionFactory
         // public delegate* unmanaged[MemberFunction]<void*, TrustLevel*, HRESULT> GetTrustLevel;
         // public delegate* unmanaged[MemberFunction]<void*, uint, <ELEMENT_TYPE>*, HRESULT> GetAt;
         // public delegate* unmanaged[MemberFunction]<void*, uint*, HRESULT> get_Size;
-        // public delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, HRESULT> IndexOf;
+        // public delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, bool*, HRESULT> IndexOf;
         // public delegate* unmanaged[MemberFunction]<void*, uint, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany;
         vftblType.Fields.Add(new FieldDefinition("QueryInterface"u8, FieldAttributes.Public, queryInterfaceType.MakeFunctionPointerType()));
         vftblType.Fields.Add(new FieldDefinition("AddRef"u8, FieldAttributes.Public, addRefType.MakeFunctionPointerType()));

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
@@ -393,7 +393,7 @@ internal static class WellKnownTypeSignatureFactory
     /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
     public static MethodSignature IReadOnlyList1GetManyImpl(TypeSignature elementType, InteropReferences interopReferences)
     {
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany'
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, uint, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany'
         return new(
             attributes: CallingConventionAttributes.Unmanaged,
             returnType: new CustomModifierTypeSignature(
@@ -402,6 +402,7 @@ internal static class WellKnownTypeSignatureFactory
                 baseType: interopReferences.Int32),
             parameterTypes: [
                 interopReferences.Void.MakePointerType(),
+                interopReferences.UInt32,
                 interopReferences.UInt32,
                 elementType.MakePointerType(),
                 interopReferences.UInt32.MakePointerType()]);
@@ -581,7 +582,7 @@ internal static class WellKnownTypeSignatureFactory
     /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
     public static MethodSignature IList1GetManyImpl(TypeSignature elementType, InteropReferences interopReferences)
     {
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany'.
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, uint, uint, <ELEMENT_TYPE>*, uint*, HRESULT> GetMany'.
         // This is the same as 'IVectorView<T>.GetMany', so we can reuse that one here (like the methods above).
         return IReadOnlyList1GetManyImpl(elementType, interopReferences);
     }

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs
@@ -372,7 +372,7 @@ internal static class WellKnownTypeSignatureFactory
     /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
     public static MethodSignature IReadOnlyList1IndexOfImpl(TypeSignature elementType, InteropReferences interopReferences)
     {
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, HRESULT> IndexOf'
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, bool*, HRESULT> IndexOf'
         return new(
             attributes: CallingConventionAttributes.Unmanaged,
             returnType: new CustomModifierTypeSignature(
@@ -382,7 +382,8 @@ internal static class WellKnownTypeSignatureFactory
             parameterTypes: [
                 interopReferences.Void.MakePointerType(),
                 elementType,
-                interopReferences.UInt32.MakePointerType()]);
+                interopReferences.UInt32.MakePointerType(),
+                interopReferences.Boolean.MakePointerType()]);
     }
 
     /// <summary>
@@ -458,18 +459,9 @@ internal static class WellKnownTypeSignatureFactory
     /// <returns>The resulting <see cref="FunctionPointerTypeSignature"/> instance.</returns>
     public static MethodSignature IList1IndexOfImpl(TypeSignature elementType, InteropReferences interopReferences)
     {
-        // Signature for 'delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, bool*, HRESULT> IndexOf'
-        return new(
-            attributes: CallingConventionAttributes.Unmanaged,
-            returnType: new CustomModifierTypeSignature(
-                modifierType: interopReferences.CallConvMemberFunction,
-                isRequired: false,
-                baseType: interopReferences.Int32),
-            parameterTypes: [
-                interopReferences.Void.MakePointerType(),
-                elementType,
-                interopReferences.UInt32.MakePointerType(),
-                interopReferences.Boolean.MakePointerType()]);
+        // Signature for 'delegate* unmanaged[MemberFunction]<void*, <ELEMENT_TYPE>, uint*, bool*, HRESULT> IndexOf'.
+        // This is the same as 'IVectorView<T>.IndexOf', so we can reuse that one here (like the methods above).
+        return IReadOnlyList1IndexOfImpl(elementType, interopReferences);
     }
 
     /// <summary>

--- a/src/WinRT.Interop.Generator/Helpers/VtableSignatureValidator.cs
+++ b/src/WinRT.Interop.Generator/Helpers/VtableSignatureValidator.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
+
+namespace WindowsRuntime.InteropGenerator.Helpers;
+
+/// <summary>
+/// A class that provides logic to validate the vtable types being emitted.
+/// </summary>
+internal static class VtableSignatureValidator
+{
+    /// <summary>
+    /// Validates that a vtable slot is declared with the same signature as the method being stored into it.
+    /// </summary>
+    /// <param name="vtableSlot">The vtable slot (i.e. the function pointer field) being initialized.</param>
+    /// <param name="method">The <see cref="MethodDefinition"/> whose address is being stored into <paramref name="vtableSlot"/>.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the two signatures don't match.</exception>
+    /// <remarks>
+    /// <para>
+    /// Storing a function pointer into a vtable slot is a plain <c>ldftn</c>/<c>stfld</c> pair, which the runtime does
+    /// not type check. That means the declared signature of a slot and the signature of the method actually placed in
+    /// it can silently disagree. That is harmless for the CCW itself (native callers only ever see the signature of the
+    /// method), but the declared signature of the slot is also what any <c>calli</c> through that same vtable is emitted
+    /// with. A mismatch is a latent bug that only manifests as stack corruption once someone calls through the slot.
+    /// </para>
+    /// <para>
+    /// Only the arity and the return type are validated, as the slot and the method are allowed to spell an individual
+    /// parameter differently. Shared (i.e. non specialized) vtables use <c>void*</c> where the implementation method
+    /// uses the exact ABI type of the element, which is ABI identical.
+    /// </para>
+    /// </remarks>
+    public static void ValidateSlot(FieldDefinition vtableSlot, MethodDefinition method)
+    {
+        MethodSignature slotSignature = ((FunctionPointerTypeSignature)vtableSlot.Signature!.FieldType).Signature;
+        MethodSignature methodSignature = method.Signature!;
+
+        // The slot declares the 'this' pointer explicitly, and the implementation methods are all static (they are
+        // marked with '[UnmanagedCallersOnly]'), so the two parameter counts should match exactly. A mismatch means
+        // the vtable declaration is out of sync with the Windows Runtime ABI of that interface method, which in
+        // practice is almost always a missing '[out, retval]' parameter on the vtable declaration.
+        if (slotSignature.ParameterTypes.Count != methodSignature.ParameterTypes.Count)
+        {
+            throw new InvalidOperationException(
+                $"The vtable slot '{vtableSlot.Name}' is declared with {slotSignature.ParameterTypes.Count} parameter(s), but the method " +
+                $"'{method.Name}' being stored into it has {methodSignature.ParameterTypes.Count}. The declared signature of a vtable slot " +
+                $"must match the Windows Runtime ABI of that method exactly, as it is also used to emit 'calli' instructions.");
+        }
+
+        // The return type of the slot carries a 'modopt(CallConvMemberFunction)' that the implementation method
+        // expresses through '[UnmanagedCallersOnly]' instead, so only compare the underlying return types here.
+        if (!SignatureComparer.Default.Equals(
+            slotSignature.ReturnType.StripByRefAndCustomModifiers(),
+            methodSignature.ReturnType.StripByRefAndCustomModifiers()))
+        {
+            throw new InvalidOperationException(
+                $"The vtable slot '{vtableSlot.Name}' is declared with return type '{slotSignature.ReturnType}', but the method " +
+                $"'{method.Name}' being stored into it returns '{methodSignature.ReturnType}'.");
+        }
+    }
+}

--- a/src/WinRT.Projection.Writer/Extensions/TypeSignatureExtensions.cs
+++ b/src/WinRT.Projection.Writer/Extensions/TypeSignatureExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Resolvers;
 using static WindowsRuntime.ProjectionWriter.References.WellKnownNamespaces;
 using static WindowsRuntime.ProjectionWriter.References.WellKnownTypeNames;
@@ -156,35 +157,6 @@ internal static class TypeSignatureExtensions
                 sig.IsString() ||
                 sig.IsObject() ||
                 resolver.IsRuntimeClassOrInterface(sig);
-        }
-
-        /// <summary>
-        /// Strips trailing <see cref="ByReferenceTypeSignature"/> and <see cref="CustomModifierTypeSignature"/>
-        /// wrappers from the signature, returning the underlying signature.
-        /// </summary>
-        /// <returns>The underlying signature with byref + custom-modifier wrappers stripped.</returns>
-        public TypeSignature StripByRefAndCustomModifiers()
-        {
-            TypeSignature current = sig;
-
-            while (true)
-            {
-                if (current is ByReferenceTypeSignature br)
-                {
-                    current = br.BaseType;
-
-                    continue;
-                }
-
-                if (current is CustomModifierTypeSignature cm)
-                {
-                    current = cm.BaseType;
-
-                    continue;
-                }
-
-                return current;
-            }
         }
 
         /// <summary>

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
@@ -3,6 +3,7 @@
 
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Errors;
 using WindowsRuntime.ProjectionWriter.Generation;
 using WindowsRuntime.ProjectionWriter.Helpers;

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Text;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Metadata.Tables;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Generation;
 using WindowsRuntime.ProjectionWriter.Helpers;
 using WindowsRuntime.ProjectionWriter.Metadata;

--- a/src/WinRT.Projection.Writer/Models/MethodSignatureMarshallingFacts.cs
+++ b/src/WinRT.Projection.Writer/Models/MethodSignatureMarshallingFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Resolvers;
 
 namespace WindowsRuntime.ProjectionWriter.Models;

--- a/src/WinRT.Projection.Writer/Resolvers/AbiTypeKindResolver.cs
+++ b/src/WinRT.Projection.Writer/Resolvers/AbiTypeKindResolver.cs
@@ -229,7 +229,7 @@ internal sealed class AbiTypeKindResolver(MetadataCache cache)
     ///   <item>Complex structs (per-field cleanup via the <c>*Marshaller</c>) — see <see cref="IsNonBlittableStruct"/></item>
     ///   <item>Generic instances (need <c>WindowsRuntimeObjectReferenceValue</c> dispose) — see <see cref="TypeSignatureExtensions.IsGenericInstance"/></item>
     /// </list>
-    /// Callers should pass the already-stripped parameter type (via <see cref="TypeSignatureExtensions.StripByRefAndCustomModifiers"/>).
+    /// Callers should pass the already-stripped parameter type (via <see cref="Generator.TypeSignatureExtensions.StripByRefAndCustomModifiers"/>).
     /// </summary>
     /// <param name="signature">The stripped (non-byref) parameter type to classify.</param>
     /// <returns><see langword="true"/> when the type requires finally-block cleanup on receive; otherwise <see langword="false"/>.</returns>

--- a/src/WinRT.Projection.Writer/Resolvers/ParameterCategoryResolver.cs
+++ b/src/WinRT.Projection.Writer/Resolvers/ParameterCategoryResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using AsmResolver.DotNet.Signatures;
+using WindowsRuntime.Generator;
 using WindowsRuntime.ProjectionWriter.Models;
 
 namespace WindowsRuntime.ProjectionWriter.Resolvers;

--- a/src/WinRT.Runtime2/InteropServices/Vtables/IVectorVftbl.cs
+++ b/src/WinRT.Runtime2/InteropServices/Vtables/IVectorVftbl.cs
@@ -32,6 +32,6 @@ internal unsafe struct IVectorVftbl
     public delegate* unmanaged[MemberFunction]<void*, void*, HRESULT> Append;
     public delegate* unmanaged[MemberFunction]<void*, HRESULT> RemoveAtEnd;
     public delegate* unmanaged[MemberFunction]<void*, HRESULT> Clear;
-    public delegate* unmanaged[MemberFunction]<void*, uint, void*, uint*, HRESULT> GetMany;
+    public delegate* unmanaged[MemberFunction]<void*, uint, uint, void*, uint*, HRESULT> GetMany;
     public delegate* unmanaged[MemberFunction]<void*, uint, void*, HRESULT> ReplaceAll;
 }

--- a/src/WinRT.Runtime2/InteropServices/Vtables/IVectorViewVftbl.cs
+++ b/src/WinRT.Runtime2/InteropServices/Vtables/IVectorViewVftbl.cs
@@ -28,5 +28,5 @@ internal unsafe struct IVectorViewVftbl
     // does not matter, since this vtable slot is never actually used within this assembly. It is only
     // used from 'WinRT.Interop.dll', which will emit specialized vtable types when necessary.
     public delegate* unmanaged[MemberFunction]<void*, void*, uint*, HRESULT> IndexOf;
-    public delegate* unmanaged[MemberFunction]<void*, uint, void*, uint*, HRESULT> GetMany;
+    public delegate* unmanaged[MemberFunction]<void*, uint, uint, void*, uint*, HRESULT> GetMany;
 }

--- a/src/WinRT.Runtime2/InteropServices/Vtables/IVectorViewVftbl.cs
+++ b/src/WinRT.Runtime2/InteropServices/Vtables/IVectorViewVftbl.cs
@@ -27,6 +27,6 @@ internal unsafe struct IVectorViewVftbl
     // parameter of a generic type (meaning it could be either 'void*' or some exact value type). This
     // does not matter, since this vtable slot is never actually used within this assembly. It is only
     // used from 'WinRT.Interop.dll', which will emit specialized vtable types when necessary.
-    public delegate* unmanaged[MemberFunction]<void*, void*, uint*, HRESULT> IndexOf;
+    public delegate* unmanaged[MemberFunction]<void*, void*, uint*, bool*, HRESULT> IndexOf;
     public delegate* unmanaged[MemberFunction]<void*, uint, uint, void*, uint*, HRESULT> GetMany;
 }


### PR DESCRIPTION
## Summary

Fix two `IVector<T>`/`IVectorView<T>` vtable slots that were declared with the wrong Windows Runtime ABI signature (`GetMany` was missing its `capacity` parameter, and `IVectorView<T>.IndexOf` was missing its `found` parameter), and add a validation step to the interop generator so this class of bug can't silently reappear.

The `GetMany` part of this is extracted out of #2517, where it was needed to unblock the `CopyTo` optimization. It stands on its own as a correctness fix, so it is split out here to keep that PR focused on the optimization work.

## Motivation

Both `IVector<T>` and `IVectorView<T>` declare these methods as:

- `HRESULT GetMany([in] UINT32 startIndex, [in] UINT32 capacity, [out] T* items, [out, retval] UINT32* actual)`
- `HRESULT IndexOf([in] T value, [out] UINT32* index, [out, retval] boolean* found)`

The declarations of those two vtable slots were missing a parameter each:

- `GetMany` was missing `capacity`, in `IVectorVftbl`, `IVectorViewVftbl`, and in the specialized vtable types the interop generator emits (via `IReadOnlyList1GetManyImpl`, which `IList1GetManyImpl` also reuses).
- `IndexOf` was missing `found`, in `IVectorViewVftbl` and in `IReadOnlyList1IndexOfImpl`. The `IVector<T>` counterpart (`IList1IndexOfImpl`) was already correct, which is why `IList<T>.IndexOf` works today: it is the only one of these slots that a `calli` is actually emitted for.

### Why no test caught this

Both were completely latent, for the same two reasons:

- **Nothing ever called through the slots.** No `calli` is emitted through `GetMany` for either interface (`CopyTo` goes through the indexer instead), and `IReadOnlyList<T>` has no `IndexOf` member at all, so the `IVectorView<T>.IndexOf` slot is never called from managed code either. The only slot in this group that is genuinely called through, `IVector<T>.IndexOf`, had the correct signature.

- **The CCW side never validates the slot.** Populating a vtable slot is a plain `ldftn`/`stfld` pair, which the runtime does not type check, and the implementation methods stored into these slots already had the correct signatures (five parameters for `GetMany`, four for `IndexOf`). So native callers were always seeing the correct signature, and the incorrect declaration never influenced any executed code path.

In other words, the declarations were dead weight until something started calling through them, which is exactly what #2517 does. Since the bug is in metadata that no test could observe at run time, the guard added here (rather than a run time test) is what actually closes the gap: it compares the two signatures at the point where they are wired together, so a mismatch fails interop generation instead of silently producing a vtable that only breaks later.

## Changes

- **`src/WinRT.Runtime2/InteropServices/Vtables/IVectorVftbl.cs`**: add the missing `capacity` parameter to `GetMany`.

- **`src/WinRT.Runtime2/InteropServices/Vtables/IVectorViewVftbl.cs`**: add the missing `capacity` parameter to `GetMany`, and the missing `found` parameter to `IndexOf`.

- **`src/WinRT.Interop.Generator/Factories/WellKnownTypeSignatureFactory.cs`**: fix `IReadOnlyList1GetManyImpl` and `IReadOnlyList1IndexOfImpl`. Now that both declarations agree, `IList1IndexOfImpl` just reuses the vector view one, as the other identical `IVector<T>` slots already do.

- **`src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs`**: update the vtable layout comment for `IReadOnlyList1Vftbl` to match.

- **`src/WinRT.Interop.Generator/Helpers/VtableSignatureValidator.cs`** (new): validates that a vtable slot is declared with the same signature as the method being stored into it. Only the arity and the return type are compared, since the two are allowed to spell an individual parameter differently: shared (i.e. non specialized) vtables use `void*` where the implementation method uses the exact ABI type of the element, which is ABI identical.

- **`src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.cs`**: run that validation in `Impl`, which is the single place where every generated vtable slot is wired to its implementation method. This sits right next to the existing check that all vtable entries are initialized.

- **`src/WinRT.Generator.Core/Extensions/TypeSignatureExtensions.cs`** (new) and **`src/WinRT.Projection.Writer/`**: move `StripByRefAndCustomModifiers` out of the projection writer and into the shared generator core (next to the other shared AsmResolver extensions, `SignatureComparerExtensions` and `RuntimeContextExtensions`), so the interop generator can use it too.

## Validation

All affected projects build clean in Release (where warnings are errors): `WinRT.Runtime`, `WinRT.Generator.Core`, `WinRT.Projection.Writer`, and all five CLI build tools.

Reintroducing either signature bug now fails interop generation for any app using `IList<T>` or `IReadOnlyList<T>`, instead of silently emitting a mismatched vtable.
