### PR TITLE
Fix nullable typeof expressions in custom property providers

### DIFF
--- a/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Emit.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Emit.cs
@@ -141,7 +141,7 @@ public partial class CustomPropertyProviderGenerator
                     // If we have a match, return the cached property implementation for the current indexer
                     writer.WriteLine(skipIfPresent: true);
                     writer.WriteLine($$"""
-                        if (type == typeof({{propertyInfo.FullyQualifiedIndexerTypeName}}))
+                        if (type == typeof({{propertyInfo.FullyQualifiedIndexerTypeNameForTypeOf}}))
                         {
                             return global::WindowsRuntime.Xaml.Generated.{{implementationTypeName}}.Instance;
                         }
@@ -263,7 +263,7 @@ public partial class CustomPropertyProviderGenerator
                     public string Name => "{{propertyInfo.Name}}";
 
                     /// <inheritdoc/>
-                    public Type Type => typeof({{propertyInfo.FullyQualifiedTypeName}});
+                    public Type Type => typeof({{propertyInfo.FullyQualifiedTypeNameForTypeOf}});
                     """, isMultiline: true);
 
                 writer.WriteLine();
@@ -392,7 +392,7 @@ public partial class CustomPropertyProviderGenerator
                     public string Name => "this";
 
                     /// <inheritdoc/>
