### PR TITLE
Fix failing ObjectLifetime tests

### DIFF
--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Initialization.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Initialization.cs
@@ -20,7 +20,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <param name="innerInstanceUnknown">The inner COM object, for COM aggregation scenarios.</param>
     /// <param name="newInstanceIid">The IID for the new instance.</param>
     /// <param name="marshalingType">The marshaling type to use for the input native object (either <paramref name="newInstanceUnknown"/> or <paramref name="innerInstanceUnknown"/>).</param>
-    /// <param name="objectReference">The <see cref="WindowsRuntimeObjectReference"/> wrapping the input COM objects.</param>
+    /// <param name="objectReference">The resulting <see cref="WindowsRuntimeObjectReference"/> instance wrapping the input COM object.</param>
     /// <remarks>
     /// <para>
     /// This method differs from <see cref="AttachUnsafe(ref void*, in Guid)"/> and other factory methods in that it also handles
@@ -214,7 +214,7 @@ public unsafe partial class WindowsRuntimeObjectReference
         // All the information gathered will flow into the creation flags for our object reference instance.
         CreateObjectReferenceFlags createObjectReferenceFlags = CreateObjectReferenceFlags.None;
 
-        // Set up reference tracking and ownership before the 'ComWrappers' registration below.
+        // Set up reference tracking and ownership before the 'ComWrappers' registration below
         if (isAggregation)
         {
             // Aggregation scenarios should avoid calling 'AddRef' on the 'acquiredNewInstanceUnknown' object.
@@ -305,18 +305,18 @@ public unsafe partial class WindowsRuntimeObjectReference
             // This allows 'ComWrappers' to manage the inner lifetime based on whether this is a
             // XAML reference tracker scenario or not (aggregation is not exclusive to XAML).
             _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance(
-                (nint)acquiredNewInstanceUnknown,
-                createObjectFlags,
-                thisInstance,
-                (nint)acquiredInnerInstanceUnknown);
+                externalComObject: (nint)acquiredNewInstanceUnknown,
+                flags: createObjectFlags,
+                wrapper: thisInstance,
+                inner: (nint)acquiredInnerInstanceUnknown);
         }
         else
         {
             // Same registration as for COM aggregation without reference tracker support for the inner instance (see above)
             _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance(
-                (nint)acquiredNewInstanceUnknown,
-                createObjectFlags,
-                thisInstance);
+                externalComObject: (nint)acquiredNewInstanceUnknown,
+                flags: createObjectFlags,
+                wrapper: thisInstance);
         }
     }
 

--- a/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Initialization.cs
+++ b/src/WinRT.Runtime2/InteropServices/ObjectReference/WindowsRuntimeObjectReference.Initialization.cs
@@ -20,7 +20,7 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// <param name="innerInstanceUnknown">The inner COM object, for COM aggregation scenarios.</param>
     /// <param name="newInstanceIid">The IID for the new instance.</param>
     /// <param name="marshalingType">The marshaling type to use for the input native object (either <paramref name="newInstanceUnknown"/> or <paramref name="innerInstanceUnknown"/>).</param>
-    /// <returns>A <see cref="WindowsRuntimeObjectReference"/> wrapping the input COM objects.</returns>
+    /// <param name="objectReference">The <see cref="WindowsRuntimeObjectReference"/> wrapping the input COM objects.</param>
     /// <remarks>
     /// <para>
     /// This method differs from <see cref="AttachUnsafe(ref void*, in Guid)"/> and other factory methods in that it also handles
@@ -31,13 +31,14 @@ public unsafe partial class WindowsRuntimeObjectReference
     /// This method takes ownership of both <paramref name="newInstanceUnknown"/> and <paramref name="innerInstanceUnknown"/>.
     /// </para>
     /// </remarks>
-    internal static WindowsRuntimeObjectReference InitializeFromManagedTypeUnsafe(
+    internal static void InitializeFromManagedTypeUnsafe(
         bool isAggregation,
         WindowsRuntimeObject thisInstance,
         ref void* newInstanceUnknown,
         ref void* innerInstanceUnknown,
         in Guid newInstanceIid,
-        CreateObjectReferenceMarshalingType marshalingType)
+        CreateObjectReferenceMarshalingType marshalingType,
+        out WindowsRuntimeObjectReference objectReference)
     {
         void* acquiredNewInstanceUnknown = newInstanceUnknown;
         void* acquiredInnerInstanceUnknown = innerInstanceUnknown;
@@ -203,27 +204,6 @@ public unsafe partial class WindowsRuntimeObjectReference
             createObjectFlags |= CreateObjectFlags.TrackerObject;
         }
 
