### PR TITLE
Skip attributes referencing non-public types

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
+++ b/src/Authoring/WinRT.SourceGenerator/WinRTTypeWriter.cs
@@ -1708,7 +1708,10 @@ namespace Generator
             foreach (var attribute in attributes)
             {
                 var attributeType = attribute.AttributeClass;
-                if (attributeType.DeclaredAccessibility != Accessibility.Public)
+                if (!attributeType.IsPubliclyAccessible() ||
+                    attribute.AttributeConstructor?.DeclaredAccessibility != Accessibility.Public ||
+                    attribute.ConstructorArguments.Any(ReferencesNonPublicType) ||
+                    attribute.NamedArguments.Any(argument => ReferencesNonPublicType(argument.Value)))
                 {
                     continue;
                 }
@@ -1753,6 +1756,30 @@ namespace Generator
                     constructorReference.First(),
                     metadataBuilder.GetOrAddBlob(attributeSignature));
             }
+        }
+
+        private static bool ReferencesNonPublicType(TypedConstant constant)
+        {
+            if (constant.Kind == TypedConstantKind.Array)
+            {
+                return constant.Values.Any(ReferencesNonPublicType);
+            }
+
+            return constant.Kind == TypedConstantKind.Type &&
+                (constant.Value is not ITypeSymbol type || !IsPubliclyAccessibleType(type));
+        }
+
+        private static bool IsPubliclyAccessibleType(ITypeSymbol type)
+        {
+            return type switch
+            {
+                IArrayTypeSymbol arrayType => IsPubliclyAccessibleType(arrayType.ElementType),
+                IPointerTypeSymbol => false,
+                IErrorTypeSymbol => false,
+                INamedTypeSymbol namedType => namedType.IsPubliclyAccessible() &&
+                    namedType.TypeArguments.All(IsPubliclyAccessibleType),
+                _ => type.IsPubliclyAccessible()
+            };
         }
 
         public override void VisitEnumDeclaration(EnumDeclarationSyntax node)

--- a/src/Tests/AuthoringTest/Program.cs
+++ b/src/Tests/AuthoringTest/Program.cs
@@ -55,6 +55,7 @@ namespace AuthoringTest
     public delegate void DoubleDelegate(double value);
     internal delegate void PrivateDelegate(uint value);
 
+    [System.Diagnostics.DebuggerTypeProxy(typeof(NonProjectedDisposableClass))]
     public sealed class BasicClass
     {
         private BasicEnum basicEnum = BasicEnum.First;


### PR DESCRIPTION
We project attributes into the WinMD even when they are not WinRT attributes.  But if they reference internal types, we shouldn't project them as they won't be accessible in the WinMD.

Fixes #2543 