-                    public Type Type => typeof({{propertyInfo.FullyQualifiedTypeName}});
+                    public Type Type => typeof({{propertyInfo.FullyQualifiedTypeNameForTypeOf}});
                     """, isMultiline: true);
 
                 // This is an indexed property, so non indexed ones will always throw

--- a/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
@@ -188,11 +188,13 @@ public partial class CustomPropertyProviderGenerator
                     continue;
                 }
 
-                // Gather all the info for the current property
+                // Keep nullability annotations in casts, but not nullable reference annotations in 'typeof' operands.
                 customPropertyInfo.Add(new CustomPropertyInfo(
                     Name: propertySymbol.Name,
                     FullyQualifiedTypeName: propertySymbol.Type.GetFullyQualifiedNameWithNullabilityAnnotations(),
+                    FullyQualifiedTypeNameForTypeOf: propertySymbol.Type.GetFullyQualifiedName(),
                     FullyQualifiedIndexerTypeName: indexerType?.GetFullyQualifiedNameWithNullabilityAnnotations(),
+                    FullyQualifiedIndexerTypeNameForTypeOf: indexerType?.GetFullyQualifiedName(),
                     CanRead: propertySymbol.GetMethod is { DeclaredAccessibility: Accessibility.Public },
                     CanWrite: propertySymbol.SetMethod is { DeclaredAccessibility: Accessibility.Public, IsInitOnly: false },
                     IsStatic: propertySymbol.IsStatic));

--- a/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/CustomPropertyProviderGenerator.Execute.cs
@@ -188,7 +188,7 @@ public partial class CustomPropertyProviderGenerator
                     continue;
                 }
 
-                // Keep nullability annotations in casts, but not nullable reference annotations in 'typeof' operands.
+                // Keep nullability annotations in casts, but not nullable reference annotations in 'typeof' operands
                 customPropertyInfo.Add(new CustomPropertyInfo(
                     Name: propertySymbol.Name,
                     FullyQualifiedTypeName: propertySymbol.Type.GetFullyQualifiedNameWithNullabilityAnnotations(),

--- a/src/Authoring/WinRT.SourceGenerator2/Models/CustomPropertyInfo.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Models/CustomPropertyInfo.cs
@@ -10,14 +10,18 @@ namespace WindowsRuntime.SourceGenerator.Models;
 /// </summary>
 /// <param name="Name">The property name.</param>
 /// <param name="FullyQualifiedTypeName">The fully qualified type name of the property.</param>
+/// <param name="FullyQualifiedTypeNameForTypeOf">The fully qualified property type name without nullable reference annotations, for use in <c>typeof</c> expressions.</param>
 /// <param name="FullyQualifiedIndexerTypeName">The fully qualified type name of the indexer parameter, if applicable.</param>
+/// <param name="FullyQualifiedIndexerTypeNameForTypeOf">The fully qualified indexer parameter type name without nullable reference annotations, for use in <c>typeof</c> expressions, if applicable.</param>
 /// <param name="CanRead">Whether the property can be read.</param>
 /// <param name="CanWrite">Whether the property can be written to.</param>
 /// <param name="IsStatic">Whether the property is static.</param>
 internal sealed record CustomPropertyInfo(
     string Name,
     string FullyQualifiedTypeName,
+    string FullyQualifiedTypeNameForTypeOf,
     string? FullyQualifiedIndexerTypeName,
+    string? FullyQualifiedIndexerTypeNameForTypeOf,
     bool CanRead,
     bool CanWrite,
     bool IsStatic)

--- a/src/Authoring/WinRT.SourceGenerator2/Models/CustomPropertyInfo.cs
+++ b/src/Authoring/WinRT.SourceGenerator2/Models/CustomPropertyInfo.cs
@@ -10,9 +10,9 @@ namespace WindowsRuntime.SourceGenerator.Models;
 /// </summary>
 /// <param name="Name">The property name.</param>
 /// <param name="FullyQualifiedTypeName">The fully qualified type name of the property.</param>
-/// <param name="FullyQualifiedTypeNameForTypeOf">The fully qualified property type name without nullable reference annotations, for use in <c>typeof</c> expressions.</param>
+/// <param name="FullyQualifiedTypeNameForTypeOf">The fully qualified property type name without nullable reference annotations, for use in <see langword="typeof"/> expressions.</param>
 /// <param name="FullyQualifiedIndexerTypeName">The fully qualified type name of the indexer parameter, if applicable.</param>
-/// <param name="FullyQualifiedIndexerTypeNameForTypeOf">The fully qualified indexer parameter type name without nullable reference annotations, for use in <c>typeof</c> expressions, if applicable.</param>
+/// <param name="FullyQualifiedIndexerTypeNameForTypeOf">The fully qualified indexer parameter type name without nullable reference annotations, for use in <see langword="typeof"/> expressions, if applicable.</param>
 /// <param name="CanRead">Whether the property can be read.</param>
 /// <param name="CanWrite">Whether the property can be written to.</param>
 /// <param name="IsStatic">Whether the property is static.</param>

--- a/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
+++ b/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -13,6 +14,125 @@ namespace WindowsRuntime.SourceGenerator.Tests;
 [TestClass]
 public class Test_CustomPropertyProviderGenerator
 {
+    [TestMethod]
+    [DataRow("string?", "string", "\"Initialized\"", typeof(string), false)]
+    [DataRow("string?", "string", "\"Initialized\"", typeof(string), true)]
+    [DataRow("object?", "object", "new object()", typeof(object), false)]
+    [DataRow("object?", "object", "new object()", typeof(object), true)]
+    [DataRow("string?[]?", "string[]", "new string?[] { \"Initialized\", null }", typeof(string[]), false)]
+    [DataRow("string?[]?", "string[]", "new string?[] { \"Initialized\", null }", typeof(string[]), true)]
+    [DataRow("List<string?>?", "List<string>", "new() { \"Initialized\", null }", typeof(List<string>), false)]
+    [DataRow("List<string?>?", "List<string>", "new() { \"Initialized\", null }", typeof(List<string>), true)]
+    [DataRow("Dictionary<string, List<int?>?>?", "Dictionary<string, List<int?>>", "new() { [\"key\"] = new() { 42, null } }", typeof(Dictionary<string, List<int?>>), false)]
+    [DataRow("Dictionary<string, List<int?>?>?", "Dictionary<string, List<int?>>", "new() { [\"key\"] = new() { 42, null } }", typeof(Dictionary<string, List<int?>>), true)]
+    [DataRow("int?", "int?", "42", typeof(int?), false)]
+    [DataRow("int?", "int?", "42", typeof(int?), true)]
+    [DataRow("DateTime?", "DateTime?", "new DateTime(2026, 9, 11)", typeof(DateTime?), false)]
+    [DataRow("DateTime?", "DateTime?", "new DateTime(2026, 9, 11)", typeof(DateTime?), true)]
+    [DataRow("KeyValuePair<string?, int?>?", "KeyValuePair<string, int?>?", "new(\"key\", 42)", typeof(KeyValuePair<string, int?>?), false)]
+    [DataRow("KeyValuePair<string?, int?>?", "KeyValuePair<string, int?>?", "new(\"key\", 42)", typeof(KeyValuePair<string, int?>?), true)]
+    [DataRow("(string? Text, int? Number)?", "(string Text, int? Number)?", "(\"Initialized\", 42)", typeof((string, int?)?), false)]
+    [DataRow("(string? Text, int? Number)?", "(string Text, int? Number)?", "(\"Initialized\", 42)", typeof((string, int?)?), true)]
+    public void NullableTypes_UseRuntimeTypesAndPreserveAccessors(string typeName, string typeOfName, string initializer, Type expectedType, bool explicitSelection)
+    {
+        string source = $$"""
+            #nullable enable
+
+            using System;
+            using System.Collections.Generic;
+            using WindowsRuntime.Xaml;
+
+            namespace MyNamespace;
+
+            [GeneratedCustomPropertyProvider{{(explicitSelection ? $"([nameof(Writable), nameof(InitOnly)], [typeof({typeOfName})])" : "")}}]
+            public sealed partial class MyType
+            {
+                private {{typeName}} indexedValue = {{initializer}};
+
+                public object? LastIndex;
+
+                public {{typeName}} Writable { get; set; }
+
+                public required {{typeName}} InitOnly { get; init; }
+
+                public {{typeName}} this[{{typeName}} index]
+                {
+                    get
+                    {
+                        LastIndex = index;
+                        return indexedValue;
+                    }
+                    set
+                    {
+                        LastIndex = index;
+                        indexedValue = value;
+                    }
+                }
+
+                public static MyType Create() => new MyType { InitOnly = {{initializer}} };
+            }
+            """;
+
+        ICustomPropertyProvider provider = CreateProvider(source);
+        ICustomProperty initOnly = provider.GetCustomProperty("InitOnly");
+        ICustomProperty writable = provider.GetCustomProperty("Writable");
+        ICustomProperty indexer = provider.GetIndexedProperty("Item", expectedType);
+
+        Assert.IsNotNull(initOnly);
+        Assert.IsNotNull(writable);
+        Assert.IsNotNull(indexer);
+        Assert.AreEqual(3, provider.GetType().Assembly.GetTypes().Count(type => typeof(ICustomProperty).IsAssignableFrom(type)));
+        Assert.IsNull(provider.GetIndexedProperty("Item", typeof(bool)));
+
+        Assert.AreEqual(expectedType, initOnly.Type);
+        Assert.IsTrue(initOnly.CanRead);
+        Assert.IsFalse(initOnly.CanWrite);
+
+        object initialValue = initOnly.GetValue(provider);
+
+        Assert.IsNotNull(initialValue);
+        Assert.IsTrue(expectedType.IsInstanceOfType(initialValue));
+        Assert.ThrowsExactly<NotSupportedException>(() => initOnly.SetValue(provider, null));
+        Assert.AreEqual(initialValue, initOnly.GetValue(provider));
+
+        Assert.AreEqual(expectedType, writable.Type);
+        Assert.IsTrue(writable.CanRead);
+        Assert.IsTrue(writable.CanWrite);
+        Assert.IsNull(writable.GetValue(provider));
+
+        writable.SetValue(provider, initialValue);
+
+        Assert.AreEqual(initialValue, writable.GetValue(provider));
+
+        writable.SetValue(provider, null);
+
+        Assert.IsNull(writable.GetValue(provider));
+
+        Assert.AreEqual(expectedType, indexer.Type);
+        Assert.IsTrue(indexer.CanRead);
+        Assert.IsTrue(indexer.CanWrite);
+
+        object indexedValue = indexer.GetIndexedValue(provider, null);
+        FieldInfo lastIndex = provider.GetType().GetField("LastIndex");
+
+        Assert.IsNotNull(indexedValue);
+        Assert.IsTrue(expectedType.IsInstanceOfType(indexedValue));
+        Assert.IsNotNull(lastIndex);
+        Assert.IsNull(lastIndex.GetValue(provider));
+
+        indexer.SetIndexedValue(provider, initialValue, initialValue);
+
+        Assert.AreEqual(initialValue, lastIndex.GetValue(provider));
+        Assert.AreEqual(initialValue, indexer.GetIndexedValue(provider, null));
+        Assert.IsNull(lastIndex.GetValue(provider));
+
+        indexer.SetIndexedValue(provider, null, null);
+
+        Assert.IsNull(lastIndex.GetValue(provider));
+        Assert.IsNull(indexer.GetIndexedValue(provider, initialValue));
+        Assert.AreEqual(initialValue, lastIndex.GetValue(provider));
+    }
+
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]

--- a/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
+++ b/src/Tests/SourceGenerator2Test/Test_CustomPropertyProviderGenerator.cs
@@ -33,7 +33,12 @@ public class Test_CustomPropertyProviderGenerator
     [DataRow("KeyValuePair<string?, int?>?", "KeyValuePair<string, int?>?", "new(\"key\", 42)", typeof(KeyValuePair<string, int?>?), true)]
     [DataRow("(string? Text, int? Number)?", "(string Text, int? Number)?", "(\"Initialized\", 42)", typeof((string, int?)?), false)]
     [DataRow("(string? Text, int? Number)?", "(string Text, int? Number)?", "(\"Initialized\", 42)", typeof((string, int?)?), true)]
-    public void NullableTypes_UseRuntimeTypesAndPreserveAccessors(string typeName, string typeOfName, string initializer, Type expectedType, bool explicitSelection)
+    public void NullableTypes_UseRuntimeTypesAndPreserveAccessors(
+        string typeName,
+        string typeOfName,
+        string initializer,
+        Type expectedType,
+        bool explicitSelection)
     {
         string source = $$"""
             #nullable enable