-        // We now need to create and register a native object wrapper (ie. RCW). Note that the 'ComWrappers' API that
-        // does this operation will call 'QueryInterface' on the supplied instance, therefore it is important that the
-        // enclosing managed object wrapper (ie. CCW) forwards to its inner object, if COM aggregation is involved.
-        // This is typically accomplished through an implementation of 'ICustomQueryInterface'. Because all of the
-        // Windows Runtime projected types have a base class, we have this common logic in 'WindowsRuntimeObject'.
-        if (isAggregation)
-        {
-            // Indicate the scenario is COM aggregation
-            createObjectFlags |= CreateObjectFlags.Aggregation;
-
-            // Here we pass both the aggregated instance and the inner instance to 'ComWrappers'.
-            // This allows 'ComWrappers' to manage the inner lifetime based on whether this is a
-            // XAML reference tracker scenario or not (aggregation is not exclusive to XAML).
-            _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance((nint)acquiredNewInstanceUnknown, createObjectFlags, thisInstance, (nint)acquiredInnerInstanceUnknown);
-        }
-        else
-        {
-            // Same registration as for COM aggregation without reference tracker support for the inner instance (see above)
-            _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance((nint)acquiredNewInstanceUnknown, createObjectFlags, thisInstance);
-        }
-
         // This value is the reference tracker pointer we will wrap in the returned object reference.
         // It mirrors 'externalComObject'. We neeed this because in some scenarios we will not actually
         // keep a reference to the input reference tracker, but rather we'll discard it in this method.
@@ -234,7 +214,7 @@ public unsafe partial class WindowsRuntimeObjectReference
         // All the information gathered will flow into the creation flags for our object reference instance.
         CreateObjectReferenceFlags createObjectReferenceFlags = CreateObjectReferenceFlags.None;
 
-        // The rest of the logic handles the reference tracker setup, after the 'ComWrappers' registration above
+        // Set up reference tracking and ownership before the 'ComWrappers' registration below.
         if (isAggregation)
         {
             // Aggregation scenarios should avoid calling 'AddRef' on the 'acquiredNewInstanceUnknown' object.
@@ -293,17 +273,51 @@ public unsafe partial class WindowsRuntimeObjectReference
         // additional overhead of the state to track the current context, and having to manage a lazy agile reference.
         if (isFreeThreaded)
         {
-            return new FreeThreadedObjectReference(externalComObject, externalReferenceTracker, createObjectReferenceFlags);
+            objectReference = new FreeThreadedObjectReference(externalComObject, externalReferenceTracker, createObjectReferenceFlags);
+        }
+        else
+        {
+            // Otherwise, use a context aware object reference to track it, with the specialized instance.
+            // In this method, the IID for the object reference depends on whether we are in an aggregation
+            // scenario. That is because if we are, then the wrapped COM object will be the inner instance,
+            // not the outer one (which would have its own default interface as IID). And the inner instance
+            // will be an 'IInspectable', when returned by the activation factory.
+            objectReference = isAggregation
+                ? new ContextAwareInspectableObjectReference(externalComObject, externalReferenceTracker, createObjectReferenceFlags)
+                : new ContextAwareInterfaceObjectReference(externalComObject, externalReferenceTracker, iid: in newInstanceIid, createObjectReferenceFlags);
         }
 
-        // Otherwise, use a context aware object reference to track it, with the specialized instance.
-        // In this method, the IID for the object reference depends on whether we are in an aggregation
-        // scenario. That is because if we are, then the wrapped COM object will be the inner instance,
-        // not the outer one (which would have its own default interface as IID). And the inner instance
-        // will be an 'IInspectable', when returned by the activation factory.
-        return isAggregation
-            ? new ContextAwareInspectableObjectReference(externalComObject, externalReferenceTracker, createObjectReferenceFlags)
-            : new ContextAwareInterfaceObjectReference(externalComObject, externalReferenceTracker, iid: in newInstanceIid, createObjectReferenceFlags);
+        // We now need to create and register a native object wrapper (ie. RCW). Note that the 'ComWrappers' API that
+        // does this operation will call 'QueryInterface' on the supplied instance, therefore it is important that the
+        // enclosing managed object wrapper (ie. CCW) forwards to its inner object, if COM aggregation is involved.
+        // This is typically accomplished through an implementation of 'ICustomQueryInterface'. Because all of the
+        // Windows Runtime projected types have a base class, we have this common logic in 'WindowsRuntimeObject'.
+        //
+        // The object reference must be assigned before this call. In aggregation scenarios, 'ComWrappers' queries
+        // the outer object for 'IReferenceTracker' during registration, and 'ICustomQueryInterface' needs the object
+        // reference to forward that query to the inner object.
+        if (isAggregation)
+        {
+            // Indicate the scenario is COM aggregation
+            createObjectFlags |= CreateObjectFlags.Aggregation;
+
+            // Here we pass both the aggregated instance and the inner instance to 'ComWrappers'.
+            // This allows 'ComWrappers' to manage the inner lifetime based on whether this is a
+            // XAML reference tracker scenario or not (aggregation is not exclusive to XAML).
+            _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance(
+                (nint)acquiredNewInstanceUnknown,
+                createObjectFlags,
+                thisInstance,
+                (nint)acquiredInnerInstanceUnknown);
+        }
+        else
+        {
+            // Same registration as for COM aggregation without reference tracker support for the inner instance (see above)
+            _ = WindowsRuntimeComWrappers.Default.GetOrRegisterObjectForComInstance(
+                (nint)acquiredNewInstanceUnknown,
+                createObjectFlags,
+                thisInstance);
+        }
     }
 
     /// <summary>

