### PR TITLE
Restore NaN-compatible validation for foundation structs

### DIFF
--- a/src/Tests/UnitTest/FoundationStructTests.cs
+++ b/src/Tests/UnitTest/FoundationStructTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.Foundation;
+
+namespace UnitTest;
+
+[TestClass]
+public class FoundationStructTests
+{
+    // Bit patterns preserve signed zeros and NaNs without relying on floating-point data row generation.
+    private const uint PositiveZeroBits = 0x00000000;
+    private const uint NegativeZeroBits = 0x80000000;
+    private const uint PositiveEpsilonBits = 0x00000001;
+    private const uint NegativeEpsilonBits = 0x80000001;
+    private const uint OneBits = 0x3F800000;
+    private const uint NegativeOneBits = 0xBF800000;
+    private const uint NegativeTwoBits = 0xC0000000;
+    private const uint MaxValueBits = 0x7F7FFFFF;
+    private const uint MinValueBits = 0xFF7FFFFF;
+    private const uint PositiveInfinityBits = 0x7F800000;
+    private const uint NegativeInfinityBits = 0xFF800000;
+    private const uint PositiveQuietNaNBits = 0x7FC00000;
+    private const uint NegativeQuietNaNBits = 0xFFC00000;
+    private const uint PositiveSignalingNaNBits = 0x7F800001;
+    private const uint NegativeSignalingNaNBits = 0xFF800001;
+
+    [TestMethod]
+    [DataRow(PositiveZeroBits)]
+    [DataRow(NegativeZeroBits)]
+    [DataRow(PositiveEpsilonBits)]
+    [DataRow(OneBits)]
+    [DataRow(MaxValueBits)]
+    [DataRow(PositiveInfinityBits)]
+    [DataRow(PositiveQuietNaNBits)]
+    [DataRow(NegativeQuietNaNBits)]
+    [DataRow(PositiveSignalingNaNBits)]
+    [DataRow(NegativeSignalingNaNBits)]
+    public void SizeConstructor_NonNegativeOrNaNDimensions_ArePreserved(uint valueBits)
+    {
+        float value = BitConverter.UInt32BitsToSingle(valueBits);
+
+        Size size = new(value, value);
+
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(size.Width));
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(size.Height));
+        Assert.IsFalse(size.IsEmpty);
+    }
+
+    [TestMethod]
+    [DataRow(PositiveZeroBits)]
+    [DataRow(NegativeZeroBits)]
+    [DataRow(PositiveEpsilonBits)]
+    [DataRow(OneBits)]
+    [DataRow(MaxValueBits)]
+    [DataRow(PositiveInfinityBits)]
+    [DataRow(PositiveQuietNaNBits)]
+    [DataRow(NegativeQuietNaNBits)]
+    [DataRow(PositiveSignalingNaNBits)]
+    [DataRow(NegativeSignalingNaNBits)]
+    public void RectConstructor_NonNegativeOrNaNDimensions_ArePreserved(uint valueBits)
+    {
+        float value = BitConverter.UInt32BitsToSingle(valueBits);
+
+        Rect rect = new(-1, -2, value, value);
+
+        Assert.AreEqual(-1f, rect.X);
+        Assert.AreEqual(-2f, rect.Y);
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Width));
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Height));
+        Assert.IsFalse(rect.IsEmpty);
+    }
+
+    [TestMethod]
+    [DataRow(PositiveZeroBits)]
+    [DataRow(NegativeZeroBits)]
+    [DataRow(PositiveEpsilonBits)]
+    [DataRow(NegativeEpsilonBits)]
+    [DataRow(OneBits)]
+    [DataRow(NegativeOneBits)]
+    [DataRow(MaxValueBits)]
+    [DataRow(MinValueBits)]
+    [DataRow(PositiveInfinityBits)]
+    [DataRow(NegativeInfinityBits)]
+    [DataRow(PositiveQuietNaNBits)]
+    [DataRow(NegativeQuietNaNBits)]
+    [DataRow(PositiveSignalingNaNBits)]
+    [DataRow(NegativeSignalingNaNBits)]
+    public void PointAndRectConstructors_Coordinates_ArePreserved(uint valueBits)
+    {
+        float value = BitConverter.UInt32BitsToSingle(valueBits);
+
+        Point point = new(value, value);
+        Rect rect = new(value, value, 1, 2);
+
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(point.X));
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(point.Y));
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.X));
+        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Y));
+    }
+
+    [TestMethod]
+    [DataRow(NegativeEpsilonBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeEpsilonBits, "height")]
+    [DataRow(NegativeOneBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeOneBits, "height")]
+    [DataRow(MinValueBits, OneBits, "width")]
+    [DataRow(OneBits, MinValueBits, "height")]
+    [DataRow(NegativeInfinityBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeInfinityBits, "height")]
+    [DataRow(NegativeOneBits, NegativeTwoBits, "width")]
+    [DataRow(NegativeQuietNaNBits, NegativeOneBits, "height")]
+    [DataRow(NegativeOneBits, NegativeQuietNaNBits, "width")]
+    public void SizeConstructor_NegativeDimension_Throws(uint widthBits, uint heightBits, string paramName)
+    {
+        float width = BitConverter.UInt32BitsToSingle(widthBits);
+        float height = BitConverter.UInt32BitsToSingle(heightBits);
+
+        ArgumentOutOfRangeException exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Size(width, height));
+
+        Assert.AreEqual(paramName, exception.ParamName);
+        Assert.AreEqual(paramName == "width" ? width : height, exception.ActualValue);
+    }
+
+    [TestMethod]
+    [DataRow(NegativeEpsilonBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeEpsilonBits, "height")]
+    [DataRow(NegativeOneBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeOneBits, "height")]
+    [DataRow(MinValueBits, OneBits, "width")]
+    [DataRow(OneBits, MinValueBits, "height")]
+    [DataRow(NegativeInfinityBits, OneBits, "width")]
+    [DataRow(OneBits, NegativeInfinityBits, "height")]
+    [DataRow(NegativeOneBits, NegativeTwoBits, "width")]
+    [DataRow(NegativeQuietNaNBits, NegativeOneBits, "height")]
+    [DataRow(NegativeOneBits, NegativeQuietNaNBits, "width")]
+    public void RectConstructor_NegativeDimension_Throws(uint widthBits, uint heightBits, string paramName)
+    {
+        float width = BitConverter.UInt32BitsToSingle(widthBits);
+        float height = BitConverter.UInt32BitsToSingle(heightBits);
+
+        ArgumentOutOfRangeException exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Rect(0, 0, width, height));
+
+        Assert.AreEqual(paramName, exception.ParamName);
+        Assert.AreEqual(paramName == "width" ? width : height, exception.ActualValue);
+    }
+
+    [TestMethod]
+    public void RectConstructor_FromLocationAndSize_PreservesNaN()
+    {
+        Rect rect = new(new Point(float.NaN, float.NaN), new Size(float.NaN, float.NaN));
+
+        Assert.IsTrue(float.IsNaN(rect.X));
+        Assert.IsTrue(float.IsNaN(rect.Y));
+        Assert.IsTrue(float.IsNaN(rect.Width));
+        Assert.IsTrue(float.IsNaN(rect.Height));
+        Assert.IsFalse(rect.IsEmpty);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void RectConstructor_FromPoints_AcceptsNaN(bool firstPointIsNaN)
+    {
+        Point nanPoint = new(float.NaN, float.NaN);
+        Rect rect = firstPointIsNaN ? new Rect(nanPoint, default(Point)) : new Rect(default(Point), nanPoint);
+
+        Assert.IsTrue(float.IsNaN(rect.X));
+        Assert.IsTrue(float.IsNaN(rect.Y));
+        Assert.IsTrue(float.IsNaN(rect.Width));
+        Assert.IsTrue(float.IsNaN(rect.Height));
+        Assert.IsFalse(rect.IsEmpty);
+    }
+
+    [TestMethod]
+    public void RectConstructor_FromEmptySize_RemainsEmpty()
+    {
+        Rect rect = new(new Point(1, 2), Size.Empty);
+
+        Assert.IsTrue(rect.IsEmpty);
+        Assert.AreEqual(Rect.Empty, rect);
+    }
+}