### PR DESCRIPTION
## Summary

Fix `GeneratedCustomPropertyProvider` emitting nullable reference annotations in `typeof` expressions for property descriptors and indexer lookup. Retain annotations in casts and preserve nullable value types.

## Motivation

Valid nullable binding models currently fail to compile with CS8639 because the generator emits expressions such as `typeof(string?)` and `typeof(object?)`. Runtime type lookup must omit nullable reference annotations without stripping `Nullable<T>` or changing init-only setter behavior.

## Changes

- **`src\Authoring\WinRT.SourceGenerator2\CustomPropertyProviderGenerator.Execute.cs`** and **`src\Authoring\WinRT.SourceGenerator2\Models\CustomPropertyInfo.cs`**: carry separate Roslyn-formatted names for `typeof` operands alongside the existing nullable-annotated cast names.
- **`src\Authoring\WinRT.SourceGenerator2\CustomPropertyProviderGenerator.Emit.cs`**: use the runtime-type names for ordinary and indexed property descriptors and indexer parameter matching.
- **`src\Tests\SourceGenerator2Test\Test_CustomPropertyProviderGenerator.cs`**: add 18 compilation-based and runtime regression cases covering nullable strings, objects, arrays, generics, structs, and tuples under automatic discovery and explicit selection. Assert descriptor type identity, null round-trips, getter/setter behavior, and read-only init properties.