--- a/src/WinRT.Runtime2/WindowsRuntimeObject.Impl.cs
+++ b/src/WinRT.Runtime2/WindowsRuntimeObject.Impl.cs
@@ -39,6 +39,11 @@ public unsafe partial class WindowsRuntimeObject
     private volatile ConcurrentDictionary<RuntimeTypeHandle, object>? _typeHandleCache;
 
     /// <summary>
+    /// The native object reference wrapped by the current instance.
+    /// </summary>
+    private readonly WindowsRuntimeObjectReference _nativeObjectReference;
+
+    /// <summary>
     /// Creates a <see cref="WindowsRuntimeObject"/> instance with the specified parameters.
     /// </summary>
     /// <param name="nativeObjectReference">The inner Windows Runtime object reference to wrap in the current instance.</param>
@@ -48,7 +53,7 @@ public unsafe partial class WindowsRuntimeObject
     {
         ArgumentNullException.ThrowIfNull(nativeObjectReference);
 
-        NativeObjectReference = nativeObjectReference;
+        _nativeObjectReference = nativeObjectReference;
     }
 
     /// <summary>
@@ -86,13 +91,14 @@ public unsafe partial class WindowsRuntimeObject
         // Initialize a 'WindowsRuntimeObjectReference' for the current native objects and the managed instance we're
         // constructing. This will also take care of registering things with 'ComWrappers', and setting up all the
         // reference tracker infrastructure, in case the native object implements the 'IReferenceTracker' interface.
-        NativeObjectReference = WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
+        WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
             isAggregation: false,
             thisInstance: this,
             newInstanceUnknown: ref defaultInterface,
             innerInstanceUnknown: ref innerInterface,
             newInstanceIid: in iid,
-            marshalingType: marshalingType);
+            marshalingType: marshalingType,
+            objectReference: out _nativeObjectReference);
     }
 
     /// <summary>
@@ -142,13 +148,14 @@ public unsafe partial class WindowsRuntimeObject
         // Initialize a 'WindowsRuntimeObjectReference' for the current native objects and the managed instance we're
         // constructing. This will also take care of registering things with 'ComWrappers', and setting up all the
         // reference tracker infrastructure, in case the native object implements the 'IReferenceTracker' interface.
-        NativeObjectReference = WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
+        WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
             isAggregation: !hasUnwrappableNativeObjectReference,
             thisInstance: this,
             newInstanceUnknown: ref defaultInterface,
             innerInstanceUnknown: ref innerInterface,
             newInstanceIid: in iid,
-            marshalingType: marshalingType);
+            marshalingType: marshalingType,
+            objectReference: out _nativeObjectReference);
 
         // Optimization: if we are activating the current type for composition, then the returned object reference
         // will wrap the 'IInspectable' pointer for the controlling instance (ie. 'innerInterface'). In this case,
@@ -206,13 +213,14 @@ public unsafe partial class WindowsRuntimeObject
         void* innerInterface = null;
 
         // Initialize the 'WindowsRuntimeObjectReference' for the default interface (same as above)
-        NativeObjectReference = WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
+        WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
             isAggregation: false,
             thisInstance: this,
             newInstanceUnknown: ref defaultInterface,
             innerInstanceUnknown: ref innerInterface,
             newInstanceIid: in iid,
-            marshalingType: marshalingType);
+            marshalingType: marshalingType,
+            objectReference: out _nativeObjectReference);
     }
 
     /// <summary>
