### PR TITLE
Fix generic collection event-source names in projections

### DIFF
--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -23,13 +23,14 @@ namespace ProjectionWriterTest.Helpers;
 internal static class ProjectionWriterRunner
 {
     /// <summary>
-    /// The namespace the projections are restricted to.
+    /// The namespace and type prefixes the projections are restricted to.
     /// </summary>
     /// <remarks>
     /// <para>
     /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
     /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
     /// still covering every projected type kind and every carried-over attribute of interest.
+    /// The two XAML collection types also cover generic vector events with projected and object arguments.
     /// </para>
     /// <para>
     /// Tests must only assert on things this namespace is guaranteed to contain in every Windows SDK:
@@ -38,7 +39,7 @@ internal static class ProjectionWriterRunner
     /// different one (an experimental API becoming stable, or not existing yet, is enough).
     /// </para>
     /// </remarks>
-    private const string IncludeNamespace = "Windows.Foundation";
+    private const string IncludeNamespaces = "Windows.Foundation,Windows.UI.Xaml.DependencyObjectCollection,Windows.UI.Xaml.Controls.ItemCollection";
 
     /// <summary>
     /// The lazily generated reference projection sources.
@@ -117,13 +118,13 @@ internal static class ProjectionWriterRunner
                 "--input-paths sdk",
                 $"--output-directory {outputDirectory}",
                 "--target-framework net10.0",
-                $"--include-namespaces {IncludeNamespace}",
+                $"--include-namespaces {IncludeNamespaces}",
                 $"--reference-projection {(referenceProjection ? "true" : "false")}"
             ]);
 
             (int exitCode, string output) = Run(toolPath, $"@{responseFile}");
 
-            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespace}':{Environment.NewLine}{output}");
+            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespaces}':{Environment.NewLine}{output}");
 
             string[] sourceFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
 

--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -17,50 +17,30 @@ namespace ProjectionWriterTest.Helpers;
 /// <remarks>
 /// The tool is invoked as a separate process with a response file, exactly as the
 /// <c>CsWinRTGenerateProjection</c> MSBuild target does, so the tests cover the real code path. Both
