### PR TITLE
Validate IInspectable in WindowsRuntimeMarshal.ConvertToManaged

### DIFF
--- a/src/Tests/UnitTest/ComWrappersTests.cs
+++ b/src/Tests/UnitTest/ComWrappersTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -17,6 +18,183 @@ namespace UnitTest;
 [TestClass]
 public unsafe class ComWrappersTests
 {
+    [TestMethod]
+    public void TestConvertToManagedNullReturnsNull()
+    {
+        Assert.IsNull(WindowsRuntimeMarshal.ConvertToManaged(null));
+    }
+
+    [TestMethod]
+    public void TestConvertToManagedManagedObjectReturnsOriginal()
+    {
+        object original = new();
+        void* target = WindowsRuntimeMarshal.ConvertToUnmanaged(original);
+
+        try
+        {
+            Assert.AreSame(original, WindowsRuntimeMarshal.ConvertToManaged(target));
+        }
+        finally
+        {
+            WindowsRuntimeMarshal.Free(target);
+        }
+    }
+
+    [TestMethod]
+    public void TestConvertToManagedManagedIUnknownWithoutIInspectableReturnsOriginal()
+    {
+        object original = new();
+        IUnknownOnlyComWrappers comWrappers = new();
+        nint target = comWrappers.GetOrCreateComInterfaceForObject(original, CreateComInterfaceFlags.None);
+        Guid iid = new("AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90");
+        nint inspectable = 0;
+
+        try
+        {
+            Assert.AreEqual(unchecked((int)0x80004002), Marshal.QueryInterface(target, in iid, out inspectable));
+            Assert.AreSame(original, WindowsRuntimeMarshal.ConvertToManaged((void*)target));
+        }
+        finally
+        {
+            WindowsRuntimeMarshal.Free((void*)inspectable);
+            WindowsRuntimeMarshal.Free((void*)target);
+            GC.KeepAlive(comWrappers);
+        }
+    }
+
+    [TestMethod]
+    public void TestConvertToManagedNativeIUnknownWithoutIInspectableThrowsArgumentException()
+    {
+        void* target = FakeInspectable.Create(nested: null, inspectableQueryHResult: unchecked((int)0x80004002));
+        void* unknown = FakeInspectable.GetIUnknown(target);
+
+        try
+        {
+            ArgumentException exception = Assert.ThrowsExactly<ArgumentException>(() => WindowsRuntimeMarshal.ConvertToManaged(unknown));
+
+            Assert.AreEqual(0, FakeInspectable.GetInvalidInspectableCallCount(target), "An IUnknown-only object must never be used as an IInspectable.");
+            Assert.AreEqual("value", exception.ParamName);
+            StringAssert.Contains(exception.Message, "IInspectable");
+            Assert.AreEqual(1, FakeInspectable.GetInspectableQueryCount(target));
+            Assert.AreEqual(1, FakeInspectable.GetReferenceCount(target));
+        }
+        finally
+        {
+            FakeInspectable.Release(target);
+        }
+    }
+
+    [TestMethod]
+    public void TestConvertToManagedPropagatesQueryInterfaceFailure()
+    {
+        void* target = FakeInspectable.Create(nested: null, inspectableQueryHResult: unchecked((int)0x80070005));
+
+        try
+        {
+            UnauthorizedAccessException exception = Assert.ThrowsExactly<UnauthorizedAccessException>(() => WindowsRuntimeMarshal.ConvertToManaged(target));
+
+            Assert.AreEqual(unchecked((int)0x80070005), exception.HResult);
+            Assert.AreEqual(1, FakeInspectable.GetReferenceCount(target));
+        }
+        finally
+        {
+            FakeInspectable.Release(target);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void TestConvertToManagedNativeObjectPreservesIdentityAndReferences(bool useIUnknown)
+    {
+        void* target = FakeInspectable.Create(nested: null);
+        void* unknown = FakeInspectable.GetIUnknown(target);
+        void* input = useIUnknown ? unknown : target;
+
+        try
+        {
+            Assert.AreNotEqual((nint)target, (nint)unknown);
+
+            object wrapper = WindowsRuntimeMarshal.ConvertToManaged(input);
+
+            Assert.IsNotNull(wrapper);
+            Assert.AreEqual(0, FakeInspectable.GetInvalidInspectableCallCount(target));
+
+            int referenceCount = FakeInspectable.GetReferenceCount(target);
+            int queryCount = FakeInspectable.GetInspectableQueryCount(target);
+
+            // Cache hits still validate public inputs, but must release the temporary QI reference
+            Assert.AreSame(wrapper, WindowsRuntimeMarshal.ConvertToManaged(unknown));
+            Assert.AreSame(wrapper, WindowsRuntimeMarshal.ConvertToManaged(target));
+            Assert.AreEqual(queryCount + 2, FakeInspectable.GetInspectableQueryCount(target));
+            Assert.AreEqual(referenceCount, FakeInspectable.GetReferenceCount(target));
+
+            void* roundTrip = WindowsRuntimeMarshal.ConvertToUnmanaged(wrapper);
+
+            try
+            {
+                Assert.AreEqual((nint)target, (nint)roundTrip);
+            }
+            finally
+            {
+                WindowsRuntimeMarshal.Free(roundTrip);
+            }
+
+            Assert.AreEqual(referenceCount, FakeInspectable.GetReferenceCount(target));
+            GC.KeepAlive(wrapper);
+        }
+        finally
+        {
+            FakeInspectable.Release(target);
+        }
+    }
+
+    [TestMethod]
+    public void TestConvertToManagedReleasesInspectableWhenWrapperCreationThrows()
+    {
+        // Let the public QI succeed, then fail the QI performed while constructing the object reference
+        void* target = FakeInspectable.Create(
+            nested: null,
+            inspectableQueryHResult: unchecked((int)0x80004002),
+            successfulInspectableQueriesBeforeFailure: 1);
+
+        try
+        {
+            Assert.ThrowsExactly<InvalidCastException>(() => WindowsRuntimeMarshal.ConvertToManaged(target));
+            Assert.AreEqual(2, FakeInspectable.GetInspectableQueryCount(target));
+            Assert.AreEqual(1, FakeInspectable.GetReferenceCount(target));
+        }
+        finally
+        {
+            FakeInspectable.Release(target);
+        }
+    }
+
+    [TestMethod]
+    public void TestInternalConvertToManagedDoesNotValidateInspectable()
+    {
+        void* target = FakeInspectable.Create(nested: null);
+
+        try
+        {
+            object wrapper = WindowsRuntimeObjectMarshaller.ConvertToManaged(target);
+
+            Assert.IsNotNull(wrapper);
+
+            int referenceCount = FakeInspectable.GetReferenceCount(target);
+            int queryCount = FakeInspectable.GetInspectableQueryCount(target);
+
+            Assert.AreSame(wrapper, WindowsRuntimeObjectMarshaller.ConvertToManaged(target));
+            Assert.AreEqual(queryCount, FakeInspectable.GetInspectableQueryCount(target));
+            Assert.AreEqual(referenceCount, FakeInspectable.GetReferenceCount(target));
+            GC.KeepAlive(wrapper);
+        }
+        finally
+        {
+            FakeInspectable.Release(target);
+        }
+    }
+
     // Marshalling a native object to managed goes through 'WindowsRuntimeComWrappers.CreateObject', which is
     // handed an interface pointer that the caller owns. Some marshallers additionally marshal nested objects
     // while they run, which re-enters the marshalling infrastructure on the same thread.
@@ -82,6 +260,26 @@ public unsafe class ComWrappersTests
     }
 }
 
+file sealed unsafe class IUnknownOnlyComWrappers : ComWrappers
+{
+    protected override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
+    {
+        count = 0;
+
+        return null;
+    }
+
+    protected override object CreateObject(nint externalComObject, CreateObjectFlags flags)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected override void ReleaseObjects(IEnumerable objects)
+    {
+        throw new NotSupportedException();
+    }
+}
+
 /// <summary>
 /// A minimal native <c>IInspectable</c> object with a hand-written vtable, used to observe reference counts
 /// and to control what happens while <c>ComWrappers</c> is creating a wrapper for it.
@@ -97,27 +295,58 @@ file static unsafe class FakeInspectable
 
     /// <summary>The shared vtable for all instances (allocated once, never freed).</summary>
     private static readonly void** Vftbl = CreateVftbl();
+    private static readonly void** UnknownVftbl = CreateUnknownVftbl();
+
+    private struct UnknownInterface
+    {
+        public void** Vftbl;
+        public Instance* Owner;
+    }
 
     /// <summary>The instance state, laid out so that the vtable pointer comes first (as COM requires).</summary>
     private struct Instance
     {
         public void** Vftbl;
+        public UnknownInterface Unknown;
         public int ReferenceCount;
+        public int InspectableQueryHResult;
+        public int SuccessfulInspectableQueriesBeforeFailure;
+        public int InspectableQueryCount;
+        public int InvalidInspectableCallCount;
 
         /// <summary>An object to marshal from <c>GetRuntimeClassName</c>, to force a re-entrant marshalling operation.</summary>
         public nint Nested;
     }
 
     /// <summary>Creates a new instance with a reference count of 1.</summary>
-    public static void* Create(void* nested)
+    public static void* Create(void* nested, int inspectableQueryHResult = 0, int successfulInspectableQueriesBeforeFailure = 0)
     {
         Instance* instance = (Instance*)NativeMemory.AllocZeroed((nuint)sizeof(Instance));
 
         instance->Vftbl = Vftbl;
+        instance->Unknown.Vftbl = UnknownVftbl;
+        instance->Unknown.Owner = instance;
         instance->ReferenceCount = 1;
+        instance->InspectableQueryHResult = inspectableQueryHResult;
+        instance->SuccessfulInspectableQueriesBeforeFailure = successfulInspectableQueriesBeforeFailure;
         instance->Nested = (nint)nested;
 
         return instance;
+    }
+
+    public static void* GetIUnknown(void* thisPtr)
+    {
+        return &((Instance*)thisPtr)->Unknown;
+    }
+
+    public static int GetInspectableQueryCount(void* thisPtr)
+    {
+        return Volatile.Read(ref ((Instance*)thisPtr)->InspectableQueryCount);
+    }
+
+    public static int GetInvalidInspectableCallCount(void* thisPtr)
+    {
+        return Volatile.Read(ref ((Instance*)thisPtr)->InvalidInspectableCallCount);
     }
 
     /// <summary>Gets the current reference count of a given instance.</summary>
@@ -146,6 +375,20 @@ file static unsafe class FakeInspectable
         return vftbl;
     }
 
