### PR TITLE
Fix CCW discovery for generated bindable property values

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1319,13 +1319,17 @@ namespace Generator
             }
             else if (context.Node is PropertyDeclarationSyntax propertyDeclaration)
             {
+                var isGeneratedBindableCustomPropertyClass =
+                    context.SemanticModel.GetDeclaredSymbol(propertyDeclaration) is IPropertySymbol propertySymbol &&
+                    GeneratorHelper.IsGeneratedBindableCustomPropertyClass(context.SemanticModel.Compilation, propertySymbol.ContainingSymbol);
+
                 // Detect scenarios where the property declaration has an initializer and is to a boxed or cast type during initialization.
                 if (propertyDeclaration.Initializer != null)
                 {
                     var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
                     if (leftSymbol is INamedTypeSymbol namedType)
                     {
-                        AddVtableAttributesForExpression(propertyDeclaration.Initializer.Value, namedType);
+                        AddVtableAttributesForExpression(propertyDeclaration.Initializer.Value, namedType, isGeneratedBindableCustomPropertyClass);
                     }
                 }
                 else if (propertyDeclaration.ExpressionBody != null)
@@ -1333,7 +1337,7 @@ namespace Generator
                     var leftSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclaration.Type).Symbol;
                     if (leftSymbol is INamedTypeSymbol namedType)
                     {
-                        AddVtableAttributesForExpression(propertyDeclaration.ExpressionBody.Expression, namedType);
+                        AddVtableAttributesForExpression(propertyDeclaration.ExpressionBody.Expression, namedType, isGeneratedBindableCustomPropertyClass);
                     }
                 }
             }
@@ -1355,7 +1359,11 @@ namespace Generator
                     var propertyTypeSymbol = context.SemanticModel.GetSymbolInfo(propertyDeclarationSyntax.Type).Symbol;
                     if (propertyTypeSymbol is ITypeSymbol typeSymbol)
                     {
-                        AddVtableAttributesForExpression(returnDeclaration.Expression, typeSymbol);
+                        var isGeneratedBindableCustomPropertyClass =
+                            context.SemanticModel.GetDeclaredSymbol(propertyDeclarationSyntax) is IPropertySymbol propertySymbol &&
+                            GeneratorHelper.IsGeneratedBindableCustomPropertyClass(context.SemanticModel.Compilation, propertySymbol.ContainingSymbol);
+
+                        AddVtableAttributesForExpression(returnDeclaration.Expression, typeSymbol, isGeneratedBindableCustomPropertyClass);
                     }
                 }
             }

--- a/src/Tests/SourceGeneratorTest/AotOptimizerTests.cs
+++ b/src/Tests/SourceGeneratorTest/AotOptimizerTests.cs
@@ -121,6 +121,59 @@ public class AotOptimizerTests
         Assert.IsFalse(generated.Contains("System.Collections.Generic.List`1[System.Int32]"));
     }
 
+    [TestMethod]
+    public void GeneratedBindableCustomProperty_DiscoversPropertyTypes()
+    {
+        const string source = """
+            using System.Collections.ObjectModel;
+            using WinRT;
+
+            [GeneratedBindableCustomProperty]
+            internal partial class ViewModel
+            {
+                private readonly ObservableCollection<string> items = new();
+
+                public ObservableCollection<string> Items
+                {
+                    get { return items; }
+                }
+
+                public ObservableCollection<int> Numbers { get; } = new();
+
+                public ObservableCollection<double> Values => new();
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        Assert.IsTrue(generated.Contains("System.Collections.ObjectModel.ObservableCollection`1[System.String]"));
+        Assert.IsTrue(generated.Contains("System.Collections.ObjectModel.ObservableCollection`1[System.Int32]"));
+        Assert.IsTrue(generated.Contains("System.Collections.ObjectModel.ObservableCollection`1[System.Double]"));
+        Assert.IsTrue(generated.Contains("Windows.Foundation.Collections.IVector`1<String>"));
+    }
+
+    [TestMethod]
+    public void NonBindableProperties_DoNotDiscoverConcreteTypes()
+    {
+        const string source = """
+            using System.Collections.ObjectModel;
+
+            internal class ViewModel
+            {
+                private readonly ObservableCollection<string> items = new();
+
+                public ObservableCollection<string> Items
+                {
+                    get { return items; }
+                }
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        Assert.IsFalse(generated.Contains("System.Collections.ObjectModel.ObservableCollection`1[System.String]"));
+    }
+
     private static string RunAotOptimizer(string source)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));


### PR DESCRIPTION
## Description

Fixes #2458.

`GeneratedBindableCustomProperty` generates accessors that return bindable
property values through `object`, but those generated accessors cannot be
analyzed by the same source-generator pass. For getter-only collection
properties, the concrete return type was therefore omitted from
`WinRTGlobalVtableLookup.g.cs` unless another authored or XAML-generated
expression happened to expose it across the WinRT ABI.

This caused UWP XAML bindings such as
`ItemsSource="{Binding DisplayItems}"` to return an
`ObservableCollection<string>` without registering its `IVector<string>`
CCW projection. Applications had to add an unrelated property to the page
code-behind or explicitly use `GeneratedWinRTExposedExternalType` to root
the collection.

## Changes

- Propagate the existing generated-bindable-property discovery flag through
  property initializers, expression-bodied properties, and block-bodied
  getter returns.
- Add source-generator regressions for all three property forms.
- Verify non-bindable properties do not trigger additional lookup generation.
- Verify the generated lookup includes the correct WinRT projections.

## Validation

- SourceGenerator regression tests.
- Validated the repro case from #2458 with the fix.