### PR TITLE
Fix WinRT.Host assembly probing boundary

### DIFF
--- a/src/Authoring/WinRT.Host/WinRT.Host.cpp
+++ b/src/Authoring/WinRT.Host/WinRT.Host.cpp
@@ -4,6 +4,7 @@
 #include "hostfxr_status.h"
 #include <filesystem>
 #include <sstream>
+#include <string_view>
 
 #undef GetObject  
 
@@ -269,6 +270,59 @@ std::wstring find_mapped_target_assembly(
     return target_assembly;
 }
 
+bool probe_for_target_file_with_suffix(
+    std::filesystem::path const& host_path,
+    std::wstring const& target_file,
+    wchar_t const* suffix,
+    std::vector<std::filesystem::path>& probe_paths,
+    std::filesystem::path& target_path)
+{
+    auto probe_path = host_path / (target_file + suffix);
+    if (std::find(probe_paths.begin(), probe_paths.end(), probe_path)
+        != probe_paths.end())
+    {
+        return false;
+    }
+
+    if (std::filesystem::exists(probe_path))
+    {
+        target_path = std::move(probe_path);
+        return true;
+    }
+
+    probe_paths.emplace_back(std::move(probe_path));
+    return false;
+}
+
+std::filesystem::path probe_for_target_file(
+    std::filesystem::path const& host_path,
+    std::wstring_view target_file,
+    std::vector<std::filesystem::path>& probe_paths)
+{
+    std::wstring candidate{target_file};
+
+    while (!candidate.empty())
+    {
+        std::filesystem::path target_path;
+        if (probe_for_target_file_with_suffix(
+                host_path, candidate, L".Server.dll", probe_paths, target_path)
+            || probe_for_target_file_with_suffix(
+                host_path, candidate, L".dll", probe_paths, target_path))
+        {
+            return target_path;
+        }
+
+        const auto count = candidate.rfind('.');
+        if (count == std::wstring::npos)
+        {
+            return {};
+        }
+        candidate.resize(count);
+    }
+
+    return {};
+}
+
 std::filesystem::path probe_for_target_assembly(
     std::filesystem::path const& host_module,
     winrt::hstring const& class_id)
@@ -276,69 +330,24 @@ std::filesystem::path probe_for_target_assembly(
     const auto host_file = host_module.filename();
     const auto host_path = host_module.parent_path();
 
-    std::filesystem::path target_path;
-    std::wstring target_file;
-
     std::vector<std::filesystem::path> probe_paths;
-
-    auto probe = [&](const wchar_t* suffix)
-    {
-        auto probe_path = host_path / (target_file + suffix);
-        if (std::find(probe_paths.begin(), probe_paths.end(), probe_path)
-            == probe_paths.end())
-        {
-            if (std::filesystem::exists(probe_path))
-            {
-                target_path = probe_path;
-                return true;
-            }
-            probe_paths.emplace_back(std::move(probe_path));
-        }
-        return false;
-    };
-
-    auto shorten_target_file = [&]()
-    {
-        const auto count = target_file.rfind('.');
-        if (count == std::wstring::npos)
-        {
-            target_file.clear();
-            return false;
-        }
-        target_file.resize(count);
-        return true;
-    };
-
-    auto probe_target = [&]()
-    {
-        while (true)
-        {
-            if (probe(L".Server.dll") || probe(L".dll"))
-            {
-                return true;
-            }
-            if (!shorten_target_file())
-            {
-                return false;
-            }
-        }
-    };
 
     // Probe for target assembly by host name, if renamed (most common)
     if (::CompareStringOrdinal(
         host_file.c_str(), -1, L"WinRT.Host.dll", -1, TRUE) != CSTR_EQUAL)
     {
         probe_paths.push_back(host_module);
-        target_file = host_file.stem().wstring();
-        if (probe_target())
+        auto const target_file = host_file.stem().wstring();
+        if (auto target_path = probe_for_target_file(host_path, target_file, probe_paths);
+            !target_path.empty())
         {
             return target_path;
         }
     }
 
     // Probe for target assembly by runtime class name (less common)
-    target_file = class_id.c_str();
-    if (probe_target())
+    if (auto target_path = probe_for_target_file(host_path, class_id.c_str(), probe_paths);
+        !target_path.empty())
     {
         return target_path;
     }

--- a/src/Authoring/WinRT.Host/WinRT.Host.cpp
+++ b/src/Authoring/WinRT.Host/WinRT.Host.cpp
@@ -273,13 +273,14 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
     auto host_path = host_module;
     host_path.remove_filename();
 
-    std::wstring target_path;
+    std::filesystem::path target_path;
+    std::wstring target_file;
 
-    std::vector<std::wstring> probe_paths;
+    std::vector<std::filesystem::path> probe_paths;
 
     auto probe = [&](const wchar_t* suffix)
     {
-        auto probe_path = target_path + suffix;
+        auto probe_path = host_path / (target_file + suffix);
         auto end = probe_paths.end();
         if (std::find(probe_paths.begin(), end, probe_path) == end)
         {
@@ -292,16 +293,15 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
         }
         return false;
     };
-
     auto shorten_target_path = [&]()
     {
-        std::size_t count = target_path.rfind('.');
+        std::size_t count = target_file.rfind('.');
         if (count == std::wstring::npos)
         {
-            target_path.clear();
+            target_file.clear();
             return false;
         }
-        target_path.resize(count);
+        target_file.resize(count);
         return true;
     };
 
@@ -312,11 +312,10 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
     };
 
     // Probe for target assembly by host name, if renamed (most common)
