### PR TITLE
Reduce exception overhead

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
@@ -124,23 +124,11 @@ public static unsafe class RestrictedErrorInfo
                 // available, we need to concatinate them to produce the final exception message.
                 if (errorCode == restrictedError)
                 {
-                    // Append the description first
-                    if (!string.IsNullOrEmpty(description))
-                    {
-                        errorMessage += description;
-
-                        if (!string.IsNullOrEmpty(restrictedDescription))
-                        {
-                            errorMessage += " ";
-                        }
-                    }
-
-                    // Next append the restricted description. If we have both, we insert a space to separate
-                    // the two. We're not using a newline, as exception messages should always be a single line.
-                    if (!string.IsNullOrEmpty(restrictedDescription))
-                    {
-                        errorMessage += restrictedDescription;
-                    }
+                    errorMessage = string.IsNullOrEmpty(description)
+                        ? restrictedDescription
+                        : string.IsNullOrEmpty(restrictedDescription)
+                            ? description
+                            : string.Concat(description, " ", restrictedDescription);
                 }
             }
             catch (Exception e)

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
@@ -120,10 +120,10 @@ public static unsafe class RestrictedErrorInfo
 
                 if (errorCode == restrictedError)
                 {
-                    // Format the exception message. If we have both a description and a restricted description,
-                    // we insert a space to separate the two. We're not using a newline, as exception messages
-                    // should always be a single line. We're intentionally using this ternary expression with no
-                    // interpolation to avoid allocating intermediate buffers/strings, which would add overhead.
+                    // For cross-language Windows Runtime exceptions, 'GetErrorDetails' can provide a general
+                    // description and a more specific restricted description. If both are present, insert a
+                    // space between them rather than a newline so the exception message remains a single line.
+                    // Use this ternary without interpolation to avoid intermediate buffers and strings.
                     errorMessage = string.IsNullOrEmpty(description)
                         ? restrictedDescription
                         : string.IsNullOrEmpty(restrictedDescription)

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
@@ -118,12 +118,12 @@ public static unsafe class RestrictedErrorInfo
 
                 restrictedReference = IRestrictedErrorInfoMethods.GetReference(restrictedErrorInfoPtr);
 
-                // For cross language Windows Runtime exceptions, general information will be available in the description,
-                // which is populated from 'IRestrictedErrorInfo.GetErrorDetails', and more specific information will be
-                // available in 'restrictedError', which also comes from 'IRestrictedErrorInfo.GetErrorDetails'. If both are
-                // available, we need to concatinate them to produce the final exception message.
                 if (errorCode == restrictedError)
                 {
+                    // Format the exception message. If we have both a description and a restricted description,
+                    // we insert a space to separate the two. We're not using a newline, as exception messages
+                    // should always be a single line. We're intentionally using this ternary expression with no
+                    // interpolation to avoid allocating intermediate buffers/strings, which would add overhead.
                     errorMessage = string.IsNullOrEmpty(description)
                         ? restrictedDescription
                         : string.IsNullOrEmpty(restrictedDescription)

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
@@ -130,12 +130,20 @@ internal static unsafe class RestrictedErrorInfoHelpers
     {
         IDictionary? exceptionData = exception.Data;
 
-        if (exceptionData is not null)
+        if (exceptionData is not null && exceptionData.Count > 0)
         {
             restrictedErrorObject = exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference] as WindowsRuntimeObjectReference;
+
+            if (restrictedErrorObject is null)
+            {
+                isLanguageException = false;
+
+                return false;
+            }
+
             isLanguageException = exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] is true;
 
-            return restrictedErrorObject is not null;
+            return true;
         }
 
         restrictedErrorObject = null;

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
@@ -16,6 +16,9 @@ namespace WindowsRuntime.InteropServices;
 /// </remarks>
 internal static unsafe class RestrictedErrorInfoHelpers
 {
+    private static readonly object BoxedTrue = true;
+    private static readonly object BoxedFalse = false;
+
     /// <summary>
     /// Retrieves the current restricted error info object and sets it for propagation if available.
     /// </summary>
@@ -53,7 +56,7 @@ internal static unsafe class RestrictedErrorInfoHelpers
         {
             // Keep the error object alive so that users could retrieve error information later from the exception data
             exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference] = restrictedErrorObject;
-            exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] = hasRestrictedLanguageErrorObject;
+            exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] = hasRestrictedLanguageErrorObject ? BoxedTrue : BoxedFalse;
         }
     }
 
@@ -104,7 +107,7 @@ internal static unsafe class RestrictedErrorInfoHelpers
 
             // Propagate the 'IRestrictedErrorInfo' object reference, so we can restore it later to forward the exception info
             exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference] = restrictedErrorObject;
-            exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] = hasRestrictedLanguageErrorObject;
+            exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] = hasRestrictedLanguageErrorObject ? BoxedTrue : BoxedFalse;
 
             if (internalGetGlobalErrorStateException is not null)
             {
@@ -129,13 +132,8 @@ internal static unsafe class RestrictedErrorInfoHelpers
 
         if (exceptionData is not null)
         {
-            restrictedErrorObject = exceptionData.Contains(WellKnownExceptionDataKeys.RestrictedErrorObjectReference)
-                ? (WindowsRuntimeObjectReference?)exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference]
-                : null;
-
-            isLanguageException =
-                exceptionData.Contains(WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject) &&
-                (bool)exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject]!;
+            restrictedErrorObject = exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference] as WindowsRuntimeObjectReference;
+            isLanguageException = exceptionData[WellKnownExceptionDataKeys.HasRestrictedLanguageErrorObject] is true;
 
             return restrictedErrorObject is not null;
         }

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfoHelpers.cs
@@ -16,7 +16,10 @@ namespace WindowsRuntime.InteropServices;
 /// </remarks>
 internal static unsafe class RestrictedErrorInfoHelpers
 {
+    /// <summary>A cached boxed <see langword="true"/> value, to avoid allocations.</summary>
     private static readonly object BoxedTrue = true;
+
+    /// <summary>A cached boxed <see langword="false"/> value, to avoid allocations.</summary>
     private static readonly object BoxedFalse = false;
 
     /// <summary>
@@ -128,9 +131,7 @@ internal static unsafe class RestrictedErrorInfoHelpers
         [NotNullWhen(true)] out WindowsRuntimeObjectReference? restrictedErrorObject,
         out bool isLanguageException)
     {
-        IDictionary? exceptionData = exception.Data;
-
-        if (exceptionData is not null && exceptionData.Count > 0)
+        if (exception.Data is IDictionary { Count: > 0 } exceptionData)
         {
             restrictedErrorObject = exceptionData[WellKnownExceptionDataKeys.RestrictedErrorObjectReference] as WindowsRuntimeObjectReference;
 


### PR DESCRIPTION
Based on the benchmarks, the native exception saves 24 bytes from cached Boolean metadata and approximately 88 bytes by avoiding intermediate message strings. The restored managed exception saves the 24-byte Boolean box.