--- a/src/Tests/UnitTest/FoundationStructTests.cs
+++ b/src/Tests/UnitTest/FoundationStructTests.cs
@@ -9,7 +9,7 @@ namespace UnitTest;
 [TestClass]
 public class FoundationStructTests
 {
-    // Bit patterns preserve signed zeros and NaNs without relying on floating-point data row generation.
+    // Use bit patterns for signed zeros and NaN variants, avoiding floating-point data row generation.
     private const uint PositiveZeroBits = 0x00000000;
     private const uint NegativeZeroBits = 0x80000000;
     private const uint PositiveEpsilonBits = 0x00000001;
@@ -43,8 +43,8 @@ public class FoundationStructTests
 
         Size size = new(value, value);
 
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(size.Width));
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(size.Height));
+        AssertValuePreserved(valueBits, size.Width);
+        AssertValuePreserved(valueBits, size.Height);
         Assert.IsFalse(size.IsEmpty);
     }
 
@@ -67,8 +67,8 @@ public class FoundationStructTests
 
         Assert.AreEqual(-1f, rect.X);
         Assert.AreEqual(-2f, rect.Y);
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Width));
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Height));
+        AssertValuePreserved(valueBits, rect.Width);
+        AssertValuePreserved(valueBits, rect.Height);
         Assert.IsFalse(rect.IsEmpty);
     }
 