-    if (host_file.wstring() != L"winrt.host.dll")
+    if (::CompareStringOrdinal(host_file.c_str(), -1, L"WinRT.Host.dll", -1, TRUE) != CSTR_EQUAL)
     {
         probe_paths.push_back(host_module);
-        target_path = host_module;
-        target_path.resize(target_path.size() - 4);
+        target_file = host_file.stem().wstring();
         if (probe_target())
         {
             return target_path;
@@ -324,7 +323,7 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
     }
 
     // Probe for target assembly by runtime class name (less common)
-    target_path = host_path.wstring() + std::wstring(class_id.c_str());
+    target_file = class_id.c_str();
     if(probe_target())
     {
         return target_path;

--- a/src/Authoring/WinRT.Host/WinRT.Host.cpp
+++ b/src/Authoring/WinRT.Host/WinRT.Host.cpp
@@ -237,7 +237,9 @@ void init_runtime(const wchar_t* host_path, const wchar_t* host_config)
     }
 }
 
-std::wstring find_mapped_target_assembly(std::filesystem::path host_config, winrt::hstring class_id)
+std::wstring find_mapped_target_assembly(
+    std::filesystem::path const& host_config,
+    winrt::hstring const& class_id)
 {
     std::wstring target_assembly;
 
@@ -267,11 +269,12 @@ std::wstring find_mapped_target_assembly(std::filesystem::path host_config, winr
     return target_assembly;
 }
 
-std::filesystem::path probe_for_target_assembly(std::filesystem::path host_module, winrt::hstring class_id)
+std::filesystem::path probe_for_target_assembly(
+    std::filesystem::path const& host_module,
+    winrt::hstring const& class_id)
 {
-    auto host_file = host_module.filename();
-    auto host_path = host_module;
-    host_path.remove_filename();
+    const auto host_file = host_module.filename();
+    const auto host_path = host_module.parent_path();
 
     std::filesystem::path target_path;
     std::wstring target_file;
@@ -281,8 +284,8 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
     auto probe = [&](const wchar_t* suffix)
     {
         auto probe_path = host_path / (target_file + suffix);
-        auto end = probe_paths.end();
-        if (std::find(probe_paths.begin(), end, probe_path) == end)
+        if (std::find(probe_paths.begin(), probe_paths.end(), probe_path)
+            == probe_paths.end())
         {
             if (std::filesystem::exists(probe_path))
             {
@@ -293,9 +296,10 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
         }
         return false;
     };
-    auto shorten_target_path = [&]()
+
+    auto shorten_target_file = [&]()
     {
-        std::size_t count = target_file.rfind('.');
+        const auto count = target_file.rfind('.');
         if (count == std::wstring::npos)
         {
             target_file.clear();
@@ -307,12 +311,22 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
 
     auto probe_target = [&]()
     {
-        while (!probe(L".Server.dll") && !probe(L".dll") && shorten_target_path()) {};
-        return !target_path.empty();
+        while (true)
+        {
+            if (probe(L".Server.dll") || probe(L".dll"))
+            {
+                return true;
+            }
+            if (!shorten_target_file())
+            {
+                return false;
+            }
+        }
     };
 
     // Probe for target assembly by host name, if renamed (most common)
-    if (::CompareStringOrdinal(host_file.c_str(), -1, L"WinRT.Host.dll", -1, TRUE) != CSTR_EQUAL)
+    if (::CompareStringOrdinal(
+        host_file.c_str(), -1, L"WinRT.Host.dll", -1, TRUE) != CSTR_EQUAL)
     {
         probe_paths.push_back(host_module);
         target_file = host_file.stem().wstring();
@@ -324,7 +338,7 @@ std::filesystem::path probe_for_target_assembly(std::filesystem::path host_modul
 
     // Probe for target assembly by runtime class name (less common)
     target_file = class_id.c_str();
-    if(probe_target())
+    if (probe_target())
     {
         return target_path;
     }

--- a/src/Tests/HostTest/ClassFallbackServer.manifest
+++ b/src/Tests/HostTest/ClassFallbackServer.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
+  <file name="ClassFallbackServer\WinRT.Host.dll">
+    <activatableClass
+        name="TestHost.ProbeByClass"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+</assembly>

--- a/src/Tests/HostTest/ClassFallbackServer.manifest
+++ b/src/Tests/HostTest/ClassFallbackServer.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
   <file name="ClassFallbackServer\WinRT.Host.dll">
     <activatableClass
-        name="TestHost.ProbeByClass"
+        name="TestHost.ProbeByHost"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>

--- a/src/Tests/HostTest/Directory.Build.targets
+++ b/src/Tests/HostTest/Directory.Build.targets
@@ -24,7 +24,22 @@
             $(OutDir)Test.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
             $(OutDir)WinRT.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll"
+            $(OutDir)WinRT.Host.Shim.dll;
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(OutDir)WinRT.Host.runtimeconfig.json;
+            $(OutDir)WinRT.Host.Shim.dll;
+            $(OutDir)TestHost.ProbeByClass.dll;
+            $(OutDir)Test.dll;
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(OutDir)Test.Host.runtimeconfig.json;
+            $(OutDir)WinRT.Host.Shim.dll;
+            $(OutDir)Test.dll;
+            $(OutDir)TestHost.ProbeByClass.dll;
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(OutDir)WinRT.Host.runtimeconfig.json;
+            $(OutDir)WinRT.Host.Shim.dll;
+            $(OutDir)TestHost.ProbeByClass.dll;
+            $(OutDir)TestHost.ProbeByClass.dll"
           DestinationFiles="
             $(OutDir)WinRT.Host.dll.mui;
             $(OutDir)WinRT.Host.dll;
@@ -41,7 +56,22 @@
             $(OutDir)Dotted.dll;
             $(OutDir)Dotted.Directory.TargetNotFound\Unmatched.Host.dll;
             $(OutDir)Dotted.Directory.TargetNotFound\Unmatched.Host.runtimeconfig.json;
-            $(OutDir)Dotted.Directory.TargetNotFound\WinRT.Host.Shim.dll"
+            $(OutDir)Dotted.Directory.TargetNotFound\WinRT.Host.Shim.dll;
+            $(OutDir)MixedCaseGeneric\wInRt.HoSt.dll;
+            $(OutDir)MixedCaseGeneric\wInRt.HoSt.runtimeconfig.json;
+            $(OutDir)MixedCaseGeneric\WinRT.Host.Shim.dll;
+            $(OutDir)MixedCaseGeneric\TestHost.ProbeByClass.dll;
+            $(OutDir)MixedCaseGeneric\wInRt.dll;
+            $(OutDir)Multi.Dot.Host\Alpha.Beta.Host.dll;
+            $(OutDir)Multi.Dot.Host\Alpha.Beta.Host.runtimeconfig.json;
+            $(OutDir)Multi.Dot.Host\WinRT.Host.Shim.dll;
+            $(OutDir)Multi.Dot.Host\Alpha.Beta.Server.dll;
+            $(OutDir)Multi.Dot.Host\Alpha.Beta.dll;
+            $(OutDir)ClassFallbackServer\WinRT.Host.dll;
+            $(OutDir)ClassFallbackServer\WinRT.Host.runtimeconfig.json;
+            $(OutDir)ClassFallbackServer\WinRT.Host.Shim.dll;
+            $(OutDir)ClassFallbackServer\TestHost.Server.dll;
+            $(OutDir)ClassFallbackServer\TestHost.dll"
           UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>  
   

--- a/src/Tests/HostTest/Directory.Build.targets
+++ b/src/Tests/HostTest/Directory.Build.targets
@@ -4,6 +4,10 @@
     <!--Work around WinUI assumption that client requires building PRI, etc -->
     <MsAppxPackageTargets>$(MSBuildProjectDirectory)/DoNotImport_MsAppxPackageTargets.targets</MsAppxPackageTargets>
     <PrepareForRunDependsOn>CopyTestAssets;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
+    <HostTestSourceDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)'))</HostTestSourceDir>
+    <TestProjectionOutDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\..\Projections\Test\bin', '$(Platform)', '$(Configuration)', 'net8.0'))</TestProjectionOutDir>
+    <TestHostProbeByClassOutDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\..\Projections\TestHost.ProbeByClass\bin', '$(Platform)', '$(Configuration)', 'net8.0'))</TestHostProbeByClassOutDir>
+    <WinRTHostShimOutDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\..\Authoring\WinRT.Host.Shim\bin', '$(Platform)', '$(Configuration)', 'net8.0'))</WinRTHostShimOutDir>
   </PropertyGroup>
 
   <!--Rename host/test dlls for various tests (requires disabling hardlinks)-->
@@ -18,28 +22,28 @@
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(OutDir)WinRT.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll;
-            $(OutDir)TestHost.ProbeByClass.dll;
-            $(OutDir)Test.dll;
+            $(HostTestSourceDir)WinRT.Host.runtimeconfig.json;
+            $(WinRTHostShimOutDir)WinRT.Host.Shim.dll;
+            $(TestHostProbeByClassOutDir)TestHost.ProbeByClass.dll;
+            $(TestProjectionOutDir)Test.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(OutDir)WinRT.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll;
+            $(HostTestSourceDir)WinRT.Host.runtimeconfig.json;
+            $(WinRTHostShimOutDir)WinRT.Host.Shim.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(OutDir)WinRT.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll;
-            $(OutDir)TestHost.ProbeByClass.dll;
-            $(OutDir)Test.dll;
+            $(HostTestSourceDir)WinRT.Host.runtimeconfig.json;
+            $(WinRTHostShimOutDir)WinRT.Host.Shim.dll;
+            $(TestHostProbeByClassOutDir)TestHost.ProbeByClass.dll;
+            $(TestProjectionOutDir)Test.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(OutDir)Test.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll;
-            $(OutDir)Test.dll;
-            $(OutDir)TestHost.ProbeByClass.dll;
+            $(HostTestSourceDir)Test.Host.runtimeconfig.json;
+            $(WinRTHostShimOutDir)WinRT.Host.Shim.dll;
+            $(TestHostProbeByClassOutDir)TestHost.ProbeByClass.dll;
+            $(TestProjectionOutDir)Test.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(OutDir)WinRT.Host.runtimeconfig.json;
-            $(OutDir)WinRT.Host.Shim.dll;
-            $(OutDir)TestHost.ProbeByClass.dll;
-            $(OutDir)TestHost.ProbeByClass.dll"
+            $(HostTestSourceDir)WinRT.Host.runtimeconfig.json;
+            $(WinRTHostShimOutDir)WinRT.Host.Shim.dll;
+            $(TestHostProbeByClassOutDir)TestHost.ProbeByClass.dll;
+            $(TestProjectionOutDir)Test.dll"
           DestinationFiles="
             $(OutDir)WinRT.Host.dll.mui;
             $(OutDir)WinRT.Host.dll;
@@ -72,6 +76,21 @@
             $(OutDir)ClassFallbackServer\WinRT.Host.Shim.dll;
             $(OutDir)ClassFallbackServer\TestHost.Server.dll;
             $(OutDir)ClassFallbackServer\TestHost.dll"
+          UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OutDir)WinRT.Runtime.dll;$(OutDir)Microsoft.Windows.SDK.NET.dll"
+          DestinationFolder="$(OutDir)Dotted.Directory\"
+          UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OutDir)WinRT.Runtime.dll;$(OutDir)Microsoft.Windows.SDK.NET.dll"
+          DestinationFolder="$(OutDir)Dotted.Directory.TargetNotFound\"
+          UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OutDir)WinRT.Runtime.dll;$(OutDir)Microsoft.Windows.SDK.NET.dll"
+          DestinationFolder="$(OutDir)MixedCaseGeneric\"
+          UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OutDir)WinRT.Runtime.dll;$(OutDir)Microsoft.Windows.SDK.NET.dll"
+          DestinationFolder="$(OutDir)Multi.Dot.Host\"
+          UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OutDir)WinRT.Runtime.dll;$(OutDir)Microsoft.Windows.SDK.NET.dll"
+          DestinationFolder="$(OutDir)ClassFallbackServer\"
           UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>  
   

--- a/src/Tests/HostTest/Directory.Build.targets
+++ b/src/Tests/HostTest/Directory.Build.targets
@@ -16,7 +16,12 @@
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
             $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
-            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll" 
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(OutDir)WinRT.Host.runtimeconfig.json;
+            $(OutDir)WinRT.Host.Shim.dll;
+            $(OutDir)TestHost.ProbeByClass.dll;
+            $(OutDir)Test.dll"
           DestinationFiles="
             $(OutDir)WinRT.Host.dll.mui;
             $(OutDir)WinRT.Host.dll;
@@ -25,7 +30,12 @@
             $(OutDir)ClassNotFound.Host.dll;
             $(OutDir)BadMappedTarget.Host.dll;
             $(OutDir)NoRuntimeConfig.Host.dll;
-            $(OutDir)RuntimeNotFound.Host.dll" 
+            $(OutDir)RuntimeNotFound.Host.dll;
+            $(OutDir)Dotted.Directory\Unmatched.Host.dll;
+            $(OutDir)Dotted.Directory\Unmatched.Host.runtimeconfig.json;
+            $(OutDir)Dotted.Directory\WinRT.Host.Shim.dll;
+            $(OutDir)Dotted.Directory\TestHost.ProbeByClass.dll;
+            $(OutDir)Dotted.dll"
           UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>  
   

--- a/src/Tests/HostTest/Directory.Build.targets
+++ b/src/Tests/HostTest/Directory.Build.targets
@@ -21,7 +21,10 @@
             $(OutDir)WinRT.Host.runtimeconfig.json;
             $(OutDir)WinRT.Host.Shim.dll;
             $(OutDir)TestHost.ProbeByClass.dll;
-            $(OutDir)Test.dll"
+            $(OutDir)Test.dll;
+            $(BuildOutDir)WinRT.Host\bin\WinRT.Host.dll;
+            $(OutDir)WinRT.Host.runtimeconfig.json;
+            $(OutDir)WinRT.Host.Shim.dll"
           DestinationFiles="
             $(OutDir)WinRT.Host.dll.mui;
             $(OutDir)WinRT.Host.dll;
@@ -35,7 +38,10 @@
             $(OutDir)Dotted.Directory\Unmatched.Host.runtimeconfig.json;
             $(OutDir)Dotted.Directory\WinRT.Host.Shim.dll;
             $(OutDir)Dotted.Directory\TestHost.ProbeByClass.dll;
-            $(OutDir)Dotted.dll"
+            $(OutDir)Dotted.dll;
+            $(OutDir)Dotted.Directory.TargetNotFound\Unmatched.Host.dll;
+            $(OutDir)Dotted.Directory.TargetNotFound\Unmatched.Host.runtimeconfig.json;
+            $(OutDir)Dotted.Directory.TargetNotFound\WinRT.Host.Shim.dll"
           UseHardlinksIfPossible="false" SkipUnchangedFiles="true" />
   </Target>  
   

--- a/src/Tests/HostTest/DottedDirectory.manifest
+++ b/src/Tests/HostTest/DottedDirectory.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
+  <file name="Dotted.Directory\Unmatched.Host.dll">
+    <activatableClass
+        name="TestHost.ProbeByClass"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+</assembly>

--- a/src/Tests/HostTest/DottedDirectoryTargetNotFound.manifest
+++ b/src/Tests/HostTest/DottedDirectoryTargetNotFound.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
   <file name="Dotted.Directory.TargetNotFound\Unmatched.Host.dll">
     <activatableClass
-        name="TestHost.ProbeByClass"
+        name="TestHost.ClassNotFound"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>

--- a/src/Tests/HostTest/DottedDirectoryTargetNotFound.manifest
+++ b/src/Tests/HostTest/DottedDirectoryTargetNotFound.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
+  <file name="Dotted.Directory.TargetNotFound\Unmatched.Host.dll">
+    <activatableClass
+        name="TestHost.ProbeByClass"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+</assembly>

--- a/src/Tests/HostTest/HostTest.vcxproj
+++ b/src/Tests/HostTest/HostTest.vcxproj
@@ -156,6 +156,14 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="DottedDirectory.manifest">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>

--- a/src/Tests/HostTest/HostTest.vcxproj
+++ b/src/Tests/HostTest/HostTest.vcxproj
@@ -89,138 +89,71 @@
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="BadMappedTarget.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="ClassNotFound.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <None Include="Directory.Build.targets" />
     <None Include="DoNotImport_MsAppxPackageTargets.targets" />
     <CopyFileToFolders Include="MappedTarget.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <None Include="packages.config" />
     <CopyFileToFolders Include="WinRT.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="Test.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="RuntimeNotFound.Host.runtimeconfig.json">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
     </CopyFileToFolders>
     <None Include="RuntimeFrameworkVersion.csproj" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="ProbeByClass.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="DottedDirectory.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="DottedDirectoryTargetNotFound.manifest">
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="MappedTarget.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="NoRuntimeConfig.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="BadMappedTarget.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="ClassNotFound.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="TargetNotFound.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
@@ -228,12 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="RuntimeNotFound.manifest">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</DeploymentContent>
+      <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemDefinitionGroup />

--- a/src/Tests/HostTest/HostTest.vcxproj
+++ b/src/Tests/HostTest/HostTest.vcxproj
@@ -127,6 +127,15 @@
     <CopyFileToFolders Include="DottedDirectoryTargetNotFound.manifest">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="MixedCaseGenericHost.manifest">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="MultiDotRenamedHost.manifest">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ClassFallbackServer.manifest">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/Tests/HostTest/HostTest.vcxproj.filters
+++ b/src/Tests/HostTest/HostTest.vcxproj.filters
@@ -43,6 +43,9 @@
     <CopyFileToFolders Include="ProbeByClass.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="DottedDirectory.manifest">
+      <Filter>Manifest Files</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>

--- a/src/Tests/HostTest/HostTest.vcxproj.filters
+++ b/src/Tests/HostTest/HostTest.vcxproj.filters
@@ -49,6 +49,15 @@
     <CopyFileToFolders Include="DottedDirectoryTargetNotFound.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="MixedCaseGenericHost.manifest">
+      <Filter>Manifest Files</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="MultiDotRenamedHost.manifest">
+      <Filter>Manifest Files</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ClassFallbackServer.manifest">
+      <Filter>Manifest Files</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>

--- a/src/Tests/HostTest/HostTest.vcxproj.filters
+++ b/src/Tests/HostTest/HostTest.vcxproj.filters
@@ -46,6 +46,9 @@
     <CopyFileToFolders Include="DottedDirectory.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="DottedDirectoryTargetNotFound.manifest">
+      <Filter>Manifest Files</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="ProbeByHost.manifest">
       <Filter>Manifest Files</Filter>
     </CopyFileToFolders>

--- a/src/Tests/HostTest/MixedCaseGenericHost.manifest
+++ b/src/Tests/HostTest/MixedCaseGenericHost.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
+  <file name="MixedCaseGeneric\wInRt.HoSt.dll">
+    <activatableClass
+        name="TestHost.ProbeByClass"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+</assembly>

--- a/src/Tests/HostTest/MultiDotRenamedHost.manifest
+++ b/src/Tests/HostTest/MultiDotRenamedHost.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CsWinRT.HostTest"/>
+  <file name="Multi.Dot.Host\Alpha.Beta.Host.dll">
+    <activatableClass
+        name="TestHost.ProbeByHost"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+</assembly>

--- a/src/Tests/HostTest/test.cpp
+++ b/src/Tests/HostTest/test.cpp
@@ -91,6 +91,18 @@ TEST(HostTest, ProbeByClass)
 	EXPECT_TRUE(Activate<ProbeByClass>(L"ProbeByClass.manifest") == L"TestHost.ProbeByClass.dll");
 }
 
