### PR TITLE
Fix HResult and mapped value type parameter marshalling in generated projections

### DIFF
--- a/src/Tests/TestComponentCSharp/MarshalledValuesTest.cpp
+++ b/src/Tests/TestComponentCSharp/MarshalledValuesTest.cpp
@@ -1,0 +1,106 @@
+#include "pch.h"
+#include "MarshalledValuesTest.h"
+#include "MarshalledValuesTest.g.cpp"
+
+namespace WF = winrt::Windows::Foundation;
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    winrt::hresult MarshalledValuesTest::Result()
+    {
+        return _result;
+    }
+
+    void MarshalledValuesTest::Result(winrt::hresult const& value)
+    {
+        _result = value;
+    }
+
+    winrt::hresult MarshalledValuesTest::SwapResult(winrt::hresult const& value)
+    {
+        return std::exchange(_result, value);
+    }
+
+    void MarshalledValuesTest::ExchangeResult(winrt::hresult const& value, winrt::hresult& previous)
+    {
+        previous = std::exchange(_result, value);
+    }
+
+    void MarshalledValuesTest::ExchangeDateTime(WF::DateTime const& value, WF::DateTime& previous)
+    {
+        previous = std::exchange(_dateTime, value);
+    }
+
+    void MarshalledValuesTest::ExchangeTimeSpan(WF::TimeSpan const& value, WF::TimeSpan& previous)
+    {
+        previous = std::exchange(_timeSpan, value);
+    }
+
+    void MarshalledValuesTest::ExchangeTypeName(winrt::Windows::UI::Xaml::Interop::TypeName const& value, winrt::Windows::UI::Xaml::Interop::TypeName& previous)
+    {
+        previous = std::exchange(_typeName, value);
+    }
+
+    WF::DateTime MarshalledValuesTest::OffsetDateTime(WF::DateTime const& value, WF::TimeSpan const& offset)
+    {
+        return value + offset;
+    }
+
+    winrt::hresult MarshalledValuesTest::CallResultProperty(TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value)
+    {
+        target.Result(value);
+
+        return target.Result();
+    }
+
+    winrt::hresult MarshalledValuesTest::CallSwapResult(TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value)
+    {
+        return target.SwapResult(value);
+    }
+
+    winrt::hresult MarshalledValuesTest::CallExchangeResult(TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value)
+    {
+        winrt::hresult previous;
+
+        target.ExchangeResult(value, previous);
+
+        return previous;
+    }
+
+    WF::DateTime MarshalledValuesTest::CallExchangeDateTime(TestComponentCSharp::IMarshalledValues const& target, WF::DateTime const& value)
+    {
+        WF::DateTime previous;
+
+        target.ExchangeDateTime(value, previous);
+
+        return previous;
+    }
+
+    WF::TimeSpan MarshalledValuesTest::CallExchangeTimeSpan(TestComponentCSharp::IMarshalledValues const& target, WF::TimeSpan const& value)
+    {
+        WF::TimeSpan previous;
+
+        target.ExchangeTimeSpan(value, previous);
+
+        return previous;
+    }
+
+    winrt::Windows::UI::Xaml::Interop::TypeName MarshalledValuesTest::CallExchangeTypeName(TestComponentCSharp::IMarshalledValues const& target, winrt::Windows::UI::Xaml::Interop::TypeName const& value)
+    {
+        winrt::Windows::UI::Xaml::Interop::TypeName previous;
+
+        target.ExchangeTypeName(value, previous);
+
+        return previous;
+    }
+
+    WF::DateTime MarshalledValuesTest::CallOffsetDateTime(TestComponentCSharp::IMarshalledValues const& target, WF::DateTime const& value, WF::TimeSpan const& offset)
+    {
+        return target.OffsetDateTime(value, offset);
+    }
+
+    winrt::hresult MarshalledValuesTest::InvokeHandleResult(TestComponentCSharp::HandleResult const& handler, winrt::hresult const& value)
+    {
+        return handler(value);
+    }
+}

--- a/src/Tests/TestComponentCSharp/MarshalledValuesTest.h
+++ b/src/Tests/TestComponentCSharp/MarshalledValuesTest.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "MarshalledValuesTest.g.h"
+
+namespace winrt::TestComponentCSharp::implementation
+{
+    struct MarshalledValuesTest : MarshalledValuesTestT<MarshalledValuesTest>
+    {
+        MarshalledValuesTest() = default;
+
+        winrt::hresult Result();
+        void Result(winrt::hresult const& value);
+        winrt::hresult SwapResult(winrt::hresult const& value);
+        void ExchangeResult(winrt::hresult const& value, winrt::hresult& previous);
+        void ExchangeDateTime(winrt::Windows::Foundation::DateTime const& value, winrt::Windows::Foundation::DateTime& previous);
+        void ExchangeTimeSpan(winrt::Windows::Foundation::TimeSpan const& value, winrt::Windows::Foundation::TimeSpan& previous);
+        void ExchangeTypeName(winrt::Windows::UI::Xaml::Interop::TypeName const& value, winrt::Windows::UI::Xaml::Interop::TypeName& previous);
+        winrt::Windows::Foundation::DateTime OffsetDateTime(winrt::Windows::Foundation::DateTime const& value, winrt::Windows::Foundation::TimeSpan const& offset);
+
+        static winrt::hresult CallResultProperty(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value);
+        static winrt::hresult CallSwapResult(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value);
+        static winrt::hresult CallExchangeResult(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::hresult const& value);
+        static winrt::Windows::Foundation::DateTime CallExchangeDateTime(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::Windows::Foundation::DateTime const& value);
+        static winrt::Windows::Foundation::TimeSpan CallExchangeTimeSpan(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::Windows::Foundation::TimeSpan const& value);
+        static winrt::Windows::UI::Xaml::Interop::TypeName CallExchangeTypeName(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::Windows::UI::Xaml::Interop::TypeName const& value);
+        static winrt::Windows::Foundation::DateTime CallOffsetDateTime(winrt::TestComponentCSharp::IMarshalledValues const& target, winrt::Windows::Foundation::DateTime const& value, winrt::Windows::Foundation::TimeSpan const& offset);
+        static winrt::hresult InvokeHandleResult(winrt::TestComponentCSharp::HandleResult const& handler, winrt::hresult const& value);
+
+    private:
+        winrt::hresult _result{};
+        winrt::Windows::Foundation::DateTime _dateTime{};
+        winrt::Windows::Foundation::TimeSpan _timeSpan{};
+        winrt::Windows::UI::Xaml::Interop::TypeName _typeName{};
+    };
+}
+
+namespace winrt::TestComponentCSharp::factory_implementation
+{
+    struct MarshalledValuesTest : MarshalledValuesTestT<MarshalledValuesTest, implementation::MarshalledValuesTest>
+    {
+    };
+}

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.idl
@@ -643,6 +643,53 @@ namespace TestComponentCSharp
         CustomReadOnlyDictionaryTest(Windows.Foundation.Collections.IMapView<String, String> mapView);
     }
 
