### PR TITLE
Add throwing buffer data accessors

### DIFF
--- a/src/Tests/UnitTest/BufferMarshalTests.cs
+++ b/src/Tests/UnitTest/BufferMarshalTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.Foundation;
+using Windows.Storage.Streams;
+using WindowsRuntime.InteropServices;
+
+namespace UnitTest;
+
+[TestClass]
+public class BufferMarshalTests
+{
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(3)]
+    public unsafe void GetDataUnsafe_NativeBuffer_ReturnsUnderlyingData(int length)
+    {
+        byte[] expected = new byte[length];
+        Array.Fill(expected, (byte)0x42);
+        IBuffer buffer = new Windows.Storage.Streams.Buffer((uint)length);
+        expected.CopyTo(0, buffer, 0, length);
+
+        byte* data = WindowsRuntimeBufferMarshal.GetDataUnsafe(buffer);
+
+        Assert.IsTrue(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(buffer, out byte* expectedData));
+        Assert.IsTrue(data == expectedData);
+        CollectionAssert.AreEqual(expected, new ReadOnlySpan<byte>(data, length).ToArray());
+
+        GC.KeepAlive(buffer);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public unsafe void GetDataUnsafe_ManagedBuffer_ReturnsUnderlyingData(bool pinned)
+    {
+        byte[] source = [1, 2, 3, 4];
+        IBuffer buffer = pinned
+            ? WindowsRuntimeBuffer.Create(source, 1, 2, 3)
+            : source.AsBuffer(1, 2, 3);
+
+        byte* data = WindowsRuntimeBufferMarshal.GetDataUnsafe(buffer);
+
+        Assert.IsTrue(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(buffer, out byte* expectedData));
+        Assert.IsTrue(data == expectedData);
+        CollectionAssert.AreEqual(new byte[] { 2, 3 }, new ReadOnlySpan<byte>(data, 2).ToArray());
+
+        data[0] = 42;
+
+        Assert.AreEqual((byte)42, buffer.GetByte(0));
+
+        GC.KeepAlive(buffer);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public unsafe void GetDataUnsafe_EmptyManagedBuffer_ReturnsUnderlyingData(bool pinned)
+    {
+        IBuffer buffer = pinned
+            ? WindowsRuntimeBuffer.Create(0)
+            : Array.Empty<byte>().AsBuffer();
+
+        byte* data = WindowsRuntimeBufferMarshal.GetDataUnsafe(buffer);
+
+        Assert.IsTrue(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(buffer, out byte* expectedData));
+        Assert.IsTrue(data == expectedData);
+
+        GC.KeepAlive(buffer);
+    }
+
+    [TestMethod]
+    public unsafe void GetDataUnsafe_NullBuffer_ThrowsArgumentNullException()
+    {
+        Assert.IsFalse(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(null, out byte* data));
+        Assert.IsTrue(data == null);
+
+        ArgumentNullException exception = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            WindowsRuntimeBufferMarshal.GetDataUnsafe(null!);
+        });
+
+        Assert.AreEqual("buffer", exception.ParamName);
+    }
+
+    [TestMethod]
+    public unsafe void GetDataUnsafe_UnsupportedBuffer_ThrowsArgumentException()
+    {
+        IBuffer buffer = new UnsupportedBuffer();
+
+        Assert.IsFalse(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(buffer, out byte* data));
+        Assert.IsTrue(data == null);
+
+        ArgumentException exception = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            WindowsRuntimeBufferMarshal.GetDataUnsafe(buffer);
+        });
+
+        Assert.AreEqual("buffer", exception.ParamName);
+    }
+
+    [TestMethod]
+    [DataRow(0u)]
+    [DataRow(256u)]
+    public unsafe void GetDataUnsafe_MemoryBufferReference_ReturnsUnderlyingDataAndCapacity(uint expectedCapacity)
+    {
+        using var buffer = new MemoryBuffer(expectedCapacity);
+        using var reference = buffer.CreateReference();
+
+        byte* data = WindowsRuntimeBufferMarshal.GetDataUnsafe(reference, out uint capacity);
+
+        Assert.AreEqual(expectedCapacity, capacity);
+        Assert.IsTrue(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(reference, out byte* expectedData, out uint capacityFromTryGet));
+        Assert.IsTrue(data == expectedData);
+        Assert.AreEqual(expectedCapacity, capacityFromTryGet);
+
+        if (capacity > 0)
+        {
+            data[0] = 42;
+            data[capacity - 1] = 84;
+
+            Assert.AreEqual((byte)42, expectedData[0]);
+            Assert.AreEqual((byte)84, expectedData[capacity - 1]);
+        }
+
+        GC.KeepAlive(reference);
+    }
+
+    [TestMethod]
+    public unsafe void GetDataUnsafe_NullMemoryBufferReference_ThrowsArgumentNullException()
+    {
+        Assert.IsFalse(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(null, out byte* data, out uint capacity));
+        Assert.IsTrue(data == null);
+        Assert.AreEqual(0u, capacity);
+
+        ArgumentNullException exception = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            WindowsRuntimeBufferMarshal.GetDataUnsafe(null!, out _);
+        });
+
+        Assert.AreEqual("buffer", exception.ParamName);
+    }
+
+    [TestMethod]
+    public unsafe void GetDataUnsafe_UnsupportedMemoryBufferReference_ThrowsArgumentException()
+    {
+        using IMemoryBufferReference reference = new UnsupportedMemoryBufferReference();
+
+        Assert.IsFalse(WindowsRuntimeBufferMarshal.TryGetDataUnsafe(reference, out byte* data, out uint capacity));
+        Assert.IsTrue(data == null);
+        Assert.AreEqual(0u, capacity);
+
+        ArgumentException exception = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            WindowsRuntimeBufferMarshal.GetDataUnsafe(reference, out _);
+        });
+
+        Assert.AreEqual("buffer", exception.ParamName);
+    }
+
+    [WindowsRuntimeManagedOnlyType]
+    private sealed class UnsupportedBuffer : IBuffer
+    {
+        public uint Capacity => 0;
+
+        public uint Length { get; set; }
+    }
+
+    [WindowsRuntimeManagedOnlyType]
+    private sealed class UnsupportedMemoryBufferReference : IMemoryBufferReference
+    {
+        public uint Capacity => 0;
+
+        public event EventHandler<IMemoryBufferReference, object> Closed
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/WinRT.Runtime2/InteropServices/Buffers/WindowsRuntimeBufferHelpers.cs
+++ b/src/WinRT.Runtime2/InteropServices/Buffers/WindowsRuntimeBufferHelpers.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Windows.Foundation;
 using Windows.Storage.Streams;
 
 namespace WindowsRuntime.InteropServices;
 
 /// <summary>
-/// Provides internal helpers for working with <see cref="IBuffer"/> objects.
+/// Provides internal helpers for working with Windows Runtime buffer types.
 /// </summary>
 internal static class WindowsRuntimeBufferHelpers
 {
@@ -171,6 +172,36 @@ internal static class WindowsRuntimeBufferHelpers
         }
 
         data = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get the underlying data for the specified buffer, only if backed by native memory.
+    /// </summary>
+    /// <param name="buffer">The input <see cref="IMemoryBufferReference"/> instance.</param>
+    /// <param name="data">The underlying data, if retrieved.</param>
+    /// <param name="capacity">The capacity of the buffer, if retrieved.</param>
+    /// <returns>Whether <paramref name="data"/> could be retrieved.</returns>
+    public static unsafe bool TryGetNativeData(IMemoryBufferReference buffer, out byte* data, out uint capacity)
+    {
+        if (buffer is WindowsRuntimeObject { HasUnwrappableNativeObjectReference: true } bufferObject)
+        {
+            using WindowsRuntimeObjectReferenceValue bufferByteAccessValue = bufferObject.NativeObjectReference.AsValue(WellKnownInterfaceIIDs.IID_IMemoryBufferByteAccess);
+
+            fixed (byte** dataPtr = &data)
+            fixed (uint* capacityPtr = &capacity)
+            {
+                HRESULT hresult = IMemoryBufferByteAccessVftbl.GetBufferUnsafe(bufferByteAccessValue.GetThisPtrUnsafe(), dataPtr, capacityPtr);
+
+                RestrictedErrorInfo.ThrowExceptionForHR(hresult);
+            }
+
+            return true;
+        }
+
+        data = null;
+        capacity = 0;
 
         return false;
     }

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeBufferMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeBufferMarshal.cs
@@ -78,19 +78,8 @@ public static partial class WindowsRuntimeBufferMarshal
             goto Failure;
         }
 
