### PR TITLE
Generate CCW metadata for IReadOnlyDictionary and dictionary key/value collections

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
+++ b/src/Authoring/WinRT.SourceGenerator/AotOptimizer.cs
@@ -1654,6 +1654,8 @@ namespace Generator
                 return;
             }
 
+            bool isDictionary = false;
+
             foreach (var iface in classType.AllInterfaces)
             {
                 if (iface.MetadataName == "IEnumerable`1")
@@ -1662,7 +1664,20 @@ namespace Generator
                 }
                 else if (iface.MetadataName == "IDictionary`2")
                 {
+                    isDictionary = true;
+
                     LookupAndAddVtableAttributeForGenericType("System.Collections.ObjectModel.ReadOnlyDictionary`2", iface.TypeArguments);
+                    LookupAndAddVtableAttributeForGenericType("System.Collections.Generic.KeyValuePair`2", iface.TypeArguments);
+                    LookupAndAddVtableAttributeForGenericType("ABI.System.Collections.Generic.ConstantSplittableMap`2", iface.TypeArguments);
+                }
+                else if (iface.MetadataName == "IReadOnlyDictionary`2")
+                {
+                    isDictionary = true;
+
+                    // 'IReadOnlyDictionary<K, V>' is projected as 'IMapView<K, V>'. Iterating it hands out
+                    // 'KeyValuePair<K, V>' values and its 'Split' method hands out 'ConstantSplittableMap<K, V>'
+                    // instances, so both need CCW entries. Types also implementing 'IDictionary<K, V>' get these
+                    // from the branch above, but types only implementing the read only interface would be missed.
                     LookupAndAddVtableAttributeForGenericType("System.Collections.Generic.KeyValuePair`2", iface.TypeArguments);
                     LookupAndAddVtableAttributeForGenericType("ABI.System.Collections.Generic.ConstantSplittableMap`2", iface.TypeArguments);
                 }
@@ -1670,6 +1685,12 @@ namespace Generator
                 {
                     LookupAndAddVtableAttributeForGenericType("System.Collections.ObjectModel.ReadOnlyCollection`1", iface.TypeArguments);
                 }
+            }
+
+            if (isDictionary)
+            {
+                AddVtableAttributesForDictionaryCollectionProperty("Keys");
+                AddVtableAttributesForDictionaryCollectionProperty("Values");
             }
 
             if (classType is INamedTypeSymbol namedType && IsDerivedFromOrIsObservableCollection(namedType))
@@ -1721,6 +1742,48 @@ namespace Generator
                     if (vtableAttribute != default)
                     {
                         vtableAttributes.Add(vtableAttribute);
+                    }
+                }
+            }
+
+            // The 'Keys' and 'Values' properties of a dictionary hand out concrete collection types (e.g.
+            // 'Dictionary<K, V>.ValueCollection') which never appear by name in user code and are therefore
+            // never discovered by the rest of the generator. They are commonly marshaled on their own though
+            // (e.g. '{x:Bind ViewModel.Dictionary.Values}'), which requires a CCW for them, so add one here.
+            void AddVtableAttributesForDictionaryCollectionProperty(string propertyName)
+            {
+                for (ITypeSymbol type = classType; type is not null; type = type.BaseType)
+                {
+                    foreach (var member in type.GetMembers(propertyName))
+                    {
+                        // Only consider the public property, as the explicit interface implementations just return
+                        // the same instance typed as an interface, which tells us nothing about the concrete type.
+                        if (member is not IPropertySymbol
+                            {
+                                IsStatic: false,
+                                DeclaredAccessibility: Accessibility.Public,
+                                Type: INamedTypeSymbol { TypeKind: TypeKind.Class, IsAbstract: false } collectionType
+                            })
+                        {
+                            continue;
+                        }
+
+                        var vtableAttribute = GetVtableAttributeToAdd(collectionType, isManagedOnlyType, isWinRTType, mapper, compilation, false);
+                        if (vtableAttribute != default)
+                        {
+                            vtableAttributes.Add(vtableAttribute);
+                        }
+
+                        // The native caller will enumerate the collection, so it needs the enumerator adapter too.
+                        foreach (var collectionInterface in collectionType.AllInterfaces)
+                        {
+                            if (collectionInterface.MetadataName == "IEnumerable`1")
+                            {
+                                AddEnumeratorAdapterForType(collectionInterface.TypeArguments[0], mapper, compilation, isManagedOnlyType, isWinRTType, vtableAttributes);
+                            }
+                        }
+
+                        return;
                     }
                 }
             }

--- a/src/Tests/FunctionalTests/Collections/Program.cs
+++ b/src/Tests/FunctionalTests/Collections/Program.cs
@@ -477,6 +477,37 @@ if (objectArr.Length != 2 || objectArr[0] is not Class c || c != instance || obj
     return 105;
 }
 
