### PR TITLE
Fix hidden properties in custom property provider generation

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -138,6 +139,7 @@ public partial class CustomPropertyProviderGenerator
             token.ThrowIfCancellationRequested();
 
             using PooledArrayBuilder<CustomPropertyInfo> customPropertyInfo = new();
+            HashSet<string> discoveredPropertyNames = new(StringComparer.Ordinal);
 
             // Enumerate all members of the annotated type to discover all properties
             foreach (ISymbol symbol in typeSymbol.EnumerateAllMembers())
@@ -147,6 +149,13 @@ public partial class CustomPropertyProviderGenerator
                 // Only gather public properties, and ignore overrides (we'll find the base definition instead).
                 // We also ignore partial property implementations, as we only care about the partial definitions.
                 if (symbol is not IPropertySymbol { DeclaredAccessibility: Accessibility.Public, IsOverride: false, PartialDefinitionPart: null } propertySymbol)
+                {
+                    continue;
+                }
+
+                // The hierarchy is enumerated most-derived first. A hidden property must not produce
+                // another descriptor, even if the hiding property's type cannot be boxed.
+                if (!propertySymbol.IsIndexer && !discoveredPropertyNames.Add(propertySymbol.Name))
                 {
                     continue;
                 }

--- a/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
+++ b/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Data;
@@ -12,6 +13,294 @@ namespace WindowsRuntime.SourceGenerator.Tests;
 [TestClass]
 public class Test_CustomPropertyProviderGenerator
 {
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void HiddenProperties_GenericBase_UsesMostDerivedProperty(bool explicitSelection)
+    {
+        string source = $$"""
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Behavior
+            {
+                public object AssociatedObject { get; private set; } = "target";
+
+                public int Inherited { get; set; } = 42;
+            }
+
+            public class Behavior<T> : Behavior where T : class
+            {
+                public new T AssociatedObject => (T)base.AssociatedObject;
+            }
+
+            [GeneratedCustomPropertyProvider{{(explicitSelection ? "([nameof(AssociatedObject), nameof(IsEnabled), nameof(Inherited)], [])" : "")}}]
+            public sealed partial class MyType : Behavior<string>
+            {
+                public bool IsEnabled { get; set; }
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+
+        AssertReadOnlyProperty(provider, "AssociatedObject", "target");
+        Assert.AreEqual(3, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+
+        ICustomProperty isEnabled = provider.GetCustomProperty("IsEnabled");
+
+        Assert.IsNotNull(isEnabled);
+        Assert.AreEqual(typeof(bool), isEnabled.Type);
+        Assert.IsTrue(isEnabled.CanRead);
+        Assert.IsTrue(isEnabled.CanWrite);
+        Assert.AreEqual(false, isEnabled.GetValue(provider));
+
+        isEnabled.SetValue(provider, true);
+
+        Assert.AreEqual(true, isEnabled.GetValue(provider));
+
+        ICustomProperty inherited = provider.GetCustomProperty("Inherited");
+
+        Assert.IsNotNull(inherited);
+        Assert.AreEqual(typeof(int), inherited.Type);
+        Assert.IsTrue(inherited.CanRead);
+        Assert.IsTrue(inherited.CanWrite);
+        Assert.AreEqual(42, inherited.GetValue(provider));
+
+        inherited.SetValue(provider, 100);
+
+        Assert.AreEqual(100, inherited.GetValue(provider));
+    }
+
+    [TestMethod]
+    [DataRow("object", "get;", true, false, false)]
+    [DataRow("object", "get;", true, false, true)]
+    [DataRow("string", "get;", true, false, false)]
+    [DataRow("string", "get;", true, false, true)]
+    [DataRow("object", "get; set;", true, true, false)]
+    [DataRow("string", "get; set;", true, true, true)]
+    [DataRow("object", "get; init;", true, false, false)]
+    [DataRow("string", "get; init;", true, false, true)]
+    [DataRow("object", "private get; set;", false, true, false)]
+    [DataRow("string", "private get; set;", false, true, true)]
+    [DataRow("object", "get; private set;", true, false, false)]
+    [DataRow("string", "get; private set;", true, false, true)]
+    public void HiddenProperties_NonGeneric_UsesMostDerivedAccessors(string baseType, string accessors, bool canRead, bool canWrite, bool explicitSelection)
+    {
+        string source = $$"""
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Base
+            {
+                public {{baseType}} Value { get; set; } = "Base";
+            }
+
+            [GeneratedCustomPropertyProvider{{(explicitSelection ? "([nameof(Value), nameof(StoredValue)], [])" : "")}}]
+            public partial class MyType : Base
+            {
+                public new string Value { {{accessors}} } = "Derived";
+
+                public string StoredValue => Value;
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+        ICustomProperty property = provider.GetCustomProperty("Value");
+
+        Assert.IsNotNull(property);
+        Assert.AreEqual("Value", property.Name);
+        Assert.AreEqual(typeof(string), property.Type);
+        Assert.AreEqual(canRead, property.CanRead);
+        Assert.AreEqual(canWrite, property.CanWrite);
+        Assert.AreEqual(2, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+
+        if (canRead)
+        {
+            Assert.AreEqual("Derived", property.GetValue(provider));
+        }
+        else
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => property.GetValue(provider));
+        }
+
+        if (canWrite)
+        {
+            property.SetValue(provider, "Updated");
+        }
+        else
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => property.SetValue(provider, "Updated"));
+        }
+
+        AssertReadOnlyProperty(provider, "StoredValue", canWrite ? "Updated" : "Derived");
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void HiddenProperties_IndexerOverloads_ArePreserved(bool explicitSelection)
+    {
+        string source = $$"""
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Base
+            {
+                public object Value => "Base";
+
+                public int this[int index] => index + 1;
+            }
+
+            [GeneratedCustomPropertyProvider{{(explicitSelection ? "([nameof(Value)], [typeof(int), typeof(string)])" : "")}}]
+            public partial class MyType : Base
+            {
+                public new string Value => "Derived";
+
+                public string this[string index] => index + "!";
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+
+        AssertReadOnlyProperty(provider, "Value", "Derived");
+        Assert.AreEqual(3, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+
+        ICustomProperty intIndexer = provider.GetIndexedProperty("Item", typeof(int));
+        ICustomProperty stringIndexer = provider.GetIndexedProperty("Item", typeof(string));
+
+        Assert.IsNotNull(intIndexer);
+        Assert.IsNotNull(stringIndexer);
+        Assert.AreEqual(typeof(int), intIndexer.Type);
+        Assert.AreEqual(typeof(string), stringIndexer.Type);
+        Assert.IsTrue(intIndexer.CanRead);
+        Assert.IsFalse(intIndexer.CanWrite);
+        Assert.IsTrue(stringIndexer.CanRead);
+        Assert.IsFalse(stringIndexer.CanWrite);
+        Assert.AreEqual(43, intIndexer.GetIndexedValue(provider, 42));
+        Assert.AreEqual("key!", stringIndexer.GetIndexedValue(provider, "key"));
+    }
+
+    [TestMethod]
+    public void HiddenProperties_OverriddenProperty_UsesHiddenDefinition()
+    {
+        const string source = """
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Base
+            {
+                public virtual object Value => "Base";
+            }
+
+            public class Intermediate : Base
+            {
+                public new virtual string Value => "Intermediate";
+            }
+
+            [GeneratedCustomPropertyProvider]
+            public partial class MyType : Intermediate
+            {
+                public override string Value => "Derived";
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+
+        AssertReadOnlyProperty(provider, "Value", "Derived");
+        Assert.AreEqual(1, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+    }
+
+    [TestMethod]
+    public void HiddenProperties_PartialProperty_UsesDefinition()
+    {
+        const string source = """
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Base
+            {
+                public object Value { get; set; } = "Base";
+            }
+
+            [GeneratedCustomPropertyProvider]
+            public partial class MyType : Base
+            {
+                private string value = "Derived";
+
+                public new partial string Value { get; set; }
+
+                public new partial string Value
+                {
+                    get => value;
+                    set => this.value = value;
+                }
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+        ICustomProperty property = provider.GetCustomProperty("Value");
+
+        Assert.IsNotNull(property);
+        Assert.AreEqual(typeof(string), property.Type);
+        Assert.IsTrue(property.CanRead);
+        Assert.IsTrue(property.CanWrite);
+        Assert.AreEqual("Derived", property.GetValue(provider));
+        Assert.AreEqual(1, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+
+        property.SetValue(provider, "Updated");
+
+        Assert.AreEqual("Updated", property.GetValue(provider));
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void HiddenProperties_UnboxableProperty_DoesNotExposeHiddenBase(bool explicitSelection)
+    {
+        string source = $$"""
+            using System;
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            public class Base
+            {
+                public string Value => "Base";
+
+                public string Inherited => "Inherited";
+            }
+
+            [GeneratedCustomPropertyProvider{{(explicitSelection ? "([nameof(Value), nameof(Inherited)], [])" : "")}}]
+            public partial class MyType : Base
+            {
+                public new Span<int> Value => default;
+
+                public static MyType Create() => new MyType();
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+
+        Assert.IsNull(provider.GetCustomProperty("Value"));
+        AssertReadOnlyProperty(provider, "Inherited", "Inherited");
+        Assert.AreEqual(1, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+    }
+
     [TestMethod]
     [DataRow("sealed partial class", false)]
     [DataRow("sealed partial class", true)]

--- a/src/Tests/SourceGenerator2Test/Test_GeneratedCustomPropertyProviderAttributeArgumentAnalyzer.cs
+++ b/src/Tests/SourceGenerator2Test/Test_GeneratedCustomPropertyProviderAttributeArgumentAnalyzer.cs
@@ -121,6 +121,29 @@ public class Test_GeneratedCustomPropertyProviderAttributeArgumentAnalyzer
     }
 
     [TestMethod]
+    public async Task HiddenInheritedPropertyName_DoesNotWarn()
+    {
+        const string source = """
+            using WindowsRuntime.Xaml;
+
+            public class Behavior
+            {
+                public object AssociatedObject { get; private set; } = "target";
+            }
+
+            public class Behavior<T> : Behavior where T : class
+            {
+                public new T AssociatedObject => (T)base.AssociatedObject;
+            }
+
+            [GeneratedCustomPropertyProvider([nameof(AssociatedObject)], [])]
+            public partial class MyType : Behavior<string>;
+            """;
+
+        await CSharpAnalyzerTest<GeneratedCustomPropertyProviderAttributeArgumentAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
     public async Task InheritedIndexerType_DoesNotWarn()
     {
         string source = """


### PR DESCRIPTION
## Summary

Resolve hidden non-indexer properties before generating `ICustomPropertyProvider` implementations. Keep the most-derived eligible property so each name produces a single lookup entry and helper with the correct type and accessor semantics.

## Motivation

A public `new` property, such as `Behavior<T>.AssociatedObject` hiding `Behavior.AssociatedObject`, currently causes the generator to emit duplicate helper classes and switch arms, breaking compilation. Generated access already resolves through the annotated type, so discovery must select the corresponding derived property rather than also emitting an incorrect descriptor for the hidden base property.

## Changes

- **`src\Authoring\WinRT.SourceGenerator2\CustomPropertyProviderGenerator.Execute.cs`**: Track non-indexer property names using ordinal comparison during the existing derived-to-base traversal. Reserve names before boxing filters to prevent falling back to hidden base properties, while preserving indexer overloads and existing override/partial-property filtering.
- **`src\Tests\SourceGenerator2Test\Test_CustomPropertyProviderGenerator.cs`**: Add compilation and runtime regressions covering generic and nongeneric hiding, same and changed property types, explicit selection, accessor semantics including init-only properties, unrelated inherited properties, indexer overloads, overrides, partial properties, and unboxable hiding properties. Assert the expected helper count and descriptor behavior using the existing compilation helper.
- **`src\Tests\SourceGenerator2Test\Test_GeneratedCustomPropertyProviderAttributeArgumentAnalyzer.cs`**: Cover explicit selection of a hidden inherited property without analyzer diagnostics.