-/// projection modes are generated once per test run and cached, since generating them is the
-/// expensive part and every test only inspects the resulting text.
+/// reference/implementation modes and UWP/WinUI inputs are cached separately, since generating them
+/// is the expensive part and every test only inspects the resulting text.
 /// </remarks>
 internal static class ProjectionWriterRunner
 {
     /// <summary>
-    /// The namespace and type prefixes the projections are restricted to.
+    /// The generated sources, cached separately for each output mode and XAML input.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
-    /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
-    /// still covering every projected type kind and every carried-over attribute of interest.
-    /// The two XAML collection types also cover generic vector events with projected and 'object' arguments.
-    /// </para>
-    /// <para>
-    /// Tests must only assert on things this namespace is guaranteed to contain in every Windows SDK:
-    /// the input metadata is whichever SDK is installed on the machine, so an assertion that some API
-    /// carries a given attribute is really an assertion about that SDK, and breaks when an agent has a
-    /// different one (an experimental API becoming stable, or not existing yet, is enough).
-    /// </para>
+    /// Lazy initialization prevents concurrent tests from generating the same sources more than once.
     /// </remarks>
-    private const string IncludeNamespaces = "Windows.Foundation,Windows.UI.Xaml.DependencyObjectCollection,Windows.UI.Xaml.Controls.ItemCollection";
-
-    /// <summary>
-    /// The lazily generated reference projection sources.
-    /// </summary>
-    private static readonly Lazy<string> ReferenceProjectionSources = new(static () => Generate(referenceProjection: true));
-
-    /// <summary>
-    /// The lazily generated implementation projection sources.
-    /// </summary>
-    private static readonly Lazy<string> ImplementationProjectionSources = new(static () => Generate(referenceProjection: false));
+    private static readonly ConcurrentDictionary<(bool ReferenceProjection, bool UseWinUI), Lazy<string>> Sources = new();
 
     /// <summary>
     /// Gets all generated C# sources for the requested projection mode, concatenated.
     /// </summary>
     /// <param name="referenceProjection">Whether to get the reference projection (rather than the implementation projection).</param>
+    /// <param name="useWinUI">Whether to use WinUI metadata and collection types instead of UWP XAML.</param>
     /// <returns>The concatenated contents of every generated <c>.cs</c> file.</returns>
-    public static string GetSources(bool referenceProjection)
+    public static string GetSources(bool referenceProjection, bool useWinUI = false)
     {
-        return referenceProjection
-            ? ReferenceProjectionSources.Value
-            : ImplementationProjectionSources.Value;
+        return Sources.GetOrAdd(
+            (referenceProjection, useWinUI),
+            static input => new(() => Generate(input.ReferenceProjection, input.UseWinUI))).Value;
     }
 
     /// <summary>
@@ -97,11 +77,21 @@ internal static class ProjectionWriterRunner
     /// <summary>
     /// Generates a projection for the requested mode and returns all generated sources, concatenated.
     /// </summary>
+    /// <remarks>
+    /// Each fixture projects 'Windows.Foundation' and two collection types from the selected XAML
+    /// namespace. WinUI metadata is an additional input, not a replacement for its Windows SDK dependencies.
+    /// The SDK input is whichever version is installed, so tests must assert stable projection behavior
+    /// rather than incidental metadata such as whether a particular API is experimental.
+    /// </remarks>
     /// <param name="referenceProjection">Whether to generate a reference projection.</param>
+    /// <param name="useWinUI">Whether to use WinUI metadata and collection types instead of UWP XAML.</param>
     /// <returns>The concatenated contents of every generated <c>.cs</c> file.</returns>
-    private static string Generate(bool referenceProjection)
+    private static string Generate(bool referenceProjection, bool useWinUI)
     {
-        string toolPath = GetGeneratorPath();
+        string toolPath = GetRequiredFilePath("ProjectionRefGeneratorAssemblyPath");
+        string inputPaths = useWinUI ? $"sdk,{GetRequiredFilePath("WinUIMetadataPath")}" : "sdk";
+        string xamlNamespace = useWinUI ? "Microsoft.UI.Xaml" : "Windows.UI.Xaml";
+        string includeNamespaces = $"Windows.Foundation,{xamlNamespace}.DependencyObjectCollection,{xamlNamespace}.Controls.ItemCollection";
         string workingDirectory = Path.Combine(Path.GetTempPath(), $"ProjectionWriterTest_{Guid.NewGuid():N}");
         string outputDirectory = Path.Combine(workingDirectory, "Generated");
 
@@ -115,16 +105,16 @@ internal static class ProjectionWriterRunner
             // input token makes the tool resolve the Windows SDK metadata installed on the machine.
             File.WriteAllLines(responseFile,
             [
-                "--input-paths sdk",
+                $"--input-paths {inputPaths}",
                 $"--output-directory {outputDirectory}",
                 "--target-framework net10.0",
-                $"--include-namespaces {IncludeNamespaces}",
+                $"--include-namespaces {includeNamespaces}",
                 $"--reference-projection {(referenceProjection ? "true" : "false")}"
             ]);
 
             (int exitCode, string output) = Run(toolPath, $"@{responseFile}");
 
-            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{IncludeNamespaces}':{Environment.NewLine}{output}");
+            Assert.AreEqual(0, exitCode, $"The projection writer failed for '{includeNamespaces}':{Environment.NewLine}{output}");
 
             string[] sourceFiles = Directory.GetFiles(outputDirectory, "*.cs", SearchOption.AllDirectories);
 
@@ -169,20 +159,21 @@ internal static class ProjectionWriterRunner
     }
 
     /// <summary>
-    /// Resolves the path to the built <c>cswinrtprojectionrefgen</c> tool from assembly metadata.
+    /// Resolves a required tool or input file path from assembly metadata.
     /// </summary>
-    /// <returns>The full path of the tool assembly.</returns>
-    private static string GetGeneratorPath()
+    /// <param name="metadataName">The assembly metadata key containing the path.</param>
+    /// <returns>The full path of the required file.</returns>
+    private static string GetRequiredFilePath(string metadataName)
     {
         string? path = typeof(ProjectionWriterRunner).Assembly
             .GetCustomAttributes<AssemblyMetadataAttribute>()
-            .FirstOrDefault(static attribute => attribute.Key == "ProjectionRefGeneratorAssemblyPath")?.Value;
+            .FirstOrDefault(attribute => attribute.Key == metadataName)?.Value;
 
-        Assert.IsFalse(string.IsNullOrEmpty(path), "The 'ProjectionRefGeneratorAssemblyPath' assembly metadata was not found.");
+        Assert.IsFalse(string.IsNullOrEmpty(path), $"The '{metadataName}' assembly metadata was not found.");
 
         string fullPath = Path.GetFullPath(path!);
 
-        Assert.IsTrue(File.Exists(fullPath), $"The projection generator was not found at '{fullPath}'.");
+        Assert.IsTrue(File.Exists(fullPath), $"The file specified by '{metadataName}' was not found at '{fullPath}'.");
 
         return fullPath;
     }

--- a/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
+++ b/src/Tests/ProjectionWriterTest/Helpers/ProjectionWriterRunner.cs
@@ -30,7 +30,7 @@ internal static class ProjectionWriterRunner
     /// <c>Windows.Foundation</c> (which also covers <c>Windows.Foundation.Collections</c> and
     /// <c>Windows.Foundation.Metadata</c>) is small enough to generate in well under a second, while
     /// still covering every projected type kind and every carried-over attribute of interest.
-    /// The two XAML collection types also cover generic vector events with projected and object arguments.
+    /// The two XAML collection types also cover generic vector events with projected and 'object' arguments.
     /// </para>
     /// <para>
     /// Tests must only assert on things this namespace is guaranteed to contain in every Windows SDK:

--- a/src/Tests/ProjectionWriterTest/ProjectionWriterTest.csproj
+++ b/src/Tests/ProjectionWriterTest/ProjectionWriterTest.csproj
@@ -34,6 +34,11 @@
     <PackageReference Include="MSTest.SourceGeneration" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Only the metadata is needed: do not import WinUI build targets or reference its assemblies. -->
+    <PackageDownload Include="Microsoft.WindowsAppSDK.WinUI" Version="[$(MicrosoftWinAppSDKWinUIVersion)]" />
+  </ItemGroup>
+
   <!--
     Build the reference projection generator tool, but do not reference its assembly: the tests invoke
     it as a separate process (end-to-end), driving the projection writer exactly as a real build does.
@@ -54,10 +59,12 @@
                       Private="false" />
   </ItemGroup>
 
-  <!-- Pass the built tool's path to the tests via assembly metadata -->
+  <!-- Pass the built tool and the pinned WinUI metadata paths to the tests via assembly metadata. -->
   <ItemGroup>
     <AssemblyMetadata Include="ProjectionRefGeneratorAssemblyPath"
                       Value="$(MSBuildThisFileDirectory)..\..\WinRT.Projection.Ref.Generator\bin\$(Configuration)\net10.0\cswinrtprojectionrefgen.dll" />
+    <AssemblyMetadata Include="WinUIMetadataPath"
+                      Value="$(NuGetPackageRoot)microsoft.windowsappsdk.winui\$(MicrosoftWinAppSDKWinUIVersion)\metadata\Microsoft.UI.Xaml.winmd" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/ProjectionWriterTest/Test_EventSources.cs
+++ b/src/Tests/ProjectionWriterTest/Test_EventSources.cs
@@ -6,14 +6,14 @@ using ProjectionWriterTest.Helpers;
 namespace ProjectionWriterTest;
 
 /// <summary>
-/// Tests the names used to construct generic event sources in WinRT.Interop.
+/// Tests the names used to construct generic event sources in 'WinRT.Interop'.
 /// </summary>
 [TestClass]
 public class Test_EventSources
 {
     /// <summary>
     /// Specialized event sources use the runtime event-source base name, not the delegate name
-    /// followed by an EventSource suffix after its generic arguments.
+    /// followed by an 'EventSource' suffix after its generic arguments.
     /// </summary>
     [TestMethod]
     [DataRow("VectorChangedEventHandlerEventSource'1<<#Windows>Windows-UI-Xaml-DependencyObject>")]

--- a/src/Tests/ProjectionWriterTest/Test_EventSources.cs
+++ b/src/Tests/ProjectionWriterTest/Test_EventSources.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ProjectionWriterTest.Helpers;
+
+namespace ProjectionWriterTest;
+
+/// <summary>
+/// Tests the names used to construct generic event sources in WinRT.Interop.
+/// </summary>
+[TestClass]
+public class Test_EventSources
+{
+    /// <summary>
+    /// Specialized event sources use the runtime event-source base name, not the delegate name
+    /// followed by an EventSource suffix after its generic arguments.
+    /// </summary>
+    [TestMethod]
+    [DataRow("VectorChangedEventHandlerEventSource'1<<#Windows>Windows-UI-Xaml-DependencyObject>")]
+    [DataRow("VectorChangedEventHandlerEventSource'1<object>")]
+    [DataRow("MapChangedEventHandlerEventSource'2<string|string>")]
+    [DataRow("MapChangedEventHandlerEventSource'2<string|object>")]
+    [DataRow("EventHandlerEventSource'1<<#Windows>Windows-Foundation-Diagnostics-TracingStatusChangedEventArgs>")]
+    [DataRow("EventHandlerEventSource'2<<#Windows>Windows-Foundation-Diagnostics-ILoggingChannel|object>")]
+    public void GenericEvent_UsesInteropEventSourceConstructor(string eventSourceName)
+    {
+        string attribute = $"[return: UnsafeAccessorType(\"ABI.WindowsRuntime.InteropServices.<#CsWinRT>{eventSourceName}, WinRT.Interop\")]";
+
+        Assert.IsTrue(ProjectionWriterRunner.GetSources(referenceProjection: false).Contains(attribute),
+            $"The projection should construct '{eventSourceName}' in WinRT.Interop.");
+        Assert.IsFalse(ProjectionWriterRunner.GetSources(referenceProjection: true).Contains(attribute),
+            "Reference projections should not reference implementation-only event sources.");
+    }
+}

--- a/src/Tests/ProjectionWriterTest/Test_EventSources.cs
+++ b/src/Tests/ProjectionWriterTest/Test_EventSources.cs
@@ -16,19 +16,47 @@ public class Test_EventSources
     /// followed by an 'EventSource' suffix after its generic arguments.
     /// </summary>
     [TestMethod]
-    [DataRow("VectorChangedEventHandlerEventSource'1<<#Windows>Windows-UI-Xaml-DependencyObject>")]
-    [DataRow("VectorChangedEventHandlerEventSource'1<object>")]
-    [DataRow("MapChangedEventHandlerEventSource'2<string|string>")]
-    [DataRow("MapChangedEventHandlerEventSource'2<string|object>")]
-    [DataRow("EventHandlerEventSource'1<<#Windows>Windows-Foundation-Diagnostics-TracingStatusChangedEventArgs>")]
-    [DataRow("EventHandlerEventSource'2<<#Windows>Windows-Foundation-Diagnostics-ILoggingChannel|object>")]
-    public void GenericEvent_UsesInteropEventSourceConstructor(string eventSourceName)
+    [DataRow(false, "VectorChangedEventHandlerEventSource'1<<#Windows>Windows-UI-Xaml-DependencyObject>")]
+    [DataRow(false, "VectorChangedEventHandlerEventSource'1<object>")]
+    [DataRow(true, "VectorChangedEventHandlerEventSource'1<<Microsoft-UI-Xaml>Microsoft-UI-Xaml-DependencyObject>")]
+    [DataRow(true, "VectorChangedEventHandlerEventSource'1<object>")]
+    [DataRow(false, "MapChangedEventHandlerEventSource'2<string|string>")]
+    [DataRow(false, "MapChangedEventHandlerEventSource'2<string|object>")]
+    [DataRow(true, "MapChangedEventHandlerEventSource'2<string|string>")]
+    [DataRow(true, "MapChangedEventHandlerEventSource'2<string|object>")]
+    [DataRow(false, "EventHandlerEventSource'1<<#Windows>Windows-Foundation-Diagnostics-TracingStatusChangedEventArgs>")]
+    [DataRow(false, "EventHandlerEventSource'2<<#Windows>Windows-Foundation-Diagnostics-ILoggingChannel|object>")]
+    [DataRow(true, "EventHandlerEventSource'1<<#Windows>Windows-Foundation-Diagnostics-TracingStatusChangedEventArgs>")]
+    [DataRow(true, "EventHandlerEventSource'2<<#Windows>Windows-Foundation-Diagnostics-ILoggingChannel|object>")]
+    public void GenericEvent_UsesInteropEventSourceConstructor(bool useWinUI, string eventSourceName)
     {
         string attribute = $"[return: UnsafeAccessorType(\"ABI.WindowsRuntime.InteropServices.<#CsWinRT>{eventSourceName}, WinRT.Interop\")]";
 
-        Assert.IsTrue(ProjectionWriterRunner.GetSources(referenceProjection: false).Contains(attribute),
+        Assert.IsTrue(ProjectionWriterRunner.GetSources(referenceProjection: false, useWinUI).Contains(attribute),
             $"The projection should construct '{eventSourceName}' in WinRT.Interop.");
-        Assert.IsFalse(ProjectionWriterRunner.GetSources(referenceProjection: true).Contains(attribute),
+        Assert.IsFalse(ProjectionWriterRunner.GetSources(referenceProjection: true, useWinUI).Contains(attribute),
             "Reference projections should not reference implementation-only event sources.");
+    }
+
+    /// <summary>
+    /// Each input fixture projects only its selected XAML namespaces in both output modes.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public void XamlCollections_UseSelectedNamespaces(bool referenceProjection, bool useWinUI)
+    {
+        string sources = ProjectionWriterRunner.GetSources(referenceProjection, useWinUI);
+        string expectedNamespace = useWinUI ? "Microsoft.UI.Xaml" : "Windows.UI.Xaml";
+        string unexpectedNamespace = useWinUI ? "Windows.UI.Xaml" : "Microsoft.UI.Xaml";
+
+        Assert.IsTrue(sources.Contains($"namespace {expectedNamespace}"),
+            $"The fixture should project '{expectedNamespace}'.");
+        Assert.IsTrue(sources.Contains($"namespace {expectedNamespace}.Controls"),
+            $"The fixture should project '{expectedNamespace}.Controls'.");
+        Assert.IsFalse(sources.Contains($"namespace {unexpectedNamespace}"),
+            $"The fixture should not project '{unexpectedNamespace}'.");
     }
 }

--- a/src/WinRT.Projection.Writer/Helpers/InteropTypeNameWriter.cs
+++ b/src/WinRT.Projection.Writer/Helpers/InteropTypeNameWriter.cs
@@ -140,9 +140,12 @@ internal static class InteropTypeNameWriter
             _ = sb.Append("ABI.");
         }
 
-        // Special case for EventSource on Windows.Foundation event-handler delegate types
-        // (e.g. EventHandler<T>, TypedEventHandler<S,R>).
-        if (nameType == TypedefNameType.EventSource && typeNs == WindowsFoundation)
+        // The interop generator names these event sources after their specialized runtime base
+        // types, with EventSource before the generic arity and arguments.
+        bool isCollectionEventHandler = typeNs == WindowsFoundationCollections
+            && typeName is "VectorChangedEventHandler`1" or "MapChangedEventHandler`2";
+
+        if (nameType == TypedefNameType.EventSource && (typeNs == WindowsFoundation || isCollectionEventHandler))
         {
             // Determine generic arity from the .winmd type name (e.g. "EventHandler`1" => 1).
             int arity = 0;
@@ -153,7 +156,9 @@ internal static class InteropTypeNameWriter
                 arity = parsed;
             }
 
-            _ = sb.Append("WindowsRuntime.InteropServices.<#CsWinRT>EventHandlerEventSource'");
+            _ = sb.Append("WindowsRuntime.InteropServices.<#CsWinRT>");
+            _ = sb.Append(isCollectionEventHandler ? typeName.AsSpan(0, tickIdx) : "EventHandler");
+            _ = sb.Append("EventSource'");
             _ = sb.Append(arity.ToString(CultureInfo.InvariantCulture));
 
             // Append the generic args (if any).

--- a/src/WinRT.Projection.Writer/Helpers/InteropTypeNameWriter.cs
+++ b/src/WinRT.Projection.Writer/Helpers/InteropTypeNameWriter.cs
@@ -141,13 +141,13 @@ internal static class InteropTypeNameWriter
         }
 
         // The interop generator names these event sources after their specialized runtime base
-        // types, with EventSource before the generic arity and arguments.
+        // types, with 'EventSource' before the generic arity and arguments.
         bool isCollectionEventHandler = typeNs == WindowsFoundationCollections
             && typeName is "VectorChangedEventHandler`1" or "MapChangedEventHandler`2";
 
         if (nameType == TypedefNameType.EventSource && (typeNs == WindowsFoundation || isCollectionEventHandler))
         {
-            // Determine generic arity from the .winmd type name (e.g. "EventHandler`1" => 1).
+            // Determine generic arity from the .winmd type name (e.g. 'EventHandler`1' => 1).
             int arity = 0;
             int tickIdx = typeName.IndexOf('`');
 


### PR DESCRIPTION
## Summary

Correct the projection writer's constructor references for generic vector and map event sources so they match the types emitted into `WinRT.Interop.dll`. Add regression coverage for both UWP XAML and WinUI metadata, in reference and implementation projections.

## Motivation

Subscribing to `DependencyObjectCollection.VectorChanged` throws `TypeLoadException` because the projection requests an event-source type with a different namespace and name layout from the generated implementation. This blocks `BehaviorCollection` construction in XamlBehaviors and reproduces without any XamlBehaviors dependency. Observable map events have the same naming mismatch.

WinUI uses the same collection delegates with different projected type arguments, so coverage also needs to distinguish `Microsoft.UI.Xaml.DependencyObject` and its metadata assembly marker from the Windows SDK equivalent.

## Changes

- **`src\WinRT.Projection.Writer\Helpers\InteropTypeNameWriter.cs`**: encode collection event sources using their specialized runtime base names in `ABI.WindowsRuntime.InteropServices`, with `EventSource` before the generic arity and arguments. Preserve the existing Foundation event-handler naming path.
- **`src\Tests\ProjectionWriterTest\Helpers\ProjectionWriterRunner.cs`**: reuse the generator subprocess harness with separate, lazily cached UWP/WinUI inputs and reference/implementation outputs.
- **`src\Tests\ProjectionWriterTest\ProjectionWriterTest.csproj`**: download the repository-pinned WinUI package for metadata only, without importing its build targets or referencing its assemblies.
- **`src\Tests\ProjectionWriterTest\Test_EventSources.cs`**: cover vector, map, and Foundation event-source constructors in both fixtures, including the WinUI assembly marker, absence of implementation-only references in reference projections, and XAML namespace isolation.

## Validation

- All 37 `ProjectionWriterTest` cases pass. Temporarily reinstating the original naming guard causes all eight UWP/WinUI collection-event cases to fail.
- The isolated Windows SDK reproduction passes callback and unsubscription checks for `DependencyObjectCollection`, `ItemCollection`, `StringMap`, and `PropertySet` on CoreCLR and Native AOT with regenerated SDK projections.
- WinUI coverage exercises source generation with real WinUI metadata; it does not require WinUI runtime activation.