### PR TITLE
Fix CCWs for IStringable-only types

### DIFF
--- a/.github/skills/interop-generator/SKILL.md
+++ b/.github/skills/interop-generator/SKILL.md
@@ -637,6 +637,8 @@ Builds the interface entries list for CCW (COM Callable Wrapper) types. Each use
 5. `IInspectable`
 6. `IUnknown` (always last)
 
+User-defined layouts normally require at least one additional metadata/component entry. The only built-in-only exception is an explicitly implemented, recognized `IStringable` interface, selected through the same resolver as its reserved vtable slot. `InteropDefinitions.UserDefinedInterfaceEntries` validates every request against its implemented-interface set before consulting the count-keyed layout cache. Automatic `IStringable` support and an `object.ToString()` override do not qualify. Types implementing only `[GeneratedComInterface]` interfaces (including `IMarshal`) remain excluded by discovery.
+
 ### `InteropMarshallerTypeResolver`
 
 Locates the marshaller type for a given type signature. Resolution order:

--- a/src/Tests/UnitTest/ComInteropTests.cs
+++ b/src/Tests/UnitTest/ComInteropTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices.Marshalling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.DataTransfer.DragDrop.Core;
+using Windows.Foundation;
 using Windows.Graphics.Display;
 using Windows.Graphics.Printing;
 using Windows.Media;
@@ -17,6 +18,8 @@ using Windows.UI.Input.Core;
 using Windows.UI.Input.Spatial;
 using Windows.UI.ViewManagement;
 using TestComponentCSharp;