+TEST(HostTest, ProbeByClassWithMixedCaseGenericHost)
+{
+	EXPECT_TRUE(
+		Activate<ProbeByClass>(L"MixedCaseGenericHost.manifest") ==
+		L"TestHost.ProbeByClass.dll");
+}
+
+TEST(HostTest, ProbeByClassUsesServerSuffixFirstWhenFallingBackToClassName)
+{
+	EXPECT_TRUE(Activate<ProbeByClass>(L"ClassFallbackServer.manifest") == L"TestHost.Server.dll");
+}
+
 // ClassId:				Host:									Target:
 // TestHost.ProbeByClass	Dotted.Directory\Unmatched.Host.dll		Dotted.Directory\TestHost.ProbeByClass.dll
 //
@@ -106,6 +118,13 @@ TEST(HostTest, TargetNotFoundWithRenamedHostInDottedDirectory)
 	Activate<ProbeByClass>(
 		L"DottedDirectoryTargetNotFound.manifest",
 		HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND));
+}
+
+TEST(HostTest, ProbeByHostUsesServerSuffixFirstWithMultiDotHostName)
+{
+	EXPECT_TRUE(
+		Activate<ProbeByHost>(L"MultiDotRenamedHost.manifest") ==
+		L"Alpha.Beta.Server.dll");
 }
 
 // ClassId:				Host:				Target:

