### PR TITLE
Qualify System types in CsWinRT 2.x polyfill

### DIFF
--- a/nuget/Microsoft.Windows.CsWinRT.CsWinRT2Polyfills.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.CsWinRT2Polyfills.targets
@@ -56,7 +56,10 @@ namespace WinRT
     /// This in turns ensures that the necessary metadata is kept during trimming so that the cast can work correctly in all scenarios.
     /// </summary>
     /// <seealso cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/>
-    [global::System.AttributeUsage(global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Field,
+        AllowMultiple = true,
+        Inherited = false)]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::Microsoft.CodeAnalysis.Embedded]
     [global::System.Diagnostics.Conditional("CSWINRT2_0_POLYFILL_ATTRIBUTES")]

--- a/nuget/Microsoft.Windows.CsWinRT.CsWinRT2Polyfills.targets
+++ b/nuget/Microsoft.Windows.CsWinRT.CsWinRT2Polyfills.targets
@@ -55,18 +55,18 @@ namespace WinRT
     /// An attribute that indicates that the annotated member or field (initializer) is performing a dynamic cast to a Windows Runtime type.
     /// This in turns ensures that the necessary metadata is kept during trimming so that the cast can work correctly in all scenarios.
     /// </summary>
-    /// <seealso cref="DynamicDependencyAttribute"/>
-    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    /// <seealso cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/>
+    [global::System.AttributeUsage(global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::Microsoft.CodeAnalysis.Embedded]
     [global::System.Diagnostics.Conditional("CSWINRT2_0_POLYFILL_ATTRIBUTES")]
-    internal sealed class DynamicWindowsRuntimeCastAttribute : Attribute
+    internal sealed class DynamicWindowsRuntimeCastAttribute : global::System.Attribute
     {
         /// <summary>
         /// Creates a new <see cref="DynamicWindowsRuntimeCastAttribute"/> instance with the specified parameters.
         /// </summary>
         /// <param name="type">The Windows Runtime type being used for the cast.</param>
-        public DynamicWindowsRuntimeCastAttribute(Type type)
+        public DynamicWindowsRuntimeCastAttribute(global::System.Type type)
         {
         }
     }


### PR DESCRIPTION
## Summary

Fully qualify the `System` types emitted by the CsWinRT 2.x polyfill target so the generated source compiles without consumer-provided global usings.

## Motivation

The generated `DynamicWindowsRuntimeCastAttribute` currently relies on `System` being imported by the consuming project. Projects that disable implicit usings fail to compile the supported polyfill with unresolved `AttributeUsage`, `AttributeTargets`, `Attribute`, and `Type` symbols.

## Changes

- **`nuget/Microsoft.Windows.CsWinRT.CsWinRT2Polyfills.targets`**: Emit global qualifications for all framework types referenced by `DynamicWindowsRuntimeCastAttribute`, including its documentation reference.