-        // Similar handling as in 'WindowsRuntimeBufferHelpers.TryGetNativeData', but for native 'IMemoryBufferByteAccess' instances
-        if (buffer is WindowsRuntimeObject { HasUnwrappableNativeObjectReference: true } bufferObject)
+        if (WindowsRuntimeBufferHelpers.TryGetNativeData(buffer, out data, out capacity))
         {
-            using WindowsRuntimeObjectReferenceValue bufferByteAccessValue = bufferObject.NativeObjectReference.AsValue(WellKnownInterfaceIIDs.IID_IMemoryBufferByteAccess);
-
-            fixed (byte** dataPtr = &data)
-            fixed (uint* capacityPtr = &capacity)
-            {
-                HRESULT hresult = IMemoryBufferByteAccessVftbl.GetBufferUnsafe(bufferByteAccessValue.GetThisPtrUnsafe(), dataPtr, capacityPtr);
-
-                RestrictedErrorInfo.ThrowExceptionForHR(hresult);
-            }
-
             return true;
         }
 

--- a/src/WinRT.Runtime2/InteropServices/WindowsRuntimeBufferMarshal.cs
+++ b/src/WinRT.Runtime2/InteropServices/WindowsRuntimeBufferMarshal.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Windows.Foundation;
 using Windows.Storage.Streams;