+using WindowsRuntime.InteropServices;
+using WindowsRuntime.InteropServices.Marshalling;
 
 namespace UnitTest
 {
@@ -33,6 +36,34 @@ namespace UnitTest
     [TestClass]
     public class ComInteropTests
     {
+        [TestMethod]
+        public unsafe void TestIStringableOnlyCCW()
+        {
+            using WindowsRuntimeObjectReferenceValue ccw = WindowsRuntimeInterfaceMarshaller<IStringable>.ConvertToUnmanaged(
+                new StringableOnly(), typeof(IStringable).GUID);
+
+            void* thisPtr = ccw.GetThisPtrUnsafe();
+            void* result = null;
+
+            Assert.AreNotEqual(IntPtr.Zero, (IntPtr)thisPtr);
+
+            try
+            {
+                Marshal.ThrowExceptionForHR(((delegate* unmanaged[MemberFunction]<void*, void**, int>)(*(void***)thisPtr)[6])(thisPtr, &result));
+
+                Assert.AreEqual("server test", HStringMarshaller.ConvertToManaged(result));
+            }
+            finally
+            {
+                HStringMarshaller.Free(result);
+            }
+        }
+
+        private sealed class StringableOnly : IStringable
+        {
+            public override string ToString() => "server test";
+        }
+
         [TestMethod]
         public void TestHWND()
         {

--- a/src/Tests/UnitTest/ComInteropTests.cs
+++ b/src/Tests/UnitTest/ComInteropTests.cs
@@ -37,10 +37,14 @@ namespace UnitTest
     public class ComInteropTests
     {
         [TestMethod]
-        public unsafe void TestIStringableOnlyCCW()
+        [DataRow(false)]
+        [DataRow(true)]
+        public unsafe void TestIStringableCCW(bool withAdditionalInterface)
         {
+            IStringable instance = withAdditionalInterface ? new StringableAndDisposable() : new StringableOnly();
+
             using WindowsRuntimeObjectReferenceValue ccw = WindowsRuntimeInterfaceMarshaller<IStringable>.ConvertToUnmanaged(
-                new StringableOnly(), typeof(IStringable).GUID);
+                instance, typeof(IStringable).GUID);
 
             void* thisPtr = ccw.GetThisPtrUnsafe();
             void* result = null;
@@ -62,6 +66,13 @@ namespace UnitTest
         private sealed class StringableOnly : IStringable
         {
             public override string ToString() => "server test";
+        }
+
+        private sealed class StringableAndDisposable : IStringable, IDisposable
+        {
+            public override string ToString() => "server test";
+
+            public void Dispose() { }
         }
 
         [TestMethod]

--- a/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.UserDefinedType.cs
+++ b/src/WinRT.Interop.Generator/Builders/InteropTypeDefinitionBuilder.UserDefinedType.cs
@@ -82,7 +82,7 @@ internal partial class InteropTypeDefinitionBuilder
                 interopReferences: interopReferences));
 
             // Get or create the interface entries type for this user-defined type (we reuse them based on number of entries)
-            interfaceEntriesType = interopDefinitions.UserDefinedInterfaceEntries(entriesList.Count);
+            interfaceEntriesType = interopDefinitions.UserDefinedInterfaceEntries(entriesList.Count, vtableTypes);
 
             InteropTypeDefinitionBuilder.InterfaceEntriesImpl(
                 ns: "WindowsRuntime.Interop.UserDefinedTypes"u8,

--- a/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
+++ b/src/WinRT.Interop.Generator/Factories/WellKnownTypeDefinitionFactory.cs
@@ -1195,8 +1195,11 @@ internal static partial class WellKnownTypeDefinitionFactory
     /// <param name="numberOfEntries">The number of COM interface entries to generate in the type.</param>
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <returns>The resulting <see cref="TypeDefinition"/> instance.</returns>
+    /// <remarks>Request eligibility is validated by <see cref="InteropDefinitions.UserDefinedInterfaceEntries"/> before accessing its cache.</remarks>
     public static TypeDefinition UserDefinedInterfaceEntriesType(int numberOfEntries, InteropReferences interopReferences)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(numberOfEntries, InteropInterfaceEntriesResolver.NumberOfNativeComInterfaceEntries);
+
         TypeDefinition interfaceEntriesType = new(
             ns: null,
             name: $"<UserDefinedInterfaceEntries(Count={numberOfEntries})>",
@@ -1208,8 +1211,6 @@ internal static partial class WellKnownTypeDefinitionFactory
 
         // Calculate the number of dynamic entries, i.e. the ones from explicitly implemented interfaces
         int numberOfDynamicEntries = numberOfEntries - InteropInterfaceEntriesResolver.NumberOfNativeComInterfaceEntries;
-
-        ArgumentOutOfRangeException.ThrowIfLessThan(numberOfDynamicEntries, 1, nameof(numberOfEntries));
 
         // Add a field for each interface entry
         for (int i = 0; i < numberOfDynamicEntries; i++)

--- a/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
+++ b/src/WinRT.Interop.Generator/References/InteropDefinitions.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using AsmResolver.DotNet;
 using WindowsRuntime.InteropGenerator.Factories;
+using WindowsRuntime.InteropGenerator.Models;
+using WindowsRuntime.InteropGenerator.Resolvers;
 
 namespace WindowsRuntime.InteropGenerator.References;
 
@@ -217,9 +220,22 @@ internal sealed class InteropDefinitions
     /// Gets the <see cref="TypeDefinition"/> for the COM interface entries type for user-defined types with the specified number of entries.
     /// </summary>
     /// <param name="numberOfEntries">The number of COM interface entries to generate in the type.</param>
+    /// <param name="vtableTypes">The interfaces explicitly implemented by the user-defined type.</param>
     /// <returns>The resulting <see cref="TypeDefinition"/> instance.</returns>
-    public TypeDefinition UserDefinedInterfaceEntries(int numberOfEntries)
+    /// <remarks>
+    /// A layout without additional entries requires an explicit <c>IStringable</c> implementation.
+    /// Types implementing only <c>IMarshal</c> are not exposed by Windows Runtime type discovery.
+    /// </remarks>
+    public TypeDefinition UserDefinedInterfaceEntries(int numberOfEntries, TypeSignatureEquatableSet vtableTypes)
     {
+        // Validate each request before consulting the count-keyed cache, including cache hits.
+        // Only an explicit implementation selected for the reserved slot permits a built-in-only layout.
+        if (numberOfEntries != InteropInterfaceEntriesResolver.NumberOfNativeComInterfaceEntries ||
+            !InteropInterfaceEntriesResolver.TryGetUserDefinedIStringableInterfaceImplementation(vtableTypes, _interopReferences, out _))
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(numberOfEntries, InteropInterfaceEntriesResolver.NumberOfNativeComInterfaceEntries + 1);
+        }
+
         return _userDefinedInterfaceEntries.GetOrAdd(
             key: numberOfEntries,
             valueFactory: numberOfEntries => WellKnownTypeDefinitionFactory.UserDefinedInterfaceEntriesType(numberOfEntries, _interopReferences));

--- a/src/WinRT.Interop.Generator/Resolvers/InteropInterfaceEntriesResolver.cs
+++ b/src/WinRT.Interop.Generator/Resolvers/InteropInterfaceEntriesResolver.cs
@@ -287,7 +287,7 @@ internal static class InteropInterfaceEntriesResolver
     /// <param name="interopReferences">The <see cref="InteropReferences"/> instance to use.</param>
     /// <param name="interfaceEntryInfo">The resulting <see cref="InteropInterfaceEntryInfo"/> value for <c>IStringable</c>, if found.</param>
     /// <returns>Whether <paramref name="interfaceEntryInfo"/> was found.</returns>
-    private static bool TryGetUserDefinedIStringableInterfaceImplementation(
+    public static bool TryGetUserDefinedIStringableInterfaceImplementation(
         TypeSignatureEquatableSet vtableTypes,
         InteropReferences interopReferences,
         [NotNullWhen(true)] out InteropInterfaceEntryInfo? interfaceEntryInfo)


### PR DESCRIPTION
## Summary

Allow an `IStringable`-only managed type to generate a CCW while preserving validation of zero-additional-interface requests.

## Motivation

An explicit `Windows.Foundation.IStringable` implementation occupies a reserved built-in slot, so it contributes no additional interface entry. Requiring an additional entry caused executable interop generation to fail with `CSWINRTINTEROPGEN0039` for this valid type shape.

## Changes

- **`src\WinRT.Interop.Generator\`**: pass the implemented-interface set to layout lookup, reuse the existing resolver to recognize explicit `IStringable` implementations, and validate every request before accessing the count-keyed cache. Keep structural count validation in the layout factory and leave discovery and other reserved-interface restrictions unchanged.
- **`src\Tests\UnitTest\ComInteropTests.cs`**: add one `IStringable`-only type and one regression that creates its CCW, calls `ToString` through the native vtable, checks the returned string, and releases the string and COM reference. No new test project or CI changes.
- **`.github\skills\interop-generator\SKILL.md`**: document the narrow allowance and cache-validation boundary.

## Validation

- Built the interop generator in Release. The unchanged standalone `.0` control still runs, and the unchanged `.1` repro fails with the original package but builds and runs with the source-built generator.
- Ran the regression's native CCW assertions in an isolated `.1` app on both CoreCLR and Native AOT.
- Full `UnitTest` project execution is blocked locally by a pre-existing `C1083` failure for its long-named C++ fixture, followed by secondary XAML error-handler failures.