@@ -253,13 +261,14 @@ public unsafe partial class WindowsRuntimeObject
             defaultInterface: out void* defaultInterface);
 
         // Initialize a 'WindowsRuntimeObjectReference' object (see detailed explanation above)
-        NativeObjectReference = WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
+        WindowsRuntimeObjectReference.InitializeFromManagedTypeUnsafe(
             isAggregation: !hasUnwrappableNativeObjectReference,
             thisInstance: this,
             newInstanceUnknown: ref defaultInterface,
             innerInstanceUnknown: ref innerInterface,
             newInstanceIid: in iid,
-            marshalingType: marshalingType);
+            marshalingType: marshalingType,
+            objectReference: out _nativeObjectReference);
 
         // Optimization: pre-cache the inspectable object reference if possible (see detailed explanation above)
         if (!hasUnwrappableNativeObjectReference)
@@ -275,7 +284,7 @@ public unsafe partial class WindowsRuntimeObject
     /// This object reference should point to an <c>IInspectable</c> native object.
     /// </remarks>
     [WindowsRuntimeImplementationOnlyMember]
-    protected internal WindowsRuntimeObjectReference NativeObjectReference { get; }
+    protected internal WindowsRuntimeObjectReference NativeObjectReference => _nativeObjectReference;
 
     /// <summary>
     /// Gets a value indicating whether the current instance has an unwrappable native object reference.
@@ -572,10 +581,9 @@ public unsafe partial class WindowsRuntimeObject
         // We explicitly don't handle overridable interfaces, as well as 'IInspectable' and 'IWeakReferenceSource'.
         // This last one in particular must be ignored to avoid issues when an RCW object is used as a target
         // for a 'WeakReference' object. Lastly, we also need to not handle this 'QueryInterface' request when
-        // 'NativeObjectReference' is 'null', which will be the case during initialization (because objects are
-        // constructed entirely from this base 'WindowsRuntimeObject' type). In that case, 'QueryInterface' calls
-        // will be coming for the outer instance from the inner one, where the outer calls 'GetInterface' first,
-        // and they wouldn't need to be handled anyway.
+        // 'NativeObjectReference' is 'null', which is the case during activation before the inner object reference
+        // has been created. In that case, 'QueryInterface' calls come from the inner object to the outer instance,
+        // where the outer calls 'GetInterface' first, and they don't need to be handled here.
         if (IsOverridableInterface(in iid) ||
             WellKnownWindowsInterfaceIIDs.IID_IInspectable == iid ||
             WellKnownWindowsInterfaceIIDs.IID_IWeakReferenceSource == iid ||

--- a/src/WinRT.Runtime2/WindowsRuntimeObject.Impl.cs
+++ b/src/WinRT.Runtime2/WindowsRuntimeObject.Impl.cs
@@ -23,6 +23,11 @@ namespace WindowsRuntime;
 public unsafe partial class WindowsRuntimeObject
 {
     /// <summary>
+    /// The native object reference wrapped by the current instance.
+    /// </summary>
+    private readonly WindowsRuntimeObjectReference _nativeObjectReference;
+
+    /// <summary>
     /// The lazy-loaded, cached object reference for <c>IInspectable</c> for the current object.
     /// </summary>
     /// <remarks>
@@ -37,11 +42,6 @@ public unsafe partial class WindowsRuntimeObject
     /// The lazy-loaded cache of additional data associated to type handles.
     /// </summary>
     private volatile ConcurrentDictionary<RuntimeTypeHandle, object>? _typeHandleCache;
-
-    /// <summary>
-    /// The native object reference wrapped by the current instance.
-    /// </summary>
-    private readonly WindowsRuntimeObjectReference _nativeObjectReference;
 
     /// <summary>
     /// Creates a <see cref="WindowsRuntimeObject"/> instance with the specified parameters.
@@ -284,7 +284,11 @@ public unsafe partial class WindowsRuntimeObject
     /// This object reference should point to an <c>IInspectable</c> native object.
     /// </remarks>
     [WindowsRuntimeImplementationOnlyMember]
-    protected internal WindowsRuntimeObjectReference NativeObjectReference => _nativeObjectReference;
+    protected internal WindowsRuntimeObjectReference NativeObjectReference
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _nativeObjectReference;
+    }
 
     /// <summary>
     /// Gets a value indicating whether the current instance has an unwrappable native object reference.


### PR DESCRIPTION
Initialize the native object reference before ComWrappers registration so registration-time IReferenceTracker queries can be forwarded to the inner object.