+    // 'HResult' (projected as 'System.Exception'), the mapped value types 'DateTime' and 'TimeSpan',
+    // and 'Windows.UI.Xaml.Interop.TypeName' (projected as 'System.Type') all have an ABI
+    // representation that differs from their projected one, yet unlike strings and reference types
+    // they don't cross the ABI as an opaque pointer. This interface covers every parameter position
+    // where that distinction matters. It is deliberately a standalone interface (i.e. not
+    // '[exclusiveto]' to a runtimeclass), because that is what makes CsWinRT emit CCW stubs for it,
+    // and the CCW stubs are what exercise the managed side as the callee rather than the caller.
+    interface IMarshalledValues
+    {
+        // Property setter (a distinct CCW call site from a method parameter)
+        Windows.Foundation.HResult Result{ get; set; };
+
+        // Method parameter and return value
+        Windows.Foundation.HResult SwapResult(Windows.Foundation.HResult value);
+
+        // Non-retval 'out' parameters, which are marshalled separately from the return value
+        void ExchangeResult(Windows.Foundation.HResult value, out Windows.Foundation.HResult previous);
+        void ExchangeDateTime(Windows.Foundation.DateTime value, out Windows.Foundation.DateTime previous);
+        void ExchangeTimeSpan(Windows.Foundation.TimeSpan value, out Windows.Foundation.TimeSpan previous);
+        void ExchangeTypeName(Windows.UI.Xaml.Interop.TypeName value, out Windows.UI.Xaml.Interop.TypeName previous);
+
+        // 'ref const' (WinRT 'in T') parameters, which are passed by pointer rather than by value
+        Windows.Foundation.DateTime OffsetDateTime(ref const Windows.Foundation.DateTime value, ref const Windows.Foundation.TimeSpan offset);
+    }
+
+    // Delegates get the same CCW stubs as interfaces, so they need the same coverage
+    delegate Windows.Foundation.HResult HandleResult(Windows.Foundation.HResult value);
+
+    [default_interface]
+    runtimeclass MarshalledValuesTest : IMarshalledValues
+    {
+        MarshalledValuesTest();
+
+        // Invoke each 'IMarshalledValues' member from native code, so that tests can validate the
+        // marshalling of every parameter shape it covers independently. Passing a managed
+        // implementation exercises the CCW direction, and the instance members of this class
+        // exercise the RCW direction of the same shapes.
+        static Windows.Foundation.HResult CallResultProperty(IMarshalledValues target, Windows.Foundation.HResult value);
+        static Windows.Foundation.HResult CallSwapResult(IMarshalledValues target, Windows.Foundation.HResult value);
+        static Windows.Foundation.HResult CallExchangeResult(IMarshalledValues target, Windows.Foundation.HResult value);
+        static Windows.Foundation.DateTime CallExchangeDateTime(IMarshalledValues target, Windows.Foundation.DateTime value);
+        static Windows.Foundation.TimeSpan CallExchangeTimeSpan(IMarshalledValues target, Windows.Foundation.TimeSpan value);
+        static Windows.UI.Xaml.Interop.TypeName CallExchangeTypeName(IMarshalledValues target, Windows.UI.Xaml.Interop.TypeName value);
+        static Windows.Foundation.DateTime CallOffsetDateTime(IMarshalledValues target, Windows.Foundation.DateTime value, Windows.Foundation.TimeSpan offset);
+        static Windows.Foundation.HResult InvokeHandleResult(HandleResult handler, Windows.Foundation.HResult value);
+    }
+
     // SupportedOSPlatform warning tests
     [contract(Windows.Foundation.UniversalApiContract, 10)]
     [attributeusage(target_all)]

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj
@@ -92,6 +92,7 @@
     <ClInclude Include="CustomIterableTest.h" />
     <ClInclude Include="CustomReadOnlyDictionaryTest.h" />
     <ClInclude Include="ManualProjectionTestClasses.h" />
+    <ClInclude Include="MarshalledValuesTest.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Class.h">
       <DependentUpon>TestComponentCSharp.idl</DependentUpon>
@@ -115,6 +116,7 @@
     <ClCompile Include="DeprecatedClasses.cpp" />
     <ClCompile Include="CustomIterableTest.cpp" />
     <ClCompile Include="CustomReadOnlyDictionaryTest.cpp" />
+    <ClCompile Include="MarshalledValuesTest.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
+++ b/src/Tests/TestComponentCSharp/TestComponentCSharp.vcxproj.filters
@@ -27,6 +27,7 @@
     <ClCompile Include="NonUniqueClass.cpp" />
     <ClCompile Include="CustomIterableTest.cpp" />
     <ClCompile Include="CustomReadOnlyDictionaryTest.cpp" />
+    <ClCompile Include="MarshalledValuesTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -47,6 +48,7 @@
     <ClInclude Include="NonUniqueClass.h" />
     <ClInclude Include="CustomIterableTest.h" />
     <ClInclude Include="CustomReadOnlyDictionaryTest.h" />
+    <ClInclude Include="MarshalledValuesTest.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponentCSharp.idl" />