+    private static void** CreateUnknownVftbl()
+    {
+        // Pad the IUnknown vtable with a trap so a regression fails an assertion rather than crashing
+        // the test host by calling past the three valid slots. This does not expose IInspectable.
+        void** vftbl = (void**)NativeMemory.AllocZeroed(6, (nuint)sizeof(void*));
+
+        vftbl[0] = (delegate* unmanaged[MemberFunction]<void*, Guid*, void**, int>)&QueryInterfaceUnknown;
+        vftbl[1] = (delegate* unmanaged[MemberFunction]<void*, uint>)&AddRefUnknown;
+        vftbl[2] = (delegate* unmanaged[MemberFunction]<void*, uint>)&ReleaseUnknown;
+        vftbl[4] = (delegate* unmanaged[MemberFunction]<void*, void**, int>)&InvalidGetRuntimeClassName;
+
+        return vftbl;
+    }
+
     private static uint AddRefCore(Instance* instance)
     {
         return (uint)Interlocked.Increment(ref instance->ReferenceCount);
@@ -166,20 +409,68 @@ file static unsafe class FakeInspectable
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
     private static int QueryInterface(void* thisPtr, Guid* iid, void** ppvObject)
     {
+        return QueryInterfaceCore((Instance*)thisPtr, iid, ppvObject);
+    }
+
+    private static int QueryInterfaceCore(Instance* instance, Guid* iid, void** ppvObject)
+    {
+        *ppvObject = null;
+
         // Respond to 'IAgileObject' as well, so that the object is treated as free-threaded. This keeps the
         // marshalling path deterministic, and independent of the COM apartment the test happens to run on.
-        if (*iid == IID_IUnknown || *iid == IID_IInspectable || *iid == IID_IAgileObject)
+        if (*iid == IID_IUnknown || *iid == IID_IAgileObject)
         {
-            _ = AddRefCore((Instance*)thisPtr);
+            _ = AddRefCore(instance);
 
-            *ppvObject = thisPtr;
+            *ppvObject = &instance->Unknown;
 
             return 0; // S_OK
         }
 
-        *ppvObject = null;
+        if (*iid == IID_IInspectable)
+        {
+            int queryCount = Interlocked.Increment(ref instance->InspectableQueryCount);
+
+            if (instance->InspectableQueryHResult < 0 && queryCount > instance->SuccessfulInspectableQueriesBeforeFailure)
+            {
+                return instance->InspectableQueryHResult;
+            }
+
+            _ = AddRefCore(instance);
+
+            *ppvObject = instance;
+
+            return 0; // S_OK
+        }
 
         return unchecked((int)0x80004002); // E_NOINTERFACE
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int QueryInterfaceUnknown(void* thisPtr, Guid* iid, void** ppvObject)
+    {
+        return QueryInterfaceCore(((UnknownInterface*)thisPtr)->Owner, iid, ppvObject);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static uint AddRefUnknown(void* thisPtr)
+    {
+        return AddRefCore(((UnknownInterface*)thisPtr)->Owner);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static uint ReleaseUnknown(void* thisPtr)
+    {
+        return ReleaseCore(((UnknownInterface*)thisPtr)->Owner);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
+    private static int InvalidGetRuntimeClassName(void* thisPtr, void** className)
+    {
+        _ = Interlocked.Increment(ref ((UnknownInterface*)thisPtr)->Owner->InvalidInspectableCallCount);
+        *className = null;
+
+        return unchecked((int)0x80004001); // E_NOTIMPL
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
@@ -194,6 +194,8 @@ public static unsafe class WindowsRuntimeMarshal
 
         hresult.Assert();
 
+        // Use the queried 'IInspectable' pointer for conversion: the original pointer may refer to a
+        // different interface with an incompatible vtable, even if the object implements 'IInspectable'.
         try
         {
             return WindowsRuntimeObjectMarshaller.ConvertToManaged(inspectablePtr);

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -146,18 +147,61 @@ public static unsafe class WindowsRuntimeMarshal
     }
 
     /// <summary>
-    /// Converts an unmanaged pointer to a Windows Runtime object to a managed object, either by unwrapping the
+    /// Converts an unmanaged pointer to a COM object to a managed object, either by unwrapping the
     /// original managed object that was previously marshalled, or retrieving or creating an RCW for it.
     /// </summary>
-    /// <param name="value">The input object to convert to managed.</param>
-    /// <returns>The resulting managed managed object.</returns>
+    /// <param name="value">A valid COM interface pointer to the input object, or <see langword="null"/>.</param>
+    /// <returns>The resulting managed object, or <see langword="null"/> if <paramref name="value"/> is <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is not a recognized managed CCW and does not implement <c>IInspectable</c>.</exception>
+    /// <remarks>
+    /// Native objects must implement <c>IInspectable</c>, which is queried before creating or retrieving an RCW.
+    /// This method does not take ownership of the input pointer: the caller remains responsible for releasing it.
+    /// </remarks>
     /// <seealso cref="System.Runtime.InteropServices.Marshalling.ComInterfaceMarshaller{T}.ConvertToManaged"/>
     public static object? ConvertToManaged(void* value)
     {
 #if WINDOWS_RUNTIME_REFERENCE_ASSEMBLY
         throw null;
 #elif WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY
-        return WindowsRuntimeObjectMarshaller.ConvertToManaged(value);
+        if (value is null)
+        {
+            return null;
+        }
+
+        // Unwrap recognized managed CCWs before requiring 'IInspectable', which they might not implement
+        if (TryGetManagedObject(value, out object? managedObject))
+        {
+            return managedObject;
+        }
+
+        // Only the public API accepts arbitrary COM interface pointers. Internal marshallers already
+        // receive the correct interface pointer and must not pay for this extra 'QueryInterface' call.
+        HRESULT hresult = IUnknownVftbl.QueryInterfaceUnsafe(value, in WellKnownWindowsInterfaceIIDs.IID_IInspectable, out void* inspectablePtr);
+
+        if (hresult == WellKnownErrorCodes.E_NOINTERFACE)
+        {
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowArgumentException()
+            {
+                throw new ArgumentException(
+                    "The native COM object cannot be converted to a managed Windows Runtime object " +
+                    "because it does not implement 'IInspectable'.", nameof(value));
+            }
+
+            ThrowArgumentException();
+        }
+
+        hresult.Assert();
+
+        try
+        {
+            return WindowsRuntimeObjectMarshaller.ConvertToManaged(inspectablePtr);
+        }
+        finally
+        {
+            _ = IUnknownVftbl.ReleaseUnsafe(inspectablePtr);
+        }
 #endif
     }
 


### PR DESCRIPTION
## Summary

Validate native COM pointers passed to `WindowsRuntimeMarshal.ConvertToManaged` before treating them as `IInspectable`. Throw a descriptive `ArgumentException` identifying the `value` parameter when the object does not implement `IInspectable`, instead of invoking an invalid vtable slot.

## Motivation

The public API previously forwarded arbitrary COM interface pointers to an internal marshaller that assumes an `IInspectable`-compatible vtable. An `IUnknown`-only object could crash the process, and even an object implementing `IInspectable` could be unsafe when passed through a different interface pointer.

## Changes

- **`src/WinRT.Runtime2/InteropServices/WindowsRuntimeMarshal.cs`**: query `IInspectable` only at the public API boundary, use the returned interface pointer, and release the temporary reference on both success and failure. Preserve null handling and recognized managed CCW round trips, propagate other query failures, document ownership and exceptions, and isolate exception construction in the existing annotated local throw-helper pattern.
- **`src/Tests/UnitTest/ComWrappersTests.cs`**: add coverage for nulls, managed CCWs (including COM-only CCWs), unsupported native objects, adjusted interface pointers, cached RCW identity, reference balancing, query failures, and wrapper-creation failures. A padded test vtable detects the original invalid call without crashing the test host.
- Leave internal runtime marshallers, generated projections, and interop-generator output unchanged; include coverage that the internal conversion path does not incur the public validation query.

The runtime fix and test coverage are grouped into separate commits.
