### PR TITLE
Fix exception marshalling for generated COM interfaces

### DIFF
--- a/src/Tests/UnitTest/ComGenerationTests.cs
+++ b/src/Tests/UnitTest/ComGenerationTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using TestComponentCSharp;
+using WindowsRuntime.InteropServices;
+using WindowsRuntime.InteropServices.Marshalling;
 
 namespace UnitTest
 {
@@ -10,6 +12,35 @@ namespace UnitTest
     internal partial interface IComInteropGenerated
     {
         Int64 ReturnWindowHandle(IntPtr hwnd, Guid iid);
+    }
+
+    [GeneratedComInterface(Options = ComInterfaceOptions.ManagedObjectWrapper, ExceptionToUnmanagedMarshaller = typeof(RestrictedErrorInfoExceptionMarshaller))]
+    [Guid("09E1CDE3-76A5-4E01-B0EE-18D48860A55A")]
+    internal partial interface IExceptionMarshalling
+    {
+        void Invoke();
+    }
+
+    // A second view of the same COM interface exposes its HRESULT as a marshalled exception.
+    [GeneratedComInterface(Options = ComInterfaceOptions.ComObjectWrapper)]
+    [Guid("09E1CDE3-76A5-4E01-B0EE-18D48860A55A")]
+    internal partial interface IExceptionMarshallingPreserveSig
+    {
+        [PreserveSig]
+        [return: MarshalUsing(typeof(RestrictedErrorInfoExceptionMarshaller))]
+        Exception Invoke();
+    }
+
+    [GeneratedComClass]
+    internal sealed partial class ExceptionMarshalling(Exception exception) : IExceptionMarshalling
+    {
+        public void Invoke()
+        {
+            if (exception is not null)
+            {
+                throw exception;
+            }
+        }
     }
 
     [TestClass]
@@ -35,6 +66,65 @@ namespace UnitTest
                 var value = comInterop.ReturnWindowHandle(hwnd, IID_IComInterop);
                 var hwndValue = hwnd.ToInt32();
                 Assert.AreEqual(hwndValue, value);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public unsafe void TestRestrictedErrorInfoExceptionMarshaller_UnmanagedToManagedOut(bool throwException)
+        {
+            Exception expectedException = throwException ? new NotImplementedException("Generated COM exception") : null;
+            var instance = new ExceptionMarshalling(expectedException);
+            void* target = ComInterfaceMarshaller<IExceptionMarshalling>.ConvertToUnmanaged(instance);
+
+            try
+            {
+                UnitTestHelper.RoClearError();
+
+                int hresult = ((delegate* unmanaged[MemberFunction]<void*, int>)(*(void***)target)[3])(target);
+
+                Assert.AreEqual(expectedException?.HResult ?? 0, hresult);
+                Assert.AreSame(expectedException, RestrictedErrorInfo.GetExceptionForHR(hresult));
+            }
+            finally
+            {
+                ComInterfaceMarshaller<IExceptionMarshalling>.Free(target);
+                UnitTestHelper.RoClearError();
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public unsafe void TestRestrictedErrorInfoExceptionMarshaller_ManagedToUnmanagedOut(bool throwException)
+        {
+            Exception expectedException = throwException ? new NotImplementedException("Generated COM exception") : null;
+            var instance = new ExceptionMarshalling(expectedException);
+            void* target = ComInterfaceMarshaller<IExceptionMarshalling>.ConvertToUnmanaged(instance);
+
+            try
+            {
+                // Force an RCW instead of unwrapping the CCW, so the generated native-call stub is exercised.
+                object wrapper = UniqueComInterfaceMarshaller<IExceptionMarshallingPreserveSig>.ConvertToManaged(target);
+
+                try
+                {
+                    UnitTestHelper.RoClearError();
+
+                    Exception actualException = ((IExceptionMarshallingPreserveSig)wrapper).Invoke();
+
+                    Assert.AreSame(expectedException, actualException);
+                }
+                finally
+                {
+                    ((ComObject)wrapper).FinalRelease();
+                }
+            }
+            finally
+            {
+                ComInterfaceMarshaller<IExceptionMarshalling>.Free(target);
+                UnitTestHelper.RoClearError();
             }
         }
     }

--- a/src/WinRT.Runtime2/InteropServices/Marshalling/RestrictedErrorInfoExceptionMarshaller.cs
+++ b/src/WinRT.Runtime2/InteropServices/Marshalling/RestrictedErrorInfoExceptionMarshaller.cs
@@ -18,6 +18,7 @@ namespace WindowsRuntime.InteropServices.Marshalling;
 /// </remarks>
 /// <see href="https://learn.microsoft.com/windows/win32/api/restrictederrorinfo/nn-restrictederrorinfo-irestrictederrorinfo"/>.
 [CustomMarshaller(typeof(Exception), MarshalMode.ManagedToUnmanagedOut, typeof(RestrictedErrorInfoExceptionMarshaller))]
+[CustomMarshaller(typeof(Exception), MarshalMode.UnmanagedToManagedOut, typeof(RestrictedErrorInfoExceptionMarshaller))]
 public static class RestrictedErrorInfoExceptionMarshaller
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Add the missing `UnmanagedToManagedOut` annotation to `RestrictedErrorInfoExceptionMarshaller` so `[GeneratedComInterface]` can use it to marshal managed exceptions back to native callers.

## Motivation

The marshaller only registered `ManagedToUnmanagedOut`, so configuring it as `ExceptionToUnmanagedMarshaller` caused the .NET COM source generator to report `SYSLIB1051`. Existing exception tests did not exercise this marshaller through generated COM interfaces, leaving this configuration unsupported without regression coverage.

## Changes

- **`src\WinRT.Runtime2\InteropServices\Marshalling\RestrictedErrorInfoExceptionMarshaller.cs`**: register `UnmanagedToManagedOut` alongside the existing `ManagedToUnmanagedOut` mode.
- **`src\Tests\UnitTest\ComGenerationTests.cs`**: add generated COM interfaces and a managed implementation to cover both directions, including successful calls, HRESULT conversion, and preservation of the original exception. Force a unique RCW for the return-value case so the test crosses the generated COM boundary rather than unwrapping the managed object, and release COM references and thread error state after each case.