@@ -13,6 +14,40 @@ namespace WindowsRuntime.InteropServices;
 /// </summary>
 public static partial class WindowsRuntimeBufferMarshal
 {
+    /// <summary>
+    /// Gets a pointer to the underlying data representation of the <see cref="IBuffer"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to get the data pointer for.</param>
+    /// <returns>The pointer to the underlying data representation of the buffer.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="buffer"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if the underlying data representation of <paramref name="buffer"/> cannot be retrieved.</exception>
+    /// <exception cref="InvalidCastException">Thrown if <paramref name="buffer"/> is a native object that doesn't implement <see href="https://learn.microsoft.com/windows/win32/api/robuffer/nf-robuffer-ibufferbyteaccess"><c>IBufferByteAccess</c></see>.</exception>
+    /// <exception cref="Exception">Thrown if invoking <see href="https://learn.microsoft.com/windows/win32/api/robuffer/nf-robuffer-ibufferbyteaccess-buffer"><c>IBufferByteAccess.Buffer</c></see> on the input buffer fails.</exception>
+    /// <remarks>
+    /// Callers are responsible for ensuring that the buffer is kept alive while the pointer is in use. For instance,
+    /// they can use <see cref="GC.KeepAlive"/> after the last use of the pointer, to ensure that this is the case.
+    /// </remarks>
+    public static unsafe byte* GetDataUnsafe(IBuffer buffer)
+    {
+#if WINDOWS_RUNTIME_REFERENCE_ASSEMBLY
+        throw null;
+#elif WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        if (!TryGetDataUnsafe(buffer, out byte* data))
+        {
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowArgumentException()
+                => throw new ArgumentException(WindowsRuntimeExceptionMessages.Argument_InvalidIBufferInstance, nameof(buffer));
+
+            ThrowArgumentException();
+        }
+
+        return data;
+#endif
+    }
+
     /// <summary>
     /// Tries to get a pointer to the underlying data representation of the <see cref="IBuffer"/>.
     /// </summary>
@@ -52,6 +87,41 @@ public static partial class WindowsRuntimeBufferMarshal
         data = null;
 
         return false;
+#endif
+    }
+
+    /// <summary>
+    /// Gets a pointer to the underlying data representation of the <see cref="IMemoryBufferReference"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to get the data pointer for.</param>
+    /// <param name="capacity">The capacity of the buffer.</param>
+    /// <returns>The pointer to the underlying data representation of the buffer.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="buffer"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if the underlying data representation of <paramref name="buffer"/> cannot be retrieved.</exception>
+    /// <exception cref="InvalidCastException">Thrown if <paramref name="buffer"/> is a native object that doesn't implement <see href="https://learn.microsoft.com/previous-versions//mt297505(v=vs.85)"><c>IMemoryBufferByteAccess</c></see>.</exception>
+    /// <exception cref="Exception">Thrown if invoking <see href="https://learn.microsoft.com/windows/win32/winrt/imemorybufferbyteaccess-getbuffer"><c>IMemoryBufferByteAccess.GetBuffer</c></see> on the input buffer fails.</exception>
+    /// <remarks>
+    /// Callers are responsible for ensuring that the buffer is kept alive while the pointer is in use. For instance,
+    /// they can use <see cref="GC.KeepAlive"/> after the last use of the pointer, to ensure that this is the case.
+    /// </remarks>
+    public static unsafe byte* GetDataUnsafe(IMemoryBufferReference buffer, out uint capacity)
+    {
+#if WINDOWS_RUNTIME_REFERENCE_ASSEMBLY
+        throw null;
+#elif WINDOWS_RUNTIME_IMPLEMENTATION_ASSEMBLY
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        if (!TryGetDataUnsafe(buffer, out byte* data, out capacity))
+        {
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowArgumentException()
+                => throw new ArgumentException(WindowsRuntimeExceptionMessages.Argument_InvalidIMemoryBufferReferenceInstance, nameof(buffer));
+
+            ThrowArgumentException();
+        }
+
+        return data;
 #endif
     }
 