--- a/src/Tests/UnitTest/ExceptionTests.cs
+++ b/src/Tests/UnitTest/ExceptionTests.cs
@@ -5,13 +5,27 @@ using WindowsRuntime.InteropServices;
 
 namespace UnitTest
 {
+    // The 'IRestrictedErrorInfo' object of a thread is ambient, sticky state: it is set as a side effect of
+    // some previous failure on that same thread (ie. any failing native call), and CsWinRT deliberately puts
+    // it back after reading it, so that it also outlives the call that observed it. 'GetExceptionForHR' uses
+    // it to enrich (or outright restore) the exception it produces, but it may only do so when the error info
+    // actually belongs to the 'HRESULT' being converted. Associating an unrelated error object with a new
+    // exception is not just cosmetic: 'GetHRForException' reads the 'HRESULT' back out of the attached error
+    // object, so such an exception would later marshal out as an entirely different error code.
     [TestClass]
     public class ExceptionTests
     {
+        private const int E_NOTIMPL = unchecked((int)0x80004001);
+        private const int RPC_E_WRONG_THREAD = unchecked((int)0x8001010E);
+        private const int ERROR_INVALID_WINDOW_HANDLE = unchecked((int)0x80070578);
+
+        private const string MatchingErrorMessage = "Matching originated error";
+        private const string UnrelatedErrorMessage = "Unrelated originated error";
+
         [TestMethod]
         public void TestGetExceptionForHR_WithValidHResult_ReturnsSystemFormattedException()
         {
-            const int RPC_E_WRONG_THREAD = unchecked((int)0x8001010E);
+            UnitTestHelper.RoClearError();
 
             Exception exception = RestrictedErrorInfo.GetExceptionForHR(RPC_E_WRONG_THREAD);
             Assert.IsNotNull(exception);
@@ -20,6 +34,150 @@ namespace UnitTest
             if (CultureInfo.CurrentUICulture.Name == "en-US")
             {
                 Assert.AreEqual("The application called an interface that was marshalled for a different thread. (0x8001010E)", exception.Message);
+            }
+        }
+
+        [TestMethod]
+        public void TestGetExceptionForHR_WithoutRestrictedErrorInfo_MapsHResultOnly()
+        {
+            UnitTestHelper.RoClearError();
+
+            Exception exception = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+            Assert.IsInstanceOfType<NotImplementedException>(exception);
+            Assert.AreEqual(E_NOTIMPL, exception.HResult);
+            Assert.IsNull(exception.Data["__RestrictedErrorObjectReference"]);
+            Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(exception));
+        }
+
+        [TestMethod]
+        public void TestGetExceptionForHR_WithMatchingRestrictedErrorInfo_AssociatesErrorInfo()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(E_NOTIMPL, MatchingErrorMessage));
+
+                Exception exception = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+                Assert.IsInstanceOfType<NotImplementedException>(exception);
+                Assert.AreEqual(E_NOTIMPL, exception.HResult);
+
+                // The error info does belong to this 'HRESULT', so all its details flow into the exception
+                Assert.Contains(MatchingErrorMessage, exception.Message);
+                Assert.AreEqual(MatchingErrorMessage, exception.Data["RestrictedDescription"]);
+                Assert.IsNotNull(exception.Data["__RestrictedErrorObjectReference"]);
+
+                // Associating the error info must still round-trip the original 'HRESULT'
+                Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(exception));
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        public void TestGetExceptionForHR_WithMismatchedRestrictedErrorInfo_IgnoresErrorInfo()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, UnrelatedErrorMessage));
+
+                Exception exception = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+                Assert.IsInstanceOfType<NotImplementedException>(exception);
+                Assert.AreEqual(E_NOTIMPL, exception.HResult);
+
+                // None of the details of the unrelated error info may leak into the exception
+                Assert.DoesNotContain(UnrelatedErrorMessage, exception.Message);
+                Assert.IsNull(exception.Data["Description"]);
+                Assert.IsNull(exception.Data["RestrictedDescription"]);
+                Assert.IsNull(exception.Data["__RestrictedErrorObjectReference"]);
+
+                // Most importantly, marshalling the exception back out must produce the 'HRESULT' it was
+                // created for, and not the one carried by the unrelated error info of the current thread
+                Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(exception));
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        public void TestGetExceptionForHR_WithMismatchedRestrictedErrorInfo_PreservesThreadErrorInfo()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, UnrelatedErrorMessage));
+
+                // Ignoring the error info must not consume it: it is only ever borrowed, so it stays on the
+                // thread for whichever call it actually belongs to (ie. an 'HRESULT' ABI return value)
+                _ = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+                Exception exception = RestrictedErrorInfo.GetExceptionForHR(ERROR_INVALID_WINDOW_HANDLE);
+
+                Assert.AreEqual(UnrelatedErrorMessage, exception.Data["RestrictedDescription"]);
+                Assert.IsNotNull(exception.Data["__RestrictedErrorObjectReference"]);
+                Assert.AreEqual(ERROR_INVALID_WINDOW_HANDLE, RestrictedErrorInfo.GetHRForException(exception));
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        public void TestGetHRForException_WithMismatchedRestrictedErrorInfo_ReturnsExceptionHResult()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, UnrelatedErrorMessage));
+
+                Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(new NotImplementedException()));
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        public void TestGetHRForException_AfterGetExceptionForHRWithMismatchedRestrictedErrorInfo_RoundTripsHResult()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, UnrelatedErrorMessage));
+
+                // This is exactly the round-trip a 'Windows.Foundation.HResult' does when it is marshalled
+                // into managed code by a CCW stub and then marshalled back out again (eg. a property setter
+                // followed by its getter). The 'HRESULT' has to survive it completely unchanged.
+                Exception exception = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+                Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(exception));
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        public void TestThrowExceptionForHR_WithMismatchedRestrictedErrorInfo_ThrowsMappedException()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, UnrelatedErrorMessage));
+
+                NotImplementedException exception = Assert.ThrowsExactly<NotImplementedException>(
+                    () => RestrictedErrorInfo.ThrowExceptionForHR(E_NOTIMPL));
+
+                Assert.AreEqual(E_NOTIMPL, exception.HResult);
+                Assert.DoesNotContain(UnrelatedErrorMessage, exception.Message);
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
             }
         }
     }

