### PR TITLE
Only emit namespace additions backed by the input metadata

### DIFF
--- a/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
+++ b/src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs
@@ -261,9 +261,22 @@ internal sealed partial class ProjectionGenerator
         _token.ThrowIfCancellationRequested();
         if (_settings.AdditionFilter.Includes(ns))
         {
-            foreach (string resName in Additions.EnumerateByNamespace(ns))
+            foreach (Addition addition in Additions.EnumerateByNamespace(ns))
             {
-                using Stream? stream = typeof(ProjectionWriter).Assembly.GetManifestResourceStream(resName);
+                // Additions are hand-written companions to types that come from the projected
+                // metadata: they either augment one (eg. 'partial struct Thickness') or replace a
+                // custom-mapped one while still being written against its metadata-only siblings
+                // (eg. 'Duration', which has a field of type 'DurationType'). Namespaces are not
+                // owned by a single metadata source though: WinUI 2 reuses 'Microsoft.UI.Xaml' but
+                // declares only 'XamlContract' in it, so emitting the additions there would produce
+                // types referencing enums that don't exist. Skip any addition whose metadata types
+                // are absent from the input metadata.
+                if (!IsAdditionSupportedByMetadata(addition))
+                {
+                    continue;
+                }
+
+                using Stream? stream = typeof(ProjectionWriter).Assembly.GetManifestResourceStream(addition.ResourceName);
 
                 if (stream is null)
                 {
@@ -280,6 +293,25 @@ internal sealed partial class ProjectionGenerator
         string filename = ns + ".cs";
         string fullPath = Path.Combine(_settings.OutputFolder, filename);
         writer.FlushToFile(fullPath);
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether all the Windows Runtime types a namespace addition is defined in terms of are
+    /// declared by the projected metadata.
+    /// </summary>
+    /// <param name="addition">The addition to check.</param>
+    /// <returns>Whether <paramref name="addition"/> can be emitted.</returns>
+    private bool IsAdditionSupportedByMetadata(in Addition addition)
+    {
+        foreach (string requiredType in addition.RequiredTypes)
+        {
+            if (_cache.Find(requiredType) is null)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 }

--- a/src/WinRT.Projection.Writer/Helpers/Additions.cs
+++ b/src/WinRT.Projection.Writer/Helpers/Additions.cs
@@ -1,10 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 
 namespace WindowsRuntime.ProjectionWriter.Helpers;
+
+/// <summary>
+/// A namespace addition: the content of a <c>.cs</c> file that gets appended to the projection of a
+/// namespace, together with the Windows Runtime types it is defined in terms of.
+/// </summary>
+/// <param name="ResourceName">
+/// The embedded-resource manifest name of the addition, as resolved by a
+/// <see cref="System.Reflection.Assembly.GetManifestResourceStream(string)"/> call.
+/// </param>
+/// <param name="RequiredTypes">
+/// The full names of the Windows Runtime types the addition is defined in terms of, either because
+/// it augments them (eg. <c>partial struct Thickness</c>) or because it is written against them
+/// (eg. <c>Duration</c>, which has a field of the metadata-only <c>DurationType</c> enum). The
+/// addition is only emitted when the projected metadata declares all of them.
+/// </param>
+internal readonly record struct Addition(string ResourceName, string[] RequiredTypes);
 
 /// <summary>
 /// Registry of namespace addition files.
@@ -14,87 +31,139 @@ namespace WindowsRuntime.ProjectionWriter.Helpers;
 internal static class Additions
 {
     /// <summary>
-    /// Lookup of the embedded-resource manifest names for a given target namespace, in the
-    /// order they should be appended to the projection of that namespace. Each manifest name
-    /// resolves to a <see cref="System.Reflection.Assembly.GetManifestResourceStream(string)"/>
-    /// call.
+    /// Lookup of the additions registered for a given target namespace, in the order they should be
+    /// appended to the projection of that namespace.
     /// </summary>
-    private static readonly FrozenDictionary<string, string[]> ByNamespace = new Dictionary<string, string[]>
+    /// <remarks>
+    /// A namespace is not owned by a single metadata source: WinUI 2 for instance reuses the
+    /// <c>Microsoft.UI.Xaml</c> namespace but declares none of the XAML value types in it. That is
+    /// why each addition also declares the metadata types it needs (see
+    /// <see cref="Addition.RequiredTypes"/>), rather than keying off the namespace name alone.
+    /// </remarks>
+    private static readonly FrozenDictionary<string, Addition[]> ByNamespace = new Dictionary<string, Addition[]>
     {
         ["Microsoft.UI.Dispatching"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Dispatching.Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Dispatching.Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext.cs",
+                ["Microsoft.UI.Dispatching.DispatcherQueue"]),
         ],
         ["Microsoft.UI.Xaml"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.CornerRadius.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.Duration.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.GridLength.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.SR.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.Thickness.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.CornerRadius.cs",
+                ["Microsoft.UI.Xaml.CornerRadius"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.Duration.cs",
+                ["Microsoft.UI.Xaml.Duration", "Microsoft.UI.Xaml.DurationType"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.GridLength.cs",
+                ["Microsoft.UI.Xaml.GridLength", "Microsoft.UI.Xaml.GridUnitType"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.SR.cs",
+                ["Microsoft.UI.Xaml.CornerRadius", "Microsoft.UI.Xaml.GridLength"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Microsoft.UI.Xaml.Thickness.cs",
+                ["Microsoft.UI.Xaml.Thickness"]),
         ],
         ["Microsoft.UI.Xaml.Controls.Primitives"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Controls.Primitives.Microsoft.UI.Xaml.Controls.Primitives.GeneratorPosition.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Controls.Primitives.Microsoft.UI.Xaml.Controls.Primitives.GeneratorPosition.cs",
+                ["Microsoft.UI.Xaml.Controls.Primitives.GeneratorPosition"]),
         ],
         ["Microsoft.UI.Xaml.Media"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Microsoft.UI.Xaml.Media.Matrix.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Microsoft.UI.Xaml.Media.Matrix.cs",
+                ["Microsoft.UI.Xaml.Media.Matrix"]),
         ],
         ["Microsoft.UI.Xaml.Media.Animation"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Animation.Microsoft.UI.Xaml.Media.Animation.KeyTime.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Animation.Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Animation.Microsoft.UI.Xaml.Media.Animation.KeyTime.cs",
+                ["Microsoft.UI.Xaml.Media.Animation.KeyTime"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Animation.Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.cs",
+                ["Microsoft.UI.Xaml.Media.Animation.RepeatBehavior", "Microsoft.UI.Xaml.Media.Animation.RepeatBehaviorType"]),
         ],
         ["Microsoft.UI.Xaml.Media.Media3D"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Media3D.Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Microsoft.UI.Xaml.Media.Media3D.Microsoft.UI.Xaml.Media.Media3D.Matrix3D.cs",
+                ["Microsoft.UI.Xaml.Media.Media3D.Matrix3D"]),
         ],
         ["Windows.Storage"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.Storage.WindowsRuntimeStorageExtensions.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.Storage.WindowsRuntimeStorageExtensions.cs",
+                ["Windows.Storage.IStorageFile", "Windows.Storage.IStorageFolder"]),
         ],
         ["Windows.UI"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Windows.UI.Color.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Windows.UI.Color.cs",
+                ["Windows.UI.Color"]),
         ],
         ["Windows.UI.Xaml"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.System.DispatcherQueueSynchronizationContext.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.CornerRadius.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.Duration.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.GridLength.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.SR.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.Thickness.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.System.DispatcherQueueSynchronizationContext.cs",
+                ["Windows.System.DispatcherQueue"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.CornerRadius.cs",
+                ["Windows.UI.Xaml.CornerRadius"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.Duration.cs",
+                ["Windows.UI.Xaml.Duration", "Windows.UI.Xaml.DurationType"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.GridLength.cs",
+                ["Windows.UI.Xaml.GridLength", "Windows.UI.Xaml.GridUnitType"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.SR.cs",
+                ["Windows.UI.Xaml.CornerRadius", "Windows.UI.Xaml.GridLength"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Windows.UI.Xaml.Thickness.cs",
+                ["Windows.UI.Xaml.Thickness"]),
         ],
         ["Windows.UI.Xaml.Controls.Primitives"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Controls.Primitives.Windows.UI.Xaml.Controls.Primitives.GeneratorPosition.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Controls.Primitives.Windows.UI.Xaml.Controls.Primitives.GeneratorPosition.cs",
+                ["Windows.UI.Xaml.Controls.Primitives.GeneratorPosition"]),
         ],
         ["Windows.UI.Xaml.Media"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Windows.UI.Xaml.Media.Matrix.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Windows.UI.Xaml.Media.Matrix.cs",
+                ["Windows.UI.Xaml.Media.Matrix"]),
         ],
         ["Windows.UI.Xaml.Media.Animation"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Animation.Windows.UI.Xaml.Media.Animation.KeyTime.cs",
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Animation.Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Animation.Windows.UI.Xaml.Media.Animation.KeyTime.cs",
+                ["Windows.UI.Xaml.Media.Animation.KeyTime"]),
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Animation.Windows.UI.Xaml.Media.Animation.RepeatBehavior.cs",
+                ["Windows.UI.Xaml.Media.Animation.RepeatBehavior", "Windows.UI.Xaml.Media.Animation.RepeatBehaviorType"]),
         ],
         ["Windows.UI.Xaml.Media.Media3D"] =
         [
-            "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Media3D.Windows.UI.Xaml.Media.Media3D.Matrix3D.cs",
+            new(
+                "WindowsRuntime.ProjectionWriter.Resources.Additions.Windows.UI.Xaml.Media.Media3D.Windows.UI.Xaml.Media.Media3D.Matrix3D.cs",
+                ["Windows.UI.Xaml.Media.Media3D.Matrix3D"]),
         ],
     }.ToFrozenDictionary();
 
     /// <summary>
-    /// Enumerates the embedded-resource manifest names registered for the given target namespace,
-    /// in the order they should be appended to the projection of that namespace. Returns an empty
-    /// sequence when no additions are registered for <paramref name="ns"/>.
+    /// Enumerates the additions registered for the given target namespace, in the order they should
+    /// be appended to the projection of that namespace. Returns an empty span when no additions are
+    /// registered for <paramref name="ns"/>.
     /// </summary>
     /// <param name="ns">The target namespace.</param>
-    /// <returns>The manifest resource names; an empty sequence if none.</returns>
-    public static IEnumerable<string> EnumerateByNamespace(string ns)
+    /// <returns>The registered additions; an empty span if none.</returns>
+    public static ReadOnlySpan<Addition> EnumerateByNamespace(string ns)
     {
-        return ByNamespace.TryGetValue(ns, out string[]? resourceNames) ? resourceNames : [];
+        return ByNamespace.TryGetValue(ns, out Addition[]? additions) ? additions : [];
     }
 }


### PR DESCRIPTION
## Summary

Namespace additions in the projection writer are now only emitted when the input metadata actually declares the Windows Runtime types they are written against. This fixes generating a projection for WinUI 2 (`Microsoft.UI.Xaml` 2.8.x), which today produces C# that does not compile.

## Motivation

The projection writer appends hand-written `.cs` additions to the projection of a namespace. Some of them augment a type that comes from metadata (`partial struct Thickness`, `partial struct Matrix`, `partial struct Color`), and some replace a custom-mapped type but are still written in terms of its metadata-only siblings (`Duration` has a field of type `DurationType`, `GridLength` has one of type `GridUnitType`).

Until now the decision to emit an addition was keyed purely on the namespace name. That assumes a namespace is owned by a single metadata source, which is not true: WinUI 2 reuses the `Microsoft.UI.Xaml` namespace, but its `.winmd` declares only `XamlContract` there. The additions were therefore emitted into a projection where none of the types they depend on exist, and the generated `Microsoft.UI.Xaml.cs` failed to compile with four `CS0246` errors for `DurationType` and `GridUnitType`. The same root cause also left `Microsoft.UI.Xaml.Thickness` and `Microsoft.UI.Xaml.Media.Matrix` emitted as `partial struct` declarations with no declaring part, which silently dropped them from the public surface. This blocks projecting WinUI 2 against CsWinRT 3.0, and was hit while prototyping the Microsoft Store client on CsWinRT 3.0.

Restoring the CsWinRT 2.x behavior was considered and rejected: 2.x emitted the full set of six types into `Microsoft.UI.Xaml`, but nothing in the WinUI 2 API surface binds to them — it binds to the real `Windows.UI.Xaml.*` types — so they were unreferenced duplicates. Making the additions metadata-driven instead is both smaller and more general: it fixes `Matrix` in the same pass, and any future occurrence of the same shape, rather than special-casing the XAML value types or gating on `CsWinRTUseWindowsUIXamlProjections`.

Generated output was verified to be byte-identical for the three shipping projections (Windows SDK, 301 files; UWP XAML SDK, 30 files; WinAppSDK/WinUI 3, 72 files), so the only behavioral change is the WinUI 2 case, where `Microsoft.UI.Xaml.cs` goes from 592 lines to 39 and the reproduction project now builds clean with no source workaround.

## Changes

- **`src/WinRT.Projection.Writer/Helpers/Additions.cs`**: added an `Addition` record pairing an addition's embedded-resource manifest name with the full names of the Windows Runtime types it is defined in terms of, and changed the registry from `namespace -> string[]` to `namespace -> Addition[]`. Every registered addition now declares its required types (for example `Duration` requires both `Duration` and `DurationType`, and the shared `SR` helper requires `CornerRadius` and `GridLength`, its only two consumers). `EnumerateByNamespace` now returns a `ReadOnlySpan<Addition>`.

- **`src/WinRT.Projection.Writer/Generation/ProjectionGenerator.Namespace.cs`**: phase 4 now skips any addition whose required types are absent from the metadata cache, through a new `IsAdditionSupportedByMetadata` helper.