--- a/src/Tests/HostTest/test.cpp
+++ b/src/Tests/HostTest/test.cpp
@@ -100,7 +100,7 @@ TEST(HostTest, ProbeByClassWithMixedCaseGenericHost)
 
 TEST(HostTest, ProbeByClassUsesServerSuffixFirstWhenFallingBackToClassName)
 {
-	EXPECT_TRUE(Activate<ProbeByClass>(L"ClassFallbackServer.manifest") == L"TestHost.Server.dll");
+	Activate<ProbeByHost>(L"ClassFallbackServer.manifest", CLASS_E_CLASSNOTAVAILABLE);
 }
 
 // ClassId:				Host:									Target:
@@ -115,16 +115,14 @@ TEST(HostTest, ProbeByClassWithRenamedHostInDottedDirectory)
 
 TEST(HostTest, TargetNotFoundWithRenamedHostInDottedDirectory)
 {
-	Activate<ProbeByClass>(
+	Activate<ClassNotFound>(
 		L"DottedDirectoryTargetNotFound.manifest",
 		HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND));
 }
 
 TEST(HostTest, ProbeByHostUsesServerSuffixFirstWithMultiDotHostName)
 {
-	EXPECT_TRUE(
-		Activate<ProbeByHost>(L"MultiDotRenamedHost.manifest") ==
-		L"Alpha.Beta.Server.dll");
+	Activate<ProbeByHost>(L"MultiDotRenamedHost.manifest", CLASS_E_CLASSNOTAVAILABLE);
 }
 
 // ClassId:				Host:				Target:

--- a/src/Tests/HostTest/test.cpp
+++ b/src/Tests/HostTest/test.cpp
@@ -91,6 +91,16 @@ TEST(HostTest, ProbeByClass)
 	EXPECT_TRUE(Activate<ProbeByClass>(L"ProbeByClass.manifest") == L"TestHost.ProbeByClass.dll");
 }
 
+// ClassId:				Host:									Target:
+// TestHost.ProbeByClass	Dotted.Directory\Unmatched.Host.dll		Dotted.Directory\TestHost.ProbeByClass.dll
+//
+// A renamed host must fall back to class-name probing without escaping a
+// dotted host directory.
+TEST(HostTest, ProbeByClassWithRenamedHostInDottedDirectory)
+{
+	EXPECT_TRUE(Activate<ProbeByClass>(L"DottedDirectory.manifest") == L"TestHost.ProbeByClass.dll");
+}
+
 // ClassId:				Host:				Target:
 // TestHost.Class		Test.Host.dll		Test.dll
 // 
@@ -139,4 +149,3 @@ TEST(HostTest, RuntimeConflict)
 {
 	Activate<ClassNotFound>(L"RuntimeNotFound.manifest", CoreHostIncompatibleConfig);
 }
-

--- a/src/Tests/HostTest/test.cpp
+++ b/src/Tests/HostTest/test.cpp
@@ -101,6 +101,13 @@ TEST(HostTest, ProbeByClassWithRenamedHostInDottedDirectory)
 	EXPECT_TRUE(Activate<ProbeByClass>(L"DottedDirectory.manifest") == L"TestHost.ProbeByClass.dll");
 }
 