--- a/src/Tests/UnitTest/MarshalledValuesTests.cs
+++ b/src/Tests/UnitTest/MarshalledValuesTests.cs
@@ -1,0 +1,278 @@
+using System;
+using TestComponentCSharp;
+
+namespace UnitTest
+{
+    // 'Windows.Foundation.HResult' (projected as 'System.Exception'), the mapped value types
+    // 'Windows.Foundation.DateTime' / 'Windows.Foundation.TimeSpan' (projected as 'System.DateTimeOffset'
+    // and 'System.TimeSpan'), and 'Windows.UI.Xaml.Interop.TypeName' (projected as 'System.Type') all
+    // have an ABI representation that differs from their projected one, but they don't cross the ABI as
+    // an opaque pointer like strings and reference types do. Every parameter position therefore needs
+    // its own marshalling step, in both the RCW (managed caller) and the CCW (managed callee) direction.
+    // 'IMarshalledValues' is a standalone interface precisely so that CCW stubs are generated for it,
+    // which is what exercises the managed side as the callee.
+    [TestClass]
+    public class MarshalledValuesTests
+    {
+        [TestMethod]
+        public void ManagedImplementation_HResultPropertySetter_MarshalsValue()
+        {
+            ManagedMarshalledValues target = new();
+            Exception value = new NotImplementedException();
+
+            Exception result = MarshalledValuesTest.CallResultProperty(target, value);
+
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+            Assert.AreEqual(value.HResult, result.HResult);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_HResultPropertySetter_MarshalsNull()
+        {
+            ManagedMarshalledValues target = new() { Result = new NotImplementedException() };
+
+            Exception result = MarshalledValuesTest.CallResultProperty(target, null);
+
+            Assert.IsNull(target.Result);
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_HResultMethodParameter_MarshalsValue()
+        {
+            Exception previous = new NotImplementedException();
+            Exception value = new NotSupportedException();
+            ManagedMarshalledValues target = new() { Result = previous };
+
+            Exception result = MarshalledValuesTest.CallSwapResult(target, value);
+
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+            Assert.AreEqual(previous.HResult, result.HResult);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_HResultOutParameter_MarshalsValue()
+        {
+            Exception previous = new NotImplementedException();
+            Exception value = new NotSupportedException();
+            ManagedMarshalledValues target = new() { Result = previous };
+
+            Exception result = MarshalledValuesTest.CallExchangeResult(target, value);
+
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+            Assert.AreEqual(previous.HResult, result.HResult);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_DateTimeOutParameter_MarshalsValue()
+        {
+            DateTimeOffset previous = new(1993, 3, 22, 8, 30, 0, TimeSpan.Zero);
+            DateTimeOffset value = DateTimeOffset.Now;
+            ManagedMarshalledValues target = new() { DateTime = previous };
+
+            DateTimeOffset result = MarshalledValuesTest.CallExchangeDateTime(target, value);
+
+            Assert.AreEqual(value, target.DateTime);
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_TimeSpanOutParameter_MarshalsValue()
+        {
+            TimeSpan previous = TimeSpan.FromSeconds(42);
+            TimeSpan value = TimeSpan.FromMinutes(7);
+            ManagedMarshalledValues target = new() { TimeSpan = previous };
+
+            TimeSpan result = MarshalledValuesTest.CallExchangeTimeSpan(target, value);
+
+            Assert.AreEqual(value, target.TimeSpan);
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_TypeNameOutParameter_MarshalsValue()
+        {
+            Type previous = typeof(int);
+            Type value = typeof(MarshalledValuesTests);
+            ManagedMarshalledValues target = new() { TypeName = previous };
+
+            Type result = MarshalledValuesTest.CallExchangeTypeName(target, value);
+
+            Assert.AreEqual(value, target.TypeName);
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void ManagedImplementation_MappedValueTypeInParameters_MarshalValues()
+        {
+            DateTimeOffset value = new(1993, 3, 22, 8, 30, 0, TimeSpan.Zero);
+            TimeSpan offset = TimeSpan.FromHours(3);
+
+            DateTimeOffset result = MarshalledValuesTest.CallOffsetDateTime(new ManagedMarshalledValues(), value, offset);
+
+            Assert.AreEqual(value + offset, result);
+        }
+
+        [TestMethod]
+        public void ManagedDelegate_HResultParameter_MarshalsValue()
+        {
+            Exception observed = null;
+            Exception value = new NotImplementedException();
+
+            Exception result = MarshalledValuesTest.InvokeHandleResult(
+                argument =>
+                {
+                    observed = argument;
+
+                    return new NotSupportedException();
+                },
+                value);
+
+            Assert.AreEqual(value.HResult, observed.HResult);
+            Assert.AreEqual(new NotSupportedException().HResult, result.HResult);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_HResultProperty_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            Exception value = new NotImplementedException();
+
+            target.Result = value;
+
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_HResultMethodParameter_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            Exception previous = new NotImplementedException();
+            Exception value = new NotSupportedException();
+
+            target.Result = previous;
+
+            Exception result = target.SwapResult(value);
+
+            Assert.AreEqual(previous.HResult, result.HResult);
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_HResultOutParameter_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            Exception previous = new NotImplementedException();
+            Exception value = new NotSupportedException();
+
+            target.Result = previous;
+
+            target.ExchangeResult(value, out Exception result);
+
+            Assert.AreEqual(previous.HResult, result.HResult);
+            Assert.AreEqual(value.HResult, target.Result.HResult);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_DateTimeOutParameter_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            DateTimeOffset previous = new(1993, 3, 22, 8, 30, 0, TimeSpan.Zero);
+            DateTimeOffset value = DateTimeOffset.Now;
+
+            target.ExchangeDateTime(previous, out _);
+            target.ExchangeDateTime(value, out DateTimeOffset result);
+
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_TimeSpanOutParameter_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            TimeSpan previous = TimeSpan.FromSeconds(42);
+            TimeSpan value = TimeSpan.FromMinutes(7);
+
+            target.ExchangeTimeSpan(previous, out _);
+            target.ExchangeTimeSpan(value, out TimeSpan result);
+
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_TypeNameOutParameter_MarshalsValue()
+        {
+            MarshalledValuesTest target = new();
+            Type previous = typeof(int);
+            Type value = typeof(MarshalledValuesTests);
+
+            target.ExchangeTypeName(previous, out _);
+            target.ExchangeTypeName(value, out Type result);
+
+            Assert.AreEqual(previous, result);
+        }
+
+        [TestMethod]
+        public void NativeImplementation_MappedValueTypeInParameters_MarshalValues()
+        {
+            MarshalledValuesTest target = new();
+            DateTimeOffset value = new(1993, 3, 22, 8, 30, 0, TimeSpan.Zero);
+            TimeSpan offset = TimeSpan.FromHours(3);
+
+            DateTimeOffset result = target.OffsetDateTime(value, offset);
+
+            Assert.AreEqual(value + offset, result);
+        }
+
+        // Managed implementation of the interface, so that the native side of the tests above calls
+        // back into managed code through the generated CCW stubs.
+        private sealed class ManagedMarshalledValues : IMarshalledValues
+        {
+            public Exception Result { get; set; }
+
+            public DateTimeOffset DateTime { get; set; }
+
+            public TimeSpan TimeSpan { get; set; }
+
+            public Type TypeName { get; set; }
+
+            public Exception SwapResult(Exception value)
+            {
+                Exception previous = Result;
+
+                Result = value;
+
+                return previous;
+            }
+
+            public void ExchangeResult(Exception value, out Exception previous)
+            {
+                previous = Result;
+                Result = value;
+            }
+
+            public void ExchangeDateTime(DateTimeOffset value, out DateTimeOffset previous)
+            {
+                previous = DateTime;
+                DateTime = value;
+            }
+
+            public void ExchangeTimeSpan(TimeSpan value, out TimeSpan previous)
+            {
+                previous = TimeSpan;
+                TimeSpan = value;
+            }
+
+            public void ExchangeTypeName(Type value, out Type previous)
+            {
+                previous = TypeName;
+                TypeName = value;
+            }
+
+            public DateTimeOffset OffsetDateTime(in DateTimeOffset value, in TimeSpan offset)
+            {
+                return value + offset;
+            }
+        }
+    }
+}

--- a/src/Tests/UnitTest/MarshalledValuesTests.cs
+++ b/src/Tests/UnitTest/MarshalledValuesTests.cs
@@ -14,6 +14,8 @@ namespace UnitTest
     [TestClass]
     public class MarshalledValuesTests
     {
+        private const int ERROR_INVALID_WINDOW_HANDLE = unchecked((int)0x80070578);
+
         [TestMethod]
         public void ManagedImplementation_HResultPropertySetter_MarshalsValue()
         {
@@ -24,6 +26,33 @@ namespace UnitTest
 
             Assert.AreEqual(value.HResult, target.Result.HResult);
             Assert.AreEqual(value.HResult, result.HResult);
+        }
+
+        // Same as above, but with an unrelated 'IRestrictedErrorInfo' left on the current thread, exactly
+        // like any previously failed native call would leave behind (eg. the COM interop tests calling
+        // 'GetForWindow' with an invalid window handle). That state is ambient and sticky, so marshalling a
+        // 'Windows.Foundation.HResult' must never pick it up: the exception the CCW setter creates from the
+        // incoming 'HRESULT' would otherwise carry the unrelated error object, and the CCW getter would then
+        // marshal that exception back out as the unrelated error code instead of the original one.
+        [TestMethod]
+        public void ManagedImplementation_HResultPropertySetter_MarshalsValueWithUnrelatedThreadErrorInfo()
+        {
+            try
+            {
+                Assert.IsTrue(UnitTestHelper.OriginateError(ERROR_INVALID_WINDOW_HANDLE, "Unrelated originated error"));
+
+                ManagedMarshalledValues target = new();
+                Exception value = new NotImplementedException();
+
+                Exception result = MarshalledValuesTest.CallResultProperty(target, value);
+
+                Assert.AreEqual(value.HResult, target.Result.HResult);
+                Assert.AreEqual(value.HResult, result.HResult);
+            }
+            finally
+            {
+                UnitTestHelper.RoClearError();
+            }
         }
 
         [TestMethod]

--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -3064,6 +3064,27 @@ namespace UnitTest
             }
         }
 
+        // After a managed exception propagates out through a CCW and back into managed code, the
+        // 'IRestrictedErrorInfo' object it produced is left on the current thread (CsWinRT only ever borrows
+        // it, it never consumes it). Marshalling an unrelated 'Windows.Foundation.HResult' afterwards must
+        // not pick that ambient state up: the resulting exception has to carry the 'HRESULT' it was created
+        // for, both on itself and when it is marshalled back out through the ABI.
+        [TestMethod]
+        public void TestExceptionPropagation_DoesNotLeakErrorInfoIntoUnrelatedHResults()
+        {
+            const int E_NOTIMPL = unchecked((int)0x80004001);
+
+            var properties = new ThrowingManagedProperties(new ArgumentNullException("foo"));
+
+            _ = Assert.ThrowsExactly<ArgumentNullException>(() => TestObject.CopyProperties(properties));
+
+            Exception exception = RestrictedErrorInfo.GetExceptionForHR(E_NOTIMPL);
+
+            Assert.IsInstanceOfType<NotImplementedException>(exception);
+            Assert.AreEqual(E_NOTIMPL, exception.HResult);
+            Assert.AreEqual(E_NOTIMPL, RestrictedErrorInfo.GetHRForException(exception));
+        }
+
         class ManagedProperties : IProperties1
         {
             private readonly int _value;

--- a/src/Tests/UnitTest/UnitTestHelper.cs
+++ b/src/Tests/UnitTest/UnitTestHelper.cs
@@ -38,13 +38,13 @@ public static partial class UnitTestHelper
     /// </summary>
     /// <param name="error">The <c>HRESULT</c> to originate the error info for.</param>
     /// <param name="message">The error message to associate with the error info.</param>
-    /// <returns>Whether the error info was originated.</returns>
+    /// <returns>
+    /// Whether the error info was originated. This is <see langword="false"/> only if <paramref name="error"/>
+    /// is a success code. Originating replaces whatever error info the thread already had, so callers don't
+    /// need to clear it first.
+    /// </returns>
     internal static unsafe bool OriginateError(int error, string message)
     {
-        // 'RoOriginateError' is a no-op if the current thread already has originated error
-        // info for the same 'HRESULT', so always start from a clean slate to be deterministic
-        RoClearError();
-
         fixed (char* pMessage = message)
         {
             return RoOriginateErrorW(error, (uint)message.Length, pMessage) != 0;

--- a/src/Tests/UnitTest/UnitTestHelper.cs
+++ b/src/Tests/UnitTest/UnitTestHelper.cs
@@ -20,6 +20,37 @@ public static partial class UnitTestHelper
     [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
     internal static unsafe partial int WindowsDeleteString(void* hstring);
 
+    [LibraryImport("api-ms-win-core-winrt-error-l1-1-1.dll")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static unsafe partial int RoOriginateErrorW(int error, uint cchMax, char* message);
+
+    /// <summary>
+    /// Clears the <c>IRestrictedErrorInfo</c> object associated with the current thread.
+    /// </summary>
+    [LibraryImport("api-ms-win-core-winrt-error-l1-1-1.dll")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial void RoClearError();
+
+    /// <summary>
+    /// Associates an <c>IRestrictedErrorInfo</c> object with the current thread, exactly like a failing
+    /// native call would. That state is ambient and sticky: it outlives the call that produced it, until
+    /// something else originates a new error or clears it. Tests use this to reproduce a "dirty" thread.
+    /// </summary>
+    /// <param name="error">The <c>HRESULT</c> to originate the error info for.</param>
+    /// <param name="message">The error message to associate with the error info.</param>
+    /// <returns>Whether the error info was originated.</returns>
+    internal static unsafe bool OriginateError(int error, string message)
+    {
+        // 'RoOriginateError' is a no-op if the current thread already has originated error
+        // info for the same 'HRESULT', so always start from a clean slate to be deterministic
+        RoClearError();
+
+        fixed (char* pMessage = message)
+        {
+            return RoOriginateErrorW(error, (uint)message.Length, pMessage) != 0;
+        }
+    }
+
     [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs
@@ -508,22 +508,31 @@ internal static partial class AbiMethodBodyFactory
                     rhs = $"ConvertToUnmanaged_{raw}(null, __{raw}).DetachThisPtrUnsafe()";
                 }
 
-                // For enums, function pointer signature uses the projected enum type, no cast needed.
-                // For bool, cast to byte. For char, cast to ushort.
-                // For the local managed value, marshal through <Type>Marshaller.ConvertToUnmanaged
-                // before writing it into the *out ABI struct slot.
+                // HResult, System.Type and the mapped value types (DateTime/TimeSpan) all project to a
+                // managed type that differs from their ABI struct, so the local has to go through their
+                // marshaller before it can be written into the *out ABI slot.
+                else if (underlying.IsHResultException())
+                {
+                    rhs = $"global::ABI.System.ExceptionMarshaller.ConvertToUnmanaged(__{raw})";
+                }
+                else if (underlying.IsSystemType())
+                {
+                    rhs = $"global::ABI.System.TypeMarshaller.ConvertToUnmanaged(__{raw})";
+                }
+                else if (context.AbiTypeKindResolver.IsMappedAbiValueType(underlying))
+                {
+                    rhs = $"{AbiTypeHelpers.GetMappedMarshallerName(underlying)}.ConvertToUnmanaged(__{raw})";
+                }
 
-                // Non-blittable struct (e.g. authored BasicStruct with string fields): marshal
-                // the local managed value through <Type>Marshaller.ConvertToUnmanaged before
-                // writing it into the *out ABI struct slot.write_marshal_from_managed
-                //: "Marshaller.ConvertToUnmanaged(local)".
+                // Non-blittable struct (e.g. an authored struct with string fields): marshal the local
+                // managed value through <Type>Marshaller.ConvertToUnmanaged as well.
                 else if (context.AbiTypeKindResolver.IsNonBlittableStruct(underlying))
                 {
                     rhs = $"{AbiTypeHelpers.GetMarshallerFullName(writer, context, underlying)}.ConvertToUnmanaged(__{raw})";
                 }
                 else
                 {
-                    // Enums, bool, char, and primitives: the local __<raw> is already the ABI form.
+                    // Blittable structs, enums, bool, char and primitives: the local __<raw> is already the ABI form.
                     rhs = $"__{raw}";
                 }
                 writer.WriteLine($"*{ptr} = {rhs};");
@@ -758,6 +767,12 @@ internal static partial class AbiMethodBodyFactory
             // Mapped value type input (DateTime/TimeSpan): the parameter is the ABI type;
             // convert to the projected managed type via the marshaller.
             writer.Write($"{AbiTypeHelpers.GetMappedMarshallerName(p.Type)}.ConvertToManaged({pname})");
+        }
+        else if (p.Type.IsHResultException())
+        {
+            // HResult input: excluded from 'IsMappedAbiValueType', but marshalled the same way
+            // (the parameter is 'global::ABI.System.Exception', the projection is 'System.Exception').
+            writer.Write($"global::ABI.System.ExceptionMarshaller.ConvertToManaged({pname})");
         }
         else if (p.Type.IsSystemType())
         {

--- a/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
+++ b/src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs
@@ -84,52 +84,15 @@ internal static partial class AbiMethodBodyFactory
                 continue;
             }
 
-            if (cat == ParameterCategory.Out)
+            if (cat is ParameterCategory.Out or ParameterCategory.Ref)
             {
-                TypeSignature uOut = p.Type.StripByRefAndCustomModifiers();
+                TypeSignature underlying = p.Type.StripByRefAndCustomModifiers();
+
+                // Both WinRT 'out T' and 'in T' are passed as a pointer to the ABI form of the value,
+                // which is exactly the type the corresponding local declared further below is typed as.
                 _ = fp.Append(", ");
-
-                if (uOut.IsAbiRefLike(context.AbiTypeKindResolver))
-                {
-                    _ = fp.Append("void**");
-                }
-                else if (uOut.IsSystemType())
-                {
-                    _ = fp.Append(WellKnownAbiTypeNames.AbiSystemTypePointer);
-                }
-                else if (context.AbiTypeKindResolver.IsNonBlittableStruct(uOut))
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetAbiStructTypeName(context, uOut)); _ = fp.Append('*');
-                }
-                else if (context.AbiTypeKindResolver.IsBlittableStruct(uOut))
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetBlittableStructAbiType(context, uOut)); _ = fp.Append('*');
-                }
-                else
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetAbiPrimitiveType(context.Cache, uOut)); _ = fp.Append('*');
-                }
-
-                continue;
-            }
-
-            if (cat == ParameterCategory.Ref)
-            {
-                TypeSignature uRef = p.Type.StripByRefAndCustomModifiers();
-                _ = fp.Append(", ");
-
-                if (context.AbiTypeKindResolver.IsNonBlittableStruct(uRef))
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetAbiStructTypeName(context, uRef)); _ = fp.Append('*');
-                }
-                else if (context.AbiTypeKindResolver.IsBlittableStruct(uRef))
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetBlittableStructAbiType(context, uRef)); _ = fp.Append('*');
-                }
-                else
-                {
-                    _ = fp.Append(AbiTypeHelpers.GetAbiPrimitiveType(context.Cache, uRef)); _ = fp.Append('*');
-                }
+                _ = fp.Append(AbiTypeHelpers.GetAbiLocalTypeName(context, underlying));
+                _ = fp.Append('*');
 
                 continue;
             }
@@ -273,12 +236,14 @@ internal static partial class AbiMethodBodyFactory
         {
             ParameterInfo p = sig.Parameters[i];
 
-            if (ParameterCategoryResolver.Resolve(p) != ParameterCategory.In)
+            if (!ParameterCategoryResolver.Resolve(p).IsScalarInput())
             {
                 continue;
             }
 
-            if (!p.Type.IsHResultException())
+            TypeSignature pType = p.Type.StripByRefAndCustomModifiers();
+
+            if (!pType.IsHResultException())
             {
                 continue;
             }
@@ -293,19 +258,21 @@ internal static partial class AbiMethodBodyFactory
         {
             ParameterInfo p = sig.Parameters[i];
 
-            if (ParameterCategoryResolver.Resolve(p) != ParameterCategory.In)
+            if (!ParameterCategoryResolver.Resolve(p).IsScalarInput())
             {
                 continue;
             }
 
-            if (!context.AbiTypeKindResolver.IsMappedAbiValueType(p.Type))
+            TypeSignature pType = p.Type.StripByRefAndCustomModifiers();
+
+            if (!context.AbiTypeKindResolver.IsMappedAbiValueType(pType))
             {
                 continue;
             }
 
             string localName = p.GetParamLocalName(paramNameOverride);
             string callName = p.GetParamName(paramNameOverride);
-            writer.WriteLine($"{AbiTypeHelpers.GetMappedAbiTypeName(p.Type)} __{localName} = {AbiTypeHelpers.GetMappedMarshallerName(p.Type)}.ConvertToUnmanaged({callName});");
+            writer.WriteLine($"{AbiTypeHelpers.GetMappedAbiTypeName(pType)} __{localName} = {AbiTypeHelpers.GetMappedMarshallerName(pType)}.ConvertToUnmanaged({callName});");
         }
 
         // Declare locals for complex-struct input parameters (e.g. ProfileUsage with nested
@@ -556,8 +523,8 @@ internal static partial class AbiMethodBodyFactory
         }
 
         // Emit typed fixed lines for Ref params.
-        // Skip Ref+NonBlittableStruct: those are marshalled via __local (no fixed needed) and
-        // passed as &__local at the call site (the is-value-type-in path).
+        // Skip the types that require a marshalled ABI local: those have no pinnable projected value
+        // and are passed as &__local at the call site instead.
         int typedFixedCount = 0;
         for (int i = 0; i < sig.Parameters.Count; i++)
         {
@@ -566,17 +533,16 @@ internal static partial class AbiMethodBodyFactory
 
             if (cat == ParameterCategory.Ref)
             {
-                TypeSignature uRefSkip = p.Type.StripByRefAndCustomModifiers();
+                TypeSignature uRef = p.Type.StripByRefAndCustomModifiers();
 
-                if (context.AbiTypeKindResolver.IsNonBlittableStruct(uRefSkip))
+                if (context.AbiTypeKindResolver.RequiresMarshalledAbiInputLocal(uRef))
                 {
                     continue;
                 }
 
                 string callName = p.GetParamName(paramNameOverride);
                 string localName = p.GetParamLocalName(paramNameOverride);
-                TypeSignature uRef = uRefSkip;
-                string abiType = context.AbiTypeKindResolver.IsBlittableStruct(uRef) ? AbiTypeHelpers.GetBlittableStructAbiType(context, uRef) : AbiTypeHelpers.GetAbiPrimitiveType(context.Cache, uRef);
+                string abiType = AbiTypeHelpers.GetAbiLocalTypeName(context, uRef);
                 writer.WriteLine($"fixed({abiType}* _{localName} = &{callName})");
                 typedFixedCount++;
             }
@@ -828,9 +794,10 @@ internal static partial class AbiMethodBodyFactory
                 string localName = p.GetParamLocalName(paramNameOverride);
                 TypeSignature uRefArg = p.Type.StripByRefAndCustomModifiers();
 
-                if (context.AbiTypeKindResolver.IsNonBlittableStruct(uRefArg))
+                if (context.AbiTypeKindResolver.RequiresMarshalledAbiInputLocal(uRefArg))
                 {
-                    // Complex struct 'in' (Ref) param: pass &__local (the marshaled ABI struct).
+                    // 'in T' param whose ABI form differs from the projected one: pass &__local
+                    // (the marshalled ABI value).
                     writer.Write(isMultiline: true, $$"""
                         ,
                           &__{{localName}}
@@ -992,6 +959,14 @@ internal static partial class AbiMethodBodyFactory
             else if (uOut.IsSystemType())
             {
                 writer.Write($"global::ABI.System.TypeMarshaller.ConvertToManaged(__{localName})");
+            }
+            else if (uOut.IsHResultException())
+            {
+                writer.Write($"global::ABI.System.ExceptionMarshaller.ConvertToManaged(__{localName})");
+            }
+            else if (context.AbiTypeKindResolver.IsMappedAbiValueType(uOut))
+            {
+                writer.Write($"{AbiTypeHelpers.GetMappedMarshallerName(uOut)}.ConvertToManaged(__{localName})");
             }
             else if (context.AbiTypeKindResolver.IsNonBlittableStruct(uOut))
             {

--- a/src/WinRT.Projection.Writer/Resolvers/AbiTypeKindResolver.cs
+++ b/src/WinRT.Projection.Writer/Resolvers/AbiTypeKindResolver.cs
@@ -240,6 +240,23 @@ internal sealed class AbiTypeKindResolver(MetadataCache cache)
             || signature.IsGenericInstance();
 
     /// <summary>
+    /// Returns whether a scalar input parameter (a WinRT by-value <c>in</c> or <c>in T</c> parameter)
+    /// of type <paramref name="signature"/> has to be marshalled into a separate ABI-form local before
+    /// the call, because its ABI representation is a different type than its projected one. This covers:
+    /// <list type="bullet">
+    ///   <item>Complex structs (per-field marshalling) — see <see cref="IsNonBlittableStruct"/></item>
+    ///   <item>Mapped value types (WinRT <c>DateTime</c> / <c>TimeSpan</c>) — see <see cref="IsMappedAbiValueType"/></item>
+    ///   <item><c>HResult</c> (projected as <see cref="System.Exception"/>) — see <see cref="TypeSignatureExtensions.IsHResultException"/></item>
+    /// </list>
+    /// For a WinRT <c>in T</c> parameter this also means the local (rather than the projected value) is
+    /// what gets passed by pointer, since the projected value has no pinnable ABI-compatible layout.
+    /// </summary>
+    /// <param name="signature">The stripped (non-byref) parameter type to classify.</param>
+    /// <returns><see langword="true"/> when the type needs a marshalled ABI local; otherwise <see langword="false"/>.</returns>
+    public bool RequiresMarshalledAbiInputLocal(TypeSignature signature)
+        => Resolve(signature) is AbiTypeKind.NonBlittableStruct or AbiTypeKind.MappedAbiValueType or AbiTypeKind.HResultException;
+
+    /// <summary>
     /// Classifies <paramref name="elementType"/> into one of the six
     /// <see cref="AbiArrayElementKind"/> values used by the per-element pointer-type ladders.
     /// This is the discriminator-only form -- callers translate the kind into the per-site

--- a/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
+++ b/src/WinRT.Runtime2/InteropServices/Exceptions/RestrictedErrorInfo.cs
@@ -75,12 +75,6 @@ public static unsafe class RestrictedErrorInfo
             // So if any exceptions are thrown internally here, we'll continue and just forward those too.
             try
             {
-                // Initialize an object reference for the global 'IRestrictedErrorInfo' object we retrieved.
-                // We will always need this, regardless of whether we can restore the global exception or not.
-                restrictedErrorInfoToSave = WindowsRuntimeObjectReference.CreateUnsafe(
-                    thisPtr: restrictedErrorInfoPtr,
-                    iid: WellKnownWindowsInterfaceIIDs.IID_IRestrictedErrorInfo)!;
-
                 // Check if the stored exception is a language exception, which we can return directly
                 if (IUnknownVftbl.QueryInterfaceUnsafe(
                     thisPtr: restrictedErrorInfoPtr,
@@ -96,6 +90,10 @@ public static unsafe class RestrictedErrorInfo
                         {
                             restoredExceptionFromGlobalState = true;
 
+                            restrictedErrorInfoToSave = WindowsRuntimeObjectReference.CreateUnsafe(
+                                thisPtr: restrictedErrorInfoPtr,
+                                iid: WellKnownWindowsInterfaceIIDs.IID_IRestrictedErrorInfo)!;
+
                             RestrictedErrorInfoHelpers.AddExceptionData(exception, restrictedErrorInfoToSave, true);
 
                             return exception;
@@ -107,19 +105,36 @@ public static unsafe class RestrictedErrorInfo
                     }
                 }
 
-                // We're going to create a new exception, so first we extract all the available info
-                // from the global 'IRestrictedErrorInfo' object, to attach it to the managed exception.
+                // We're going to create a new exception, so first we extract all the available info from
+                // the global 'IRestrictedErrorInfo' object, to possibly attach it to the managed exception.
                 IRestrictedErrorInfoMethods.GetErrorDetails(
                     thisPtr: restrictedErrorInfoPtr,
-                    description: out description,
+                    description: out string? globalDescription,
                     error: out HRESULT restrictedError,
-                    restrictedDescription: out restrictedDescription,
-                    capabilitySid: out restrictedCapabilitySid);
+                    restrictedDescription: out string? globalRestrictedDescription,
+                    capabilitySid: out string? globalRestrictedCapabilitySid);
 
-                restrictedReference = IRestrictedErrorInfoMethods.GetReference(restrictedErrorInfoPtr);
-
+                // The thread's 'IRestrictedErrorInfo' object is just ambient state: it is set as a side
+                // effect of some previous failure on this same thread, and 'BorrowErrorInfo' deliberately
+                // puts it right back, so that it also outlives this call. That means there is no guarantee
+                // whatsoever that it has anything to do with the 'HRESULT' being converted here. That is
+                // especially true for 'Windows.Foundation.HResult' values, which are just data crossing the
+                // ABI, and which never set the thread's error info to begin with. Associating an unrelated
+                // error object with the new exception would not just attach a misleading description to it:
+                // 'GetHRForException' reads the 'HRESULT' back out of the attached error object, so such an
+                // exception would later marshal back out as an entirely different error code. Just like
+                // 'AttachErrorInfo' does, use a matching 'HRESULT' as the heuristic for the association.
                 if (errorCode == restrictedError)
                 {
+                    description = globalDescription;
+                    restrictedDescription = globalRestrictedDescription;
+                    restrictedCapabilitySid = globalRestrictedCapabilitySid;
+                    restrictedReference = IRestrictedErrorInfoMethods.GetReference(restrictedErrorInfoPtr);
+
+                    restrictedErrorInfoToSave = WindowsRuntimeObjectReference.CreateUnsafe(
+                        thisPtr: restrictedErrorInfoPtr,
+                        iid: WellKnownWindowsInterfaceIIDs.IID_IRestrictedErrorInfo)!;
+
                     // For cross-language Windows Runtime exceptions, 'GetErrorDetails' can provide a general
                     // description and a more specific restricted description. If both are present, insert a
                     // space between them rather than a newline so the exception message remains a single line.


### PR DESCRIPTION
## Summary

The projection writer skipped the marshalling step for `Windows.Foundation.HResult` (and, in a few positions, for `System.Type` and the mapped value types `DateTime` / `TimeSpan`) in several parameter positions, so the generated projection assigned an ABI value where the projected type was expected and failed to compile. This fixes every affected position and adds test coverage for each of them.

## Motivation

Any Windows Runtime interface with an `HRESULT` input parameter produced a projection that fails to build with `CS0029`. The failure happens in the *consuming app's* build, when `cswinrtprojectiongen` generates the merged projection, so it blocks consumption of the component entirely. Found with some Microsoft Store projection .dll-s.

The root cause is that each emission site had its own hand written ladder mapping a type to its ABI form, and those ladders had drifted: `IsMappedAbiValueType` deliberately excludes `HResult` (it is handled explicitly everywhere else), so `HResult` silently fell through to the "already in ABI form" fallback. Investigating that turned up four more positions with the same class of gap, all of which are fixed here.

The bug went unnoticed because CCW stubs are only emitted for standalone interfaces, and every existing `HResult` member in `TestComponentCSharp.idl` lives on `runtimeclass Class`, whose members sit on an `[exclusiveto]` interface that never gets CCW stubs.

## What was broken

| Direction | Position | Affected types |
|---|---|---|
| CCW (`Do_Abi`) | input parameter, property setter, delegate `Invoke` | `HResult` |
| CCW (`Do_Abi`) | non-retval `out` parameter write-back | `HResult`, `System.Type`, `DateTime`, `TimeSpan` |
| RCW | function pointer signature for `out T` | `HResult`, `DateTime`, `TimeSpan` |
| RCW | `out` parameter read-back | `HResult`, `DateTime`, `TimeSpan` |
| RCW | function pointer signature and pinning for `in T` (`ref const`) | `DateTime`, `TimeSpan` |

## Changes

- **`src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.DoAbi.cs`**: added the missing `HResult` branch to `EmitDoAbiParamArgConversion` (which covers method parameters, property setters and delegate `Invoke` stubs, since they share the emitter), and the missing `HResult` / `System.Type` / mapped value type branches to the `out` parameter write-back.

- **`src/WinRT.Projection.Writer/Factories/AbiMethodBodyFactory.RcwCaller.cs`**: the function pointer signature builder had its own duplicate ABI type ladder for `out T` and `in T`, and neither copy handled `HResult` or the mapped value types, so both slots were typed `int*` while the matching local was the real ABI type. Both branches now share `GetAbiLocalTypeName`, which is the same helper that types the local, so the two cannot drift apart again. Also added the matching `ConvertToManaged` to the `out` read-back, and routed `in T` parameters whose ABI form differs from the projected one through a marshalled ABI local instead of pinning the projected value.

- **`src/WinRT.Projection.Writer/Resolvers/AbiTypeKindResolver.cs`**: added `RequiresMarshalledAbiInputLocal`, so "this input needs a separate ABI local" is named once instead of being re-derived as "is it a complex struct?" at each of the sites that have to agree on it.

- **`src/Tests/TestComponentCSharp/`**: added `IMarshalledValues`, a standalone interface covering every parameter position where the ABI and projected representations differ, the `HandleResult` delegate for the delegate stub path, and `MarshalledValuesTest`, which implements the interface natively (the RCW direction) and exposes one static per member that invokes it from native code (the CCW direction).

- **`src/Tests/UnitTest/MarshalledValuesTests.cs`**: 16 tests covering each shape in both directions.

## Validation

- Full `UnitTest` suite passes (549 / 550; the one failure is `TestDataTransferManager`, which asserts that `DataTransferManager.GetForWindow(0)` throws and is environment dependent, on a code path this PR does not touch).
- `ProjectionWriterTest` passes (21 / 21).
- The whole Windows SDK projection (`WinRT.Sdk.Projection.dll`) plus the merged projection regenerate and compile cleanly, which exercises the shared ladder refactor across the full SDK surface.
- Reverting the writer changes and rebuilding makes the merged projection fail with 15 `CS0029` / `CS1503` / `CS0266` errors, one for each broken position, so the new coverage is verified to catch the regression rather than merely to pass.