--- a/src/WinRT.Runtime2/Properties/WindowsRuntimeExceptionMessages.cs
+++ b/src/WinRT.Runtime2/Properties/WindowsRuntimeExceptionMessages.cs
@@ -36,6 +36,8 @@ internal static class WindowsRuntimeExceptionMessages
 
     public const string Argument_InvalidIBufferInstance = "The provided 'IBuffer' instance is not valid, and retrieving its underlying data failed.";
 
+    public const string Argument_InvalidIMemoryBufferReferenceInstance = "The provided 'IMemoryBufferReference' instance is not valid, and retrieving its underlying data failed.";
+
     public const string Argument_StreamPositionBeyondEndOfStream = "The specified position is beyond the end of the stream.";
 
     public const string ArgumentOutOfRange_BufferLengthExceedsArrayMaxLength = "The specified buffer length exceeds the maximum array length.";


### PR DESCRIPTION
## Summary

Add throwing `GetDataUnsafe` overloads for `IBuffer` and `IMemoryBufferReference`. Move native memory-buffer byte access into the shared internal buffer helpers.

## Motivation

Callers that require a pointer to a buffer's data should not have to repeat `TryGetDataUnsafe` checks and exception handling. Thin throwing wrappers provide that convenience while keeping exception construction in local helpers, and centralizing native access makes the handling of both buffer interfaces consistent.

## Changes

- **`src\WinRT.Runtime2\InteropServices\WindowsRuntimeBufferMarshal.cs`**: Add the two pointer-returning getters as wrappers over the corresponding `TryGetDataUnsafe` methods. Check for null inputs directly in each getter, use parameterless local helpers that only throw `ArgumentException` when retrieval fails, preserve native interop exceptions, and document the new APIs and pointer lifetime requirements.
- **`src\WinRT.Runtime2\InteropServices\Buffers\WindowsRuntimeBufferHelpers.cs`**: Move `IMemoryBufferReference` native interop into a `TryGetNativeData` overload without changing the existing public `TryGetDataUnsafe` behavior.
- **`src\WinRT.Runtime2\Properties\WindowsRuntimeExceptionMessages.cs`**: Add an error message for unsupported memory-buffer references.
- **`src\Tests\UnitTest\BufferMarshalTests.cs`**: Cover native, managed, pinned, and empty buffers; pointer identity, writable data, and capacity results; and null and unsupported input exceptions.