+// Regression test for https://github.com/microsoft/CsWinRT/issues/2537. Binding to the 'Keys' or 'Values'
+// of a dictionary marshals the concrete collection type behind them (eg. 'Dictionary<K, V>.ValueCollection'),
+// which never appears by name in user code and so needs to be discovered through the dictionary itself.
+var readOnlyDictionary = CustomClass.DictionaryInstance;
+
+instance.BindableIterableProperty = readOnlyDictionary.Values;
+if (readOnlyDictionary.Values != instance.BindableIterableProperty)
+{
+    return 106;
+}
+
+instance.BindableIterableProperty = readOnlyDictionary.Keys;
+if (readOnlyDictionary.Keys != instance.BindableIterableProperty)
+{
+    return 106;
+}
+
+var dictionary = CustomClass.DictionaryInstance3;
+
+instance.BindableIterableProperty = dictionary.Values;
+if (dictionary.Values != instance.BindableIterableProperty)
+{
+    return 106;
+}
+
+instance.BindableIterableProperty = dictionary.Keys;
+if (dictionary.Keys != instance.BindableIterableProperty)
+{
+    return 106;
+}
+
 return 100;
 
 static bool SequencesEqual<T>(IEnumerable<T> x, params IEnumerable<T>[] list) => list.All((y) => x.SequenceEqual(y));
@@ -505,6 +536,8 @@ sealed partial class CustomClass : INotifyPropertyChanged
             return new Dictionary<int, CustomClass>();
         }
     }
+
+    public static IDictionary<string, CustomClass> DictionaryInstance3 { get; } = new Dictionary<string, CustomClass>();
 }
 
 sealed partial class CustomObservableCollection : System.Collections.ObjectModel.ObservableCollection<CustomClass>

--- a/src/Tests/SourceGeneratorTest/AotOptimizerTests.cs
+++ b/src/Tests/SourceGeneratorTest/AotOptimizerTests.cs
@@ -174,6 +174,138 @@ public class AotOptimizerTests
         Assert.IsFalse(generated.Contains("System.Collections.ObjectModel.ObservableCollection`1[System.String]"));
     }
 