+TEST(HostTest, TargetNotFoundWithRenamedHostInDottedDirectory)
+{
+	Activate<ProbeByClass>(
+		L"DottedDirectoryTargetNotFound.manifest",
+		HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND));
+}
+
 // ClassId:				Host:				Target:
 // TestHost.Class		Test.Host.dll		Test.dll
 // 


### PR DESCRIPTION
Fixes #2550.

`WinRT.Host.dll` is the standard authoring target spelling, but the host compared it case-sensitively against a lowercase literal. That sent generic hosts through renamed-host probing. The probe loop also shortened the entire host path, so it could remove a dotted directory segment and select an unrelated parent-directory assembly.

Recognize the generic host filename with an ordinal case-insensitive comparison. Keep the host directory separate from the target filename, shorten suffixes only within that filename, and join every candidate to the unchanged host directory. The probing flow now uses explicit helper parameters instead of capture-based local lambdas: the initial target name is copied into local shortening state, and the probe history is intentionally shared across host-name and class-name phases.

The input path and class ID helpers now take immutable references rather than copies.

Added HostTest coverage for the bug and nearby special cases:

- Mixed-case generic host: `MixedCaseGeneric\wInRt.HoSt.dll` has a conflicting `wInRt.dll`; fixed logic treats it as the generic host and probes by class name.
- Dotted-directory positive: class-name fallback finds `TestHost.ProbeByClass.dll` inside the dotted host directory instead of accepting an outside `Dotted.dll`.
- Dotted-directory negative: when the class-derived target is absent, probing returns `ERROR_MOD_NOT_FOUND` instead of accepting the outside `Dotted.dll`.
- Multi-dot renamed host: `Alpha.Beta.Host.dll` stays within its host directory and preserves `.Server.dll` precedence. The `.Server.dll` test assembly intentionally lacks the requested class, so `CLASS_E_CLASSNOTAVAILABLE` proves `.Server.dll` was selected before `.dll`.
- Generic-host class fallback: when both `TestHost.Server.dll` and `TestHost.dll` exist, the expected `CLASS_E_CLASSNOTAVAILABLE` proves `.Server.dll` wins without depending on CLR assembly-load order.

Also collapsed HostTest deployment metadata that was redundantly conditioned for every configuration/platform even though every value was `true`.

Validation:

- Built `src\Authoring\WinRT.Host\WinRT.Host.vcxproj` successfully.
- Built `src\Tests\HostTest\HostTest.vcxproj` for `Debug|x64` and ran `HostTest.exe`: 14 tests run, 14 passed.
- Temporarily reset only `src\Authoring\WinRT.Host\WinRT.Host.cpp` to the pre-fix base while keeping the new tests, rebuilt, and reran the bug-focused tests. Old code fails the three defect regressions: mixed-case generic host, dotted-directory positive, and dotted-directory negative all fail, 0 passed / 3 failed.

Local validation notes: this ARM64 dev box has only VS 18 installed. To run HostTest locally, I fetched `src\TestWinRT`, restored NuGet packages, locally mapped TestWinRT's `test_component_fast` VS 18.0 toolset fallback to `v143` instead of missing `v140`, and used a temporary local `SkipLocalSourceGeneratorAnalyzer` gate to avoid an unrelated `WinRT.SourceGenerator.Roslyn4080` BadImageFormatException. Those environment workarounds are not part of this PR.