@@ -94,10 +94,10 @@ public class FoundationStructTests
         Point point = new(value, value);
         Rect rect = new(value, value, 1, 2);
 
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(point.X));
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(point.Y));
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.X));
-        Assert.AreEqual(valueBits, BitConverter.SingleToUInt32Bits(rect.Y));
+        AssertValuePreserved(valueBits, point.X);
+        AssertValuePreserved(valueBits, point.Y);
+        AssertValuePreserved(valueBits, rect.X);
+        AssertValuePreserved(valueBits, rect.Y);
     }
 
     [TestMethod]
@@ -180,5 +180,18 @@ public class FoundationStructTests
 
         Assert.IsTrue(rect.IsEmpty);
         Assert.AreEqual(Rect.Empty, rect);
+    }
+
+    private static void AssertValuePreserved(uint expectedBits, float actual)
+    {
+        // Floating-point loads and returns can quiet signaling NaNs, notably on x86.
+        if (float.IsNaN(BitConverter.UInt32BitsToSingle(expectedBits)))
+        {
+            Assert.IsTrue(float.IsNaN(actual));
+        }
+        else
+        {
+            Assert.AreEqual(expectedBits, BitConverter.SingleToUInt32Bits(actual));
+        }
     }
 }

--- a/src/WinRT.Runtime2/Properties/WindowsRuntimeExceptionExtensions.cs
+++ b/src/WinRT.Runtime2/Properties/WindowsRuntimeExceptionExtensions.cs
@@ -365,6 +365,28 @@ internal static class WindowsRuntimeExceptionExtensions
     extension(ArgumentOutOfRangeException)
     {
         /// <summary>
+        /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than zero.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">The name of the parameter being checked.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> is less than zero.</exception>
+        /// <remarks>NaN and negative zero are allowed.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [StackTraceHidden]
+        public static void ThrowIfLessThanZero(float value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            [StackTraceHidden]
+            static void ThrowArgumentOutOfRangeException(float value, string? paramName)
+                => ArgumentOutOfRangeException.ThrowIfNegative(value, paramName);
+
+            if (value < 0)
+            {
+                ThrowArgumentOutOfRangeException(value, paramName);
+            }
+        }
+
+        /// <summary>
         /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="length"/> exceeds <paramref name="capacity"/>.
         /// </summary>
         /// <param name="length">The specified buffer length.</param>

--- a/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Rect.cs
@@ -96,8 +96,8 @@ public struct Rect : IEquatable<Rect>, IFormattable
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="width"/> or <paramref name="height"/> are less than zero.</exception>
     public Rect(float x, float y, float width, float height)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(width);
-        ArgumentOutOfRangeException.ThrowIfNegative(height);
+        ArgumentOutOfRangeException.ThrowIfLessThanZero(width);
+        ArgumentOutOfRangeException.ThrowIfLessThanZero(height);
 
         X = x;
         Y = y;

--- a/src/WinRT.Runtime2/Windows.Foundation/Size.cs
+++ b/src/WinRT.Runtime2/Windows.Foundation/Size.cs
@@ -47,8 +47,8 @@ public struct Size : IEquatable<Size>, IFormattable
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="width"/> or <paramref name="height"/> are less than zero.</exception>
     public Size(float width, float height)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(width);
-        ArgumentOutOfRangeException.ThrowIfNegative(height);
+        ArgumentOutOfRangeException.ThrowIfLessThanZero(width);
+        ArgumentOutOfRangeException.ThrowIfLessThanZero(height);
 
         Width = width;
         Height = height;


### PR DESCRIPTION
## Summary

Restore the original comparison-based validation for `Windows.Foundation.Size` and `Windows.Foundation.Rect` in CsWinRT 3.0. NaNs and negative zero are accepted, while values less than zero still throw `ArgumentOutOfRangeException`.

## Motivation

Replacing the original `< 0` checks with `ArgumentOutOfRangeException.ThrowIfNegative` changed behavior because that API checks the floating-point sign bit, rejecting NaNs with the sign bit set (including `float.NaN`) and negative zero. Restore compatibility without duplicating exception construction at each call site.

## Changes

- **`src\WinRT.Runtime2\Properties\WindowsRuntimeExceptionExtensions.cs`**: add an aggressively inlined `ThrowIfLessThanZero` helper with a non-inlined failure path that delegates to the framework helper, preserving exception details.
- **`src\WinRT.Runtime2\Windows.Foundation\Size.cs`** and **`src\WinRT.Runtime2\Windows.Foundation\Rect.cs`**: use the shared helper for constructor width and height validation.
- **`src\Tests\UnitTest\FoundationStructTests.cs`**: add 60 regression cases for `Point`, `Size`, and `Rect`, covering signed quiet and signaling NaNs, signed zeros, subnormal and extreme finite values, infinities, validation ordering, exception parameter names and actual values, coordinate preservation, and alternate `Rect` constructors.

The runtime fix and regression coverage are kept in separate commits.