### PR TITLE
Add test coverage for marshalling dictionary Keys/Values collections

### DIFF
--- a/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
+++ b/src/Tests/UnitTest/TestComponentCSharp_Tests.cs
@@ -2805,6 +2805,87 @@ namespace UnitTest
         }
 
         [TestMethod]
+        public unsafe void TestDictionaryKeyAndValueCollectionInterfaceMarshalling()
+        {
+            // Binding a XAML control to a dictionary's keys or values (e.g. '{x:Bind vm.Dict.Values}') marshals
+            // the 'Dictionary<TKey, TValue>.KeyCollection'/'ValueCollection' nested types across the ABI, not the
+            // dictionary itself, which builds a CCW for them. Those types are never named in user code, because
+            // 'Keys'/'Values' are declared as 'IEnumerable<T>' on 'IReadOnlyDictionary<TKey, TValue>' and as
+            // 'ICollection<T>' on 'IDictionary<TKey, TValue>', so they only get one if the interop generator
+            // tracks them off the dictionary instantiation itself.
+            Dictionary<int, string> dictionary = new() { [0] = "zero", [1] = "one", [2] = "two" };
+
+            IReadOnlyDictionary<int, string> readOnlyDictionary = dictionary;
+            IDictionary<int, string> mutableDictionary = dictionary;
+
+            IEnumerable<int> readOnlyKeys = readOnlyDictionary.Keys;
+            IEnumerable<string> readOnlyValues = readOnlyDictionary.Values;
+            ICollection<int> keys = mutableDictionary.Keys;
+            ICollection<string> values = mutableDictionary.Values;
+
+            // Guard against the BCL changing which types it hands out, so that this test fails loudly rather
+            // than silently covering nothing. The types are deliberately identified by name: naming them in
+            // code would put them in this assembly's metadata, which is precisely what the scenario cannot
+            // rely on (the whole point is that they are only reachable through the interface members).
+            AssertIsDictionaryCollection(readOnlyKeys, "KeyCollection");
+            AssertIsDictionaryCollection(readOnlyValues, "ValueCollection");
+            AssertIsDictionaryCollection(keys, "KeyCollection");
+            AssertIsDictionaryCollection(values, "ValueCollection");
+
+            // 'IEnumerable<T>' is projected as 'IIterable<T>', and 'IEnumerable' as 'IBindableIterable'
+            AssertCcwExposesIterableInterfaces(readOnlyKeys, new Guid("81A643FB-F51C-5565-83C4-F96425777B66"));
+            AssertCcwExposesIterableInterfaces(readOnlyValues, new Guid("E2FCC7C1-3BFC-5A0B-B2B0-72E769D1CB7E"));
+
+            // Enumerate the keys from native code, through 'IIterable<int>'
+            int sum = 0;
+
+            using (IEnumerator<int> iterator = TestObject.GetIteratorForCollection(readOnlyKeys))
+            {
+                while (iterator.MoveNext())
+                {
+                    sum += iterator.Current;
+                }
+            }
+
+            Assert.AreEqual(3, sum);
+
+            // Same thing through a projected API taking a bindable iterable, which is what XAML uses to bind
+            // an 'ItemsSource'. The values have to be sequential from 0, because the native setter validates that.
+            TestObject.BindableIterableProperty = readOnlyKeys;
+            CollectionAssert.AreEqual(new[] { 0, 1, 2 }, TestObject.BindableIterableProperty.Cast<int>().ToArray());
+
+            static void AssertIsDictionaryCollection(IEnumerable source, string name)
+            {
+                Assert.AreEqual($"System.Collections.Generic.Dictionary`2+{name}", source.GetType().GetGenericTypeDefinition().FullName);
+            }
+
+            static void AssertCcwExposesIterableInterfaces(IEnumerable source, Guid iidIIterable)
+            {
+                Guid iidIBindableIterable = new("036D2C08-DF29-41AF-8AA2-D774BE62BA6F");
+
+                void* ccw = WindowsRuntimeMarshal.ConvertToUnmanaged(source);
+
+                try
+                {
+                    AssertHasInterface(ccw, in iidIIterable);
+                    AssertHasInterface(ccw, in iidIBindableIterable);
+                }
+                finally
+                {
+                    _ = Marshal.Release((nint)ccw);
+                }
+
+                static void AssertHasInterface(void* ccw, in Guid iid)
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.QueryInterface((nint)ccw, in iid, out nint interfaceCcw));
+                    Assert.AreNotEqual(IntPtr.Zero, interfaceCcw);
+
+                    _ = Marshal.Release(interfaceCcw);
+                }
+            }
+        }
+
+        [TestMethod]
         public void TestClassGeneric()
         {
             var objs = TestObject.GetClassVector();


### PR DESCRIPTION
## Summary

Adds a unit test covering the scenario from #2537: marshalling a dictionary's `Keys`/`Values` collections across the Windows Runtime ABI. Investigation confirmed the interop generator already handles this correctly in CsWinRT 3.0, so this PR adds no generator changes — only the missing test coverage that pins the behavior down.

## Motivation

Issue #2537 reports a Native AOT crash under CsWinRT 2.x when binding a XAML control to `someDictionary.Values` (e.g. `{x:Bind vm.Dict.Values}`). The interesting part of that scenario is that the object crossing the ABI is not the dictionary at all: it is the nested `Dictionary<TKey, TValue>.KeyCollection` / `ValueCollection` type, which needs a CCW exposing `IIterable<T>` and `IBindableIterable`.

Those types are never named in user code, and cannot be: `Keys`/`Values` are declared as `IEnumerable<T>` on `IReadOnlyDictionary<TKey, TValue>` and as `ICollection<T>` on `IDictionary<TKey, TValue>`, so the concrete nested types appear nowhere in the consuming assembly's metadata. They only get marshalling code if the interop generator derives them from the dictionary instantiation itself.

It does. `ModuleDefinitionExtensions.EnumerateTypeSignatures` does not just read the `TypeSpec` table: for each type specification it resolves the type definition and instantiates its members' signatures with that generic context. A `Dictionary<int, string>` type spec therefore yields the constructed return types of `get_Keys`/`get_Values`, and both nested collections flow through the normal user-defined-type discovery path and get CCW entries.

This was verified empirically rather than by reading alone: adding a `Dictionary<char, char>` instantiation over an otherwise unused pair of type arguments and rebuilding made the matching `KeyCollection`/`ValueCollection` CCW entries appear in the generated `WinRT.Interop.dll`, and removing it made them disappear again. That also rules out the new test passing vacuously against entries some other assembly happened to contribute.

The behavior was untested, though, which is what this PR fixes. It is a scenario that is easy to regress precisely because nothing in user code references the types involved.

## Changes

- **`src/Tests/UnitTest/TestComponentCSharp_Tests.cs`**: adds `TestDictionaryKeyAndValueCollectionInterfaceMarshalling`, modelled on the existing `TestCollectionChangedListInterfaceMarshalling`. It identifies the two nested collection types by name rather than naming them in code (naming them would put them in the test assembly's metadata, which is exactly what the scenario cannot rely on, making the coverage vacuous), asserts the CCW answers `QueryInterface` for both `IIterable<T>` and `IBindableIterable`, and then enumerates the keys from native code through `GetIteratorForCollection` and through `BindableIterableProperty`, which is the path XAML uses to bind an `ItemsSource`.

## Validation

The full unit test suite passes (559/560). The single failure, `TestDataTransferManager`, is pre-existing and environment-dependent, in a file untouched by this PR.