+    // Regression tests for https://github.com/microsoft/CsWinRT/issues/2537. A dictionary hands out its 'Keys' and
+    // 'Values' as concrete collection types (eg. 'Dictionary<K, V>.ValueCollection') that never appear by name in
+    // user code, so nothing else in the generator discovers them. Additionally, 'IReadOnlyDictionary<K, V>' (which
+    // is projected as 'IMapView<K, V>') needs the same adapter types as 'IDictionary<K, V>' for iteration and for
+    // 'IMapView.Split', which were previously only gathered for types implementing 'IDictionary<K, V>'.
+
+    [TestMethod]
+    public void ReadOnlyDictionary_DiscoversKeyAndValueCollections()
+    {
+        const string source = """
+            using System.Collections.Generic;
+
+            internal class ViewModel
+            {
+                public IReadOnlyDictionary<int, string> Dict { get; } = new Dictionary<int, string>();
+
+                public static IReadOnlyDictionary<string, byte> OtherDict => new Dictionary<string, byte>();
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+KeyCollection[System.Int32,System.String]"));
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+ValueCollection[System.Int32,System.String]"));
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+KeyCollection[System.String,System.Byte]"));
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+ValueCollection[System.String,System.Byte]"));
+
+        // The native caller iterates those collections, so their enumerator adapters are needed as well
+        Assert.IsTrue(generated.Contains("ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.Int32]"));
+        Assert.IsTrue(generated.Contains("ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.String]"));
+        Assert.IsTrue(generated.Contains("ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.Byte]"));
+    }
+
+    [TestMethod]
+    public void Dictionary_DiscoversKeyAndValueCollections()
+    {
+        const string source = """
+            using System.Collections.Generic;
+
+            internal class ViewModel
+            {
+                public IDictionary<int, string> Dict { get; } = new Dictionary<int, string>();
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+KeyCollection[System.Int32,System.String]"));
+        Assert.IsTrue(generated.Contains("System.Collections.Generic.Dictionary`2+ValueCollection[System.Int32,System.String]"));
+        Assert.IsTrue(generated.Contains("ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.Int32]"));
+        Assert.IsTrue(generated.Contains("ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.String]"));
+    }
+
+    [TestMethod]
+    public void ReadOnlyDictionaryOnlyType_DiscoversIterationAndSplitAdapters()
+    {
+        const string source = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            internal partial class ReadOnlyDict : IReadOnlyDictionary<int, string>
+            {
+                public string this[int key] => throw null;
+                public IEnumerable<int> Keys => throw null;
+                public IEnumerable<string> Values => throw null;
+                public int Count => 0;
+                public bool ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out string value) { value = null; return false; }
+                public IEnumerator<KeyValuePair<int, string>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => throw null;
+            }
+
+            internal class ViewModel
+            {
+                public object Dict { get; } = new ReadOnlyDict();
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        // 'IMapView.Split' hands out 'ConstantSplittableMap<K, V>' instances, and iterating the map hands
+        // out 'KeyValuePair<K, V>' values, so both need CCW entries of their own. The assertions match the
+        // lookup table keys exactly, as those bare type names also appear nested inside other keys.
+        Assert.IsTrue(generated.Contains("== \"ABI.System.Collections.Generic.ConstantSplittableMap`2[System.Int32,System.String]\""));
+        Assert.IsTrue(generated.Contains("== \"System.Collections.Generic.KeyValuePair`2[System.Int32,System.String]\""));
+    }
+
+    [TestMethod]
+    public void CustomDictionary_DiscoversConcreteKeyAndValueCollections()
+    {
+        // The discovery is not specific to 'Dictionary<K, V>': any dictionary handing out its keys and values
+        // through concrete collection types needs those collections on the CCW lookup table as well. The keys
+        // here are typed as an interface though, so there is no concrete type to discover for them.
+        const string source = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            internal sealed class ValueView : IEnumerable<string>
+            {
+                public IEnumerator<string> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => throw null;
+            }
+
+            internal partial class ReadOnlyDict : IReadOnlyDictionary<int, string>
+            {
+                public string this[int key] => throw null;
+                public IEnumerable<int> Keys => throw null;
+                public ValueView Values => throw null;
+                IEnumerable<string> IReadOnlyDictionary<int, string>.Values => Values;
+                public int Count => 0;
+                public bool ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out string value) { value = null; return false; }
+                public IEnumerator<KeyValuePair<int, string>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => throw null;
+            }
+
+            internal class ViewModel
+            {
+                public object Dict { get; } = new ReadOnlyDict();
+            }
+            """;
+
+        string generated = RunAotOptimizer(source);
+
+        Assert.IsTrue(generated.Contains("== \"ValueView\""));
+        Assert.IsTrue(generated.Contains("== \"ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.String]\""));
+
+        // 'Keys' is typed as 'IEnumerable<int>', which is not an instantiable type, so nothing is registered for it
+        Assert.IsFalse(generated.Contains("== \"System.Collections.Generic.IEnumerable`1[System.Int32]\""));
+        Assert.IsFalse(generated.Contains("== \"ABI.System.Collections.Generic.ToAbiEnumeratorAdapter`1[System.Int32]\""));
+    }
+
     private static string RunAotOptimizer(string source)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));


### PR DESCRIPTION
Fixes #2537

## Problem

Binding to the values of a dictionary crashes under NativeAOT:

```cs
class ViewModel
{
    public IReadOnlyDictionary<int, string> Dict { get; } = new Dictionary<int, string> { [42] = "hello" };
}
```
```xml
<ComboBox ItemsSource="{x:Bind vm.Dict.Values}" />
```

There were two gaps in `AddVtableAdapterTypeForKnownInterface` in the AOT source generator:

1. **`IReadOnlyDictionary<K, V>` was never handled.** The method special cased `IDictionary<K, V>` (registering `ReadOnlyDictionary<K, V>`, `KeyValuePair<K, V>` and `ConstantSplittableMap<K, V>`), but had no branch for `IReadOnlyDictionary<K, V>`. That interface is projected as `IMapView<K, V>`, whose `Split` method hands out `ConstantSplittableMap<K, V>` instances and whose iteration hands out `KeyValuePair<K, V>` values, so a type implementing *only* the read only interface was missing both CCW entries.

2. **`Keys` and `Values` were never discovered.** A dictionary hands those out through concrete collection types (e.g. `Dictionary<K, V>.ValueCollection`) which never appear by name in user code, so nothing in the generator ever gathered them. Marshaling one to XAML then found no vtable in the CCW lookup table, so the resulting CCW had no `IBindableIterable` and the bind crashed. This is what the repro in the issue hits: `Dictionary<int, string>` itself was registered, but `Dictionary<int, string>.ValueCollection` was not.

## Fix

- Added an `IReadOnlyDictionary<K, V>` branch registering `KeyValuePair<K, V>` and `ConstantSplittableMap<K, V>`.
- For any dictionary type, walk its public `Keys`/`Values` properties and register a vtable for the concrete collection type behind them, along with the `ToAbiEnumeratorAdapter<T>` needed to enumerate it. Interface typed `Keys`/`Values` are skipped, since there is no concrete type to discover in that case.

The lookup table is keyed by string, so this adds table entries only — no new type references in generated code.

## Testing

- 4 new tests in `AotOptimizerTests.cs`, each verified to fail without the generator change and pass with it. Full suite: 74/74 passing.
- Added an end to end regression case to the `Collections` AOT functional test that assigns `dictionary.Keys`/`dictionary.Values` to `Class.BindableIterableProperty` (typed `Microsoft.UI.Xaml.Interop.IBindableIterable`), which fails to marshal unless the collection CCW exposes `IBindableIterable`.